### PR TITLE
Added query to check if CloudTrail SNS topic is invalid. Closes #243

### DIFF
--- a/assets/queries/terraform/aws/cloudtrail_sns_topic_name_is_undefined/metadata.json
+++ b/assets/queries/terraform/aws/cloudtrail_sns_topic_name_is_undefined/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "CloudTrail SNS Topic Name Is Undefined",
+  "queryName": "CloudTrail SNS Topic Name Is Undefined",
+  "severity": "MEDIUM",
+  "category": "Logging",
+  "descriptionText": "Check if SNS topic name is set for CloudTrail",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail"
+}

--- a/assets/queries/terraform/aws/cloudtrail_sns_topic_name_is_undefined/query.rego
+++ b/assets/queries/terraform/aws/cloudtrail_sns_topic_name_is_undefined/query.rego
@@ -1,0 +1,23 @@
+package Cx
+
+CxPolicy [ result ] {
+  cloudtrail := input.document[i].resource.aws_cloudtrail[name]
+  
+  isDefined(cloudtrail)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_cloudtrail[%s]", [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": sprintf("'aws_cloudtrail[%s].sns_topic_name' is set and is not null", [name]),
+                "keyActualValue": 	sprintf("'aws_cloudtrail[%s].sns_topic_name' is undefined or null", [name])
+              }
+}
+
+isDefined(resource) = true {
+  object.get(resource,"sns_topic_name","undefined") == "undefined"
+}
+
+isDefined(resource) = true {
+  resource.sns_topic_name == null
+}

--- a/assets/queries/terraform/aws/cloudtrail_sns_topic_name_is_undefined/test/negative.tf
+++ b/assets/queries/terraform/aws/cloudtrail_sns_topic_name_is_undefined/test/negative.tf
@@ -1,0 +1,5 @@
+resource "aws_cloudtrail" "sns_topic_valid" {
+  # ... other configuration ...
+
+  sns_topic_name = "some-topic"
+}

--- a/assets/queries/terraform/aws/cloudtrail_sns_topic_name_is_undefined/test/positive.tf
+++ b/assets/queries/terraform/aws/cloudtrail_sns_topic_name_is_undefined/test/positive.tf
@@ -1,0 +1,9 @@
+resource "aws_cloudtrail" "no_sns_topic" {
+  # ... other configuration ...
+}
+
+resource "aws_cloudtrail" "sns_topic_null" {
+  # ... other configuration ...
+
+  sns_topic_name = null
+}

--- a/assets/queries/terraform/aws/cloudtrail_sns_topic_name_is_undefined/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudtrail_sns_topic_name_is_undefined/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "CloudTrail SNS Topic Name Is Undefined",
+		"severity": "MEDIUM",
+		"line": 1
+	},
+	{
+		"queryName": "CloudTrail SNS Topic Name Is Undefined",
+		"severity": "MEDIUM",
+		"line": 5
+	}
+]


### PR DESCRIPTION
Check if there is a CloudTrail resource without a valid SNS topic name set. Closes #243 