### PR TITLE
Add shared_host_pid_namespace query for Kubernetes #496

### DIFF
--- a/assets/queries/k8s/shared_host_pid_namespace/metadata.json
+++ b/assets/queries/k8s/shared_host_pid_namespace/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "shared_host_pid_namespace",
+  "queryName": "Shared Host PID Namespace",
+  "severity": "HIGH",
+  "category": null,
+  "descriptionText": "Container should not share the host process ID namespace",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/"
+}

--- a/assets/queries/k8s/shared_host_pid_namespace/query.rego
+++ b/assets/queries/k8s/shared_host_pid_namespace/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    metadata := document.metadata
+    specInfo := getSpecInfo(document)
+
+    specInfo.spec.hostPID == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.%s.hostPID", [metadata.name, specInfo.path]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'%s.hostPID' is false or undefined", [specInfo.path]),
+                "keyActualValue": 	sprintf("'%s.hostPID' is true", [specInfo.path])
+              }
+}
+
+getSpecInfo(document) = specInfo {
+    templates := {"job_template", "jobTemplate"}
+    spec := document.spec[templates[t]].spec.template.spec
+    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+} else = specInfo {
+    spec := document.spec.template.spec
+    specInfo := {"spec": spec, "path": "spec.template.spec"}
+} else = specInfo {
+    spec := document.spec
+    specInfo := {"spec": spec, "path": "spec"}
+} 

--- a/assets/queries/k8s/shared_host_pid_namespace/test/negative.yaml
+++ b/assets/queries/k8s/shared_host_pid_namespace/test/negative.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo
+spec:
+  hostPID: false
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+  volumes:
+    - name: sec-ctx-vol
+      emptyDir: { }
+  containers:
+    - name: sec-ctx-demo
+      image: busybox
+      command: [ "sh", "-c", "sleep 1h" ]
+      volumeMounts:
+        - name: sec-ctx-vol
+          mountPath: /data/demo
+      securityContext:
+        allowPrivilegeEscalation: false

--- a/assets/queries/k8s/shared_host_pid_namespace/test/positive.yaml
+++ b/assets/queries/k8s/shared_host_pid_namespace/test/positive.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo
+spec:
+  hostPID: true
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+  volumes:
+    - name: sec-ctx-vol
+      emptyDir: { }
+  containers:
+    - name: sec-ctx-demo
+      image: busybox
+      command: [ "sh", "-c", "sleep 1h" ]
+      volumeMounts:
+        - name: sec-ctx-vol
+          mountPath: /data/demo
+      securityContext:
+        allowPrivilegeEscalation: false

--- a/assets/queries/k8s/shared_host_pid_namespace/test/positive_expected_result.json
+++ b/assets/queries/k8s/shared_host_pid_namespace/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Shared Host PID Namespace",
+		"severity": "HIGH",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Closes #496 

This query checks if containers share the host process ID namespace.