### PR TITLE
Add StackdriverMonitoringIsDisabled query for Tf

### DIFF
--- a/assets/queries/terraform/gcp/stackdriver_monitoring_is_disabled/metadata.json
+++ b/assets/queries/terraform/gcp/stackdriver_monitoring_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Stackdriver_Monitoring_Disabled",
+  "queryName": "Stackdriver Monitoring is Disabled",
+  "severity": "HIGH",
+  "category": "Monitoring",
+  "descriptionText": "Kubernetes Engine Clusters must have Stackdriver Monitoring enabled, which means the attribute 'monitoring_service' must be defined and different than 'none'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster"
+}

--- a/assets/queries/terraform/gcp/stackdriver_monitoring_is_disabled/query.rego
+++ b/assets/queries/terraform/gcp/stackdriver_monitoring_is_disabled/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  not resource.monitoring_service
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'monitoring_service' is defined",
+                "keyActualValue": 	"Attribute 'monitoring_service' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.monitoring_service == "none"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'monitoring_service' is not 'none'",
+                "keyActualValue": 	"Attribute 'monitoring_service' is 'none'"
+              }
+}

--- a/assets/queries/terraform/gcp/stackdriver_monitoring_is_disabled/test/negative.tf
+++ b/assets/queries/terraform/gcp/stackdriver_monitoring_is_disabled/test/negative.tf
@@ -1,0 +1,12 @@
+#this code is a correct code for which the query should not find any result
+resource "google_container_cluster" "primary" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  monitoring_service = "monitoring.googleapis.com/kubernetes"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/stackdriver_monitoring_is_disabled/test/positive.tf
+++ b/assets/queries/terraform/gcp/stackdriver_monitoring_is_disabled/test/positive.tf
@@ -1,0 +1,23 @@
+#this is a problematic code where the query should report a result(s)
+resource "google_container_cluster" "primary1" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary2" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  monitoring_service = "none"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/stackdriver_monitoring_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/stackdriver_monitoring_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Stackdriver Monitoring is Disabled",
+		"severity": "HIGH",
+		"line": 2
+	},
+	{
+		"queryName": "Stackdriver Monitoring is Disabled",
+		"severity": "HIGH",
+		"line": 13
+	}
+]


### PR DESCRIPTION
Adding Stackdriver Monitoring is Disabled query for Terraform, that checks if the attribute 'monitoring_service' is defined and different than 'none'.

Closes #137 