### PR TITLE
Add service_account_token_automount_not_disabled query for Kubernetes #512

### DIFF
--- a/assets/queries/k8s/service_account_token_automount_not_disabled/metadata.json
+++ b/assets/queries/k8s/service_account_token_automount_not_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "service_account_token_automount_not_disabled",
+  "queryName": "Service Account Token Automount Not Disabled",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Service Account Tokens are automatically mounted even if not necessary",
+  "descriptionUrl": "https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server"
+}

--- a/assets/queries/k8s/service_account_token_automount_not_disabled/query.rego
+++ b/assets/queries/k8s/service_account_token_automount_not_disabled/query.rego
@@ -1,0 +1,45 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    metadata := document.metadata
+    specInfo := getSpecInfo(document)
+
+    object.get(specInfo.spec, "automountServiceAccountToken", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.%s", [metadata.name, specInfo.path]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'%s.automountServiceAccountToken' is false", [specInfo.path]),
+                "keyActualValue": 	sprintf("'%s.automountServiceAccountToken' is undefined", [specInfo.path])
+              }
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    metadata := document.metadata
+    specInfo := getSpecInfo(document)
+
+    specInfo.spec.automountServiceAccountToken == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.%s.automountServiceAccountToken", [metadata.name, specInfo.path]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'%s.automountServiceAccountToken' is false", [specInfo.path]),
+                "keyActualValue": 	sprintf("'%s.automountServiceAccountToken' is true", [specInfo.path])
+              }
+}
+
+getSpecInfo(document) = specInfo {
+    templates := {"job_template", "jobTemplate"}
+    spec := document.spec[templates[t]].spec.template.spec
+    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+} else = specInfo {
+    spec := document.spec.template.spec
+    specInfo := {"spec": spec, "path": "spec.template.spec"}
+} else = specInfo {
+    spec := document.spec
+    specInfo := {"spec": spec, "path": "spec"}
+}  

--- a/assets/queries/k8s/service_account_token_automount_not_disabled/test/negative.yaml
+++ b/assets/queries/k8s/service_account_token_automount_not_disabled/test/negative.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo
+spec:
+  automountServiceAccountToken: false
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+  volumes:
+    - name: sec-ctx-vol
+      emptyDir: { }
+  containers:
+    - name: sec-ctx-demo
+      image: busybox
+      command: [ "sh", "-c", "sleep 1h" ]
+      volumeMounts:
+        - name: sec-ctx-vol
+          mountPath: /data/demo
+      securityContext:
+        allowPrivilegeEscalation: false

--- a/assets/queries/k8s/service_account_token_automount_not_disabled/test/positive.yaml
+++ b/assets/queries/k8s/service_account_token_automount_not_disabled/test/positive.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 3000
+    fsGroup: 2000
+  volumes:
+    - name: sec-ctx-vol
+      emptyDir: { }
+  containers:
+    - name: sec-ctx-demo
+      image: busybox
+      command: [ "sh", "-c", "sleep 1h" ]
+      volumeMounts:
+        - name: sec-ctx-vol
+          mountPath: /data/demo
+      securityContext:
+        allowPrivilegeEscalation: false

--- a/assets/queries/k8s/service_account_token_automount_not_disabled/test/positive_expected_result.json
+++ b/assets/queries/k8s/service_account_token_automount_not_disabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Service Account Token Automount Not Disabled",
+		"severity": "MEDIUM",
+		"line": 5
+	}
+]


### PR DESCRIPTION
Closes #512 

This query checks if automountServiceAccountToken is not disabled (true or undefined)