### PR TITLE
Added query to check if gmail accounts are in use

### DIFF
--- a/assets/queries/terraform/gcp/iam_binding_gmail_accounts_are_used/metadata.json
+++ b/assets/queries/terraform/gcp/iam_binding_gmail_accounts_are_used/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "IAM_Binding_Check_No_Gmail_Accounts",
+  "queryName": "IAM Binding Check No Gmail Accounts",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "Gmail accounts are being used instead of corporate credentials",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#google_project_iam_binding"
+}

--- a/assets/queries/terraform/gcp/iam_binding_gmail_accounts_are_used/query.rego
+++ b/assets/queries/terraform/gcp/iam_binding_gmail_accounts_are_used/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy [ result ] {
+  members := input.document[i].resource.google_project_iam_binding[name].members
+  mail:= members[_]
+
+  contains(mail,"gmail.com")
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_project_iam_binding[%s].members.%s", [name,mail]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "'members' cannot contain Gmail account addresses",
+                "keyActualValue": 	sprintf("'members' has email address: %s",[mail])
+              }
+}

--- a/assets/queries/terraform/gcp/iam_binding_gmail_accounts_are_used/test/negative.tf
+++ b/assets/queries/terraform/gcp/iam_binding_gmail_accounts_are_used/test/negative.tf
@@ -1,0 +1,8 @@
+resource "google_project_iam_binding" "project" {
+  project = "your-project-id"
+  role    = "roles/editor"
+
+  members = [
+    "user:jane@example.com",
+  ]
+}

--- a/assets/queries/terraform/gcp/iam_binding_gmail_accounts_are_used/test/positive.tf
+++ b/assets/queries/terraform/gcp/iam_binding_gmail_accounts_are_used/test/positive.tf
@@ -1,0 +1,8 @@
+resource "google_project_iam_binding" "project" {
+  project = "your-project-id"
+  role    = "roles/editor"
+
+  members = [
+    "user:jane@gmail.com",
+  ]
+}

--- a/assets/queries/terraform/gcp/iam_binding_gmail_accounts_are_used/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/iam_binding_gmail_accounts_are_used/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "IAM Binding Check No Gmail Accounts",
+		"severity": "HIGH",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Added query to check when members of a project are using their own Gmail accounts instead of the corporate login credentials.
Closes #105 