### PR TITLE
Add SQS with SSE disabled query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/sqs_with_sse_disabled/metadata.json
+++ b/assets/queries/terraform/aws/sqs_with_sse_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "sqs_with_sse_disabled",
+  "queryName": "SQS with SSE disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Amazon Simple Queue Service (SQS) queue is not protecting the contents of their messages using Server-Side Encryption (SSE)",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue"
+}

--- a/assets/queries/terraform/aws/sqs_with_sse_disabled/query.rego
+++ b/assets/queries/terraform/aws/sqs_with_sse_disabled/query.rego
@@ -1,0 +1,36 @@
+package Cx
+
+CxPolicy [ result ] {
+  
+  resource := input.document[i].resource.aws_sqs_queue[name]
+  object.get(resource, "kms_master_key_id", "undefined") == "undefined"
+  
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("aws_sqs_queue[%s]", [name]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "aws_sqs_queue.kms_master_key_id is defined",
+                "keyActualValue":   "aws_sqs_queue.kms_master_key_id is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  
+  resource := input.document[i].resource.aws_sqs_queue[name]
+  isKeyEmpty(resource.kms_master_key_id)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("aws_sqs_queue[%s].kms_master_key_id", [name]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "aws_sqs_queue.kms_master_key_id not null or ''",
+                "keyActualValue":   "aws_sqs_queue.kms_master_key_id null or ''"
+              }
+}
+
+isKeyEmpty(key) {
+	key == null
+}
+isKeyEmpty(key) {
+	key == ""
+}

--- a/assets/queries/terraform/aws/sqs_with_sse_disabled/test/negative.tf
+++ b/assets/queries/terraform/aws/sqs_with_sse_disabled/test/negative.tf
@@ -1,0 +1,5 @@
+resource "aws_sqs_queue" "terraform_queue" {
+  name                              = "terraform-example-queue"
+  kms_master_key_id                 = "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = 300
+}

--- a/assets/queries/terraform/aws/sqs_with_sse_disabled/test/positive.tf
+++ b/assets/queries/terraform/aws/sqs_with_sse_disabled/test/positive.tf
@@ -1,0 +1,16 @@
+resource "aws_sqs_queue" "terraform_queue" {
+  name                              = "terraform-example-queue"
+  kms_data_key_reuse_period_seconds = 300
+}
+
+resource "aws_sqs_queue" "terraform_queue1" {
+  name                              = "terraform-example-queue"
+  kms_master_key_id                 = ""
+  kms_data_key_reuse_period_seconds = 300
+}
+
+resource "aws_sqs_queue" "terraform_queue2" {
+  name                              = "terraform-example-queue"
+  kms_master_key_id                 = null
+  kms_data_key_reuse_period_seconds = 300
+}

--- a/assets/queries/terraform/aws/sqs_with_sse_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sqs_with_sse_disabled/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "SQS with SSE disabled",
+		"severity": "HIGH",
+		"line": 1
+	},
+	{
+		"queryName": "SQS with SSE disabled",
+		"severity": "HIGH",
+		"line": 8
+	},
+	{
+		"queryName": "SQS with SSE disabled",
+		"severity": "HIGH",
+		"line": 14
+	}
+]


### PR DESCRIPTION
Closes #301 

Added new query SQS with SSE disabled for Terraform.

Amazon Simple Queue Service (SQS) queue is not protecting the contents of their messages using Server-Side Encryption (SSE).