### PR TITLE
Add DB Instance Publicly Accessible Query

### DIFF
--- a/assets/queries/terraform/aws/db_instance_publicly_accessible/metadata.json
+++ b/assets/queries/terraform/aws/db_instance_publicly_accessible/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "DB_Instance_Publicly_Accessible",
+  "queryName": "DB Instance Publicly Accessible",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "The feature Publicly Accessible must be false",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#publicly_accessible"
+}

--- a/assets/queries/terraform/aws/db_instance_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/db_instance_publicly_accessible/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].resource.aws_db_instance[name]
+  resource.publicly_accessible
+ 
+	result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey": 	      sprintf("aws_db_instance[%s].publicly_accessible", [name]),
+                "issueType":		    "IncorrectValue",
+                "keyExpectedValue": sprintf("'aws_db_instance[%s].publicly_accessible' is false", [name]),
+                "keyActualValue":   sprintf("'aws_db_instance[%s].publicly_accessible' is true", [name])
+              }
+}
+

--- a/assets/queries/terraform/aws/db_instance_publicly_accessible/test/negative.tf
+++ b/assets/queries/terraform/aws/db_instance_publicly_accessible/test/negative.tf
@@ -1,0 +1,12 @@
+resource "aws_db_instance" "default" {
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
+  publicly_accessible = false
+}

--- a/assets/queries/terraform/aws/db_instance_publicly_accessible/test/positive.tf
+++ b/assets/queries/terraform/aws/db_instance_publicly_accessible/test/positive.tf
@@ -1,0 +1,12 @@
+resource "aws_db_instance" "default" {
+  allocated_storage    = 20
+  storage_type         = "gp2"
+  engine               = "mysql"
+  engine_version       = "5.7"
+  instance_class       = "db.t2.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "foobarbaz"
+  parameter_group_name = "default.mysql5.7"
+  publicly_accessible = true
+}

--- a/assets/queries/terraform/aws/db_instance_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/db_instance_publicly_accessible/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "DB Instance Publicly Accessible",
+		"severity": "HIGH",
+		"line": 11
+	}
+]


### PR DESCRIPTION
Added new query for Terraform.

Provide a aws_db_instance resource and a resource to manage the publicly_accessible feature

Closes #259 