### PR TITLE
Add storage_container_with_public_access query for Terraform #208

### DIFF
--- a/assets/queries/terraform/azure/storage_container_with_public_access/metadata.json
+++ b/assets/queries/terraform/azure/storage_container_with_public_access/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "storage_container_with_public_access",
+  "queryName": "Storage Container with Public Access",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "Anonymous, public read access to a container and its blobs are enabled in Azure Blob Storage",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container#container_access_type"
+}

--- a/assets/queries/terraform/azure/storage_container_with_public_access/query.rego
+++ b/assets/queries/terraform/azure/storage_container_with_public_access/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy [ result ] {
+    resource := input.document[i].resource.azurerm_storage_container[name]
+    
+    resource.container_access_type != "private"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_storage_container[%s].container_access_type", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'container_access_type' is equal to 'private'",
+                "keyActualValue": 	"'container_access_type' is not equal to 'private'"
+              }
+}

--- a/assets/queries/terraform/azure/storage_container_with_public_access/test/negative.tf
+++ b/assets/queries/terraform/azure/storage_container_with_public_access/test/negative.tf
@@ -1,0 +1,11 @@
+resource "azurerm_storage_container" "example" {
+  name                  = "vhds"
+  storage_account_name  = azurerm_storage_account.example.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "example2" {
+  name                  = "vhds2"
+  storage_account_name  = azurerm_storage_account.example.name
+  // default is "private"
+}

--- a/assets/queries/terraform/azure/storage_container_with_public_access/test/positive.tf
+++ b/assets/queries/terraform/azure/storage_container_with_public_access/test/positive.tf
@@ -1,0 +1,5 @@
+resource "azurerm_storage_container" "example" {
+  name                  = "vhds"
+  storage_account_name  = azurerm_storage_account.example.name
+  container_access_type = "blob"
+}

--- a/assets/queries/terraform/azure/storage_container_with_public_access/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/storage_container_with_public_access/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Storage Container with Public Access",
+		"severity": "HIGH",
+		"line": 4
+	}
+]


### PR DESCRIPTION
Closes #208 

Added new query Storage Container with Public Access for Terraform.

Anonymous, public read access to a container and its blobs can be enabled in Azure Blob storage.