### PR TITLE
Add query to check if Redis cache allows non SSL connections. closes #331

### DIFF
--- a/assets/queries/terraform/azure/redis_cache_non_ssl_allowed/metadata.json
+++ b/assets/queries/terraform/azure/redis_cache_non_ssl_allowed/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Redis_Cache_Allows_Non_SSL_Connections",
+  "queryName": "Redis Cache Allows Non SSL Connections",
+  "severity": "MEDIUM",
+  "category": "Encryption and Key Management",
+  "descriptionText": "Check if any Redis Cache resource allows non-SSL connections.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/redis_cache"
+}

--- a/assets/queries/terraform/azure/redis_cache_non_ssl_allowed/query.rego
+++ b/assets/queries/terraform/azure/redis_cache_non_ssl_allowed/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy [ result ] {
+  cache := input.document[i].resource.azurerm_redis_cache[name]
+  cache.enable_non_ssl_port == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("azurerm_redis_cache[%s].enable_non_ssl_port", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue":  sprintf("'azurerm_redis_cache[%s].enable_non_ssl_port' is false or undefined (false as default)", [name]),
+                "keyActualValue": 	 sprintf("'azurerm_redis_cache[%s].enable_non_ssl_port' is true", [name])
+              }
+}

--- a/assets/queries/terraform/azure/redis_cache_non_ssl_allowed/test/negative.tf
+++ b/assets/queries/terraform/azure/redis_cache_non_ssl_allowed/test/negative.tf
@@ -1,0 +1,27 @@
+resource "azurerm_redis_cache" "non_ssl_disabled" {
+  name                = "example-cache"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  capacity            = 2
+  family              = "C"
+  sku_name            = "Standard"
+  enable_non_ssl_port = false
+  minimum_tls_version = "1.2"
+
+  redis_configuration {
+  }
+}
+
+resource "azurerm_redis_cache" "non_ssl_disabled_too" {
+  name                = "example-cache"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  capacity            = 2
+  family              = "C"
+  sku_name            = "Standard"
+ 
+  minimum_tls_version = "1.2"
+
+  redis_configuration {
+  }
+}

--- a/assets/queries/terraform/azure/redis_cache_non_ssl_allowed/test/positive.tf
+++ b/assets/queries/terraform/azure/redis_cache_non_ssl_allowed/test/positive.tf
@@ -1,0 +1,13 @@
+resource "azurerm_redis_cache" "non_ssl_disabled" {
+  name                = "example-cache"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  capacity            = 2
+  family              = "C"
+  sku_name            = "Standard"
+  enable_non_ssl_port = true
+  minimum_tls_version = "1.2"
+
+  redis_configuration {
+  }
+}

--- a/assets/queries/terraform/azure/redis_cache_non_ssl_allowed/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/redis_cache_non_ssl_allowed/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Redis Cache Allows Non SSL Connections",
+		"severity": "MEDIUM",
+		"line": 8
+	}
+]


### PR DESCRIPTION
Check if Redis cache allows non SSL connections, enabling non SSL port (6379). Closes #331