### PR TITLE
Add ClusterLabels are Disabled query for Terraform

### DIFF
--- a/assets/queries/terraform/gcp/cluster_labels_are_disabled/metadata.json
+++ b/assets/queries/terraform/gcp/cluster_labels_are_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Cluster_Labels_Disabled",
+  "queryName": "Cluster Labels are Disabled",
+  "severity": "HIGH",
+  "category": "Operational Efficiency",
+  "descriptionText": "Kubernetes Clusters must be configured with labels, which means the attribute 'resource_labels' must be defined",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster"
+}

--- a/assets/queries/terraform/gcp/cluster_labels_are_disabled/query.rego
+++ b/assets/queries/terraform/gcp/cluster_labels_are_disabled/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  not resource.resource_labels
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'resource_labels' is defined",
+                "keyActualValue": 	"Attribute 'resource_labels' is undefined"
+              }
+}

--- a/assets/queries/terraform/gcp/cluster_labels_are_disabled/test/negative.tf
+++ b/assets/queries/terraform/gcp/cluster_labels_are_disabled/test/negative.tf
@@ -1,0 +1,15 @@
+#this code is a correct code for which the query should not find any result
+resource "google_container_cluster" "primary" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  resource_labels {
+      
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/cluster_labels_are_disabled/test/positive.tf
+++ b/assets/queries/terraform/gcp/cluster_labels_are_disabled/test/positive.tf
@@ -1,0 +1,11 @@
+#this is a problematic code where the query should report a result(s)
+resource "google_container_cluster" "primary" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/cluster_labels_are_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/cluster_labels_are_disabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Cluster Labels are Disabled",
+		"severity": "HIGH",
+		"line": 2
+	}
+]


### PR DESCRIPTION
Adding ClusterLabels are Disabled query for Terraform, that checks if the attribute 'resource_labels' is defined.

Closes #151 