### PR TITLE
Add AWS Config Agg All Regions Not Enabled query

### DIFF
--- a/assets/queries/terraform/aws/config_configuration_aggregator_all_regions_not_enabled/metadata.json
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_all_regions_not_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "AWS_Config_Configuration_Aggregator_All_Regions_Not_Enabled",
+  "queryName": "AWS Config Configuration Aggregator All Regions Not Enabled",
+  "severity": "HIGH",
+  "category": "Logging",
+  "descriptionText": "AWS Config Configuration Aggregator All Regions must be set to True",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_configuration_aggregator#all_regions"
+}

--- a/assets/queries/terraform/aws/config_configuration_aggregator_all_regions_not_enabled/query.rego
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_all_regions_not_enabled/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].resource.aws_config_configuration_aggregator[name]
+	
+	resource[type].all_regions != true    
+    
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_config_configuration_aggregator[%s].%s.all_regions", [name, type]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'aws_db_instance[%s].[%s].all_regions' is true", [name, type]),
+                "keyActualValue": sprintf("'aws_db_instance[%s].[%s].all_regions' is false", [name, type])
+              }
+}
+

--- a/assets/queries/terraform/aws/config_configuration_aggregator_all_regions_not_enabled/test/negative.tf
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_all_regions_not_enabled/test/negative.tf
@@ -1,0 +1,19 @@
+resource "aws_config_configuration_aggregator" "account" {
+  name = "example"
+
+  account_aggregation_source {
+    all_regions = true
+
+  }
+}
+
+resource "aws_config_configuration_aggregator" "organization" {
+  depends_on = [aws_iam_role_policy_attachment.organization]
+
+  name = "example" # Required
+
+  organization_aggregation_source {
+    all_regions = true
+    role_arn    = aws_iam_role.organization.arn
+  }
+}

--- a/assets/queries/terraform/aws/config_configuration_aggregator_all_regions_not_enabled/test/positive.tf
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_all_regions_not_enabled/test/positive.tf
@@ -1,0 +1,19 @@
+resource "aws_config_configuration_aggregator" "account" {
+  name = "example"
+
+  account_aggregation_source {
+    all_regions = false
+
+  }
+}
+
+resource "aws_config_configuration_aggregator" "organization" {
+  depends_on = [aws_iam_role_policy_attachment.organization]
+
+  name = "example" # Required
+
+  organization_aggregation_source {
+    all_regions = false
+    role_arn    = aws_iam_role.organization.arn
+  }
+}

--- a/assets/queries/terraform/aws/config_configuration_aggregator_all_regions_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_all_regions_not_enabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "AWS Config Configuration Aggregator All Regions Not Enabled",
+		"severity": "HIGH",
+		"line": 5
+	},
+	{
+		"queryName": "AWS Config Configuration Aggregator All Regions Not Enabled",
+		"severity": "HIGH",
+		"line": 16
+	}
+]


### PR DESCRIPTION
Added new query for Terraform.

Provide a aws_config_configuration_aggregator resource and a resource to manage the all_regions feature

Closes #288 