### PR TITLE
Add SQL Server Predictable Admin Account name query for Terraform 

### DIFF
--- a/assets/queries/terraform/azure/sql_server_predictable_admin_account_name/metadata.json
+++ b/assets/queries/terraform/azure/sql_server_predictable_admin_account_name/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "SQL_Server_Predictable_Admin_Account_Name",
+  "queryName": "SQL Server Predictable Admin Account Name",
+  "severity": "MEDIUM",
+  "category": "Identity and Access Management",
+  "descriptionText": "Azure SQL Server's Admin account login must avoid using names like 'Admin', that are too predictable, which means the attribute 'administrator_login' must be set to a name that is not easy to predict",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sql_server"
+}

--- a/assets/queries/terraform/azure/sql_server_predictable_admin_account_name/query.rego
+++ b/assets/queries/terraform/azure/sql_server_predictable_admin_account_name/query.rego
@@ -1,0 +1,33 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.azurerm_sql_server[name]
+  count(resource.administrator_login) == 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_sql_server[%s].administrator_login", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'azurerm_sql_server[%s].administrator_login' is not empty'", [name]),
+                "keyActualValue": 	sprintf("'azurerm_sql_server[%s].administrator_login' is empty", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.azurerm_sql_server[name]
+  check_predictable(resource.administrator_login)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_sql_server[%s].administrator_login", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'azurerm_sql_server[%s].administrator_login' is not predictable'", [name]),
+                "keyActualValue": 	sprintf("'azurerm_sql_server[%s].administrator_login' is predictable", [name]),
+              }
+}
+
+check_predictable (x) {
+	predictable_names := {"admin", "administrator", "root", "user", "azure_admin", "azure_administrator", "guest"}
+	some i
+    	lower(x) == predictable_names[i]
+}

--- a/assets/queries/terraform/azure/sql_server_predictable_admin_account_name/test/negative.tf
+++ b/assets/queries/terraform/azure/sql_server_predictable_admin_account_name/test/negative.tf
@@ -1,0 +1,33 @@
+#this code is a correct code for which the query should not find any result
+resource "azurerm_resource_group" "example" {
+  name     = "database-rg"
+  location = "West US"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplesa"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_sql_server" "example" {
+  name                         = "mssqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = azurerm_resource_group.example.location
+  version                      = "12.0"
+  administrator_login          = "UnpredictableAdminLogin"
+  administrator_login_password = "thisIsDog11"
+
+  extended_auditing_policy {
+    storage_endpoint                        = azurerm_storage_account.example.primary_blob_endpoint
+    storage_account_access_key              = azurerm_storage_account.example.primary_access_key
+    storage_account_access_key_is_secondary = true
+    retention_in_days                       = 6
+  }
+
+  tags = {
+    environment = "production"
+  }
+}

--- a/assets/queries/terraform/azure/sql_server_predictable_admin_account_name/test/positive.tf
+++ b/assets/queries/terraform/azure/sql_server_predictable_admin_account_name/test/positive.tf
@@ -1,0 +1,53 @@
+#this is a problematic code where the query should report a result(s)
+resource "azurerm_resource_group" "example" {
+  name     = "database-rg"
+  location = "West US"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplesa"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_sql_server" "example1" {
+  name                         = "mssqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = azurerm_resource_group.example.location
+  version                      = "12.0"
+  administrator_login          = ""
+  administrator_login_password = "thisIsDog11"
+
+  extended_auditing_policy {
+    storage_endpoint                        = azurerm_storage_account.example.primary_blob_endpoint
+    storage_account_access_key              = azurerm_storage_account.example.primary_access_key
+    storage_account_access_key_is_secondary = true
+    retention_in_days                       = 6
+  }
+
+  tags = {
+    environment = "production"
+  }
+}
+
+resource "azurerm_sql_server" "example2" {
+  name                         = "mssqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = azurerm_resource_group.example.location
+  version                      = "12.0"
+  administrator_login          = "Admin"
+  administrator_login_password = "thisIsDog11"
+
+  extended_auditing_policy {
+    storage_endpoint                        = azurerm_storage_account.example.primary_blob_endpoint
+    storage_account_access_key              = azurerm_storage_account.example.primary_access_key
+    storage_account_access_key_is_secondary = true
+    retention_in_days                       = 6
+  }
+
+  tags = {
+    environment = "production"
+  }
+}

--- a/assets/queries/terraform/azure/sql_server_predictable_admin_account_name/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/sql_server_predictable_admin_account_name/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "SQL Server Predictable Admin Account Name",
+		"severity": "MEDIUM",
+		"line": 20
+	},
+	{
+		"queryName": "SQL Server Predictable Admin Account Name",
+		"severity": "MEDIUM",
+		"line": 40
+	}
+]


### PR DESCRIPTION
Adding SQL Server Predictable Admin Account name query for Terraform, that checks if the attribute 'administrator_login' is set to a name that is not easy to predict (e.g. Admin, Root...).

Closes #282