### PR TITLE
Add role_assignment_of_guest_users query for Terraform #262

### DIFF
--- a/assets/queries/terraform/azure/role_assignment_of_guest_users/metadata.json
+++ b/assets/queries/terraform/azure/role_assignment_of_guest_users/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "role_assignment_of_guest_users",
+  "queryName": "Role Assignment Of Guest Users",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "There is a role assignment for guest user",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment"
+}

--- a/assets/queries/terraform/azure/role_assignment_of_guest_users/query.rego
+++ b/assets/queries/terraform/azure/role_assignment_of_guest_users/query.rego
@@ -1,0 +1,13 @@
+package Cx
+
+CxPolicy [ result ] {
+    role_assign := input.document[i].resource.azurerm_role_assignment[name]
+    role_assign.role_definition_name == "Guest"
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_role_assignment[%s].role_definition_name", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("azurerm_role_assignment[%s].role_definition_name not equal to 'Guest'", [name]),
+                "keyActualValue": 	sprintf("azurerm_role_assignment[%s].role_definition_name equals to 'Guest'", [name]),
+              }
+}

--- a/assets/queries/terraform/azure/role_assignment_of_guest_users/test/negative.tf
+++ b/assets/queries/terraform/azure/role_assignment_of_guest_users/test/negative.tf
@@ -1,0 +1,5 @@
+resource "azurerm_role_assignment" "example" {
+  scope                = data.azurerm_subscription.primary.id
+  role_definition_name = "Reader"
+  principal_id         = data.azurerm_client_config.example.object_id
+}

--- a/assets/queries/terraform/azure/role_assignment_of_guest_users/test/positive.tf
+++ b/assets/queries/terraform/azure/role_assignment_of_guest_users/test/positive.tf
@@ -1,0 +1,5 @@
+resource "azurerm_role_assignment" "example" {
+  scope                = data.azurerm_subscription.primary.id
+  role_definition_name = "Guest"
+  principal_id         = data.azurerm_client_config.example.object_id
+}

--- a/assets/queries/terraform/azure/role_assignment_of_guest_users/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/role_assignment_of_guest_users/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Role Assignment Of Guest Users",
+		"severity": "HIGH",
+		"line": 3
+	}
+]


### PR DESCRIPTION
Closes #262 

Added new query Role Assignment Of Guest Users for Terraform.

This query checks if 'azurerm_role_assignment.role_definition_name' equals 'Guest'.