### PR TITLE
Add psp_allows_sharing_host_ipc query for Kubernetes #504

### DIFF
--- a/assets/queries/k8s/psp_allows_sharing_host_ipc/metadata.json
+++ b/assets/queries/k8s/psp_allows_sharing_host_ipc/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "psp_allows_sharing_host_ipc",
+  "queryName": "PSP Allows Sharing Host IPC",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Pod Security Policy allows containers to share the host IPC namespace",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/"
+}

--- a/assets/queries/k8s/psp_allows_sharing_host_ipc/query.rego
+++ b/assets/queries/k8s/psp_allows_sharing_host_ipc/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    metadata := document.metadata
+    document.kind == "PodSecurityPolicy"
+
+    document.spec.hostIPC == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.hostIPC", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'spec.hostIPC' is false or undefined",
+                "keyActualValue": 	"'spec.hostIPC' is true"
+              }
+} 

--- a/assets/queries/k8s/psp_allows_sharing_host_ipc/test/negative.yaml
+++ b/assets/queries/k8s/psp_allows_sharing_host_ipc/test/negative.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: example
+spec:
+  hostIPC: false 

--- a/assets/queries/k8s/psp_allows_sharing_host_ipc/test/positive.yaml
+++ b/assets/queries/k8s/psp_allows_sharing_host_ipc/test/positive.yaml
@@ -1,0 +1,6 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: example
+spec:
+  hostIPC: true 

--- a/assets/queries/k8s/psp_allows_sharing_host_ipc/test/positive_expected_result.json
+++ b/assets/queries/k8s/psp_allows_sharing_host_ipc/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "PSP Allows Sharing Host IPC",
+		"severity": "MEDIUM",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Closes #504 

This query detects if a Pod Security Policy allows containers to share the host IPC namespace.