### PR TITLE
Add VPC Flow Logs are not Enabled query for Terraform #462

### DIFF
--- a/assets/queries/terraform/aws/aws_vpc_flow_logs_enabled/metadata.json
+++ b/assets/queries/terraform/aws/aws_vpc_flow_logs_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "aws_vpc_flow_logs_enabled",
+  "queryName": "VPC Flow Logs are not Enabled",
+  "severity": "MEDIUM",
+  "category": "Logging",
+  "descriptionText": "Sees if the id of the flow logs is the same as the vpc, if they are VPC flow logs are Enabled",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc"
+}

--- a/assets/queries/terraform/aws/aws_vpc_flow_logs_enabled/query.rego
+++ b/assets/queries/terraform/aws/aws_vpc_flow_logs_enabled/query.rego
@@ -1,0 +1,35 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource
+  awsVpc := resource.aws_vpc[name_vpc]
+  awsVpcId := sprintf("${aws_vpc.%s.id}", [name_vpc])
+  awsFlowLogsId := resource.aws_flow_log
+  contains(awsFlowLogsId,awsVpcId) == false
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("aws_vpc[%s]", [name_vpc]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("aws_vpc[%s] is the same as Flow Logs VPC id", [name_vpc]),
+				        "keyActualValue": sprintf("aws_vpc[%s] is not the same as Flow Logs VPC id", [name_vpc]),
+              }
+}
+
+CxPolicy [ result ] {
+  awsFlowLogsId := input.document[i].resource.aws_flow_log[name_logs]
+  object.get(awsFlowLogsId, "vpc_id", "undefined") == "undefined"
+    
+	result := {
+                "documentId": input.document[i].id,
+                "searchKey": sprintf("aws_flow_log[%s]", [name_logs]),
+                "issueType": "MissingAttribute",
+                "keyExpectedValue": sprintf("aws_flow_log[%s].vpc_id is defined", [name_logs]),
+                "keyActualValue": sprintf("aws_flow_log[%s].vpc_id is undefined", [name_logs])
+              }
+}
+
+contains(array, elem) = true {
+  array[_].vpc_id == elem
+} else = false { true }
+

--- a/assets/queries/terraform/aws/aws_vpc_flow_logs_enabled/test/negative.tf
+++ b/assets/queries/terraform/aws/aws_vpc_flow_logs_enabled/test/negative.tf
@@ -1,0 +1,17 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_flow_log" "example" {
+  iam_role_arn    = aws_iam_role.example.arn
+  log_destination = aws_cloudwatch_log_group.example.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.example.id
+}
+
+resource "aws_flow_log" "example2" {
+  iam_role_arn    = aws_iam_role.example.arn
+  log_destination = aws_cloudwatch_log_group.example.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.main.id
+}

--- a/assets/queries/terraform/aws/aws_vpc_flow_logs_enabled/test/positive.tf
+++ b/assets/queries/terraform/aws/aws_vpc_flow_logs_enabled/test/positive.tf
@@ -1,0 +1,17 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_flow_log" "example" {
+  iam_role_arn    = aws_iam_role.example.arn
+  log_destination = aws_cloudwatch_log_group.example.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.example.id
+}
+
+resource "aws_flow_log" "example2" {
+  iam_role_arn    = aws_iam_role.example.arn
+  log_destination = aws_cloudwatch_log_group.example.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.example2.id
+}

--- a/assets/queries/terraform/aws/aws_vpc_flow_logs_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/aws_vpc_flow_logs_enabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "VPC Flow Logs are not Enabled",
+		"severity": "MEDIUM",
+		"line": 1
+	}
+]


### PR DESCRIPTION
Sees if the id of the flow logs is the same as the vpc, if they are VPC, flow logs are Enabled #462 .