### PR TITLE
Added query to check if project-wide ssh keys are unblocked. Closes #326

### DIFF
--- a/assets/queries/terraform/gcp/project-wide_ssh_keys_are_enabled/metadata.json
+++ b/assets/queries/terraform/gcp/project-wide_ssh_keys_are_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Project-wide_SSH_Keys_Are_Enabled_In_VM_Instances",
+  "queryName": "Project-wide SSH Keys Are Enabled In VM Instances",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Check if SSH keys are enabled project-wide in VM instances",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance"
+}

--- a/assets/queries/terraform/gcp/project-wide_ssh_keys_are_enabled/query.rego
+++ b/assets/queries/terraform/gcp/project-wide_ssh_keys_are_enabled/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+CxPolicy [ result ] {
+  compute := input.document[i].resource.google_compute_instance[name]
+  metadata := compute.metadata
+  ssh_keys_enabled := object.get(metadata,"block-project-ssh-keys","undefined")
+  not isTrue(ssh_keys_enabled)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_compute_instance[%s].metadata.block-project-ssh-keys", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("google_compute_instance[%s].metadata.block-project-ssh-keys is true", [name]),
+                "keyActualValue": sprintf("google_compute_instance[%s].metadata.block-project-ssh-keys is %s", [name,ssh_keys_enabled])
+              }
+}
+
+CxPolicy [ result ] {
+  compute := input.document[i].resource.google_compute_instance[name]
+  not compute.metadata
+  
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_compute_instance[%s]", [name]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": sprintf("google_compute_instance[%s].metadata is set", [name]),
+                "keyActualValue": sprintf("google_compute_instance[%s].metadata is undefined", [name])
+              }
+}
+
+isTrue(ssh_keys_enabled) = true {
+  is_string(ssh_keys_enabled)
+  lower(ssh_keys_enabled) == "true"
+}
+
+isTrue(ssh_keys_enabled) = true {
+  is_boolean(ssh_keys_enabled)
+  ssh_keys_enabled
+}

--- a/assets/queries/terraform/gcp/project-wide_ssh_keys_are_enabled/test/negative.tf
+++ b/assets/queries/terraform/gcp/project-wide_ssh_keys_are_enabled/test/negative.tf
@@ -1,0 +1,38 @@
+resource "google_compute_instance" "ssh_keys_blocked" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  // Local SSD disk
+  scratch_disk {
+    interface = "SCSI"
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata = {
+    #... some other metadata
+    
+    block-project-ssh-keys = "TRUE"
+  }
+
+  metadata_startup_script = "echo hi > /test.txt"
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}

--- a/assets/queries/terraform/gcp/project-wide_ssh_keys_are_enabled/test/positive.tf
+++ b/assets/queries/terraform/gcp/project-wide_ssh_keys_are_enabled/test/positive.tf
@@ -1,0 +1,71 @@
+resource "google_compute_instance" "ssh_keys_unblocked" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  // Local SSD disk
+  scratch_disk {
+    interface = "SCSI"
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata = {
+    #... some other metadata
+    block-project-ssh-keys = false
+  }
+
+  metadata_startup_script = "echo hi > /test.txt"
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+
+resource "google_compute_instance" "no_metadata" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  // Local SSD disk
+  scratch_disk {
+    interface = "SCSI"
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata_startup_script = "echo hi > /test.txt"
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+

--- a/assets/queries/terraform/gcp/project-wide_ssh_keys_are_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/project-wide_ssh_keys_are_enabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Project-wide SSH Keys Are Enabled In VM Instances",
+		"severity": "MEDIUM",
+		"line": 29
+	},
+	{
+		"queryName": "Project-wide SSH Keys Are Enabled In VM Instances",
+		"severity": "MEDIUM",
+		"line": 39
+	}
+]


### PR DESCRIPTION
Check if SSH keys are enabled project-wide in VM instances. More information in [here](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#block-project-keys). Closes #326 