### PR TITLE
Added query to check IAM password policy enforces min len. Closes #166

### DIFF
--- a/assets/queries/terraform/aws/iam_password_mininum_length/metadata.json
+++ b/assets/queries/terraform/aws/iam_password_mininum_length/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "IAM_Password_Without_Valid_Minimum_Length",
+  "queryName": "IAM Password Without Valid Minimum Length",
+  "severity": "MEDIUM",
+  "category": "IAM",
+  "descriptionText": "Check if IAM account password has the required minimum length",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy"
+}

--- a/assets/queries/terraform/aws/iam_password_mininum_length/query.rego
+++ b/assets/queries/terraform/aws/iam_password_mininum_length/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy [ result ] {
+  password_policy := input.document[i].resource.aws_iam_account_password_policy[name]
+  not password_policy.minimum_password_length
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_iam_account_password_policy[%s]", [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "'minimum_password_length' is set and no less than 8",
+                "keyActualValue": 	"'minimum_password_length' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  password_policy := input.document[i].resource.aws_iam_account_password_policy[name]
+  min_length := password_policy.minimum_password_length
+
+  to_number(min_length) < 8
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_iam_account_password_policy[%s].minimum_password_length", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": "'minimum_password_length' is set and no less than 8",
+                "keyActualValue": 	"'minimum_password_length' is less than 8"
+              }
+}

--- a/assets/queries/terraform/aws/iam_password_mininum_length/test/negative.tf
+++ b/assets/queries/terraform/aws/iam_password_mininum_length/test/negative.tf
@@ -1,0 +1,8 @@
+resource "aws_iam_account_password_policy" "strict" {
+  minimum_password_length        = 8
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_uppercase_characters   = true
+  require_symbols                = true
+  allow_users_to_change_password = true
+}

--- a/assets/queries/terraform/aws/iam_password_mininum_length/test/positive.tf
+++ b/assets/queries/terraform/aws/iam_password_mininum_length/test/positive.tf
@@ -1,0 +1,16 @@
+resource "aws_iam_account_password_policy" "no_mininum" {
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_uppercase_characters   = true
+  require_symbols                = true
+  allow_users_to_change_password = true
+}
+
+resource "aws_iam_account_password_policy" "low_minimum" {
+  minimum_password_length        = 3
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_uppercase_characters   = true
+  require_symbols                = true
+  allow_users_to_change_password = true
+}

--- a/assets/queries/terraform/aws/iam_password_mininum_length/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_password_mininum_length/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "IAM Password Without Valid Minimum Length",
+		"severity": "MEDIUM",
+		"line": 1
+	},
+	{
+		"queryName": "IAM Password Without Valid Minimum Length",
+		"severity": "MEDIUM",
+		"line": 10
+	}
+]


### PR DESCRIPTION
Check if IAM account password policy enforces a minimum length and if that minimum is sufficient. Closes #166 