### PR TITLE
Add Redshift Not Encrypted query for Terraform #343

### DIFF
--- a/assets/queries/terraform/aws/redshift_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/redshift_not_encrypted/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "redshift_not_encrypted",
+  "queryName": "Redshift Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "Check if 'encrypted' field is false or undefined (default is false)",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#encrypted"
+}

--- a/assets/queries/terraform/aws/redshift_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/redshift_not_encrypted/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy [ result ] {
+  cluster := input.document[i].resource.aws_redshift_cluster[name]
+  object.get(cluster, "encrypted", "undefined") == "undefined"
+  
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("aws_redshift_cluster[%s]", [name]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "aws_redshift_cluster.encrypted is defined",
+                "keyActualValue":   "aws_redshift_cluster.encrypted is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  cluster := input.document[i].resource.aws_redshift_cluster[name]
+  cluster.encrypted == false
+  
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("aws_redshift_cluster[%s].encrypted", [name]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "aws_redshift_cluster.encrypted is false",
+                "keyActualValue":   "aws_redshift_cluster.encrypted is true"
+              }
+}

--- a/assets/queries/terraform/aws/redshift_not_encrypted/test/negative.tf
+++ b/assets/queries/terraform/aws/redshift_not_encrypted/test/negative.tf
@@ -1,0 +1,9 @@
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "Mustbe8characters"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+  encrypted          = true
+}

--- a/assets/queries/terraform/aws/redshift_not_encrypted/test/positive.tf
+++ b/assets/queries/terraform/aws/redshift_not_encrypted/test/positive.tf
@@ -1,0 +1,18 @@
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "Mustbe8characters"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+}
+
+resource "aws_redshift_cluster" "default1" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "Mustbe8characters"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+  encrypted          = false
+}

--- a/assets/queries/terraform/aws/redshift_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/redshift_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Redshift Not Encrypted",
+		"severity": "HIGH",
+		"line": 1
+	},
+	{
+		"queryName": "Redshift Not Encrypted",
+		"severity": "HIGH",
+		"line": 17
+	}
+]


### PR DESCRIPTION
Closes #343 

Added new query Redshift Not Encrypted for Terraform.

Check if 'encrypted' field is false or undefined (default is false).