### PR TITLE
Add redis_not_compliant query Closes #475

### DIFF
--- a/assets/queries/terraform/aws/redis_not_compliant/metadata.json
+++ b/assets/queries/terraform/aws/redis_not_compliant/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "redis_not_compliant",
+  "queryName": "Redis Not Compliant",
+  "severity": "HIGH",
+  "category": "Data Security",
+  "descriptionText": "Check if the redis version is compliant with the necessary AWS PCI DSS requirements",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster#engine_version"
+}

--- a/assets/queries/terraform/aws/redis_not_compliant/query.rego
+++ b/assets/queries/terraform/aws/redis_not_compliant/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_elasticache_cluster[name] 
+  min_version_string = "4.0.10"
+  eval_version_number(resource.engine_version) <= eval_version_number(min_version_string)
+	
+    result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey": 	      sprintf("resource.aws_elasticache_cluster[%s].engine_version", [name]),
+                "issueType":		  "IncorrectValue",
+                "keyExpectedValue":   sprintf("resource.aws_elasticache_cluster[%s].engine_version is compliant with the requirements", [name]),
+                "keyActualValue": 	  sprintf("resource.aws_elasticache_cluster[%s].engine_version isn't compliant with the requirements", [name])
+              }
+}
+
+eval_version_number(engine_version) = numeric_version {
+	version = split(engine_version, ".")
+	numeric_version = to_number(version[0]) * 100 + to_number(version[1]) * 10 + to_number(version[2])
+}

--- a/assets/queries/terraform/aws/redis_not_compliant/query.rego
+++ b/assets/queries/terraform/aws/redis_not_compliant/query.rego
@@ -3,14 +3,14 @@ package Cx
 CxPolicy [ result ] {
   resource := input.document[i].resource.aws_elasticache_cluster[name] 
   min_version_string = "4.0.10"
-  eval_version_number(resource.engine_version) <= eval_version_number(min_version_string)
+  eval_version_number(resource.engine_version) < eval_version_number(min_version_string)
 	
     result := {
                 "documentId": 		  input.document[i].id,
-                "searchKey": 	      sprintf("resource.aws_elasticache_cluster[%s].engine_version", [name]),
-                "issueType":		  "IncorrectValue",
-                "keyExpectedValue":   sprintf("resource.aws_elasticache_cluster[%s].engine_version is compliant with the requirements", [name]),
-                "keyActualValue": 	  sprintf("resource.aws_elasticache_cluster[%s].engine_version isn't compliant with the requirements", [name])
+                "searchKey":        sprintf("aws_elasticache_cluster[%s].engine_version", [name]),
+                "issueType":		    "IncorrectValue",
+                "keyExpectedValue": sprintf("aws_elasticache_cluster[%s].engine_version is compliant with the requirements", [name]),
+                "keyActualValue":   sprintf("aws_elasticache_cluster[%s].engine_version isn't compliant with the requirements", [name])
               }
 }
 

--- a/assets/queries/terraform/aws/redis_not_compliant/test/negative.tf
+++ b/assets/queries/terraform/aws/redis_not_compliant/test/negative.tf
@@ -1,0 +1,10 @@
+#this code is a correct code for which the query should not find any result
+resource "aws_elasticache_cluster" "negative_example" {
+  cluster_id           = "cluster-example"
+  engine               = "redis"
+  node_type            = "cache.m4.large"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis3.2"
+  engine_version       = "5.0.0"
+  port                 = 6379
+}

--- a/assets/queries/terraform/aws/redis_not_compliant/test/positive.tf
+++ b/assets/queries/terraform/aws/redis_not_compliant/test/positive.tf
@@ -1,0 +1,10 @@
+#this is a problematic code where the query should report a result(s)
+resource "aws_elasticache_cluster" "positive_example" {
+  cluster_id           = "cluster-example"
+  engine               = "redis"
+  node_type            = "cache.m4.large"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis3.2"
+  engine_version       = "2.6.13"
+  port                 = 6379
+}

--- a/assets/queries/terraform/aws/redis_not_compliant/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/redis_not_compliant/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Redis Not Compliant",
+		"severity": "HIGH",
+		"line": 8
+	}
+]


### PR DESCRIPTION
Closes #475 
Checks if the Redis version is compliant with the necessary AWS PCI DSS requirements