### PR TITLE
Add CronJob Deadline Not Configured query for Kubernetes

### DIFF
--- a/assets/queries/k8s/cronjob_deadline_not_configured/metadata.json
+++ b/assets/queries/k8s/cronjob_deadline_not_configured/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "CronJob_Deadline_Not_Configured",
+  "queryName": "CronJob Deadline Not Configured",
+  "severity": "LOW",
+  "category": null,
+  "descriptionText": "Cronjobs must have a configured deadline, which means the attribute 'startingDeadlineSeconds' must be defined",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/"
+}

--- a/assets/queries/k8s/cronjob_deadline_not_configured/query.rego
+++ b/assets/queries/k8s/cronjob_deadline_not_configured/query.rego
@@ -1,14 +1,16 @@
 package Cx
 
 CxPolicy [ result ] {
-  spec := input.document[i].spec
-  kind := input.document[i].kind
+  document := input.document[i]
+  spec := document.spec
+  metadata := document.metadata
+  kind := document.kind
   kind == "CronJob"
   object.get(spec, "startingDeadlineSeconds", "undefined") == "undefined"
 
 	result := {
                 "documentId": 		input.document[i].id,
-                "searchKey": 	    "spec",
+                "searchKey": 	    sprintf("metadata.name=%s.spec", [metadata.name]),
                 "issueType":		"MissingAttribute",
                 "keyExpectedValue":  "spec.startingDeadlineSeconds is defined",
                 "keyActualValue": 	 "spec.startingDeadlineSeconds is not defined"

--- a/assets/queries/k8s/cronjob_deadline_not_configured/query.rego
+++ b/assets/queries/k8s/cronjob_deadline_not_configured/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy [ result ] {
+  spec := input.document[i].spec
+  kind := input.document[i].kind
+  kind == "CronJob"
+  object.get(spec, "startingDeadlineSeconds", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    "spec",
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue":  "spec.startingDeadlineSeconds is defined",
+                "keyActualValue": 	 "spec.startingDeadlineSeconds is not defined"
+              }
+}

--- a/assets/queries/k8s/cronjob_deadline_not_configured/test/negative.yaml
+++ b/assets/queries/k8s/cronjob_deadline_not_configured/test/negative.yaml
@@ -1,0 +1,20 @@
+#this code is a correct code for which the query should not find any result
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "*/1 * * * *"
+  startingDeadlineSeconds: 100
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/assets/queries/k8s/cronjob_deadline_not_configured/test/positive.yaml
+++ b/assets/queries/k8s/cronjob_deadline_not_configured/test/positive.yaml
@@ -1,0 +1,19 @@
+#this is a problematic code where the query should report a result(s)
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/assets/queries/k8s/cronjob_deadline_not_configured/test/positive_expected_result.json
+++ b/assets/queries/k8s/cronjob_deadline_not_configured/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "CronJob Deadline Not Configured",
+		"severity": "LOW",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Adding CronJob Deadline Not Configured query for Kubernetes, that checks if the attribute 'startingDeadlineSeconds' is defined.

Closes #510