### PR TITLE
Add query to check ElasticSearch domain encryption w/ KMS. closes #169

### DIFF
--- a/assets/queries/terraform/aws/elasticsearch_kms_cmk_encryption_disabled/metadata.json
+++ b/assets/queries/terraform/aws/elasticsearch_kms_cmk_encryption_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ElasticSearch_Encryption_With_KMS_Is_Disabled",
+  "queryName": "ElasticSearch Encryption With KMS Is Disabled",
+  "severity": "MEDIUM",
+  "category": "Encryption and Key Management",
+  "descriptionText": "Check if any ElasticSearch domain isn't encrypted with KMS",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain"
+}

--- a/assets/queries/terraform/aws/elasticsearch_kms_cmk_encryption_disabled/query.rego
+++ b/assets/queries/terraform/aws/elasticsearch_kms_cmk_encryption_disabled/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy [ result ] {
+  domain := input.document[i].resource.aws_elasticsearch_domain[name]
+  rest := domain.encrypt_at_rest
+
+  not rest.kms_key_id
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_elasticsearch_domain[%s].encrypt_at_rest", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'aws_elasticsearch_domain[%s].encrypt_at_rest.kms_key_id' is set with encryption at rest",[name]),
+                "keyActualValue": sprintf("'aws_elasticsearch_domain[%s].encrypt_at_rest.kms_key_id' is undefined", [name])
+              }
+}

--- a/assets/queries/terraform/aws/elasticsearch_kms_cmk_encryption_disabled/test/negative.tf
+++ b/assets/queries/terraform/aws/elasticsearch_kms_cmk_encryption_disabled/test/negative.tf
@@ -1,0 +1,9 @@
+resource "aws_elasticsearch_domain" "example" {
+  domain_name           = "example"
+  elasticsearch_version = "1.5"
+
+  encrypt_at_rest {
+      enabled = true
+      kms_key_id = "some-key-id"
+  }
+}

--- a/assets/queries/terraform/aws/elasticsearch_kms_cmk_encryption_disabled/test/positive.tf
+++ b/assets/queries/terraform/aws/elasticsearch_kms_cmk_encryption_disabled/test/positive.tf
@@ -1,0 +1,8 @@
+resource "aws_elasticsearch_domain" "example" {
+  domain_name           = "example"
+  elasticsearch_version = "1.5"
+
+  encrypt_at_rest {
+      enabled = true
+  }
+}

--- a/assets/queries/terraform/aws/elasticsearch_kms_cmk_encryption_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticsearch_kms_cmk_encryption_disabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "ElasticSearch Encryption With KMS Is Disabled",
+		"severity": "MEDIUM",
+		"line": 5
+	}
+]


### PR DESCRIPTION
Check if ElasticSearch domain is being encrypted with a KMS key. Closes #169.