### PR TITLE
Add Master Auth is Disabled query for Terraform

### DIFF
--- a/assets/queries/terraform/gcp/master_authentication_is_disabled/metadata.json
+++ b/assets/queries/terraform/gcp/master_authentication_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Master_Authentication_Disabled",
+  "queryName": "Master Authentication is Disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Kubernetes Engine Clusters must have Master Authentication set to enabled, which means the attribute 'master_auth' must have the subattributes 'username' and 'password' defined and not empty",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster"
+}

--- a/assets/queries/terraform/gcp/master_authentication_is_disabled/query.rego
+++ b/assets/queries/terraform/gcp/master_authentication_is_disabled/query.rego
@@ -1,0 +1,102 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  not resource.master_auth
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'master_auth' is defined",
+                "keyActualValue": 	"Attribute 'master_auth' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth.password
+  not resource.master_auth.username
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'master_auth.username' is defined",
+                "keyActualValue": 	"Attribute 'master_auth.username' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth.username
+  not resource.master_auth.password
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'master_auth.password' is defined",
+                "keyActualValue": 	"Attribute 'master_auth.password' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth
+  not resource.master_auth.username
+  not resource.master_auth.password
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'master_auth.username' is defined and Attribute 'master_auth.password' is defined",
+                "keyActualValue": 	"Attribute 'master_auth.username' is undefined and Attribute 'master_auth.password' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth
+  count(resource.master_auth.username) == 0
+  count(resource.master_auth.password) > 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'master_auth.username' is not empty",
+                "keyActualValue": 	"Attribute 'master_auth.username' is empty"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth
+  count(resource.master_auth.username) > 0
+  count(resource.master_auth.password) == 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'master_auth.password' is not empty",
+                "keyActualValue": 	"Attribute 'master_auth.password' is empty"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.master_auth
+  count(resource.master_auth.username) == 0
+  count(resource.master_auth.password) == 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].master_auth", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'master_auth.username' is not empty and Attribute 'master_auth.password' is not empty",
+                "keyActualValue": 	"Attribute 'master_auth.username' is empty and Attribute 'master_auth.password' is empty"
+              }
+}

--- a/assets/queries/terraform/gcp/master_authentication_is_disabled/test/negative.tf
+++ b/assets/queries/terraform/gcp/master_authentication_is_disabled/test/negative.tf
@@ -1,0 +1,16 @@
+#this code is a correct code for which the query should not find any result
+resource "google_container_cluster" "primary" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    username = "a"
+    password = "a"
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/master_authentication_is_disabled/test/positive.tf
+++ b/assets/queries/terraform/gcp/master_authentication_is_disabled/test/positive.tf
@@ -1,0 +1,103 @@
+#this is a problematic code where the query should report a result(s)
+resource "google_container_cluster" "primary1" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary2" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    username = "a"
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary3" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    password = "a"
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary4" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary5" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    username = ""
+    password = "a"
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary6" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    username = "a"
+    password = ""
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary7" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  master_auth {
+    username = ""
+    password = ""
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/master_authentication_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/master_authentication_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,37 @@
+[
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 2
+	},
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 18
+	},
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 33
+	},
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 48
+	},
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 62
+	},
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 78
+	},
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 94
+	}
+]


### PR DESCRIPTION
Adding Master Authentication is Disabled query for Terraform, that checks if the attribute 'master_auth' has the sub attributes 'username' and 'password' defined and not empty

Closes #132 