### PR TITLE
Added query insecure SSL is enabled in github org webhooks. Closes #324

### DIFF
--- a/assets/queries/terraform/github/webhooks_insecure_ssl_is_enabled/metadata.json
+++ b/assets/queries/terraform/github/webhooks_insecure_ssl_is_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Insecure_SSL_Is_Enabled_For_GitHub_Organization_Webhook",
+  "queryName": "Insecure SSL Is Enabled For GitHub Organization Webhook",
+  "severity": "MEDIUM",
+  "category": "Encryption and Key Management",
+  "descriptionText": "Check if insecure SSL is being used in the GitHub organization webhooks",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/github/latest/docs/resources/organization_webhook"
+}

--- a/assets/queries/terraform/github/webhooks_insecure_ssl_is_enabled/query.rego
+++ b/assets/queries/terraform/github/webhooks_insecure_ssl_is_enabled/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy [ result ] {
+  webhook := input.document[i].resource.github_organization_webhook[name]
+  webhool.configuation.insecure_ssl == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("github_organization_webhook[%s].configuration.insecure_ssl", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("github_organization_webhook[%s].configuration.insecure_ssl is false", [name]),
+                "keyActualValue": 	sprintf("github_organization_webhook[%s].configuration.insecure_ssl is true", [name])
+              }
+}

--- a/assets/queries/terraform/github/webhooks_insecure_ssl_is_enabled/test/negative.tf
+++ b/assets/queries/terraform/github/webhooks_insecure_ssl_is_enabled/test/negative.tf
@@ -1,0 +1,13 @@
+resource "github_organization_webhook" "insecure_ssl_disabled" {
+  name = "web"
+
+  configuration {
+    url          = "https://google.de/"
+    content_type = "form"
+    insecure_ssl = false
+  }
+
+  active = false
+
+  events = ["issues"]
+}

--- a/assets/queries/terraform/github/webhooks_insecure_ssl_is_enabled/test/positive.tf
+++ b/assets/queries/terraform/github/webhooks_insecure_ssl_is_enabled/test/positive.tf
@@ -1,0 +1,13 @@
+resource "github_organization_webhook" "insecure_ssl_enabled" {
+  name = "web"
+
+  configuration {
+    url          = "https://google.de/"
+    content_type = "form"
+    insecure_ssl = true
+  }
+
+  active = false
+
+  events = ["issues"]
+}

--- a/assets/queries/terraform/github/webhooks_insecure_ssl_is_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/github/webhooks_insecure_ssl_is_enabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Insecure SSL Is Enabled For GitHub Organization Webhook",
+		"severity": "MEDIUM",
+		"line": 7
+	}
+]


### PR DESCRIPTION
Check if insecure SSL is being used in GitHub organization webhooks. Closes #324 