### PR TITLE
Added query to check if cloudwatch logging is enabled in the right host

### DIFF
--- a/assets/queries/terraform/aws/cloudwatch_logging_is_disabled/metadata.json
+++ b/assets/queries/terraform/aws/cloudwatch_logging_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "CloudWatch_Logging_Is_Disabled",
+  "queryName": "CloudWatch Logging Is Disabled",
+  "severity": "MEDIUM",
+  "category": "Logging",
+  "descriptionText": "Check if CloudWatch logging is disabled for Route53 hosted zones",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_query_log"
+}

--- a/assets/queries/terraform/aws/cloudwatch_logging_is_disabled/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_logging_is_disabled/query.rego
@@ -1,0 +1,30 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource
+  route := resource.aws_route53_zone[name]
+  not resource.aws_route53_query_log[name]
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_route53_zone[%s]", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'aws_route53_query_log' is set for respective 'aws_route53_zone'",
+                "keyActualValue": 	"'aws_route53_query_log' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  route := input.document[i].resource.aws_route53_query_log[name]
+  log_group := route.cloudwatch_log_group_arn
+
+  not regex.match(name,log_group)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_route53_query_log[%s].cloudwatch_log_group_arn", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'aws_route53_query_log' log group refers to the query log",
+                "keyActualValue": 	"'aws_route53_query_log' log group does not match with the log name"
+              }
+}

--- a/assets/queries/terraform/aws/cloudwatch_logging_is_disabled/test/negative.tf
+++ b/assets/queries/terraform/aws/cloudwatch_logging_is_disabled/test/negative.tf
@@ -1,0 +1,10 @@
+resource "aws_route53_zone" "example_com" {
+  name = "example.com"
+}
+
+resource "aws_route53_query_log" "example_com" {
+  depends_on = [aws_cloudwatch_log_resource_policy.route53-query-logging-policy]
+
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.aws_route53_example_com.arn
+  zone_id                  = aws_route53_zone.example_com.zone_id
+}

--- a/assets/queries/terraform/aws/cloudwatch_logging_is_disabled/test/positive.tf
+++ b/assets/queries/terraform/aws/cloudwatch_logging_is_disabled/test/positive.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_zone" "no_query_log" {
+  name = "example.com"
+}
+
+resource "aws_route53_zone" "log_group_mismatch" {
+  name = "example.com"
+}
+
+resource "aws_route53_query_log" "log_group_mismatch" {
+  cloudwatch_log_group_arn = aws_cloudwatch_log_group.aws_route53_log_mismatch.arn
+}

--- a/assets/queries/terraform/aws/cloudwatch_logging_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_logging_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "CloudWatch Logging Is Disabled",
+		"severity": "MEDIUM",
+		"line": 1
+	},
+	{
+		"queryName": "CloudWatch Logging Is Disabled",
+		"severity": "MEDIUM",
+		"line": 10
+	}
+]


### PR DESCRIPTION
Check if CloudWatch logging is enabled for the respective Route53 host. First, check if each route has the correspondent query log. Then verifies if the log group referred by the query log matches its name. Closes #162 