### PR TITLE
Add Stackdriver Logging is Disabled query for Tf

### DIFF
--- a/assets/queries/terraform/gcp/stackdriver_logging_is_disabled/metadata.json
+++ b/assets/queries/terraform/gcp/stackdriver_logging_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Stackdriver_Logging_Disabled",
+  "queryName": "Stackdriver Logging is Disabled",
+  "severity": "HIGH",
+  "category": "Logging",
+  "descriptionText": "Kubernetes Engine Clusters must have Stackdriver Logging enabled, which means the attribute 'logging_service' must be defined and different from 'none'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster"
+}

--- a/assets/queries/terraform/gcp/stackdriver_logging_is_disabled/query.rego
+++ b/assets/queries/terraform/gcp/stackdriver_logging_is_disabled/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  not resource.logging_service
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'logging_service' is defined",
+                "keyActualValue": 	"Attribute 'logging_service' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.logging_service == "none"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'logging_service' is not 'none'",
+                "keyActualValue": 	"Attribute 'logging_service' is 'none'"
+              }
+}

--- a/assets/queries/terraform/gcp/stackdriver_logging_is_disabled/test/negative.tf
+++ b/assets/queries/terraform/gcp/stackdriver_logging_is_disabled/test/negative.tf
@@ -1,0 +1,12 @@
+#this code is a correct code for which the query should not find any result
+resource "google_container_cluster" "primary" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  logging_service = "logging.googleapis.com/kubernetes"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/stackdriver_logging_is_disabled/test/positive.tf
+++ b/assets/queries/terraform/gcp/stackdriver_logging_is_disabled/test/positive.tf
@@ -1,0 +1,23 @@
+#this is a problematic code where the query should report a result(s)
+resource "google_container_cluster" "primary1" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary2" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  logging_service = "none"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/stackdriver_logging_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/stackdriver_logging_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Stackdriver Logging is Disabled",
+		"severity": "HIGH",
+		"line": 2
+	},
+	{
+		"queryName": "Stackdriver Logging is Disabled",
+		"severity": "HIGH",
+		"line": 13
+	}
+]


### PR DESCRIPTION
Adding Stackdriver Logging is Disabled query for Terraform, that checks if the attribute 'logging_service' is defined and different from 'none'.

Closes #140 