### PR TITLE
Add CosNodeImageNotUsed query for Terraform

### DIFF
--- a/assets/queries/terraform/gcp/cos_node_image_not_used/metadata.json
+++ b/assets/queries/terraform/gcp/cos_node_image_not_used/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "CosNodeImageNotUsed",
+  "queryName": "COS Node Image Not Used",
+  "severity": "HIGH",
+  "category": "Operational Efficiency",
+  "descriptionText": "A node image, that is not Container-Optimized OS (COS), is used for Kubernetes Engine Clusters Node image",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#node_config"
+}

--- a/assets/queries/terraform/gcp/cos_node_image_not_used/query.rego
+++ b/assets/queries/terraform/gcp/cos_node_image_not_used/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy [ result ] {
+  
+  resource := input.document[i].resource.google_container_node_pool[name]
+  
+  resource.node_config.image_type
+  lower(resource.node_config.image_type) != "cos"
+	
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_node_pool[%s].node_config.image_type", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'node_config.image_type' is 'COS'",
+                "keyActualValue": 	"'node_config.image_type' is not 'COS'"
+              }
+}

--- a/assets/queries/terraform/gcp/cos_node_image_not_used/test/negative.tf
+++ b/assets/queries/terraform/gcp/cos_node_image_not_used/test/negative.tf
@@ -1,0 +1,25 @@
+resource "google_container_cluster" "primary" {
+  name     = "my-gke-cluster"
+  location = "us-central1"
+  remove_default_node_pool = true
+  initial_node_count       = 1
+}
+
+
+resource "google_container_node_pool" "primary-pool" {
+  project = "gcp_project"
+  name    = "primary-pool"
+  region  = "us-west1"
+  cluster = google_container_cluster.primary.name
+
+  node_config {
+    image_type   = "COS"
+  }
+}
+
+ resource "google_container_node_pool" "primary-pool2" {
+  project = "gcp_project"
+  name    = "primary-pool2"
+  region  = "us-west1"
+  cluster = google_container_cluster.primary.name
+ }

--- a/assets/queries/terraform/gcp/cos_node_image_not_used/test/positive.tf
+++ b/assets/queries/terraform/gcp/cos_node_image_not_used/test/positive.tf
@@ -1,0 +1,18 @@
+resource "google_container_cluster" "primary" {
+  name     = "my-gke-cluster"
+  location = "us-central1"
+  remove_default_node_pool = true
+  initial_node_count       = 1
+}
+
+
+resource "google_container_node_pool" "primary-pool" {
+  project = "gcp_project"
+  name    = "primary-pool"
+  region  = "us-west1"
+  cluster = google_container_cluster.primary.name
+
+  node_config {
+    image_type   = "WINDOWS_LTSC"
+  }
+ }

--- a/assets/queries/terraform/gcp/cos_node_image_not_used/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/cos_node_image_not_used/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "COS Node Image Not Used",
+		"severity": "HIGH",
+		"line": 16
+	}
+]


### PR DESCRIPTION
Closes #148 

Added new query COS Node Image Not Used for Terraform.

Ensure Container-Optimized OS (COS) is used for Kubernetes Engine Clusters Node image.