### PR TITLE
Added gcp cloud sql no public access query

### DIFF
--- a/assets/queries/terraform/gcp/cloud_sql_database_has_public_access/metadata.json
+++ b/assets/queries/terraform/gcp/cloud_sql_database_has_public_access/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Cloud_SQL_DB_has_public_access",
+  "queryName": "Cloud SQL DB has public access",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Cloud SQL DB has public access",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance"
+}

--- a/assets/queries/terraform/gcp/cloud_sql_database_has_public_access/query.rego
+++ b/assets/queries/terraform/gcp/cloud_sql_database_has_public_access/query.rego
@@ -1,0 +1,71 @@
+package Cx
+
+CxPolicy [result] {
+  resource := input.document[i].resource.google_sql_database_instance[name]
+  ip_configuration := resource.settings.ip_configuration
+
+  count(ip_configuration.dynamic.authorized_networks) > 0 
+
+  authorized_network = ip_configuration.dynamic.authorized_networks[id]
+
+  authorized_network.value == "0.0.0.0"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_sql_database_instance[%s].settings.ip_configuration.dynamic.authorized_networks.%s.value", [name,id]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "'authorized_network' address is trusted",
+                "keyActualValue": 	"'authorized_network' address is not restricted: '0.0.0.0'"
+              }
+}
+
+CxPolicy [result] {
+  resource := input.document[i].resource.google_sql_database_instance[name]
+  ip_configuration := resource.settings.ip_configuration
+
+  not ip_configuration.dynamic.authorized_networks 
+
+  ip_configuration.ipv4_enabled
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_sql_database_instance[%s].settings.ip_configuration.ipv4_enabled", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "'ipv4_enabled' is disabled and 'private_network' is defined when there are no authorized networks",
+                "keyActualValue": 	"'ipv4_enabled' is enabled when there are no authorized networks"
+              }
+}
+
+CxPolicy [result] {
+  resource := input.document[i].resource.google_sql_database_instance[name]
+  ip_configuration := resource.settings.ip_configuration
+
+  not ip_configuration.dynamic.authorized_networks 
+  
+  not ip_configuration.ipv4_enabled
+  not ip_configuration.private_network
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_sql_database_instance[%s].settings.ip_configuration", [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "'ipv4_enabled' is disabled and 'privatenetwork' is defined when there are no authorized networks",
+                "keyActualValue": 	"'private_network' is not defined when there are no authorized networks"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_sql_database_instance[name]
+  settings := resource.settings
+
+  not settings.ip_configuration
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_sql_database_instance[%s].settings", [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "'ip_configuration' is defined and allow only trusted networks",
+                "keyActualValue": 	"'ip_configuration' is not defined"
+              }
+}
+

--- a/assets/queries/terraform/gcp/cloud_sql_database_has_public_access/test/negative.tf
+++ b/assets/queries/terraform/gcp/cloud_sql_database_has_public_access/test/negative.tf
@@ -1,0 +1,39 @@
+resource "google_sql_database_instance" "private_network" {
+
+  name   = "private-instance-1"
+  database_version = "POSTGRES_11"
+  settings {
+    ip_configuration {
+      ipv4_enabled = false
+      private_network = "some_private_network"
+    }
+  }
+}
+
+resource "google_sql_database_instance" "authorized_networks" {
+  name             = "postgres-instance-2"
+  database_version = "POSTGRES_11"
+
+  settings {
+    tier = "db-f1-micro"
+
+    ip_configuration {
+
+      dynamic "authorized_networks" {
+
+        content {
+          name  = "some_trusted_network"
+          value = "some_trusted_network_address"
+        }
+      }
+
+      dynamic "authorized_networks" {
+
+        content {
+          name  = "another_trusted_network"
+          value = "another_trusted_network_address"
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/gcp/cloud_sql_database_has_public_access/test/positive.tf
+++ b/assets/queries/terraform/gcp/cloud_sql_database_has_public_access/test/positive.tf
@@ -1,0 +1,62 @@
+resource "google_sql_database_instance" "no_config" {
+  name             = "master-instance"
+  database_version = "POSTGRES_11"
+  region           = "us-central1"
+
+  settings {
+    # Second-generation instance tiers are based on the machine
+    # type. See argument reference below.
+    tier = "db-f1-micro"
+  }
+}
+
+resource "google_sql_database_instance" "public_authorized_network" {
+  name             = "postgres-instance-2"
+  database_version = "POSTGRES_11"
+
+  settings {
+    tier = "db-f1-micro"
+
+    ip_configuration {
+
+      dynamic "authorized_networks" {
+
+        content {
+          name  = "pub-network"
+          value = "0.0.0.0"
+        }
+      }
+    }
+  }
+}
+
+resource "google_sql_database_instance" "ipv4_enabled" {
+  name             = "master-instance"
+  database_version = "POSTGRES_11"
+  region           = "us-central1"
+
+  settings {
+    # Second-generation instance tiers are based on the machine
+    # type. See argument reference below.
+    tier = "db-f1-micro"
+
+    ip_configuration {
+        ipv4_enabled = true
+        private_network = "some_private_network"
+    }
+  }
+}
+
+resource "google_sql_database_instance" "no_private_network_config" {
+  name             = "master-instance"
+  database_version = "POSTGRES_11"
+  region           = "us-central1"
+
+  settings {
+    # Second-generation instance tiers are based on the machine
+    # type. See argument reference below.
+    tier = "db-f1-micro"
+
+    ip_configuration {}
+  }
+}

--- a/assets/queries/terraform/gcp/cloud_sql_database_has_public_access/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/cloud_sql_database_has_public_access/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "Cloud SQL DB has public access",
+		"severity": "HIGH",
+		"line": 6
+	},
+	{
+		"queryName": "Cloud SQL DB has public access",
+		"severity": "HIGH",
+		"line": 26
+	},
+	{
+		"queryName": "Cloud SQL DB has public access",
+		"severity": "HIGH",
+		"line": 44
+	},
+	{
+		"queryName": "Cloud SQL DB has public access",
+		"severity": "HIGH",
+		"line": 60
+	}
+]


### PR DESCRIPTION
Created query to check if Cloud SQL DB's aren't configured in a private network, or that the authorized networks allow public addresses. Closes #90.