### PR TITLE
Added query to check if iam access keys are exposed. Closes #167

### DIFF
--- a/assets/queries/terraform/aws/iam_access_key_is_exposed/metadata.json
+++ b/assets/queries/terraform/aws/iam_access_key_is_exposed/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "IAM_Access_Key_Is_Exposed",
+  "queryName": "IAM Access Key Is Exposed",
+  "severity": "MEDIUM",
+  "category": "Identity and Access Management",
+  "descriptionText": "Check if IAM Access Key is active for some user besides 'root'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key"
+}

--- a/assets/queries/terraform/aws/iam_access_key_is_exposed/query.rego
+++ b/assets/queries/terraform/aws/iam_access_key_is_exposed/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy [ result ] {
+  access_key := input.document[i].resource.aws_iam_access_key[name]
+  
+  lower(object.get(access_key,"status","Active")) == "active"
+  
+  access_key.user != "root"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_iam_access_key[%s].user", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":	sprintf("'aws_iam_access_key[%s].user' is 'root' for an active access key", [name]),
+                "keyActualValue": 	sprintf("'aws_iam_access_key[%s].user' is '%s' for an active access key",[name, access_key.user])
+              }
+}

--- a/assets/queries/terraform/aws/iam_access_key_is_exposed/test/negative.tf
+++ b/assets/queries/terraform/aws/iam_access_key_is_exposed/test/negative.tf
@@ -1,0 +1,13 @@
+resource "aws_iam_access_key" "root-example-1" {
+  user = "root"
+}
+
+resource "aws_iam_access_key" "root-example-2" {
+  user = "root"
+  status = "Active"
+}
+
+resource "aws_iam_access_key" "user-example" {
+  user = "some-user"
+  status = "Inactive"
+}

--- a/assets/queries/terraform/aws/iam_access_key_is_exposed/test/positive.tf
+++ b/assets/queries/terraform/aws/iam_access_key_is_exposed/test/positive.tf
@@ -1,0 +1,8 @@
+resource "aws_iam_access_key" "user-active" {
+  user = "some-user"
+  status = "Active"
+}
+
+resource "aws_iam_access_key" "user-default" {
+  user = "some-user"
+}

--- a/assets/queries/terraform/aws/iam_access_key_is_exposed/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_access_key_is_exposed/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "IAM Access Key Is Exposed",
+		"severity": "MEDIUM",
+		"line": 2
+	},
+	{
+		"queryName": "IAM Access Key Is Exposed",
+		"severity": "MEDIUM",
+		"line": 7
+	}
+]


### PR DESCRIPTION
Check if Amazon IAM access keys are exposed to unprivileged users, i.e, root. Closes #167  