### PR TITLE
Add Root Account Has Associated Active Access Keys query for Terraform 

### DIFF
--- a/assets/queries/terraform/aws/root_account_has_associated_active_access_keys/metadata.json
+++ b/assets/queries/terraform/aws/root_account_has_associated_active_access_keys/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Root_Account_Has_Associated_Active_Access_Keys",
+  "queryName": "Root Account Has Associated Active Access Keys",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "The AWS Root Account must not have active access keys associated, which means if there are access keys associated to the Root Account, they must be inactive.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key"
+}

--- a/assets/queries/terraform/aws/root_account_has_associated_active_access_keys/query.rego
+++ b/assets/queries/terraform/aws/root_account_has_associated_active_access_keys/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_iam_access_key[name]
+  contains(lower(resource.user), "root")
+  object.get(resource, "status", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_iam_access_key[%s]", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'aws_iam_access_key[%s].status' is defined and set to 'Inactive'", [name]),
+                "keyActualValue": 	sprintf("'aws_iam_access_key[%s].status' is undefined, that defaults to 'Active'", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_iam_access_key[name]
+  contains(lower(resource.user), "root")
+  resource.status == "Active"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_iam_access_key[%s].status", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'aws_iam_access_key[%s].status' is defined and set to 'Inactive'", [name]),
+                "keyActualValue": 	sprintf("'aws_iam_access_key[%s].status' is set to 'Active'", [name]),
+              }
+}

--- a/assets/queries/terraform/aws/root_account_has_associated_active_access_keys/test/negative.tf
+++ b/assets/queries/terraform/aws/root_account_has_associated_active_access_keys/test/negative.tf
@@ -1,0 +1,34 @@
+#this code is a correct code for which the query should not find any result
+resource "aws_iam_access_key" "lb" {
+  user    = aws_iam_user.lb.name
+  pgp_key = "keybase:some_person_that_exists"
+}
+
+resource "aws_iam_user" "lb" {
+  name = "loadbalancer"
+  path = "/system/"
+}
+
+resource "aws_iam_user_policy" "lb_ro" {
+  name = "test"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+output "secret" {
+  value = aws_iam_access_key.lb.encrypted_secret
+}

--- a/assets/queries/terraform/aws/root_account_has_associated_active_access_keys/test/positive.tf
+++ b/assets/queries/terraform/aws/root_account_has_associated_active_access_keys/test/positive.tf
@@ -1,0 +1,69 @@
+#this is a problematic code where the query should report a result(s)
+resource "aws_iam_access_key" "lb1" {
+  user    = "root"
+  pgp_key = "keybase:some_person_that_exists"
+}
+
+resource "aws_iam_user" "lb" {
+  name = "loadbalancer"
+  path = "/system/"
+}
+
+resource "aws_iam_user_policy" "lb_ro" {
+  name = "test"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+output "secret" {
+  value = aws_iam_access_key.lb.encrypted_secret
+}
+
+resource "aws_iam_access_key" "lb2" {
+  user    = "root"
+  pgp_key = "keybase:some_person_that_exists"
+  status = "Active"
+}
+
+resource "aws_iam_user" "lb" {
+  name = "loadbalancer"
+  path = "/system/"
+}
+
+resource "aws_iam_user_policy" "lb_ro" {
+  name = "test"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+output "secret" {
+  value = aws_iam_access_key.lb.encrypted_secret
+}

--- a/assets/queries/terraform/aws/root_account_has_associated_active_access_keys/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/root_account_has_associated_active_access_keys/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Root Account Has Associated Active Access Keys",
+		"severity": "HIGH",
+		"line": 2
+	},
+	{
+		"queryName": "Root Account Has Associated Active Access Keys",
+		"severity": "HIGH",
+		"line": 39
+	}
+]


### PR DESCRIPTION
Adding Root Account Has Associated Active Access Keys query for Terraform, that checks if there are active access keys associated to the Root Account.

Closes #350