### PR TITLE
Update S3 bucket with any principal query for Terraform 

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_with_any_principal/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_with_any_principal/metadata.json
@@ -2,7 +2,7 @@
   "id": "S3_bucket_with_any_principal",
   "queryName": "S3 bucket with any principal",
   "severity": "HIGH",
-  "category": null,
-  "descriptionText": "S3 bucket allows actions with any Principal",
+  "category": "Identity and Access Management",
+  "descriptionText": "S3 Buckets must not allow Actions From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion. This means the 'Effect' must not be 'Allow' when there are All Principals",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy"
 }

--- a/assets/queries/terraform/aws/s3_bucket_with_any_principal/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_any_principal/query.rego
@@ -11,8 +11,8 @@ CxPolicy [ result ] {
                 "documentId": 		input.document[i].id,
                 "searchKey": 	    sprintf("%s[%s].policy.Principal", [pl[r], name]),
                 "issueType":		"IncorrectValue",
-                "keyExpectedValue": "'policy.Statement.Principal' is not equal '*'",
-                "keyActualValue": 	"'policy.Statement.Principal' is equal '*'"
+                "keyExpectedValue": sprintf("%s[%s].policy.Principal is not equal to '*'", [pl[r], name]),
+                "keyActualValue": 	sprintf("%s[%s].policy.Principal is equal to '*'", [pl[r], name])
               }
 }
 
@@ -26,8 +26,8 @@ CxPolicy [ result ] {
     result := {
                 "documentId": 		input.document[i].id,
                 "searchKey": 	    sprintf("%s[%s].policy.Principal.AWS", [pl[r], name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'policy.Statement.Principal.AWS' doesn't contain '*'",
-                "keyActualValue": 	"'policy.Statement.Principal.AWS' contains '*'"
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("%s[%s].policy.Principal.AWS doesn't contain '*'", [pl[r], name]),
+                "keyActualValue": 	sprintf("%s[%s].policy.Principal.AWS contains '*'", [pl[r], name])
               }
 }


### PR DESCRIPTION
Updating S3 bucket with any principal query for Terraform, that checks if the 'Effect' is set to 'Allow' when there are All Principals.

Closes #391