### PR TITLE
Added query to check if MQ Broker logging is enabled. closes #165

### DIFF
--- a/assets/queries/terraform/aws/mq_broker_logging_is_disabled/metadata.json
+++ b/assets/queries/terraform/aws/mq_broker_logging_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "MQ_Broker_Has_Disabled_General_Or_Audit_Logging",
+  "queryName": "MQ Broker Has Disabled General Or Audit Logging",
+  "severity": "MEDIUM",
+  "category": "Logging",
+  "descriptionText": "Check if MQ Brokers don't have logging enabled in any of the two options possible (audit and general).",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mq_broker"
+}

--- a/assets/queries/terraform/aws/mq_broker_logging_is_disabled/query.rego
+++ b/assets/queries/terraform/aws/mq_broker_logging_is_disabled/query.rego
@@ -1,0 +1,57 @@
+package Cx
+
+CxPolicy [ result ] {
+  broker := input.document[i].resource.aws_mq_broker[name]
+  logs := broker.logs
+
+  categories := ["general","audit"]
+
+  some j
+    type := categories[j]
+    logs[type] == false
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_mq_broker[%s].logs.%s", [name,type]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": "'general' and 'audit' logging are set to true",
+                "keyActualValue": 	sprintf("'%s' is set to false",[type])
+              }
+}
+
+CxPolicy [ result ] {
+  broker := input.document[i].resource.aws_mq_broker[name]
+  logs := broker.logs
+
+  categories := ["general","audit"]
+
+  some j
+    type := categories[j]
+    not has_key(logs,type)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_mq_broker[%s].logs", [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "'general' and 'audit' logging are set to true",
+                "keyActualValue": 	"'general' and/or 'audit' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  broker := input.document[i].resource.aws_mq_broker[name]
+ 
+  not broker.logs
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_mq_broker[%s]", [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "'logs' is set and enabling general AND audit logging",
+                "keyActualValue": 	"'logs' is undefined"
+              }
+}
+
+has_key(obj,key) {
+  _ = obj[key]
+}

--- a/assets/queries/terraform/aws/mq_broker_logging_is_disabled/test/negative.tf
+++ b/assets/queries/terraform/aws/mq_broker_logging_is_disabled/test/negative.tf
@@ -1,0 +1,23 @@
+resource "aws_mq_broker" "logging_enabled" {
+  broker_name = "example"
+
+  configuration {
+    id       = aws_mq_configuration.test.id
+    revision = aws_mq_configuration.test.latest_revision
+  }
+
+  engine_type        = "ActiveMQ"
+  engine_version     = "5.15.0"
+  host_instance_type = "mq.t2.micro"
+  security_groups    = [aws_security_group.test.id]
+
+  user {
+    username = "ExampleUser"
+    password = "MindTheGap"
+  }
+
+  logs {
+      general = true
+      audit = true
+  }
+}

--- a/assets/queries/terraform/aws/mq_broker_logging_is_disabled/test/positive.tf
+++ b/assets/queries/terraform/aws/mq_broker_logging_is_disabled/test/positive.tf
@@ -1,0 +1,20 @@
+resource "aws_mq_broker" "logging_disabled" {
+  broker_name = "no-logging"
+}
+
+resource "aws_mq_broker" "audit_logging_missing" {
+  broker_name = "partial-logging"
+
+  logs {
+      general = true
+  }
+}
+
+resource "aws_mq_broker" "general_logging_disabled" {
+  broker_name = "disabled-logging"
+
+  logs {
+      general = false
+      audit = true
+  }
+}

--- a/assets/queries/terraform/aws/mq_broker_logging_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/mq_broker_logging_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "MQ Broker Has Disabled General Or Audit Logging",
+		"severity": "MEDIUM",
+		"line": 1
+	},
+	{
+		"queryName": "MQ Broker Has Disabled General Or Audit Logging",
+		"severity": "MEDIUM",
+		"line": 8
+	},
+	{
+		"queryName": "MQ Broker Has Disabled General Or Audit Logging",
+		"severity": "MEDIUM",
+		"line": 17
+	}
+]


### PR DESCRIPTION
Check if MQ Broker does not enable any of the possible logging types, general and audit. Closes #165 