### PR TITLE
Add SQL Server Predictable Active Directory Account Name query for Terraform 

### DIFF
--- a/assets/queries/terraform/azure/sql_server_predictable_active_directory_admin_account_name/metadata.json
+++ b/assets/queries/terraform/azure/sql_server_predictable_active_directory_admin_account_name/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "SQL_Server_Predictable_Active_Directory_Account_Name",
+  "queryName": "SQL Server Predictable Active Directory Account Name",
+  "severity": "MEDIUM",
+  "category": "Identity and Access Management",
+  "descriptionText": "Azure SQL Server must avoid using predictable Active Directory Administrator Account names, like 'Admin', which means the attribute 'login' must be set to a name that is not easy to predict",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sql_active_directory_administrator"
+}

--- a/assets/queries/terraform/azure/sql_server_predictable_active_directory_admin_account_name/query.rego
+++ b/assets/queries/terraform/azure/sql_server_predictable_active_directory_admin_account_name/query.rego
@@ -1,0 +1,33 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.azurerm_sql_active_directory_administrator[name]
+  count(resource.login) == 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_sql_active_directory_administrator[%s].login", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'azurerm_sql_active_directory_administrator[%s].login' is not empty'", [name]),
+                "keyActualValue": 	sprintf("'azurerm_sql_active_directory_administrator[%s].login' is empty", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.azurerm_sql_active_directory_administrator[name]
+  check_predictable(resource.login)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_sql_active_directory_administrator[%s].login", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'azurerm_sql_active_directory_administrator[%s].login' is not predictable'", [name]),
+                "keyActualValue": 	sprintf("'azurerm_sql_active_directory_administrator[%s].login' is predictable", [name]),
+              }
+}
+
+check_predictable (x) {
+	predictable_names := {"admin", "administrator", "sqladmin", "root", "user", "azure_admin", "azure_administrator", "guest"}
+	some i
+    	predictable_names[i] == lower(x)
+}

--- a/assets/queries/terraform/azure/sql_server_predictable_active_directory_admin_account_name/test/negative.tf
+++ b/assets/queries/terraform/azure/sql_server_predictable_active_directory_admin_account_name/test/negative.tf
@@ -1,0 +1,24 @@
+#this code is a correct code for which the query should not find any result
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "acceptanceTestResourceGroup1"
+  location = "West US"
+}
+
+resource "azurerm_sql_server" "example" {
+  name                         = "mysqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = azurerm_resource_group.example.location
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_sql_active_directory_administrator" "example" {
+  server_name         = azurerm_sql_server.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  login               = "NotEasyToPredictAdmin"
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  object_id           = data.azurerm_client_config.current.object_id
+}

--- a/assets/queries/terraform/azure/sql_server_predictable_active_directory_admin_account_name/test/positive.tf
+++ b/assets/queries/terraform/azure/sql_server_predictable_active_directory_admin_account_name/test/positive.tf
@@ -1,0 +1,32 @@
+#this is a problematic code where the query should report a result(s)
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "acceptanceTestResourceGroup1"
+  location = "West US"
+}
+
+resource "azurerm_sql_server" "example" {
+  name                         = "mysqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = azurerm_resource_group.example.location
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_sql_active_directory_administrator" "example1" {
+  server_name         = azurerm_sql_server.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  login               = ""
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  object_id           = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_sql_active_directory_administrator" "example2" {
+  server_name         = azurerm_sql_server.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  login               = "Admin"
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  object_id           = data.azurerm_client_config.current.object_id
+}

--- a/assets/queries/terraform/azure/sql_server_predictable_active_directory_admin_account_name/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/sql_server_predictable_active_directory_admin_account_name/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "SQL Server Predictable Active Directory Account Name",
+		"severity": "MEDIUM",
+		"line": 21
+	},
+	{
+		"queryName": "SQL Server Predictable Active Directory Account Name",
+		"severity": "MEDIUM",
+		"line": 29
+	}
+]


### PR DESCRIPTION
Adding SQL Server Predictable Active Directory Account Name query for Terraform, that checks if the the attribute 'login' is set to a name that is not easy to predict.
(Predictable names examples - Admin, Root...)

Closes #286