### PR TITLE
Add vm_not_attached_to_network query for Terraform #401

### DIFF
--- a/assets/queries/terraform/azure/vm_not_attached_to_network/metadata.json
+++ b/assets/queries/terraform/azure/vm_not_attached_to_network/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "vm_not_attached_to_network",
+  "queryName": "VM Not Attached To Network",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "No Network Security Group is attached to the Virtual Machine",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine#network_interface_ids"
+}

--- a/assets/queries/terraform/azure/vm_not_attached_to_network/query.rego
+++ b/assets/queries/terraform/azure/vm_not_attached_to_network/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy [ result ] {
+  	vm := input.document[i].resource.azurerm_virtual_machine[name]
+    
+    vm.network_interface_ids == null
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_virtual_machine[%s].network_interface_ids", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'azurerm_virtual_machine[%s].network_interface_ids' list is not empty", [name]),
+                "keyActualValue": 	sprintf("'azurerm_virtual_machine[%s].network_interface_ids' list is empty", [name])
+              }
+}

--- a/assets/queries/terraform/azure/vm_not_attached_to_network/test/negative.tf
+++ b/assets/queries/terraform/azure/vm_not_attached_to_network/test/negative.tf
@@ -1,0 +1,23 @@
+resource "azurerm_network_interface" "main" {
+  name                = "${var.prefix}-nic"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.internal.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_virtual_machine" "main" {
+  name                  = "${var.prefix}-vm"
+  location              = azurerm_resource_group.main.location
+  resource_group_name   = azurerm_resource_group.main.name
+  network_interface_ids = [azurerm_network_interface.main.id]
+  vm_size               = "Standard_DS1_v2"
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+}

--- a/assets/queries/terraform/azure/vm_not_attached_to_network/test/positive.tf
+++ b/assets/queries/terraform/azure/vm_not_attached_to_network/test/positive.tf
@@ -1,0 +1,11 @@
+resource "azurerm_virtual_machine" "main" {
+  name                  = "${var.prefix}-vm"
+  location              = azurerm_resource_group.main.location
+  resource_group_name   = azurerm_resource_group.main.name
+  network_interface_ids = []
+  vm_size               = "Standard_DS1_v2"
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+}

--- a/assets/queries/terraform/azure/vm_not_attached_to_network/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/vm_not_attached_to_network/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "VM Not Attached To Network",
+		"severity": "HIGH",
+		"line": 5
+	}
+]


### PR DESCRIPTION
Closes #401 

This query checks if 'azurerm_virtual_machine.network_interface_ids' list is empty.