### PR TITLE
Add kms_key_no_deletion_window Closes #292

### DIFF
--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/metadata.json
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "kms_key_no_deletion_window",
+  "queryName": "KMS Key No Deletion Window",
+  "severity": "HIGH",
+  "category": "Logging",
+  "descriptionText": "AWS KMS Key should have a valid deletion window",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key"
+}

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/query.rego
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/query.rego
@@ -1,0 +1,64 @@
+package Cx
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_kms_key[name]
+  
+  resource.is_enabled == true
+  
+  resource.enable_key_rotation == true
+  
+  not resource.deletion_window_in_days
+
+
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_kms_key[%s]", [name]),
+                "issueType":		      "MissingAttribute",
+                "keyExpectedValue":   sprintf("aws_kms_key[%s].deletion_window_in_days is set and valid", [name]),
+                "keyActualValue": 	  sprintf("aws_kms_key[%s].deletion_window_in_days is undefined", [name]),
+            }
+}
+
+
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_kms_key[name]
+  
+  resource.is_enabled == true
+  
+  resource.enable_key_rotation == true
+  
+  resource.deletion_window_in_days > 30
+
+
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_kms_key[%s].deletion_window_in_days", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   sprintf("aws_kms_key[%s].deletion_window_in_days is set and valid", [name]),
+                "keyActualValue": 	  sprintf("aws_kms_key[%s].deletion_window_in_days is set but invalid", [name]),
+            }
+}
+
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_kms_key[name]
+  
+  resource.is_enabled == true
+  
+  resource.enable_key_rotation == true
+  
+  resource.deletion_window_in_days < 7
+
+
+  result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("aws_kms_key[%s].deletion_window_in_days", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   sprintf("aws_kms_key[%s].deletion_window_in_days is set and valid", [name]),
+                "keyActualValue": 	  sprintf("aws_kms_key[%s].deletion_window_in_days is set but invalid", [name]),
+            }
+}

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/query.rego
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/query.rego
@@ -41,24 +41,3 @@ CxPolicy [ result ] {
                 "keyActualValue": 	  sprintf("aws_kms_key[%s].deletion_window_in_days is set but invalid", [name]),
             }
 }
-
-
-
-CxPolicy [ result ] {
-  resource := input.document[i].resource.aws_kms_key[name]
-  
-  resource.is_enabled == true
-  
-  resource.enable_key_rotation == true
-  
-  resource.deletion_window_in_days < 7
-
-
-  result := {
-                "documentId": 		    input.document[i].id,
-                "searchKey": 	        sprintf("aws_kms_key[%s].deletion_window_in_days", [name]),
-                "issueType":		      "IncorrectValue",
-                "keyExpectedValue":   sprintf("aws_kms_key[%s].deletion_window_in_days is set and valid", [name]),
-                "keyActualValue": 	  sprintf("aws_kms_key[%s].deletion_window_in_days is set but invalid", [name]),
-            }
-}

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/test/negative.tf
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/test/negative.tf
@@ -1,0 +1,9 @@
+resource "aws_kms_key" "a1" {
+  description             = "KMS key 1"
+  
+  is_enabled = true
+
+  enable_key_rotation = true
+
+  deletion_window_in_days = 10
+}

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive.tf
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive.tf
@@ -1,0 +1,32 @@
+resource "aws_kms_key" "a" {
+  description             = "KMS key 1"
+  
+  is_enabled = true
+
+  enable_key_rotation = true
+
+}
+
+
+
+
+resource "aws_kms_key" "a2" {
+  description             = "KMS key 1"
+  
+  is_enabled = true
+
+  enable_key_rotation = true
+
+  deletion_window_in_days = 6
+}
+
+
+resource "aws_kms_key" "a3" {
+  description             = "KMS key 1"
+  
+  is_enabled = true
+
+  enable_key_rotation = true
+
+  deletion_window_in_days = 31
+}

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive.tf
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive.tf
@@ -8,19 +8,6 @@ resource "aws_kms_key" "a" {
 }
 
 
-
-
-resource "aws_kms_key" "a2" {
-  description             = "KMS key 1"
-  
-  is_enabled = true
-
-  enable_key_rotation = true
-
-  deletion_window_in_days = 6
-}
-
-
 resource "aws_kms_key" "a3" {
   description             = "KMS key 1"
   

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive_expected_result.json
@@ -1,0 +1,19 @@
+[
+	{
+		"queryName": "KMS Key No Deletion Window",
+		"severity": "HIGH",
+		"line": 1
+	},
+
+	{
+		"queryName": "KMS Key No Deletion Window",
+		"severity": "HIGH",
+		"line": 20
+	},
+
+	{
+		"queryName": "KMS Key No Deletion Window",
+		"severity": "HIGH",
+		"line": 31
+	}
+]

--- a/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/kms_key_no_deletion_window/test/positive_expected_result.json
@@ -8,12 +8,6 @@
 	{
 		"queryName": "KMS Key No Deletion Window",
 		"severity": "HIGH",
-		"line": 20
-	},
-
-	{
-		"queryName": "KMS Key No Deletion Window",
-		"severity": "HIGH",
-		"line": 31
+		"line": 18
 	}
 ]

--- a/assets/queries/terraform/kubernetes_pod/container_allow_privilege_escalation_is_true/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/container_allow_privilege_escalation_is_true/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "container_allow_privilege_escalation_is_true",
-  "queryName": "Container Allow Privileg Escalation Is True",
+  "queryName": "Container Allow Privilege Escalation Is True",
   "severity": "MEDIUM",
   "category": "Identity and Access Management",
   "descriptionText": "Admission of privileged containers should be minimized",

--- a/assets/queries/terraform/kubernetes_pod/container_allow_privilege_escalation_is_true/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/container_allow_privilege_escalation_is_true/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Container Allow Privileg Escalation Is True",
+		"queryName": "Container Allow Privilege Escalation Is True",
 		"severity": "MEDIUM",
 		"line": 11
 	}


### PR DESCRIPTION
AWS KMS Key should have a valid deletion window and this value must be between 7 and 30 days.

So, I thought in three cases:

- Attribute 'deletion_window_in_days' is undefined

- Attribute 'deletion_window_in_days' is set but greater than 30

- Attribute 'deletion_window_in_days' is set but smaller than 7


Closes #292 (This issue was already closed because of the repository transition but the query was not validated)

P.S. I changed two files of container_allow_privilege_escalation_is_true query because I detected an orthographic error