### PR TITLE
Add ami_shared_to_multiple_accounts query #226

### DIFF
--- a/assets/queries/terraform/aws/ami_shared_to_multiple_accounts/metadata.json
+++ b/assets/queries/terraform/aws/ami_shared_to_multiple_accounts/metadata.json
@@ -3,6 +3,6 @@
   "queryName": "AMI Shared To Multiple Accounts",
   "severity": "MEDIUM",
   "category": "Network Security",
-  "descriptionText": "Limits access to AWS AMIs by checking if attribute account_id has launch permission for the attribute image_id",
+  "descriptionText": "Limits access to AWS AMIs by checking if more than one account is using the same image",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ami_launch_permission"
 }

--- a/assets/queries/terraform/aws/ami_shared_to_multiple_accounts/query.rego
+++ b/assets/queries/terraform/aws/ami_shared_to_multiple_accounts/query.rego
@@ -1,68 +1,20 @@
 package Cx
 
-
 CxPolicy [ result ] {
+  
+  launch_permissions := input.document[i].resource.aws_ami_launch_permission
 
-  resource := input.document[i].resource.aws_ami_launch_permission[name]
+  account_id := launch_permissions[name].account_id
+  image_id := launch_permissions[name].image_id
   
-  account_id:= resource.account_id
-  
-  image_id := resource.image_id
-  
-  
-  launchPermissions:= { "123456789012": ["ami-12345678", "ami-12345679", "ami-12345680"],
-                        "23456789018": ["ami-12345678", "ami-12345679"],
-                        "23456782322": ["ami-12345619", "ami-12345645"],
-                      }
+  count([ account | launch_permissions[j].image_id == image_id; account := launch_permissions[j].account_id ]) > 1
 
 
-  images = object.get(launchPermissions, account_id, "not found")
-  
-  images == "not found"
-  
-  
-   result := {
-                "documentId": 		    input.document[i].id,
-                "searchKey": 	        sprintf("aws_ami_launch_permission[%s]", [name]),
+  result := {
+  			      	"documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_ami_launch_permission[%s].image_id", [name]),
                 "issueType":		      "IncorrectValue",
-                "keyExpectedValue":   "Attribute 'account_id' has launch permission for the Attribute 'image_id'",
-                "keyActualValue": 	  "Attribute 'account_id' has not launch permission at all"
+                "keyExpectedValue":   sprintf("'aws_ami_launch_permission[%s].image_id' is not shared with multiple accounts", [name]),
+                "keyActualValue": 	  sprintf("'aws_ami_launch_permission[%s].image_id' is shared with multiple accounts", [name])
             }
 }
-
-
-
-
-
-CxPolicy [ result ] {
-
-  resource := input.document[i].resource.aws_ami_launch_permission[name]
-  
-  account_id:= resource.account_id
-  
-  image_id := resource.image_id
-  
-  
-  launchPermissions:= { "123456789012": ["ami-12345678", "ami-12345679", "ami-12345680"],
-                        "23456789018": ["ami-12345678", "ami-12345679"],
-                        "23456782322": ["ami-12345619", "ami-12345645"],
-                      }
-
-
-  images = object.get(launchPermissions, account_id, "not found")
-  
-  images != "not found"
-  
-  count({x | images[x]; images[x] == image_id }) == 0
-  
-   result := {
-                "documentId": 		    input.document[i].id,
-                "searchKey": 	        sprintf("aws_ami_launch_permission[%s]", [name]),
-                "issueType":		      "IncorrectValue",
-                "keyExpectedValue":   "Attribute 'account_id' has launch permission for the Attribute 'image_id'",
-                "keyActualValue": 	  "Attribute 'account_id' has not launch permission for the attribute 'image_id'"
-            }
-}
-
-
-

--- a/assets/queries/terraform/aws/ami_shared_to_multiple_accounts/test/negative.tf
+++ b/assets/queries/terraform/aws/ami_shared_to_multiple_accounts/test/negative.tf
@@ -2,3 +2,9 @@ resource "aws_ami_launch_permission" "example" {
   image_id   = "ami-12345678"
   account_id = "123456789012"
 }
+
+
+resource "aws_ami_launch_permission" "example" {
+  image_id   = "ami-12345680"
+  account_id = "12345672"
+}

--- a/assets/queries/terraform/aws/ami_shared_to_multiple_accounts/test/positive.tf
+++ b/assets/queries/terraform/aws/ami_shared_to_multiple_accounts/test/positive.tf
@@ -8,7 +8,7 @@ resource "aws_ami_launch_permission" "example" {
 
 resource "aws_ami_launch_permission" "example2" {
 
-  image_id   = "ami-1967678"
+  image_id   = "ami-1235678"
   account_id = "123456789012"
 
 }

--- a/assets/queries/terraform/aws/ami_shared_to_multiple_accounts/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ami_shared_to_multiple_accounts/test/positive_expected_result.json
@@ -2,13 +2,13 @@
 	{
 		"queryName": "AMI Shared To Multiple Accounts",
 		"severity": "MEDIUM",
-		"line": 1
+		"line": 3
 	},
 
 
 	{
 		"queryName": "AMI Shared To Multiple Accounts",
 		"severity": "MEDIUM",
-		"line": 9
+		"line": 11
 	}
 ]


### PR DESCRIPTION
For this query, I thought in two cases:

- **Attribute 'account_id' has not launch permission at all**
I checked if the attribute 'account_id' is not a key in the launchPermissions object:

      images = object.get(launchPermissions, account_id, "not found")
      images == "not found"


- **Attribute 'account_id' has not launch permission for the specific attribute 'image_id'**
I checked if the attribute 'account_id' is a key in the launchPermissions object and if the images array has not the attribute 'image_id':

      images = object.get(launchPermissions, account_id, "not found")
      images != "not found"
      count({x | images[x]; images[x] == image_id }) == 0


Closes #226 