### PR TITLE
Add Cloud Storage Anonymous or Publicly Accessible query for Terraform 

### DIFF
--- a/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/metadata.json
+++ b/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Cloud_Storage_Anonymous_Or_Publicly_Accessible",
+  "queryName": "Cloud Storage Anonymous or Publicly Accessible",
+  "severity": "MEDIUM",
+  "category": "Identity & Access Management",
+  "descriptionText": "Cloud Storage Buckets must not be anonymously or publicly accessible, which means the attribute 'members' must not possess 'allUsers' or 'allAuthenticatedUsers'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam#google_storage_bucket_iam_binding"
+}

--- a/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/query.rego
+++ b/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/query.rego
@@ -1,0 +1,42 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_storage_bucket_iam_binding[name]
+  resource.members == null
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_storage_bucket_iam_binding[%s].members", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'google_storage_bucket_iam_binding[%s].members' is not null", [name]),
+                "keyActualValue": 	sprintf("'google_storage_bucket_iam_binding[%s].members' is null", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_storage_bucket_iam_binding[name]
+  member := resource.members[_]
+  contains(member, "allUsers")
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_storage_bucket_iam_binding[%s].members", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'google_storage_bucket_iam_binding[%s].members' does not have 'allUsers'", [name]),
+                "keyActualValue": 	sprintf("'google_storage_bucket_iam_binding[%s].members' has 'allUsers'", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.google_storage_bucket_iam_binding[name]
+  member := resource.members[_]
+  contains(member, "allAuthenticatedUsers")
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("google_storage_bucket_iam_binding[%s].members", [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'google_storage_bucket_iam_binding[%s].members' does not have 'allAuthenticatedUsers'", [name]),
+                "keyActualValue": 	sprintf("'google_storage_bucket_iam_binding[%s].members' has 'allAuthenticatedUsers'", [name]),
+              }
+}

--- a/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/test/negative.tf
+++ b/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/test/negative.tf
@@ -1,0 +1,8 @@
+#this code is a correct code for which the query should not find any result
+resource "google_storage_bucket_iam_binding" "binding" {
+  bucket = google_storage_bucket.default.name
+  role = "roles/storage.admin"
+  members = [
+    "user:jane@example.com",
+  ]
+}

--- a/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/test/positive.tf
+++ b/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/test/positive.tf
@@ -1,0 +1,18 @@
+#this is a problematic code where the query should report a result(s)
+resource "google_storage_bucket_iam_binding" "binding1" {
+  bucket = google_storage_bucket.default.name
+  role = "roles/storage.admin"
+  members = []
+}
+
+resource "google_storage_bucket_iam_binding" "binding2" {
+  bucket = google_storage_bucket.default.name
+  role = "roles/storage.admin"
+  members = ["user:jane@example.com","allUsers"]
+}
+
+resource "google_storage_bucket_iam_binding" "binding3" {
+  bucket = google_storage_bucket.default.name
+  role = "roles/storage.admin"
+  members = ["user:jane@example.com", "allAuthenticatedUsers"]
+}

--- a/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Cloud Storage Anonymous or Publicly Accessible",
+		"severity": "MEDIUM",
+		"line": 5
+	},
+	{
+		"queryName": "Cloud Storage Anonymous or Publicly Accessible",
+		"severity": "MEDIUM",
+		"line": 11
+	},
+	{
+		"queryName": "Cloud Storage Anonymous or Publicly Accessible",
+		"severity": "MEDIUM",
+		"line": 17
+	}
+]


### PR DESCRIPTION
Adding Cloud Storage Anonymous or Publicly Accessible query for Terraform, that checks if the attribute 'members' does not possess 'allUsers' or 'allAuthenticatedUsers'.

Closes #348