### PR TITLE
Add psp_allows_sharing_host_pid query for Kubernetes #488

### DIFF
--- a/assets/queries/k8s/psp_allows_sharing_host_pid/metadata.json
+++ b/assets/queries/k8s/psp_allows_sharing_host_pid/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "psp_allows_sharing_host_pid",
+  "queryName": "PSP Allows Sharing Host PID",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Pod Security Policy allows containers to share the host process ID namespace",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/"
+}

--- a/assets/queries/k8s/psp_allows_sharing_host_pid/query.rego
+++ b/assets/queries/k8s/psp_allows_sharing_host_pid/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    metadata := document.metadata
+    document.kind == "PodSecurityPolicy"
+    
+    document.spec.hostPID == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.hostPID", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'spec.hostPID' is false or undefined",
+                "keyActualValue": 	"'spec.hostPID' is true"
+              }
+}

--- a/assets/queries/k8s/psp_allows_sharing_host_pid/test/negative.yaml
+++ b/assets/queries/k8s/psp_allows_sharing_host_pid/test/negative.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: example
+spec:
+  hostPID: false

--- a/assets/queries/k8s/psp_allows_sharing_host_pid/test/positive.yaml
+++ b/assets/queries/k8s/psp_allows_sharing_host_pid/test/positive.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: example
+spec:
+  hostPID: true

--- a/assets/queries/k8s/psp_allows_sharing_host_pid/test/positive_expected_result.json
+++ b/assets/queries/k8s/psp_allows_sharing_host_pid/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "PSP Allows Sharing Host PID",
+		"severity": "MEDIUM",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Closes #488 

This query detects if a Pod Security Policy allows containers to share the host process ID namespace.