### PR TITLE
Add kms_key_no_deletion_window query   Closes #292

### DIFF
--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/metadata.json
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "kms_key_no_deletion_window",
+  "queryName": "KMS Key No Deletion Window",
+  "severity": "HIGH",
+  "category": "Logging",
+  "descriptionText": "AWS KMS Key should have a valid deletion window",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key"
+}

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/query.rego
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/query.rego
@@ -1,0 +1,64 @@
+package Cx
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_kms_key[name]
+  
+  resource.is_enabled == true
+  
+  resource.enable_key_rotation == true
+  
+  not resource.deletion_window_in_days
+
+
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_kms_key[%s]", [name]),
+                "issueType":		      "MissingAttribute",
+                "keyExpectedValue":   sprintf("aws_kms_key[%s].deletion_window_in_days is set and valid", [name]),
+                "keyActualValue": 	  sprintf("aws_kms_key[%s].deletion_window_in_days is undefined", [name]),
+            }
+}
+
+
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_kms_key[name]
+  
+  resource.is_enabled == true
+  
+  resource.enable_key_rotation == true
+  
+  resource.deletion_window_in_days > 30
+
+
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_kms_key[%s].deletion_window_in_days", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   sprintf("aws_kms_key[%s].deletion_window_in_days is set and valid", [name]),
+                "keyActualValue": 	  sprintf("aws_kms_key[%s].deletion_window_in_days is set but invalid", [name]),
+            }
+}
+
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_kms_key[name]
+  
+  resource.is_enabled == true
+  
+  resource.enable_key_rotation == true
+  
+  resource.deletion_window_in_days < 7
+
+
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_kms_key[%s].deletion_window_in_days", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   sprintf("aws_kms_key[%s].deletion_window_in_days is set and valid", [name]),
+                "keyActualValue": 	  sprintf("aws_kms_key[%s].deletion_window_in_days is set but invalid", [name]),
+            }
+}

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/test/negative.tf
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/test/negative.tf
@@ -1,0 +1,9 @@
+resource "aws_kms_key" "a1" {
+  description             = "KMS key 1"
+  
+  is_enabled = true
+
+  enable_key_rotation = true
+
+  deletion_window_in_days = 10
+}

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive.tf
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive.tf
@@ -1,0 +1,32 @@
+resource "aws_kms_key" "a" {
+  description             = "KMS key 1"
+  
+  is_enabled = true
+
+  enable_key_rotation = true
+
+}
+
+
+
+
+resource "aws_kms_key" "a2" {
+  description             = "KMS key 1"
+  
+  is_enabled = true
+
+  enable_key_rotation = true
+
+  deletion_window_in_days = 6
+}
+
+
+resource "aws_kms_key" "a3" {
+  description             = "KMS key 1"
+  
+  is_enabled = true
+
+  enable_key_rotation = true
+
+  deletion_window_in_days = 31
+}

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive_expected_result.json
@@ -1,0 +1,19 @@
+[
+	{
+		"queryName": "KMS Key No Deletion Window",
+		"severity": "HIGH",
+		"line": 1
+	},
+
+	{
+		"queryName": "KMS Key No Deletion Window",
+		"severity": "HIGH",
+		"line": 20
+	},
+
+	{
+		"queryName": "KMS Key No Deletion Window",
+		"severity": "HIGH",
+		"line": 31
+	}
+]


### PR DESCRIPTION
AWS KMS Key should have a valid deletion window and this value must be between 7 and 30 days.

So, I thought in three cases:

- Attribute 'deletion_window_in_days' is undefined

- Attribute 'deletion_window_in_days' is set but greater than 30

- Attribute 'deletion_window_in_days' is set but smaller than 7


Closes #292