### PR TITLE
Added query to check if VM instance disables oslogin. Closes #327

### DIFF
--- a/assets/queries/terraform/gcp/oslogin_instance_disabled/metadata.json
+++ b/assets/queries/terraform/gcp/oslogin_instance_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "OSLogin_Is_Disabled_In_VM_Instance",
+  "queryName": "OSLogin Is Disabled In VM Instance",
+  "severity": "MEDIUM",
+  "category": "Identity and Access Management",
+  "descriptionText": "Check if any VM instance disables OSLogin",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance"
+}

--- a/assets/queries/terraform/gcp/oslogin_instance_disabled/query.rego
+++ b/assets/queries/terraform/gcp/oslogin_instance_disabled/query.rego
@@ -1,0 +1,26 @@
+package Cx
+
+CxPolicy [ result ] {
+  compute := input.document[i].resource.google_compute_instance[name]
+  metadata := compute.metadata
+  oslogin := object.get(metadata,"enable-oslogin","undefined")
+  isFalse(oslogin)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_compute_instance[%s].metadata.enable-oslogin", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("google_compute_instance[%s].metadata.enable-oslogin is true or undefined", [name]),
+                "keyActualValue": sprintf("google_compute_instance[%s].metadata.enable-oslogin is false", [name])
+              }
+}
+
+isFalse(value) = true {
+  is_string(value)
+  lower(value) == "false"
+}
+
+isFalse(value) = true {
+  is_boolean(value)
+  not value
+}

--- a/assets/queries/terraform/gcp/oslogin_instance_disabled/test/negative.tf
+++ b/assets/queries/terraform/gcp/oslogin_instance_disabled/test/negative.tf
@@ -1,0 +1,39 @@
+resource "google_compute_instance" "ssh_keys_blocked" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  // Local SSD disk
+  scratch_disk {
+    interface = "SCSI"
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata = {
+    #... some other metadata
+
+    # or if not undefined
+    enable-oslogin = true
+  }
+
+  metadata_startup_script = "echo hi > /test.txt"
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}

--- a/assets/queries/terraform/gcp/oslogin_instance_disabled/test/positive.tf
+++ b/assets/queries/terraform/gcp/oslogin_instance_disabled/test/positive.tf
@@ -1,0 +1,38 @@
+resource "google_compute_instance" "ssh_keys_blocked" {
+  name         = "test"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  tags = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  // Local SSD disk
+  scratch_disk {
+    interface = "SCSI"
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata = {
+    #... some other metadata
+
+    enable-oslogin = "FALSE"
+  }
+
+  metadata_startup_script = "echo hi > /test.txt"
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}

--- a/assets/queries/terraform/gcp/oslogin_instance_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/oslogin_instance_disabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "OSLogin Is Disabled In VM Instance",
+		"severity": "MEDIUM",
+		"line": 30
+	}
+]


### PR DESCRIPTION
Check if any VM instance disables the OSLogin project setting to enable it. More information in [here](https://cloud.google.com/compute/docs/instances/managing-instance-access#enable_oslogin). Closes #327 