### PR TITLE
Add Network Watcher Flow Disabled query for Terraform

### DIFF
--- a/assets/queries/terraform/azure/network_watcher_flow_disabled/metadata.json
+++ b/assets/queries/terraform/azure/network_watcher_flow_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "network_watcher_flow_disabled",
+  "queryName": "Network Watcher Flow Disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Check if enable field in the resource azurerm_network_watcher_flow_log is false.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_watcher_flow_log"
+}

--- a/assets/queries/terraform/azure/network_watcher_flow_disabled/query.rego
+++ b/assets/queries/terraform/azure/network_watcher_flow_disabled/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy [ result ] {
+  
+  network := input.document[i].resource.azurerm_network_watcher_flow_log[name]
+  network.enabled = false
+  
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("azurerm_network_watcher_flow_log[%s].enable", [name]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "azurerm_network_watcher_flow_log.enabled is true",
+                "keyActualValue":   "azurerm_network_watcher_flow_log.enabled is false"
+              }
+}
+
+

--- a/assets/queries/terraform/azure/network_watcher_flow_disabled/test/negative.tf
+++ b/assets/queries/terraform/azure/network_watcher_flow_disabled/test/negative.tf
@@ -1,0 +1,13 @@
+resource "azurerm_network_watcher_flow_log" "test" {
+  network_watcher_name = azurerm_network_watcher.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+
+  network_security_group_id = azurerm_network_security_group.test.id
+  storage_account_id        = azurerm_storage_account.test.id
+  enabled                   = true
+
+  retention_policy {
+    enabled = true
+    days    = 7
+  }
+}

--- a/assets/queries/terraform/azure/network_watcher_flow_disabled/test/positive.tf
+++ b/assets/queries/terraform/azure/network_watcher_flow_disabled/test/positive.tf
@@ -1,0 +1,13 @@
+resource "azurerm_network_watcher_flow_log" "test" {
+  network_watcher_name = azurerm_network_watcher.test.name
+  resource_group_name  = azurerm_resource_group.test.name
+
+  network_security_group_id = azurerm_network_security_group.test.id
+  storage_account_id        = azurerm_storage_account.test.id
+  enabled                   = false
+
+  retention_policy {
+    enabled = true
+    days    = 7
+  }
+}

--- a/assets/queries/terraform/azure/network_watcher_flow_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/network_watcher_flow_disabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Network Watcher Flow Disabled",
+		"severity": "HIGH",
+		"line": 7
+	}
+]


### PR DESCRIPTION
Closes #283 

Added new query Network Watcher Flow Disabled for Terraform.

Check if enable field in the resource azurerm_network_watcher_flow_log is false.