### PR TITLE
Check audit log config for all services and users

### DIFF
--- a/assets/queries/terraform/gcp/iam_audit_has_not_proper_config/metadata.json
+++ b/assets/queries/terraform/gcp/iam_audit_has_not_proper_config/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "IAM_Audit_Logging_Proper_Config",
+  "queryName": "IAM Audit Logging Proper Config",
+  "severity": "HIGH",
+  "category": "Logging",
+  "descriptionText": "Audit Logging Configuration is defective",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#google_project_iam_audit_config"
+}

--- a/assets/queries/terraform/gcp/iam_audit_has_not_proper_config/query.rego
+++ b/assets/queries/terraform/gcp/iam_audit_has_not_proper_config/query.rego
@@ -1,0 +1,50 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_project_iam_audit_config[name]
+
+  resource.service != "allServices"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_project_iam_audit_config[%s].service", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "'service' must be 'allServices'",
+                "keyActualValue": 	sprintf("'service' is '%s'",[resource.service])
+              }
+} 
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_project_iam_audit_config[name]
+
+  count(resource.audit_log_config) < 3
+
+  audit_log_config = resource.audit_log_config[j]
+  audit_log_config.log_type != "DATA_READ"
+  audit_log_config.log_type != "DATA_WRITE"
+  audit_log_config.log_type != "ADMIN_READ"
+  
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_project_iam_audit_config[%s].audit_log_config.log_type", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "'log_type' must be one of 'DATA_READ', 'DATA_WRITE', or 'ADMIN_READ'",
+                "keyActualValue": 	sprintf("'log_type' is %s",[audit_log_config.log_type])
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_project_iam_audit_config[name]
+  audit_log_config = resource.audit_log_config[_]
+  
+  exempted_members = audit_log_config.exempted_members
+  count(exempted_members) != 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_project_iam_audit_config[%s].audit_log_config.exempted_members", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "'exempted_members' is empty",
+                "keyActualValue": "'exempted_members' is not empty"
+              }
+}

--- a/assets/queries/terraform/gcp/iam_audit_has_not_proper_config/test/negative.tf
+++ b/assets/queries/terraform/gcp/iam_audit_has_not_proper_config/test/negative.tf
@@ -1,0 +1,10 @@
+resource "google_project_iam_audit_config" "project" {
+  project = "your-project-id"
+  service = "allServices"
+  audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+}

--- a/assets/queries/terraform/gcp/iam_audit_has_not_proper_config/test/positive.tf
+++ b/assets/queries/terraform/gcp/iam_audit_has_not_proper_config/test/positive.tf
@@ -1,0 +1,27 @@
+resource "google_project_iam_audit_config" "not_all_services" {
+  project = "your-project-id"
+  service = "some_specific_service"
+  audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+  audit_log_config {
+    log_type = "DATA_READ"
+    exempted_members = [
+      "user:joebloggs@hashicorp.com"
+    ]
+  }
+}
+
+resource "google_project_iam_audit_config" "invalid_log_type" {
+  project = "your-project-id"
+  service = "allServices"
+  audit_log_config {
+    log_type = "INVALID_TYPE"
+  }
+  audit_log_config {
+    log_type = "DATA_READ"
+    exempted_members = [
+        "user:joebloggs@hashicorp.com"
+    ]
+  }
+}

--- a/assets/queries/terraform/gcp/iam_audit_has_not_proper_config/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/iam_audit_has_not_proper_config/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "IAM Audit Logging Proper Config",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "IAM Audit Logging Proper Config",
+		"severity": "HIGH",
+		"line": 9
+	},
+	{
+		"queryName": "IAM Audit Logging Proper Config",
+		"severity": "HIGH",
+		"line": 19
+	},
+	{
+		"queryName": "IAM Audit Logging Proper Config",
+		"severity": "HIGH",
+		"line": 23
+	}
+]


### PR DESCRIPTION
Added query to check is audit logging is configured for all services, with a valid log type, and is applied to every member of the project.