### PR TITLE
Add DB Instance Storage Not Encrypted

### DIFF
--- a/assets/queries/terraform/aws/db_instance_storage_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/db_instance_storage_not_encrypted/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "db_instance_storage_not_encrypted",
+  "queryName": "DB Instance Storage Not Encrypted",
+  "severity": "HIGH",
+  "category": "Data Security",
+  "descriptionText": "The parameter storage_encrypted in aws_db_instance must be true (the default is false)",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#storage_encrypted"
+}

--- a/assets/queries/terraform/aws/db_instance_storage_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/db_instance_storage_not_encrypted/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].resource.aws_db_instance[name]
+    not resource.storage_encrypted
+    not resource.ms_key_id 
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_db_instance[%s].storage_encrypted", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'aws_db_instance.storage_encrypted'  is true",
+                "keyActualValue": 	"'aws_db_instance.storage_encrypted' is false"
+              }
+}

--- a/assets/queries/terraform/aws/db_instance_storage_not_encrypted/test/negative.tf
+++ b/assets/queries/terraform/aws/db_instance_storage_not_encrypted/test/negative.tf
@@ -1,0 +1,26 @@
+resource "aws_db_instance" "default" {
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
+  iam_database_authentication_enabled = true
+  storage_encrypted = true
+}
+resource "aws_db_instance" "default2" {
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
+  iam_database_authentication_enabled = false
+  ms_key_id = "${aws_kms_key.my_key.key_id}"
+}

--- a/assets/queries/terraform/aws/db_instance_storage_not_encrypted/test/positive.tf
+++ b/assets/queries/terraform/aws/db_instance_storage_not_encrypted/test/positive.tf
@@ -1,0 +1,25 @@
+resource "aws_db_instance" "default" {
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
+  iam_database_authentication_enabled = false
+  storage_encrypted = false
+}
+
+resource "aws_db_instance" "default2" {
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
+}

--- a/assets/queries/terraform/aws/db_instance_storage_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/db_instance_storage_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "DB Instance Storage Not Encrypted",
+		"severity": "HIGH",
+		"line": 12
+	},
+	{
+		"queryName": "DB Instance Storage Not Encrypted",
+		"severity": "HIGH",
+		"line": 15
+	}
+]


### PR DESCRIPTION
Added queries for Terraform.

Provide a db instance resource and a resource to ensure that the storage encryption is set to true or ms_key_id is set

Closes #212