### PR TITLE
Add Using Default Service Account query for Terraform

### DIFF
--- a/assets/queries/terraform/gcp/using_default_service_account/metadata.json
+++ b/assets/queries/terraform/gcp/using_default_service_account/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Using_Default_Service_Account",
+  "queryName": "Using Default Service Account",
+  "severity": "MEDIUM",
+  "category": "Identity & Access Management",
+  "descriptionText": "Instances must not be configured to use the Default Service Account, that has full access to all Cloud APIs, which means the attribute 'service_account' and its sub attribute 'email' must be defined. Additionally, 'email' must not be empty and must also not be a default Google Compute Engine service account.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance"
+}

--- a/assets/queries/terraform/gcp/using_default_service_account/query.rego
+++ b/assets/queries/terraform/gcp/using_default_service_account/query.rego
@@ -1,0 +1,67 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_compute_instance[name]
+  object.get(resource, "service_account", "undefined") == "undefined"
+  
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_compute_instance[%s]", [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": sprintf("'google_compute_instance[%s].service_account' is defined", [name]),
+                "keyActualValue": 	sprintf("'google_compute_instance[%s].service_account' is undefined", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_compute_instance[name]
+  object.get(resource.service_account, "email", "undefined") == "undefined"
+  
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_compute_instance[%s].service_account", [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": sprintf("'google_compute_instance[%s].service_account.email' is defined", [name]),
+                "keyActualValue": 	sprintf("'google_compute_instance[%s].service_account.email' is undefined", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_compute_instance[name]
+  count(resource.service_account.email) == 0
+  
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_compute_instance[%s].service_account.email", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'google_compute_instance[%s].service_account.email' is not empty", [name]),
+                "keyActualValue": 	sprintf("'google_compute_instance[%s].service_account.email' is empty", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_compute_instance[name]
+  count(resource.service_account.email) > 0
+  not contains(resource.service_account.email, "@")
+  
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_compute_instance[%s].service_account.email", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'google_compute_instance[%s].service_account.email' is not an email", [name]),
+                "keyActualValue": 	sprintf("'google_compute_instance[%s].service_account.email' is an email", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_compute_instance[name]
+  contains(resource.service_account.email, "@developer.gserviceaccount.com")
+  
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_compute_instance[%s].service_account.email", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'google_compute_instance[%s].service_account.email' is not a default Google Compute Engine service account", [name]),
+                "keyActualValue": 	sprintf("'google_compute_instance[%s].service_account.email' is a default Google Compute Engine service account", [name]),
+              }
+}

--- a/assets/queries/terraform/gcp/using_default_service_account/test/negative.tf
+++ b/assets/queries/terraform/gcp/using_default_service_account/test/negative.tf
@@ -1,0 +1,32 @@
+#this code is a correct code for which the query should not find any result
+resource "google_compute_instance" "default" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  // Local SSD disk
+  scratch_disk {
+    interface = "SCSI"
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  service_account {
+    email = "email@email.com"
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}

--- a/assets/queries/terraform/gcp/using_default_service_account/test/positive.tf
+++ b/assets/queries/terraform/gcp/using_default_service_account/test/positive.tf
@@ -1,0 +1,130 @@
+#this is a problematic code where the query should report a result(s)
+resource "google_compute_instance" "default1" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+}
+
+resource "google_compute_instance" "default2" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+
+resource "google_compute_instance" "default3" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  service_account {
+    email = ""
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+
+resource "google_compute_instance" "default4" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  service_account {
+    email = "a"
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+
+resource "google_compute_instance" "default5" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  service_account {
+    email = "email@developer.gserviceaccount.com"
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}

--- a/assets/queries/terraform/gcp/using_default_service_account/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/using_default_service_account/test/positive_expected_result.json
@@ -1,0 +1,27 @@
+[
+	{
+		"queryName": "Using Default Service Account",
+		"severity": "MEDIUM",
+		"line": 2
+	},
+	{
+		"queryName": "Using Default Service Account",
+		"severity": "MEDIUM",
+		"line": 46
+	},
+	{
+		"queryName": "Using Default Service Account",
+		"severity": "MEDIUM",
+		"line": 73
+	},
+	{
+		"queryName": "Using Default Service Account",
+		"severity": "MEDIUM",
+		"line": 100
+	},
+	{
+		"queryName": "Using Default Service Account",
+		"severity": "MEDIUM",
+		"line": 127
+	}
+]


### PR DESCRIPTION
Adding Using Default Service Account query for Terraform, that checks if the attribute 'service_account' and its sub attribute 'email' are defined, and if 'email' is empty or is a default Google Compute Engine service account.

Closes #310