### PR TITLE
Add GKE Basic Auth is enabled query for Tf

### DIFF
--- a/assets/queries/terraform/gcp/gke_basicAuth_is_disabled/metadata.json
+++ b/assets/queries/terraform/gcp/gke_basicAuth_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "GKE_Basic_Auth_Disabled",
+  "queryName": "GKE Basic Authentication is disabled",
+  "severity": "HIGH",
+  "category": "Identity & Access Management",
+  "descriptionText": "GCP - Google Kubernetes Engine (GKE) Basic Authentication is disabled, which means the username and password provided in the master_auth block must be empty",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster"
+}

--- a/assets/queries/terraform/gcp/gke_basicAuth_is_disabled/query.rego
+++ b/assets/queries/terraform/gcp/gke_basicAuth_is_disabled/query.rego
@@ -1,0 +1,104 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  not resource.master_auth
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'master_auth' is defined",
+                "keyActualValue": 	"Attribute 'master_auth' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth
+  not resource.master_auth.username
+  resource.master_auth.password
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": "Attribute 'username' of 'master_auth' is defined and empty",
+                "keyActualValue": 	"Attribute 'username' of 'master_auth' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth
+  resource.master_auth.username
+  not resource.master_auth.password
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": "Attribute 'password' of 'master_auth' is defined and empty",
+                "keyActualValue": 	"Attribute 'password' of 'master_auth' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth
+  not resource.master_auth.username
+  not resource.master_auth.password
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attributes 'username' and 'password' are defined and empty",
+                "keyActualValue": 	"Attributes 'username' and 'password' are undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth
+  count(resource.master_auth.username) > 0
+  count(resource.master_auth.password) == 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": "Attribute 'username' of 'master_auth' is defined and empty",
+                "keyActualValue": 	"Attribute 'username' of 'master_auth' is not empty"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth
+  count(resource.master_auth.username) == 0
+  count(resource.master_auth.password) > 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": "Attribute 'password' of 'master_auth' is defined and empty",
+                "keyActualValue": 	"Attribute 'password' of 'master_auth' is not empty"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth
+  count(resource.master_auth.username) > 0
+  count(resource.master_auth.password) > 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attributes 'username' and 'password' are defined and empty",
+                "keyActualValue": 	"Attributes 'username' and 'password' are not empty"
+              }
+}

--- a/assets/queries/terraform/gcp/gke_basicAuth_is_disabled/test/negative.tf
+++ b/assets/queries/terraform/gcp/gke_basicAuth_is_disabled/test/negative.tf
@@ -1,0 +1,20 @@
+#this code is a correct code for which the query should not find any result
+resource "google_container_cluster" "primary" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    username = ""
+    password = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/gke_basicAuth_is_disabled/test/positive.tf
+++ b/assets/queries/terraform/gcp/gke_basicAuth_is_disabled/test/positive.tf
@@ -1,0 +1,127 @@
+#this is a problematic code where the query should report a result(s)
+resource "google_container_cluster" "primary1" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary2" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    username = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary3" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    password = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary4" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary5" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    username = "a"
+    password = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary6" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    username = ""
+    password = "a"
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary7" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    username = "a"
+    password = "a"
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/gke_basicAuth_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/gke_basicAuth_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,37 @@
+[
+	{
+		"queryName": "GKE Basic Authentication is disabled",
+		"severity": "HIGH",
+		"line": 2
+	},
+	{
+		"queryName": "GKE Basic Authentication is disabled",
+		"severity": "HIGH",
+		"line": 18
+	},
+	{
+		"queryName": "GKE Basic Authentication is disabled",
+		"severity": "HIGH",
+		"line": 37
+	},
+	{
+		"queryName": "GKE Basic Authentication is disabled",
+		"severity": "HIGH",
+		"line": 56
+	},
+	{
+		"queryName": "GKE Basic Authentication is disabled",
+		"severity": "HIGH",
+		"line": 74
+	},
+	{
+		"queryName": "GKE Basic Authentication is disabled",
+		"severity": "HIGH",
+		"line": 94
+	},
+	{
+		"queryName": "GKE Basic Authentication is disabled",
+		"severity": "HIGH",
+		"line": 114
+	}
+]


### PR DESCRIPTION
Added new query for Terraform, namely "GKE Basic Authentication is enabled" that finds the resource that has username and password provided in the master_auth block empty.

Closes #76 

