### PR TITLE
Add ad_admin_not_configured_for_sql_server query for Terraform #252

### DIFF
--- a/assets/queries/terraform/azure/ad_admin_not_configured_for_sql_server/metadata.json
+++ b/assets/queries/terraform/azure/ad_admin_not_configured_for_sql_server/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ad_admin_not_configured_for_sql_server",
+  "queryName": "AD Admin Not Configured For SQL Server",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "The Active Directory Administrator is not configured for a SQL server",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sql_active_directory_administrator"
+}

--- a/assets/queries/terraform/azure/ad_admin_not_configured_for_sql_server/query.rego
+++ b/assets/queries/terraform/azure/ad_admin_not_configured_for_sql_server/query.rego
@@ -1,0 +1,22 @@
+package Cx
+
+CxPolicy [ result ] {
+    sql_server := input.document[i].resource.azurerm_sql_server[name]
+    not adAdminExists(sql_server.name, sql_server.resource_group_name)
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_sql_server[%s]", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("A 'azurerm_sql_active_directory_administrator' is defined for 'azurerm_sql_server[%s]'",[name]),
+                "keyActualValue": 	sprintf("A 'azurerm_sql_active_directory_administrator' is not defined for 'azurerm_sql_server[%s]'",[name]),
+              }
+}
+
+adAdminExists(server_name, resource_group) = exists {
+	  ad_admin := input.document[i].resource.azurerm_sql_active_directory_administrator[name]
+    ad_admin.resource_group_name == resource_group
+    ad_admin.server_name == server_name
+    exists = true
+} else = false {
+	  true
+}

--- a/assets/queries/terraform/azure/ad_admin_not_configured_for_sql_server/test/negative.tf
+++ b/assets/queries/terraform/azure/ad_admin_not_configured_for_sql_server/test/negative.tf
@@ -1,0 +1,21 @@
+resource "azurerm_resource_group" "example" {
+  name     = "acceptanceTestResourceGroup1"
+  location = "West US"
+}
+
+resource "azurerm_sql_server" "example" {
+  name                         = "mysqlserver"
+  resource_group_name          = "acceptanceTestResourceGroup1"
+  location                     = "West US"
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_sql_active_directory_administrator" "example" {
+  server_name         = "mysqlserver"
+  resource_group_name = "acceptanceTestResourceGroup1"
+  login               = "sqladmin"
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  object_id           = data.azurerm_client_config.current.object_id
+}

--- a/assets/queries/terraform/azure/ad_admin_not_configured_for_sql_server/test/positive.tf
+++ b/assets/queries/terraform/azure/ad_admin_not_configured_for_sql_server/test/positive.tf
@@ -1,0 +1,13 @@
+resource "azurerm_resource_group" "example" {
+  name     = "acceptanceTestResourceGroup1"
+  location = "West US"
+}
+
+resource "azurerm_sql_server" "example" {
+  name                         = "mysqlserver"
+  resource_group_name          = "acceptanceTestResourceGroup1"
+  location                     = "West US"
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}

--- a/assets/queries/terraform/azure/ad_admin_not_configured_for_sql_server/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/ad_admin_not_configured_for_sql_server/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "AD Admin Not Configured For SQL Server",
+		"severity": "HIGH",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Closes #252 

Added new query ad_admin_not_configured_for_sql_server for Terraform.

This query checks if there is an SQL Server without an AD Admin configured.