### PR TITLE
Add All Users Group Gets Read Access query

### DIFF
--- a/assets/queries/terraform/aws/allUsers_gets_read_access/metadata.json
+++ b/assets/queries/terraform/aws/allUsers_gets_read_access/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "allUsers_group_gets_read_access",
+  "queryName": "All Users Group Gets Read Access",
+  "severity": "HIGH",
+  "category": "IAM",
+  "descriptionText": "It's not recommended to allow read access for all user groups.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#acl"
+}

--- a/assets/queries/terraform/aws/allUsers_gets_read_access/query.rego
+++ b/assets/queries/terraform/aws/allUsers_gets_read_access/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy [ result ] {
+   resource := input.document[i].resource.aws_s3_bucket[name]
+   role = "public-read"
+   resource.acl == role
+   
+   result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_s3_bucket[%s].acl", [name]),
+                "issueType":		   "IncorrectValue",
+                "keyExpectedValue": sprintf("aws_s3_bucket[%s].acl is private", [name]),
+                "keyActualValue": 	sprintf("aws_s3_bucket[%s].acl is %s", [name, role])
+              }
+}

--- a/assets/queries/terraform/aws/allUsers_gets_read_access/test/negative.tf
+++ b/assets/queries/terraform/aws/allUsers_gets_read_access/test/negative.tf
@@ -1,0 +1,9 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
+  }
+}

--- a/assets/queries/terraform/aws/allUsers_gets_read_access/test/positive.tf
+++ b/assets/queries/terraform/aws/allUsers_gets_read_access/test/positive.tf
@@ -1,0 +1,9 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+  acl    = "public-read"
+
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
+  }
+}

--- a/assets/queries/terraform/aws/allUsers_gets_read_access/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/allUsers_gets_read_access/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "All Users Group Gets Read Access",
+		"severity": "HIGH",
+		"line": 3
+	}
+]


### PR DESCRIPTION
Added new query for Terraform.

Provide a allUsers_group_gets_read_access resource and a resource to manage the acl feature

Closes #444 