### PR TITLE
Add logging_disabled_for_key_vault query for Terraform #344

### DIFF
--- a/assets/queries/terraform/azure/logging_disabled_for_key_vault/metadata.json
+++ b/assets/queries/terraform/azure/logging_disabled_for_key_vault/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "logging_disabled_for_key_vault",
+  "queryName": "Logging Disabled For Key Vault",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "Loggign for Azure Key Vault is disabled",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting"
+}

--- a/assets/queries/terraform/azure/logging_disabled_for_key_vault/query.rego
+++ b/assets/queries/terraform/azure/logging_disabled_for_key_vault/query.rego
@@ -1,0 +1,103 @@
+package Cx
+
+CxPolicy [ result ] {
+    resource := input.document[i].resource.azurerm_key_vault[resource_name]
+    getDataSourceFor(resource) == null
+    
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_key_vault[%s]", [resource_name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'data.azurerm_key_vault' is defined for 'azurerm_key_vault[%s]'", [resource_name]),
+                "keyActualValue": 	sprintf("'data.azurerm_key_vault' is not defined for 'azurerm_key_vault[%s]'", [resource_name]),
+              }
+}
+
+CxPolicy [ result ] {
+    resource := input.document[i].resource.azurerm_key_vault[resource_name]
+    data_name := getDataSourceFor(resource)
+    data_name != null
+    not monitorExistsFor(data_name)
+    
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_key_vault[%s]", [resource_name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'azurerm_monitor_diagnostic_setting' is defined for 'azurerm_key_vault[%s]'", [resource_name]),
+                "keyActualValue": 	sprintf("'azurerm_monitor_diagnostic_setting' is not defined for 'azurerm_key_vault[%s]'", [resource_name]),
+              }
+}
+
+CxPolicy [ result ] {
+    resource := input.document[i].resource.azurerm_key_vault[resource_name]
+    data_name := getDataSourceFor(resource)
+    data_name != null
+    resource_id := sprintf("${data.azurerm_key_vault.%s.id}", [data_name])
+    monitor := input.document[j].resource.azurerm_monitor_diagnostic_setting[monitor_name]
+    monitor.target_resource_id == resource_id
+    not ExistsLogAuditEvent(monitor)
+    
+    result := {
+                "documentId": 		input.document[j].id,
+                "searchKey": 	    sprintf("azurerm_monitor_diagnostic_setting[%s]", [monitor_name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'azurerm_monitor_diagnostic_setting[%s].log' is defined for category 'AuditEvent'", [monitor_name]),
+                "keyActualValue": 	sprintf("'azurerm_monitor_diagnostic_setting[%s].log' is not defined for category 'AuditEvent'", [monitor_name]),
+              }
+}
+
+CxPolicy [ result ] {
+    resource := input.document[i].resource.azurerm_key_vault[resource_name]
+    data_name := getDataSourceFor(resource)
+    data_name != null
+    resource_id := sprintf("${data.azurerm_key_vault.%s.id}", [data_name])
+    monitor := input.document[j].resource.azurerm_monitor_diagnostic_setting[monitor_name]
+    monitor.target_resource_id == resource_id
+    ExistsLogAuditEvent(monitor)
+    LogAuditEventDisabled(monitor.log)
+    
+    result := {
+                "documentId": 		input.document[j].id,
+                "searchKey": 	    sprintf("azurerm_monitor_diagnostic_setting[%s].log", [monitor_name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'azurerm_monitor_diagnostic_setting[%s].log.enabled' for category 'AuditEvent' is true or undefined", [monitor_name]),
+                "keyActualValue": 	sprintf("'azurerm_monitor_diagnostic_setting[%s].log.enabled' for category 'AuditEvent' is false", [monitor_name]),
+              }
+}
+
+monitorExistsFor(data_name) {
+    resource_id := sprintf("${data.azurerm_key_vault.%s.id}", [data_name])
+    some m
+    	input.document[i].resource.azurerm_monitor_diagnostic_setting[m].target_resource_id == resource_id
+}
+
+getDataSourceFor(resource) = result {
+	data := input.document[i].data.azurerm_key_vault[data_name]
+    data.name == resource.name
+    data.resource_group_name == resource.resource_group_name
+    result := data_name
+} else = null
+
+ExistsLogAuditEvent(monitor) {
+	logs := monitor.log
+	is_object(logs)
+    logs.category == "AuditEvent"
+}
+ExistsLogAuditEvent(monitor) {
+	logs := monitor.log
+	is_array(logs)
+    some l
+    	logs[l].category == "AuditEvent"
+}
+
+LogAuditEventDisabled(logs) {
+	is_object(logs)
+    logs.category == "AuditEvent"
+    logs.enabled == false
+}
+LogAuditEventDisabled(logs) {
+	is_array(logs)
+    some l
+    	logs[l].category == "AuditEvent"
+        logs[l].enabled == false
+}

--- a/assets/queries/terraform/azure/logging_disabled_for_key_vault/test/negative.tf
+++ b/assets/queries/terraform/azure/logging_disabled_for_key_vault/test/negative.tf
@@ -1,0 +1,21 @@
+resource "azurerm_key_vault" "example" {
+  name                        = "example-vault"
+  location                    = "West US"
+  resource_group_name         = "example-resources"
+}
+
+data "azurerm_key_vault" "example" {
+  name                = "example-vault"
+  resource_group_name = "example-resources"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "example" {
+  name               = "example"
+  target_resource_id = data.azurerm_key_vault.example.id
+  storage_account_id = data.azurerm_storage_account.example.id
+
+  log {
+    category = "AuditEvent"
+    enabled  = true
+  }
+}

--- a/assets/queries/terraform/azure/logging_disabled_for_key_vault/test/positive.tf
+++ b/assets/queries/terraform/azure/logging_disabled_for_key_vault/test/positive.tf
@@ -1,0 +1,63 @@
+// Example 1
+
+resource "azurerm_key_vault" "example" {
+  name                        = "example-vault"
+  location                    = "West US"
+  resource_group_name         = "example-resources"
+}
+
+// Example 2
+
+resource "azurerm_key_vault" "example2" {
+  name                        = "example2-vault"
+  location                    = "West US"
+  resource_group_name         = "example-resources"
+}
+
+data "azurerm_key_vault" "example2" {
+  name                = "example2-vault"
+  resource_group_name = "example-resources"
+}
+
+// Example 3
+
+resource "azurerm_key_vault" "example3" {
+  name                        = "example3-vault"
+  location                    = "West US"
+  resource_group_name         = "example-resources"
+}
+
+data "azurerm_key_vault" "example3" {
+  name                = "example3-vault"
+  resource_group_name = "example-resources"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "example3" {
+  name               = "example3"
+  target_resource_id = data.azurerm_key_vault.example3.id
+  storage_account_id = data.azurerm_storage_account.example.id
+}
+
+// Example 4
+
+resource "azurerm_key_vault" "example4" {
+  name                        = "example4-vault"
+  location                    = "West US"
+  resource_group_name         = "example-resources"
+}
+
+data "azurerm_key_vault" "example4" {
+  name                = "example4-vault"
+  resource_group_name = "example-resources"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "example4" {
+  name               = "example4"
+  target_resource_id = data.azurerm_key_vault.example4.id
+  storage_account_id = data.azurerm_storage_account.example.id
+
+  log {
+    category = "AuditEvent"
+    enabled  = false
+  }
+}

--- a/assets/queries/terraform/azure/logging_disabled_for_key_vault/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/logging_disabled_for_key_vault/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "Logging Disabled For Key Vault",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "Logging Disabled For Key Vault",
+		"severity": "HIGH",
+		"line": 11
+	},
+	{
+		"queryName": "Logging Disabled For Key Vault",
+		"severity": "HIGH",
+		"line": 35
+	},
+	{
+		"queryName": "Logging Disabled For Key Vault",
+		"severity": "HIGH",
+		"line": 59
+	}
+]


### PR DESCRIPTION
Closes #344 

This query detects if a 'azurerm_key_vault' resource has logging disabled.
It checks, for each 'azurerm_key_vault' resource, if exists a 'azurerm_monitor_diagnostic_setting' resource that targets the 'azurerm_key_vault' resource and if it defines a log with category 'AuditEvent' without 'enabled' equal to false. A data source for the 'azurerm_key_vault' resource must also be defined.