### PR TITLE
Add Network Policy is Disabled query for Terraform

### DIFF
--- a/assets/queries/terraform/gcp/network_policy_is_disabled/metadata.json
+++ b/assets/queries/terraform/gcp/network_policy_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Network_Policy_Disabled",
+  "queryName": "Network Policy is Disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Kubernetes Engine Clusters must have Network Policy enabled, meaning that the attribute 'network_policy.enabled' must be true and the attribute 'addons_config.network_policy_config.disabled' must be false ",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster"
+}

--- a/assets/queries/terraform/gcp/network_policy_is_disabled/query.rego
+++ b/assets/queries/terraform/gcp/network_policy_is_disabled/query.rego
@@ -1,0 +1,85 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  not resource.network_policy
+  resource.addons_config
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'network_policy' is defined",
+                "keyActualValue": 	"Attribute 'network_policy' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.network_policy
+  not resource.addons_config
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'addons_config' is defined",
+                "keyActualValue": 	"Attribute 'addons_config' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  not resource.network_policy
+  not resource.addons_config
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'network_policy' is defined and Attribute 'addons_config' is defined",
+                "keyActualValue": 	"Attribute 'network_policy' is undefined and Attribute 'addons_config' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.network_policy
+  resource.addons_config 
+  not resource.addons_config.network_policy_config
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].addons_config", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'addons_config.network_policy_config' is defined",
+                "keyActualValue": 	"Attribute 'addons_config.network_policy_config' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.network_policy.enabled == false
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].network_policy", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'network_policy.enabled' is true",
+                "keyActualValue": 	"Attribute 'network_policy.enabled' is false"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.network_policy.enabled == true
+  resource.addons_config.network_policy_config.disabled == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].addons_config.network_policy_config", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'addons_config.network_policy_config.disabled' is false",
+                "keyActualValue": 	"Attribute 'addons_config.network_policy_config.disabled' is true"
+              }
+}

--- a/assets/queries/terraform/gcp/network_policy_is_disabled/test/negative.tf
+++ b/assets/queries/terraform/gcp/network_policy_is_disabled/test/negative.tf
@@ -1,0 +1,20 @@
+#this code is a correct code for which the query should not find any result
+resource "google_container_cluster" "primary" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  network_policy {
+      enabled = true
+  }
+  addons_config {
+    network_policy_config {
+        disabled = false
+    }
+  }
+  networking_mode = "VPC_NATIVE"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/network_policy_is_disabled/test/positive.tf
+++ b/assets/queries/terraform/gcp/network_policy_is_disabled/test/positive.tf
@@ -1,0 +1,94 @@
+#this is a problematic code where the query should report a result(s)
+resource "google_container_cluster" "primary1" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  network_policy {
+      enabled = true
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary2" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  network_policy {
+      enabled = true
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary3" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary4" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  network_policy {
+      enabled = true
+  }
+  addons_config {
+
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary5" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  network_policy {
+      enabled = false
+  }
+  addons_config {
+    network_policy_config {
+        disabled = false
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary6" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  network_policy {
+      enabled = true
+  }
+  addons_config {
+    network_policy_config {
+        disabled = true
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/network_policy_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/network_policy_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,32 @@
+[
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 2
+	},
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 16
+	},
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 30
+	},
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 48
+	},
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 62
+	},
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 85
+	}
+]


### PR DESCRIPTION
Adding Network Policy is Disabled query for Terraform, that checks if the attribute 'network_policy.enabled' is true and the attribute 'addons_config.network_policy_config.disabled' is false.

Closes #122 