### PR TITLE
Add Public Storage Account query for Terraform

### DIFF
--- a/assets/queries/terraform/azure/public_storage_account/metadata.json
+++ b/assets/queries/terraform/azure/public_storage_account/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "public_storage_account",
+  "queryName": "Public Storage Account",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Check if 'network_rules' is open to public.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account"
+}

--- a/assets/queries/terraform/azure/public_storage_account/query.rego
+++ b/assets/queries/terraform/azure/public_storage_account/query.rego
@@ -1,0 +1,58 @@
+package Cx
+
+CxPolicy [ result ] {
+  
+  network_rules := input.document[i].resource.azurerm_storage_account[name].network_rules
+  some l
+  	network_rules.ip_rules[l] == "0.0.0.0/0"
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("azurerm_storage_account[%s].network_rules.ip_rules", [name]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "network_rules.ip_rules does not contain 0.0.0.0/0",
+                "keyActualValue":   "network_rules.ip_rules contain 0.0.0.0/0"
+              }
+}
+
+CxPolicy [ result ] {
+  
+  network_rules := input.document[i].resource.azurerm_storage_account[name].network_rules
+  object.get(network_rules, "ip_rules", "undefined") == "undefined"
+  network_rules.default_action == "Allow"
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("azurerm_storage_account[%s].network_rules", [name]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "network_rules.ip_rules is defined",
+                "keyActualValue":   "network_rules.default_action is 'Allow' and ip_rules is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  
+  rules := input.document[i].resource.azurerm_storage_account_network_rules[name]
+  some l
+  	rules.ip_rules[l] == "0.0.0.0/0"
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("azurerm_storage_account_network_rules[%s].ip_rules", [name]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "network_rules.ip_rules does not contain 0.0.0.0/0",
+                "keyActualValue":   "network_rules.ip_rules contain 0.0.0.0/0"
+              }
+}
+
+CxPolicy [ result ] {
+  
+  rules := input.document[i].resource.azurerm_storage_account_network_rules[name]
+  object.get(rules, "ip_rules", "undefined") == "undefined"
+  rules.default_action == "Allow"
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("azurerm_storage_account_network_rules[%s]", [name]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "azurerm_storage_account_network_rules.ip_rules is defined",
+                "keyActualValue":   "azurerm_storage_account_network_rules.default_action is 'Allow' and ip_rules is undefined"
+              }
+}
+

--- a/assets/queries/terraform/azure/public_storage_account/test/negative.tf
+++ b/assets/queries/terraform/azure/public_storage_account/test/negative.tf
@@ -1,0 +1,28 @@
+resource "azurerm_storage_account" "example" {
+  name                = "storageaccountname"
+  resource_group_name = azurerm_resource_group.example.name
+
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  network_rules {
+    default_action             = "Deny"
+    ip_rules                   = ["100.0.0.1"]
+    virtual_network_subnet_ids = [azurerm_subnet.example.id]
+  }
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_account_network_rules" "test" {
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_name = azurerm_storage_account.test.name
+
+  default_action             = "Allow"
+  ip_rules                   = ["127.0.0.1"]
+  virtual_network_subnet_ids = [azurerm_subnet.test.id]
+  bypass                     = ["Metrics"]
+}

--- a/assets/queries/terraform/azure/public_storage_account/test/positive.tf
+++ b/assets/queries/terraform/azure/public_storage_account/test/positive.tf
@@ -1,0 +1,55 @@
+resource "azurerm_storage_account" "example" {
+  name                = "storageaccountname"
+  resource_group_name = azurerm_resource_group.example.name
+
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  network_rules {
+    default_action             = "Deny"
+    ip_rules                   = ["0.0.0.0/0"]
+    virtual_network_subnet_ids = [azurerm_subnet.example.id]
+  }
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_account" "example2" {
+  name                = "storageaccountname"
+  resource_group_name = azurerm_resource_group.example.name
+
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  network_rules {
+    default_action             = "Allow"
+    virtual_network_subnet_ids = [azurerm_subnet.example.id]
+  }
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_account_network_rules" "test" {
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_name = azurerm_storage_account.test.name
+
+  default_action             = "Allow"
+  ip_rules                   = ["0.0.0.0/0"]
+  virtual_network_subnet_ids = [azurerm_subnet.test.id]
+  bypass                     = ["Metrics"]
+}
+
+resource "azurerm_storage_account_network_rules" "test2" {
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_name = azurerm_storage_account.test.name
+
+  default_action             = "Allow"
+  virtual_network_subnet_ids = [azurerm_subnet.test.id]
+  bypass                     = ["Metrics"]
+}

--- a/assets/queries/terraform/azure/public_storage_account/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/public_storage_account/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "Public Storage Account",
+		"severity": "HIGH",
+		"line": 11
+	},
+	{
+		"queryName": "Public Storage Account",
+		"severity": "HIGH",
+		"line": 28
+	},
+	{
+		"queryName": "Public Storage Account",
+		"severity": "HIGH",
+		"line": 43
+	},
+	{
+		"queryName": "Public Storage Account",
+		"severity": "HIGH",
+		"line": 48
+	}
+]


### PR DESCRIPTION
Closes #218 

Added new query Public Storage Account query for Terraform.

Check if 'network_rules' is open to public.