### PR TITLE
added query to check if elasticsearch is encrypted at rest. closes #168

### DIFF
--- a/assets/queries/terraform/aws/elasticsearch_encryption_at_rest_enabled/metadata.json
+++ b/assets/queries/terraform/aws/elasticsearch_encryption_at_rest_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ElasticSearch_Not_Encrypted_At_Rest",
+  "queryName": "ElasticSearch Not Encrypted At Rest",
+  "severity": "MEDIUM",
+  "category": "Encryption and Key Management",
+  "descriptionText": "Check if ElasticSearch encryption is disabled at Rest",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain"
+}

--- a/assets/queries/terraform/aws/elasticsearch_encryption_at_rest_enabled/query.rego
+++ b/assets/queries/terraform/aws/elasticsearch_encryption_at_rest_enabled/query.rego
@@ -1,0 +1,30 @@
+package Cx
+
+CxPolicy [ result ] {
+  domain := input.document[i].resource.aws_elasticsearch_domain[name]
+  
+  not domain.encrypt_at_rest
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_elasticsearch_domain[%s]", [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "'encrypt_at_rest' is set and enabled",
+                "keyActualValue": 	"'encrypt_at_rest' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  domain := input.document[i].resource.aws_elasticsearch_domain[name]
+  encrypt_at_rest := domain.encrypt_at_rest
+
+  encrypt_at_rest.enabled == false
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_elasticsearch_domain[%s].encrypt_at_rest.enabled", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "'encrypt_at_rest.enabled' is true",
+                "keyActualValue": 	"'encrypt_at_rest.enabled' is false"
+              }
+}

--- a/assets/queries/terraform/aws/elasticsearch_encryption_at_rest_enabled/test/negative.tf
+++ b/assets/queries/terraform/aws/elasticsearch_encryption_at_rest_enabled/test/negative.tf
@@ -1,0 +1,8 @@
+resource "aws_elasticsearch_domain" "encrypted_at_rest" {
+  domain_name           = "example"
+  elasticsearch_version = "1.5"
+
+  encrypt_at_rest {
+      enabled = true
+  }
+}

--- a/assets/queries/terraform/aws/elasticsearch_encryption_at_rest_enabled/test/positive.tf
+++ b/assets/queries/terraform/aws/elasticsearch_encryption_at_rest_enabled/test/positive.tf
@@ -1,0 +1,13 @@
+resource "aws_elasticsearch_domain" "not_encrypted_at_rest" {
+  domain_name           = "example"
+  elasticsearch_version = "1.5"
+}
+
+resource "aws_elasticsearch_domain" "encrypted_at_rest_disabled" {
+  domain_name           = "example"
+  elasticsearch_version = "1.5"
+
+  encrypt_at_rest {
+      enabled = false
+  }
+}

--- a/assets/queries/terraform/aws/elasticsearch_encryption_at_rest_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticsearch_encryption_at_rest_enabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "ElasticSearch Not Encrypted At Rest",
+		"severity": "MEDIUM",
+		"line": 1
+	},
+	{
+		"queryName": "ElasticSearch Not Encrypted At Rest",
+		"severity": "MEDIUM",
+		"line": 11
+	}
+]


### PR DESCRIPTION
Created query to check if ElasticSearch encryption at rest is enabled. First checks if the attribute is present, then if its enabled. Closes #168 