### PR TITLE
Add IP Forwarding Enabled query for Terraform 

### DIFF
--- a/assets/queries/terraform/gcp/ip_forwarding_is_enabled/metadata.json
+++ b/assets/queries/terraform/gcp/ip_forwarding_is_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "IP_Forwarding_Enabled",
+  "queryName": "IP Forwarding is Enabled",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Instances must not have IP forwarding enabled, which means the attribute 'can_ip_forward' must not be true",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance"
+}

--- a/assets/queries/terraform/gcp/ip_forwarding_is_enabled/query.rego
+++ b/assets/queries/terraform/gcp/ip_forwarding_is_enabled/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy [ result ] {
+  data := input.document[i].data.google_compute_instance[appserver]
+  data.can_ip_forward == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_compute_instance[%s]", [appserver]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'can_ip_forward' is false or Attribute 'can_ip_forward' is undefined",
+                "keyActualValue": 	"Attribute 'can_ip_forward' is true"
+              }
+}

--- a/assets/queries/terraform/gcp/ip_forwarding_is_enabled/test/negative.tf
+++ b/assets/queries/terraform/gcp/ip_forwarding_is_enabled/test/negative.tf
@@ -1,0 +1,6 @@
+#this code is a correct code for which the query should not find any result
+data "google_compute_instance" "appserver" {
+  name = "primary-application-server"
+  zone = "us-central1-a"
+  can_ip_forward = false
+}

--- a/assets/queries/terraform/gcp/ip_forwarding_is_enabled/test/positive.tf
+++ b/assets/queries/terraform/gcp/ip_forwarding_is_enabled/test/positive.tf
@@ -1,0 +1,6 @@
+#this is a problematic code where the query should report a result(s)
+data "google_compute_instance" "appserver" {
+  name = "primary-application-server"
+  zone = "us-central1-a"
+  can_ip_forward = true
+}

--- a/assets/queries/terraform/gcp/ip_forwarding_is_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/ip_forwarding_is_enabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "IP Forwarding is Enabled",
+		"severity": "MEDIUM",
+		"line": 2
+	}
+]


### PR DESCRIPTION
Adding IP Forwarding is Enabled query for Terraform, that checks if the attribute 'can_ip_forward' is set to true

Closes #181 