### PR TITLE
Add S3 Bucket Allows Get Action From All Principals query for Terraform 

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "S3_Bucket_Allows_Get_Action_From_All_Principals",
+  "queryName": "S3 Bucket Allows Get Action From All Principals",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "S3 Buckets must not allow Get Action From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion. This means the 'Effect' must not be 'Allow' when the 'Action' is Get, for all Principals.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy"
+}

--- a/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
@@ -1,0 +1,35 @@
+package Cx
+
+CxPolicy [ result ] {
+	pl := {"aws_s3_bucket_policy", "aws_s3_bucket"}
+	policy := input.document[i].resource[pl[r]][name].policy
+    pol := json.unmarshal(policy)
+    pol.Statement[idx].Effect = "Allow"
+    pol.Statement[idx].Principal = "*"
+	contains(lower(pol.Statement[idx].Action), "get")
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("%s[%s].policy.Action", [pl[r], name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("%s[%s].policy.Action is not a 'Get' action", [pl[r], name]),
+                "keyActualValue": 	sprintf("%s[%s].policy.Action is a 'Get' action", [pl[r], name])
+              }
+}
+
+CxPolicy [ result ] {
+	pl := {"aws_s3_bucket_policy", "aws_s3_bucket"}
+	policy := input.document[i].resource[pl[r]][name].policy
+    pol := json.unmarshal(policy)
+    pol.Statement[idx].Effect = "Allow"
+    contains(pol.Statement[idx].Principal.AWS, "*")
+	contains(lower(pol.Statement[idx].Action), "get")
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("%s[%s].policy.Action", [pl[r], name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("%s[%s].policy.Action is not a 'Get' action", [pl[r], name]),
+                "keyActualValue": 	sprintf("%s[%s].policy.Action is a 'Get' action", [pl[r], name])
+              }
+}

--- a/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/test/negative.tf
+++ b/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/test/negative.tf
@@ -1,0 +1,25 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "my_tf_test_bucket"
+}
+
+resource "aws_s3_bucket_policy" "b" {
+  bucket = aws_s3_bucket.b.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "MYBUCKETPOLICY",
+  "Statement": [
+    {
+      "Sid": "IPAllow",
+      "Effect": "Deny",
+      "Action": "s3:*",
+      "Resource": "arn:aws:s3:::my_tf_test_bucket/*",
+      "Condition": {
+         "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
+      }
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/test/positive.tf
+++ b/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/test/positive.tf
@@ -1,0 +1,51 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "my_tf_test_bucket"
+}
+
+resource "aws_s3_bucket_policy" "b1" {
+  bucket = aws_s3_bucket.b.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "MYBUCKETPOLICY",
+  "Statement": [
+    {
+      "Sid": "IPAllow",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::my_tf_test_bucket/*",
+      "Condition": {
+         "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket_policy" "b2" {
+  bucket = aws_s3_bucket.b.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "MYBUCKETPOLICY",
+  "Statement": [
+    {
+      "Sid": "IPAllow",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::my_tf_test_bucket/*",
+      "Condition": {
+         "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
+      }
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_allows_get_action_from_all_principals/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "S3 Bucket Allows Get Action From All Principals",
+		"severity": "HIGH",
+		"line": 17
+	},
+	{
+		"queryName": "S3 Bucket Allows Get Action From All Principals",
+		"severity": "HIGH",
+		"line": 42
+	}
+]


### PR DESCRIPTION
Adding S3 Bucket Allows Get Action From All Principals query for Terraform, that checks if the 'Effect' is 'Allow' when the 'Action' is Get, for all Principals.

Closes #406