### PR TITLE
Add Public Cluster is Disabled query for Terraform 

### DIFF
--- a/assets/queries/terraform/gcp/private_cluster_is_enabled/metadata.json
+++ b/assets/queries/terraform/gcp/private_cluster_is_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Private_Cluster_Disabled",
+  "queryName": "Private Cluster is Disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Kubernetes Clusters must be created with Private Clusters enabled, meaning the 'private_cluster_config' must be defined and the attributes 'enable_private_nodes' and 'enable_private_endpoint' must be true",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster"
+}

--- a/assets/queries/terraform/gcp/private_cluster_is_enabled/query.rego
+++ b/assets/queries/terraform/gcp/private_cluster_is_enabled/query.rego
@@ -1,0 +1,99 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  object.get(resource, "private_cluster_config", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s]", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'private_cluster_config' is defined",
+                "keyActualValue": 	"Attribute 'private_cluster_config' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  object.get(resource.private_cluster_config, "enable_private_endpoint", "undefined") == "undefined"
+  object.get(resource.private_cluster_config, "enable_private_nodes", "undefined") != "undefined"
+  
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].private_cluster_config", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'private_cluster_config.enable_private_endpoint' is defined",
+                "keyActualValue": 	"Attribute 'private_cluster_config.enable_private_endpoint' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  object.get(resource.private_cluster_config, "enable_private_endpoint", "undefined") != "undefined"
+  object.get(resource.private_cluster_config, "enable_private_nodes", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].private_cluster_config", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'private_cluster_config.enable_private_nodes' is defined",
+                "keyActualValue": 	"Attribute 'private_cluster_config.enable_private_nodes' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  object.get(resource.private_cluster_config, "enable_private_endpoint", "undefined") == "undefined"
+  object.get(resource.private_cluster_config, "enable_private_nodes", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].private_cluster_config", [primary]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Attribute 'private_cluster_config.enable_private_endpoint' is defined and Attribute 'private_cluster_config.enable_private_nodes' is defined",
+                "keyActualValue": 	"Attribute 'private_cluster_config.enable_private_endpoint' is undefined and Attribute 'private_cluster_config.enable_private_nodes' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.private_cluster_config.enable_private_endpoint == false
+  resource.private_cluster_config.enable_private_nodes
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].private_cluster_config", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'private_cluster_config.enable_private_endpoint' is true",
+                "keyActualValue": 	"Attribute 'private_cluster_config.enable_private_endpoint' is false"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.private_cluster_config.enable_private_endpoint
+  resource.private_cluster_config.enable_private_nodes == false
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].private_cluster_config", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'private_cluster_config.enable_private_nodes' is true",
+                "keyActualValue": 	"Attribute 'private_cluster_config.enable_private_nodes' is false"
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_container_cluster[primary]
+  resource.private_cluster_config.enable_private_endpoint == false
+  resource.private_cluster_config.enable_private_nodes == false
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_container_cluster[%s].private_cluster_config", [primary]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "Attribute 'private_cluster_config.enable_private_endpoint' is true and Attribute 'private_cluster_config.enable_private_nodes' is true",
+                "keyActualValue": 	"Attribute 'private_cluster_config.enable_private_endpoint' is false and Attribute 'private_cluster_config.enable_private_nodes' is false"
+              }
+}

--- a/assets/queries/terraform/gcp/private_cluster_is_enabled/test/negative.tf
+++ b/assets/queries/terraform/gcp/private_cluster_is_enabled/test/negative.tf
@@ -1,0 +1,15 @@
+#this code is a correct code for which the query should not find any result
+resource "google_container_cluster" "primary" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  private_cluster_config {
+        enable_private_endpoint = true
+        enable_private_nodes = true
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/private_cluster_is_enabled/test/positive.tf
+++ b/assets/queries/terraform/gcp/private_cluster_is_enabled/test/positive.tf
@@ -1,0 +1,98 @@
+#this is a problematic code where the query should report a result(s)
+resource "google_container_cluster" "primary1" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary2" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  private_cluster_config {
+        enable_private_endpoint = true
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary3" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  private_cluster_config {
+        enable_private_nodes = true
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary4" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  private_cluster_config {
+
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary5" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  private_cluster_config {
+        enable_private_endpoint = false
+        enable_private_nodes = true
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary6" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  private_cluster_config {
+        enable_private_endpoint = true
+        enable_private_nodes = false
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}
+
+resource "google_container_cluster" "primary7" {
+  name               = "marcellus-wallace"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  private_cluster_config {
+        enable_private_endpoint = false
+        enable_private_nodes = false
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/assets/queries/terraform/gcp/private_cluster_is_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/private_cluster_is_enabled/test/positive_expected_result.json
@@ -1,0 +1,37 @@
+[
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 2
+	},
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 17
+	},
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 31
+	},
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 45
+	},
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 59
+	},
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 74
+	},
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 89
+	}
+]


### PR DESCRIPTION
Adding Public Cluster is Disabled query for Terraform, that checks if the attribute 'private_cluster_config' is defined and the sub attributes 'enable_private_nodes' and 'enable_private_endpoint' are true.

Closes #193