### PR TITLE
Add Default Security Group Does Not Restrict All Traffic

### DIFF
--- a/assets/queries/terraform/aws/default_security_group_does_not_restrict_all_traffic/metadata.json
+++ b/assets/queries/terraform/aws/default_security_group_does_not_restrict_all_traffic/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "default_security_group_does_not_restrict_all_traffic",
+  "queryName": "Default Security Group Does Not Restrict All Traffic",
+  "severity": "HIGH",
+  "category": "Network Ports Security",
+  "descriptionText": "Check if default security group does not restrict all inbound and outbound traffic.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group"
+}

--- a/assets/queries/terraform/aws/default_security_group_does_not_restrict_all_traffic/query.rego
+++ b/assets/queries/terraform/aws/default_security_group_does_not_restrict_all_traffic/query.rego
@@ -1,0 +1,48 @@
+package Cx
+
+CxPolicy [ result ] {
+  sg := input.document[i].resource.aws_default_security_group[name]
+  checkCidrBlock(sg)
+    
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("aws_default_security_group[%s]", [name]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "ingress.cidr_blocks or egress.cidr_blocks diferent from '0.0.0.0/0' ",
+                "keyActualValue":   "ingress.cidr_blocks or egress.cidr_blocks are '0.0.0.0/0'"
+              }
+}
+
+CxPolicy [ result ] {
+  sg := input.document[i].resource.aws_default_security_group[name]
+  checkIpv6CidrBlock(sg)
+    
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("aws_default_security_group[%s]", [name]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "ingress.ipv6_cidr_blocks or egress.ipv6_cidr_blocks diferent from '::/0' ",
+                "keyActualValue":   "ingress.ipv6_cidr_blocks or egress.ipv6_cidr_blocks are '::/0'"
+              }
+}
+
+
+checkCidrBlock(sg) {
+    some c
+        sg.ingress.cidr_blocks[c] == "0.0.0.0/0"
+}
+
+checkCidrBlock(sg) {
+    some c
+        sg.egress.cidr_blocks[c] == "0.0.0.0/0"
+}
+
+checkIpv6CidrBlock(sg) {
+    some c
+        sg.egress.ipv6_cidr_blocks[c] == "::/0"
+}
+
+checkIpv6CidrBlock(sg) {
+    some c
+        sg.ingress.ipv6_cidr_blocks[c] == "::/0"
+}

--- a/assets/queries/terraform/aws/default_security_group_does_not_restrict_all_traffic/test/negative.tf
+++ b/assets/queries/terraform/aws/default_security_group_does_not_restrict_all_traffic/test/negative.tf
@@ -1,0 +1,20 @@
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.mainvpc.id
+
+  ingress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+    cidr_blocks = ["10.1.0.0/16"]
+    ipv6_cidr_blocks = ["250.250.250.1:8451"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["10.1.0.0/16"]
+    ipv6_cidr_blocks = ["250.250.250.1:8451"]
+  }
+}

--- a/assets/queries/terraform/aws/default_security_group_does_not_restrict_all_traffic/test/positive.tf
+++ b/assets/queries/terraform/aws/default_security_group_does_not_restrict_all_traffic/test/positive.tf
@@ -1,0 +1,41 @@
+resource "aws_default_security_group" "default1" {
+  vpc_id = aws_vpc.mainvpc.id
+
+  ingress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_default_security_group" "default2" {
+  vpc_id = aws_vpc.mainvpc.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+resource "aws_default_security_group" "default3" {
+  vpc_id = aws_vpc.mainvpc.id
+
+  ingress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}

--- a/assets/queries/terraform/aws/default_security_group_does_not_restrict_all_traffic/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/default_security_group_does_not_restrict_all_traffic/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "Default Security Group Does Not Restrict All Traffic",
+		"severity": "HIGH",
+		"line": 1
+	},
+	{
+		"queryName": "Default Security Group Does Not Restrict All Traffic",
+		"severity": "HIGH",
+		"line": 13
+	},
+	{
+		"queryName": "Default Security Group Does Not Restrict All Traffic",
+		"severity": "HIGH",
+		"line": 24
+	},
+	{
+		"queryName": "Default Security Group Does Not Restrict All Traffic",
+		"severity": "HIGH",
+		"line": 24
+	}
+]


### PR DESCRIPTION
Closes #459 

Added new query Default Security Group Does Not Restrict All Traffic for Terraform.

Check if default security group does not restrict all inbound and outbound traffic.