### PR TITLE
Add api_gateway_content_encoding query #228

### DIFF
--- a/assets/queries/terraform/aws/api_gateway_content_encoding/metadata.json
+++ b/assets/queries/terraform/aws/api_gateway_content_encoding/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "api_gateway_content_encoding",
+  "queryName": "API Gateway Content Encoding",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Enable Content Encoding through the attribute 'minimum_compression_size'. This value should be greater than -1 and smaller than 10485760",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_rest_api"
+}

--- a/assets/queries/terraform/aws/api_gateway_content_encoding/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_content_encoding/query.rego
@@ -1,0 +1,52 @@
+package Cx
+
+
+
+CxPolicy [ result ] {
+
+  resource := input.document[i].resource.aws_api_gateway_rest_api[name]
+  
+  not resource.minimum_compression_size
+  
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_api_gateway_rest_api[%s]", [name]),
+                "issueType":		      "MissingAttribute",
+                "keyExpectedValue":   "Attribute 'minimum_compression_size' is set, greater than -1 and smaller than 10485760",
+                "keyActualValue": 	  "Attribute 'minimum_compression_size' is undefined"
+            }
+}
+
+
+
+
+CxPolicy [ result ] {
+
+  resource := input.document[i].resource.aws_api_gateway_rest_api[name]
+  
+  resource.minimum_compression_size < 0
+  
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_api_gateway_rest_api[%s].minimum_compression_size", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   "Attribute 'minimum_compression_size' is set, greater than -1 and smaller than 10485760",
+                "keyActualValue": 	  "Attribute 'minimum_compression_size' is set but smaller than 0"
+            }
+}
+
+
+CxPolicy [ result ] {
+
+  resource := input.document[i].resource.aws_api_gateway_rest_api[name]
+  
+  resource.minimum_compression_size > 10485759
+  
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_api_gateway_rest_api[%s].minimum_compression_size", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   "Attribute 'minimum_compression_size' is set, greater than -1 and smaller than 10485760",
+                "keyActualValue": 	  "Attribute 'minimum_compression_size' is set but greater than 10485759"
+            }
+}

--- a/assets/queries/terraform/aws/api_gateway_content_encoding/test/negative.tf
+++ b/assets/queries/terraform/aws/api_gateway_content_encoding/test/negative.tf
@@ -1,0 +1,9 @@
+resource "aws_api_gateway_rest_api" "example" {
+  name = "regional-example"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+
+  minimum_compression_size = 0
+}

--- a/assets/queries/terraform/aws/api_gateway_content_encoding/test/positive.tf
+++ b/assets/queries/terraform/aws/api_gateway_content_encoding/test/positive.tf
@@ -1,0 +1,29 @@
+resource "aws_api_gateway_rest_api" "example1" {
+  name = "regional-example"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
+
+resource "aws_api_gateway_rest_api" "example2" {
+  name = "regional-example"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+
+  minimum_compression_size = -1
+}
+
+
+resource "aws_api_gateway_rest_api" "example3" {
+  name = "regional-example"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+
+  minimum_compression_size = 10485760
+}

--- a/assets/queries/terraform/aws/api_gateway_content_encoding/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_content_encoding/test/positive_expected_result.json
@@ -1,0 +1,19 @@
+[
+	{
+		"queryName": "API Gateway Content Encoding",
+		"severity": "MEDIUM",
+		"line": 1
+	},
+
+	{
+		"queryName": "API Gateway Content Encoding",
+		"severity": "MEDIUM",
+		"line": 17
+	},
+
+	{
+		"queryName": "API Gateway Content Encoding",
+		"severity": "MEDIUM",
+		"line": 28
+	}
+]


### PR DESCRIPTION
Since we want to enable encoding in the aws_api_gateway_rest_api resource, we need to check if the 'minimum_compression_size' is smaller than 0 or greater than 10485759, because this value should be between -1 and 10485760 (greater than -1 and smaller than 10485760).

So for this query, I thought in three cases:

- **Attribute minimum_compression_size does not exist**

- **Attribute minimum_compression_size exists but is smaller than 0**

- **Attribute minimum_compression_size exists but is greater than 10485759**

Closes #228 