### PR TITLE
Add RDS Cluster Storage Not Encrypted Terraform

### DIFF
--- a/assets/queries/terraform/aws/rds_cluster_storage_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/rds_cluster_storage_not_encrypted/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "rds_cluster_storage_not_encrypted",
+  "queryName": "RDS Cluster Storage Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "Check if RDS Cluster Storage isn't encrypted. Happens when 'kms_key_id' field is false or undefined and 'engine_mode' field null or \"\".",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#storage_encrypted"
+}

--- a/assets/queries/terraform/aws/rds_cluster_storage_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/rds_cluster_storage_not_encrypted/query.rego
@@ -1,0 +1,40 @@
+package Cx
+
+CxPolicy [ result ] {
+  cluster := input.document[i].resource.aws_rds_cluster[name]
+  cluster.kms_key_id == false
+
+ 
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("aws_rds_cluster[%s].kms_key_id", [name]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "aws_rds_cluster.kms_key_id is true",
+                "keyActualValue":   "aws_rds_cluster.kms_key_id is false"
+              }
+}
+
+CxPolicy [ result ] {
+  cluster := input.document[i].resource.aws_rds_cluster[name]
+  object.get(cluster, "kms_key_id", "undefined") == "undefined"
+  engineModeProvisioned(cluster.engine_mode)
+
+ 
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("aws_rds_cluster[%s]", [name]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "aws_rds_cluster.kms_key_id is undefined and aws_rds_cluster.engine_mode not null or ''",
+                "keyActualValue":   "aws_rds_cluster.kms_key_id is undefined and aws_rds_cluster.engine_mode is null or ''"
+              }
+}
+
+ 
+engineModeProvisioned(p) {
+    p == null
+}
+engineModeProvisioned(p) {
+    p == ""
+}

--- a/assets/queries/terraform/aws/rds_cluster_storage_not_encrypted/test/negative.tf
+++ b/assets/queries/terraform/aws/rds_cluster_storage_not_encrypted/test/negative.tf
@@ -1,0 +1,8 @@
+resource "aws_rds_cluster" "example1" {
+cluster_identifier = "example"
+db_subnet_group_name = aws_db_subnet_group.example.name
+engine_mode = "multimaster"
+master_password = "barbarbarbar"
+master_username = "foo"
+skip_final_snapshot = true
+}

--- a/assets/queries/terraform/aws/rds_cluster_storage_not_encrypted/test/positive.tf
+++ b/assets/queries/terraform/aws/rds_cluster_storage_not_encrypted/test/positive.tf
@@ -1,0 +1,17 @@
+resource "aws_rds_cluster" "example1" {
+  cluster_identifier   = "example"
+  db_subnet_group_name = aws_db_subnet_group.example.name
+  engine_mode          = ""
+  master_password      = "barbarbarbar"
+  master_username      = "foo"
+  skip_final_snapshot  = true
+}
+resource "aws_rds_cluster" "example2" {
+  cluster_identifier   = "example"
+  db_subnet_group_name = aws_db_subnet_group.example.name
+  engine_mode          = "multimaster"
+  master_password      = "barbarbarbar"
+  master_username      = "foo"
+  skip_final_snapshot  = true
+  kms_key_id           = false
+}

--- a/assets/queries/terraform/aws/rds_cluster_storage_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/rds_cluster_storage_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "RDS Cluster Storage Not Encrypted",
+		"severity": "HIGH",
+		"line": 1
+	},
+	{
+		"queryName": "RDS Cluster Storage Not Encrypted",
+		"severity": "HIGH",
+		"line": 16
+	}
+]


### PR DESCRIPTION
Closes #345 

Added new query RDS Cluster Storage Not Encrypted for Terraform.

Check if RDS Cluster Storage isn't encrypted. Happens when 'storage_encrypted' field is false or undefined