### PR TITLE
Add ECS Service Admin Role is Present query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/ecs_service_admin_role_present/metadata.json
+++ b/assets/queries/terraform/aws/ecs_service_admin_role_present/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ECS_Service_Admin_Role_Present",
+  "queryName": "ECS Service Admin Role is Present",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "ECS Services must not have Admin roles, which means the attribute 'iam_role' must not be an admin role",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service"
+}

--- a/assets/queries/terraform/aws/ecs_service_admin_role_present/query.rego
+++ b/assets/queries/terraform/aws/ecs_service_admin_role_present/query.rego
@@ -1,0 +1,13 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_ecs_service[name]
+  contains(lower(resource.iam_role), "admin")
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_ecs_service[%s].iam_role", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'aws_ecs_service[%s].iam_role' is not equal to 'admin'", [name]),
+                "keyActualValue": 	sprintf("'aws_ecs_service[%s].iam_role' is equal to 'admin'", [name]),
+              }
+}

--- a/assets/queries/terraform/aws/ecs_service_admin_role_present/test/negative.tf
+++ b/assets/queries/terraform/aws/ecs_service_admin_role_present/test/negative.tf
@@ -1,0 +1,25 @@
+#this code is a correct code for which the query should not find any result
+resource "aws_ecs_service" "mongo" {
+  name            = "mongodb"
+  cluster         = aws_ecs_cluster.foo.id
+  task_definition = aws_ecs_task_definition.mongo.arn
+  desired_count   = 3
+  iam_role        = aws_iam_role.foo.arn
+  depends_on      = [aws_iam_role_policy.foo]
+
+  ordered_placement_strategy {
+    type  = "binpack"
+    field = "cpu"
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.foo.arn
+    container_name   = "mongo"
+    container_port   = 8080
+  }
+
+  placement_constraints {
+    type       = "memberOf"
+    expression = "attribute:ecs.availability-zone in [us-west-2a, us-west-2b]"
+  }
+}

--- a/assets/queries/terraform/aws/ecs_service_admin_role_present/test/positive.tf
+++ b/assets/queries/terraform/aws/ecs_service_admin_role_present/test/positive.tf
@@ -1,0 +1,25 @@
+#this is a problematic code where the query should report a result(s)
+resource "aws_ecs_service" "mongo" {
+  name            = "mongodb"
+  cluster         = aws_ecs_cluster.foo.id
+  task_definition = aws_ecs_task_definition.mongo.arn
+  desired_count   = 3
+  iam_role        = "admin"
+  depends_on      = [aws_iam_role_policy.foo]
+
+  ordered_placement_strategy {
+    type  = "binpack"
+    field = "cpu"
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.foo.arn
+    container_name   = "mongo"
+    container_port   = 8080
+  }
+
+  placement_constraints {
+    type       = "memberOf"
+    expression = "attribute:ecs.availability-zone in [us-west-2a, us-west-2b]"
+  }
+}

--- a/assets/queries/terraform/aws/ecs_service_admin_role_present/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ecs_service_admin_role_present/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "ECS Service Admin Role is Present",
+		"severity": "HIGH",
+		"line": 7
+	}
+]


### PR DESCRIPTION
Adding ECS Service Admin Role is Present query for Terraform, that checks if the attribute 'iam_role' is not an admin role.

Closes #349