### PR TITLE
Add Redshift Publicly Accessible query Terraform

### DIFF
--- a/assets/queries/terraform/aws/redshift_publicly_accessible/metadata.json
+++ b/assets/queries/terraform/aws/redshift_publicly_accessible/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "redshift_publicly_accessible",
+  "queryName": "Redshift Publicly Accessible",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Check if 'publicly_accessible' field is true or undefined (default is true)",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster"
+}

--- a/assets/queries/terraform/aws/redshift_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/redshift_publicly_accessible/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy [ result ] {
+  
+  public := input.document[i].resource.aws_redshift_cluster[name]
+  object.get(public, "publicly_accessible", "undefined") == "undefined"
+  
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("aws_redshift_cluster[%s]", [name]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "aws_redshift_cluster.publicly_accessible is defined",
+                "keyActualValue":   "aws_redshift_cluster.publicly_accessible is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  
+  public := input.document[i].resource.aws_redshift_cluster[name]
+  public.publicly_accessible == true
+  
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("aws_redshift_cluster[%s].publicly_accessible", [name]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "aws_redshift_cluster.publicly_accessible is false",
+                "keyActualValue":   "aws_redshift_cluster.publicly_accessible is true"
+              }
+}

--- a/assets/queries/terraform/aws/redshift_publicly_accessible/test/negative.tf
+++ b/assets/queries/terraform/aws/redshift_publicly_accessible/test/negative.tf
@@ -1,0 +1,9 @@
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "Mustbe8characters"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+  publicly_accessible = false
+}

--- a/assets/queries/terraform/aws/redshift_publicly_accessible/test/positive.tf
+++ b/assets/queries/terraform/aws/redshift_publicly_accessible/test/positive.tf
@@ -1,0 +1,18 @@
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "Mustbe8characters"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+}
+
+resource "aws_redshift_cluster" "default1" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "Mustbe8characters"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+  publicly_accessible = true
+}

--- a/assets/queries/terraform/aws/redshift_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/redshift_publicly_accessible/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Redshift Publicly Accessible",
+		"severity": "HIGH",
+		"line": 1
+	},
+	{
+		"queryName": "Redshift Publicly Accessible",
+		"severity": "HIGH",
+		"line": 17
+	}
+]


### PR DESCRIPTION
Closes #338 

Added new query Redshift Publicly Accessible for Terraform.

Check if 'publicly_accessible' field is true or undefined (default is true).