### PR TITLE
Add kinesis_not_encrypted_with_kms query Closes #290

### DIFF
--- a/assets/queries/terraform/aws/kinesis_not_encrypted_with_kms/metadata.json
+++ b/assets/queries/terraform/aws/kinesis_not_encrypted_with_kms/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "kinesis_not_encrypted_with_kms",
+  "queryName": "Kinesis Not Encrypted with KMS",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "AWS Kinesis Streams and metadata should be protected with KMS",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_stream"
+}

--- a/assets/queries/terraform/aws/kinesis_not_encrypted_with_kms/query.rego
+++ b/assets/queries/terraform/aws/kinesis_not_encrypted_with_kms/query.rego
@@ -1,0 +1,57 @@
+package Cx
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_kinesis_stream[name]
+ 
+  
+  not resource.encryption_type
+
+
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_kinesis_stream[%s]", [name]),
+                "issueType":		      "MissingAttribute",
+                "keyExpectedValue":   sprintf("aws_kinesis_stream[%s].encryption_type is set", [name]),
+                "keyActualValue": 	  sprintf("aws_kinesis_stream[%s].encryption_type is undefined", [name]),
+            }
+}
+
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_kinesis_stream[name]
+ 
+  
+  resource.encryption_type == "NONE"
+
+
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_kinesis_stream[%s].encryption_type", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   sprintf("aws_kinesis_stream[%s].encryption_type is set and not NONE", [name]),
+                "keyActualValue": 	  sprintf("aws_kinesis_stream[%s].encryption_type is set but NONE", [name]),
+            }
+}
+
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_kinesis_stream[name]
+ 
+  
+  resource.encryption_type == "KMS"
+  
+  not resource.kms_key_id
+
+
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_kinesis_stream[%s]", [name]),
+                "issueType":		      "MissingAttribute",
+                "keyExpectedValue":   sprintf("aws_kinesis_stream[%s].kms_key_id is set", [name]),
+                "keyActualValue": 	  sprintf("aws_kinesis_stream[%s].kms_key_id is undefined", [name]),
+            }
+}
+

--- a/assets/queries/terraform/aws/kinesis_not_encrypted_with_kms/test/negative.tf
+++ b/assets/queries/terraform/aws/kinesis_not_encrypted_with_kms/test/negative.tf
@@ -1,0 +1,20 @@
+resource "aws_kinesis_stream" "test_stream4" {
+  name             = "terraform-kinesis-test"
+  shard_count      = 1
+  retention_period = 48
+
+  shard_level_metrics = [
+    "IncomingBytes",
+    "OutgoingBytes",
+  ]
+
+  tags = {
+    Environment = "test"
+  }
+
+
+  encryption_type = "KMS"
+
+  kms_key_id = "alias/aws/kinesis"
+}
+

--- a/assets/queries/terraform/aws/kinesis_not_encrypted_with_kms/test/positive.tf
+++ b/assets/queries/terraform/aws/kinesis_not_encrypted_with_kms/test/positive.tf
@@ -1,0 +1,59 @@
+resource "aws_kinesis_stream" "test_stream" {
+  name             = "terraform-kinesis-test"
+  shard_count      = 1
+  retention_period = 48
+
+  shard_level_metrics = [
+    "IncomingBytes",
+    "OutgoingBytes",
+  ]
+
+  tags = {
+    Environment = "test"
+  }
+}
+
+
+
+
+resource "aws_kinesis_stream" "test_stream2" {
+  name             = "terraform-kinesis-test"
+  shard_count      = 1
+  retention_period = 48
+
+  shard_level_metrics = [
+    "IncomingBytes",
+    "OutgoingBytes",
+  ]
+
+  tags = {
+    Environment = "test"
+  }
+
+
+  encryption_type = "NONE"
+}
+
+
+
+
+
+resource "aws_kinesis_stream" "test_stream3" {
+  name             = "terraform-kinesis-test"
+  shard_count      = 1
+  retention_period = 48
+
+  shard_level_metrics = [
+    "IncomingBytes",
+    "OutgoingBytes",
+  ]
+
+  tags = {
+    Environment = "test"
+  }
+
+
+  encryption_type = "KMS"
+}
+
+

--- a/assets/queries/terraform/aws/kinesis_not_encrypted_with_kms/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/kinesis_not_encrypted_with_kms/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+	{
+		"queryName": "Kinesis Not Encrypted with KMS",
+		"severity": "HIGH",
+		"line": 1
+	},
+  
+	{
+		"queryName": "Kinesis Not Encrypted with KMS",
+		"severity": "HIGH",
+		"line": 34
+	},
+
+	{
+		"queryName": "Kinesis Not Encrypted with KMS",
+		"severity": "HIGH",
+		"line": 41
+	}
+
+]


### PR DESCRIPTION
AWS Kinesis Streams and metadata should be protected with KMS. To verify that, we need to check if the attribute 'encryption_type' is set and defined as KMS and if the attribute 'kms_key_id' is set.

So, I thought in three cases:

- Attribute 'encryption_type' is undefined

- Attribute 'encryption_type' is set but defined as "NONE"


- Attribute 'encryption_type' is "KMS" but the attribute kms_key_id' is undefined

 Closes #290
