### PR TITLE
Add VMWithFullCloudAccess query for Terraform #195

### DIFF
--- a/assets/queries/terraform/gcp/vm_with_full_cloud_access/metadata.json
+++ b/assets/queries/terraform/gcp/vm_with_full_cloud_access/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "VMWithFullCloudAccess",
+  "queryName": "VM with Full Cloud Access",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "A VM instance is configured to use the default service account with full access to all Cloud APIs",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#scopes"
+}

--- a/assets/queries/terraform/gcp/vm_with_full_cloud_access/query.rego
+++ b/assets/queries/terraform/gcp/vm_with_full_cloud_access/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+CxPolicy [ result ] {
+  
+  resource := input.document[i].resource.google_compute_instance[name]
+  scopes := resource.service_account.scopes
+  
+  some j
+  	scopes[j] == "cloud-platform"
+	
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_compute_instance[%s].service_account.scopes", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'service_account.scopes' does not contain 'cloud-platform'",
+                "keyActualValue": 	"'service_account.scopes' contains 'cloud-platform'"
+              }
+}

--- a/assets/queries/terraform/gcp/vm_with_full_cloud_access/test/negative.tf
+++ b/assets/queries/terraform/gcp/vm_with_full_cloud_access/test/negative.tf
@@ -1,0 +1,22 @@
+resource "google_compute_instance" "default" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}

--- a/assets/queries/terraform/gcp/vm_with_full_cloud_access/test/positive.tf
+++ b/assets/queries/terraform/gcp/vm_with_full_cloud_access/test/positive.tf
@@ -1,0 +1,22 @@
+resource "google_compute_instance" "default" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro", "cloud-platform"]
+  }
+}

--- a/assets/queries/terraform/gcp/vm_with_full_cloud_access/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/vm_with_full_cloud_access/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "VM with Full Cloud Access",
+		"severity": "HIGH",
+		"line": 20
+	}
+]


### PR DESCRIPTION
Closes #195 

Added new query VM with Full Cloud Access for Terraform.

Instances may have been configured to use the default service account with full access to all Cloud APIs.