### PR TITLE
Add shared_host_network_namespace query for Kubernetes #476

### DIFF
--- a/assets/queries/k8s/shared_host_network_namespace/metadata.json
+++ b/assets/queries/k8s/shared_host_network_namespace/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "shared_host_network_namespace",
+  "queryName": "Shared Host Network Namespace",
+  "severity": "HIGH",
+  "category": null,
+  "descriptionText": "Container should not share the host network namespace",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/"
+}

--- a/assets/queries/k8s/shared_host_network_namespace/query.rego
+++ b/assets/queries/k8s/shared_host_network_namespace/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    metadata := document.metadata
+    specInfo := getSpecInfo(document)
+
+    specInfo.spec.hostNetwork == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.%s.hostNetwork", [metadata.name, specInfo.path]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'%s.hostNetwork' is false or undefined", [specInfo.path]),
+                "keyActualValue": 	sprintf("'%s.hostNetwork' is true", [specInfo.path])
+              }
+}
+
+getSpecInfo(document) = specInfo {
+    templates := {"job_template", "jobTemplate"}
+    spec := document.spec[templates[t]].spec.template.spec
+    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+} else = specInfo {
+    spec := document.spec.template.spec
+    specInfo := {"spec": spec, "path": "spec.template.spec"}
+} else = specInfo {
+    spec := document.spec
+    specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/shared_host_network_namespace/test/negative.yaml
+++ b/assets/queries/k8s/shared_host_network_namespace/test/negative.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+  volumes:
+    - name: sec-ctx-vol
+      emptyDir: { }
+  containers:
+    - name: sec-ctx-demo
+      image: busybox
+      command: [ "sh", "-c", "sleep 1h" ]
+      volumeMounts:
+        - name: sec-ctx-vol
+          mountPath: /data/demo
+      securityContext:
+        allowPrivilegeEscalation: false

--- a/assets/queries/k8s/shared_host_network_namespace/test/positive.yaml
+++ b/assets/queries/k8s/shared_host_network_namespace/test/positive.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo
+spec:
+  hostNetwork: true
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+  volumes:
+    - name: sec-ctx-vol
+      emptyDir: { }
+  containers:
+    - name: sec-ctx-demo
+      image: busybox
+      command: [ "sh", "-c", "sleep 1h" ]
+      volumeMounts:
+        - name: sec-ctx-vol
+          mountPath: /data/demo
+      securityContext:
+        allowPrivilegeEscalation: false

--- a/assets/queries/k8s/shared_host_network_namespace/test/positive_expected_result.json
+++ b/assets/queries/k8s/shared_host_network_namespace/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Shared Host Network Namespace",
+		"severity": "HIGH",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Closes #476 

This query detects if containers share the host network namespace.
It checks if, in the 'spec', 'hostNetwork' field is true (default is false).