### PR TITLE
Add Security Group Not Configured query for Terraform 

### DIFF
--- a/assets/queries/terraform/azure/security_group_not_configured/metadata.json
+++ b/assets/queries/terraform/azure/security_group_not_configured/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Security_Group_Not_Configured",
+  "queryName": "Security Group is Not Configured",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Azure Virtual Network subnet must be configured with a Network Security Group, which means the attribute 'security_group' must be defined and not empty",
+  "descriptionUrl": "https://www.terraform.io/docs/providers/azure/r/virtual_network.html"
+}

--- a/assets/queries/terraform/azure/security_group_not_configured/query.rego
+++ b/assets/queries/terraform/azure/security_group_not_configured/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.azure_virtual_network[name]
+  object.get(resource.subnet, "security_group", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azure_virtual_network[%s].subnet", [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": sprintf("'azure_virtual_network[%s].subnet.security_group' is defined", [name]),
+                "keyActualValue": 	sprintf("'azure_virtual_network[%s].subnet.security_group' is undefined", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.azure_virtual_network[name]
+  count(resource.subnet.security_group) == 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azure_virtual_network[%s].subnet.security_group", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'azure_virtual_network[%s].subnet.security_group' is not empty", [name]),
+                "keyActualValue": 	sprintf("'azure_virtual_network[%s].subnet.security_group' is empty", [name]),
+              }
+}

--- a/assets/queries/terraform/azure/security_group_not_configured/test/negative.tf
+++ b/assets/queries/terraform/azure/security_group_not_configured/test/negative.tf
@@ -1,0 +1,12 @@
+#this code is a correct code for which the query should not find any result
+resource "azure_virtual_network" "default" {
+  name          = "test-network"
+  address_space = ["10.1.2.0/24"]
+  location      = "West US"
+
+  subnet {
+    name           = "subnet1"
+    address_prefix = "10.1.2.0/25"
+    security_group = "a"
+  }
+}

--- a/assets/queries/terraform/azure/security_group_not_configured/test/positive.tf
+++ b/assets/queries/terraform/azure/security_group_not_configured/test/positive.tf
@@ -1,0 +1,23 @@
+#this is a problematic code where the query should report a result(s)
+resource "azure_virtual_network" "default1" {
+  name          = "test-network"
+  address_space = ["10.1.2.0/24"]
+  location      = "West US"
+
+  subnet {
+    name           = "subnet1"
+    address_prefix = "10.1.2.0/25"
+  }
+}
+
+resource "azure_virtual_network" "default2" {
+  name          = "test-network"
+  address_space = ["10.1.2.0/24"]
+  location      = "West US"
+
+  subnet {
+    name           = "subnet1"
+    address_prefix = "10.1.2.0/25"
+    security_group = ""
+  }
+}

--- a/assets/queries/terraform/azure/security_group_not_configured/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/security_group_not_configured/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Security Group is Not Configured",
+		"severity": "MEDIUM",
+		"line": 7
+	},
+	{
+		"queryName": "Security Group is Not Configured",
+		"severity": "MEDIUM",
+		"line": 21
+	}
+]


### PR DESCRIPTION
Adding Security Group Not Configured query for Terraform, that checks if the sub attribute 'security_group' of attribute 'subnet' is defined and not empty.

Closes #266