### PR TITLE
Add trusted_microsoft_services_not_enabled query for Terraform #216

### DIFF
--- a/assets/queries/terraform/azure/trusted_microsoft_services_not_enabled/metadata.json
+++ b/assets/queries/terraform/azure/trusted_microsoft_services_not_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "trusted_microsoft_services_not_enabled",
+  "queryName": "Trusted Microsoft Services Not Enabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Trusted MIcrosoft Services are not enabled for Storage Account access",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#bypass"
+}

--- a/assets/queries/terraform/azure/trusted_microsoft_services_not_enabled/query.rego
+++ b/assets/queries/terraform/azure/trusted_microsoft_services_not_enabled/query.rego
@@ -1,0 +1,74 @@
+package Cx
+
+CxPolicy [ result ] {
+    resource := input.document[i].resource.azurerm_storage_account[name]
+    object.get(resource, "network_rules", "undefined") == "undefined"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_storage_account[%s]", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'network_rules' is defined",
+                "keyActualValue": 	"'network_rules' is not defined"
+              }
+}
+
+CxPolicy [ result ] {
+    network_rules := input.document[i].resource.azurerm_storage_account[name].network_rules
+    object.get(network_rules, "bypass", "undefined") == "undefined"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_storage_account[%s].network_rules", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'network_rules.bypass' is defined",
+                "keyActualValue": 	"'network_rules.bypass' is not defined"
+              }
+}
+
+CxPolicy [ result ] {
+    resource := input.document[i].resource.azurerm_storage_account[name]
+    bypass := resource.network_rules.bypass
+    not arrayContains(bypass, "AzureServices")
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_storage_account[%s].network_rules.bypass", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'network_rules.bypass' contains 'AzureServices'",
+                "keyActualValue": 	"'network_rules.bypass' does not contain 'AzureServices'"
+              }
+}
+
+CxPolicy [ result ] {
+    resource := input.document[i].resource.azurerm_storage_account_network_rules[name]
+    object.get(resource, "bypass", "undefined") == "undefined"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_storage_account_network_rules[%s]", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'bypass' is defined",
+                "keyActualValue": 	"'bypass' is not defined"
+              }
+}
+
+CxPolicy [ result ] {
+    network_rules := input.document[i].resource.azurerm_storage_account_network_rules[name]
+    bypass := network_rules.bypass
+    not arrayContains(bypass, "AzureServices")
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_storage_account_network_rules[%s].bypass", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'bypass' contains 'AzureServices'",
+                "keyActualValue": 	"'bypass' does not contain 'AzureServices'"
+              }
+}
+
+arrayContains(items, elem) = true {
+  items[_] = elem
+} else = false {
+	true
+}

--- a/assets/queries/terraform/azure/trusted_microsoft_services_not_enabled/test/negative.tf
+++ b/assets/queries/terraform/azure/trusted_microsoft_services_not_enabled/test/negative.tf
@@ -1,0 +1,29 @@
+resource "azurerm_storage_account" "example" {
+  name                = "storageaccountname"
+  resource_group_name = azurerm_resource_group.example.name
+
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  network_rules {
+    default_action             = "Deny"
+	bypass					   = ["AzureServices"]
+    ip_rules                   = ["100.0.0.1"]
+    virtual_network_subnet_ids = [azurerm_subnet.example.id]
+  }
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_account_network_rules" "test" {
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_name = azurerm_storage_account.test.name
+
+  default_action             = "Allow"
+  ip_rules                   = ["127.0.0.1"]
+  virtual_network_subnet_ids = [azurerm_subnet.test.id]
+  bypass                     = ["Metrics", "AzureServices"]
+}

--- a/assets/queries/terraform/azure/trusted_microsoft_services_not_enabled/test/positive.tf
+++ b/assets/queries/terraform/azure/trusted_microsoft_services_not_enabled/test/positive.tf
@@ -1,0 +1,29 @@
+resource "azurerm_storage_account_network_rules" "test" {
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_name = azurerm_storage_account.test.name
+
+  default_action             = "Allow"
+  ip_rules                   = ["127.0.0.1"]
+  virtual_network_subnet_ids = [azurerm_subnet.test.id]
+  bypass                     = ["Metrics"]
+}
+
+resource "azurerm_storage_account" "example" {
+  name                = "storageaccountname"
+  resource_group_name = azurerm_resource_group.example.name
+
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  network_rules {
+    default_action             = "Deny"
+	bypass					   = ["None"]
+    ip_rules                   = ["100.0.0.1"]
+    virtual_network_subnet_ids = [azurerm_subnet.example.id]
+  }
+
+  tags = {
+    environment = "staging"
+  }
+}

--- a/assets/queries/terraform/azure/trusted_microsoft_services_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/trusted_microsoft_services_not_enabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Trusted Microsoft Services Not Enabled",
+		"severity": "HIGH",
+		"line": 8
+	},
+	{
+		"queryName": "Trusted Microsoft Services Not Enabled",
+		"severity": "HIGH",
+		"line": 21
+	}
+]


### PR DESCRIPTION
Closes #216 

Added new query Trusted Microsoft Services Not Enabled for Terraform.

Ensure 'Trusted Microsoft Services' is enabled for Storage Account access.