### PR TITLE
Add CA certificate Identifier is outdated query

### DIFF
--- a/assets/queries/terraform/aws/db_instance_rds_ca_cert_id_expired/metadata.json
+++ b/assets/queries/terraform/aws/db_instance_rds_ca_cert_id_expired/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "DB_Instance_Rds_Ca_Cert_Id_Expired",
+  "queryName": "CA certificate Identifier is outdated",
+  "severity": "HIGH",
+  "category": "Data Security",
+  "descriptionText": "The CA certificate Identifier must be rds-ca-2019",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#storage_encrypted"
+}

--- a/assets/queries/terraform/aws/db_instance_rds_ca_cert_id_expired/query.rego
+++ b/assets/queries/terraform/aws/db_instance_rds_ca_cert_id_expired/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].resource.aws_db_instance[name]
+  resource.ca_cert_identifier != "rds-ca-2019"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_db_instance[%s].ca_cert_identifier", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'aws_db_instance.ca_cert_identifier'  is 'rds-ca-2019'",
+                "keyActualValue": 	sprintf("'aws_db_instance.ca_cert_identifier' is '%s'", [resource.ca_cert_identifier])
+              }
+}

--- a/assets/queries/terraform/aws/db_instance_rds_ca_cert_id_expired/test/negative.tf
+++ b/assets/queries/terraform/aws/db_instance_rds_ca_cert_id_expired/test/negative.tf
@@ -1,0 +1,14 @@
+resource "aws_db_instance" "default" {
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
+  iam_database_authentication_enabled = true
+  storage_encrypted = true
+  ca_cert_identifier = "rds-ca-2019"
+}

--- a/assets/queries/terraform/aws/db_instance_rds_ca_cert_id_expired/test/positive.tf
+++ b/assets/queries/terraform/aws/db_instance_rds_ca_cert_id_expired/test/positive.tf
@@ -1,0 +1,14 @@
+resource "aws_db_instance" "default" {
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
+  iam_database_authentication_enabled = true
+  storage_encrypted = true
+  ca_cert_identifier = "rds-ca-2015"
+}

--- a/assets/queries/terraform/aws/db_instance_rds_ca_cert_id_expired/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/db_instance_rds_ca_cert_id_expired/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "CA certificate Identifier is outdated",
+		"severity": "HIGH",
+		"line": 13
+	}
+]


### PR DESCRIPTION
Added new query for Terraform.

Provide a aws_db_instance resource and a resource to check if ca_cert_identifier is updated

Closes #219