### PR TITLE
Add SQL Server Accessibility is Not Minimal query for Terraform 

### DIFF
--- a/assets/queries/terraform/azure/sql_server_accessibility_not_minimal/metadata.json
+++ b/assets/queries/terraform/azure/sql_server_accessibility_not_minimal/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "SQL_Server_Accessibility_Not_Minimal",
+  "queryName": "SQL Server Accessibility is Not Minimal",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Azure SQL Server Accessibility must be set to a minimal address range, which means the difference between the values of the 'end_ip_address' and 'start_ip_address' must be lesser than 256. Additionally, both ips must be different from '0.0.0.0'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sql_firewall_rule"
+}

--- a/assets/queries/terraform/azure/sql_server_accessibility_not_minimal/query.rego
+++ b/assets/queries/terraform/azure/sql_server_accessibility_not_minimal/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.azurerm_sql_firewall_rule[name]
+  resource.start_ip_address == "0.0.0.0"
+  resource.end_ip_address == "0.0.0.0"
+  
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_sql_firewall_rule[%s].start_ip_address", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'azurerm_sql_firewall_rule[%s].start_ip_address' is different from '0.0.0.0'", [name]),
+                "keyActualValue": 	sprintf("'azurerm_sql_firewall_rule[%s].start_ip_address' is equal to '0.0.0.0'", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.azurerm_sql_firewall_rule[name]
+  startIP_value := calc_value(resource.start_ip_address)
+  endIP_value := calc_value(resource.end_ip_address)
+  abs(endIP_value - startIP_value) >= 256
+  
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_sql_firewall_rule[%s].start_ip_address", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'azurerm_sql_firewall_rule[%s].start_ip_address' The difference between the value of the 'end_ip_address' and of 'start_ip_address' is lesser than 256", [name]),
+                "keyActualValue": 	sprintf("'azurerm_sql_firewall_rule[%s].start_ip_address' The difference between the value of the 'end_ip_address' and of 'start_ip_address' is greater than or equal to 256", [name]),
+              }
+}
+
+calc_value (val) = result {
+	ips := split(val, ".")
+
+    #calculate the value of an ip
+    #a.b.c.d
+    #a*16777216 + b*65536 + c*256 + d
+    result = (to_number(ips[0]) * 16777216) + (to_number(ips[1]) * 65536) + (to_number(ips[2]) * 256) + to_number(ips[3])
+}

--- a/assets/queries/terraform/azure/sql_server_accessibility_not_minimal/test/negative.tf
+++ b/assets/queries/terraform/azure/sql_server_accessibility_not_minimal/test/negative.tf
@@ -1,0 +1,22 @@
+#this code is a correct code for which the query should not find any result
+resource "azurerm_resource_group" "example" {
+  name     = "acceptanceTestResourceGroup1"
+  location = "West US"
+}
+
+resource "azurerm_sql_server" "example" {
+  name                         = "mysqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = "West US"
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_sql_firewall_rule" "example" {
+  name                = "FirewallRule1"
+  resource_group_name = azurerm_resource_group.example.name
+  server_name         = azurerm_sql_server.example.name
+  start_ip_address    = "10.0.17.62"
+  end_ip_address      = "10.0.17.62"
+}

--- a/assets/queries/terraform/azure/sql_server_accessibility_not_minimal/test/positive.tf
+++ b/assets/queries/terraform/azure/sql_server_accessibility_not_minimal/test/positive.tf
@@ -1,0 +1,30 @@
+#this is a problematic code where the query should report a result(s)
+resource "azurerm_resource_group" "example" {
+  name     = "acceptanceTestResourceGroup1"
+  location = "West US"
+}
+
+resource "azurerm_sql_server" "example" {
+  name                         = "mysqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = "West US"
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_sql_firewall_rule" "example1" {
+  name                = "FirewallRule1"
+  resource_group_name = azurerm_resource_group.example.name
+  server_name         = azurerm_sql_server.example.name
+  start_ip_address    = "0.0.0.0"
+  end_ip_address      = "0.0.0.0"
+}
+
+resource "azurerm_sql_firewall_rule" "example2" {
+  name                = "FirewallRule1"
+  resource_group_name = azurerm_resource_group.example.name
+  server_name         = azurerm_sql_server.example.name
+  start_ip_address    = "10.0.17.62"
+  end_ip_address      = "10.0.27.62"
+}

--- a/assets/queries/terraform/azure/sql_server_accessibility_not_minimal/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/sql_server_accessibility_not_minimal/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "SQL Server Accessibility is Not Minimal",
+		"severity": "MEDIUM",
+		"line": 20
+	},
+	{
+		"queryName": "SQL Server Accessibility is Not Minimal",
+		"severity": "MEDIUM",
+		"line": 28
+	}
+]


### PR DESCRIPTION
Adding SQL Server Accessibility is Not Minimal query for Terraform, that checks if the difference between the values of the 'end_ip_address' and 'start_ip_address' is lesser than 256 and if both IPs are different from '0.0.0.0'.

Closes #303