### PR TITLE
Add secrets_as_environment_variables query for Kubernetes #517

### DIFF
--- a/assets/queries/k8s/secrets_as_environment_variables/metadata.json
+++ b/assets/queries/k8s/secrets_as_environment_variables/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "secrets_as_environment_variables",
+  "queryName": "Secrets As Environment Variables",
+  "severity": "LOW",
+  "category": null,
+  "descriptionText": "Container should not use secrets as environment variables",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables"
+}

--- a/assets/queries/k8s/secrets_as_environment_variables/query.rego
+++ b/assets/queries/k8s/secrets_as_environment_variables/query.rego
@@ -1,0 +1,54 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    metadata := document.metadata
+    specInfo := getSpecInfo(document)
+    
+    containers := ["containers", "initContainers"]
+    
+    specInfo.spec[containers[c]][j].env[k].valueFrom.secretKeyRef
+    
+    container_name := specInfo.spec[containers[c]][j].name
+    env_name := specInfo.spec[containers[c]][j].env[k].name
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.%s.%s.name=%s.env.name=%s.valueFrom.secretKeyRef", [metadata.name, specInfo.path, containers[c], container_name, env_name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'%s.%s.name=%s.env.name=%s.valueFrom.secretKeyRef' is undefined", [specInfo.path, containers[c], container_name, env_name]),
+                "keyActualValue": 	sprintf("'%s.%s.name=%s.env.name=%s.valueFrom.secretKeyRef' is defined", [specInfo.path, containers[c], container_name, env_name])
+              }
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    metadata := document.metadata
+    specInfo := getSpecInfo(document)
+    
+    containers := ["containers", "initContainers"]
+    
+    specInfo.spec[containers[c]][j].envFrom[k].secretRef
+    
+    container_name := specInfo.spec[containers[c]][j].name
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.%s.%s.name=%s.envFrom", [metadata.name, specInfo.path, containers[c], container_name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'%s.%s.name=%s.envFrom.secretRef' is undefined", [specInfo.path, containers[c], container_name]),
+                "keyActualValue": 	sprintf("'%s.%s.name=%s.envFrom.secretRef' is defined", [specInfo.path, containers[c], container_name])
+              }
+}
+
+getSpecInfo(document) = specInfo {
+    templates := {"job_template", "jobTemplate"}
+    spec := document.spec[templates[t]].spec.template.spec
+    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+} else = specInfo {
+    spec := document.spec.template.spec
+    specInfo := {"spec": spec, "path": "spec.template.spec"}
+} else = specInfo {
+    spec := document.spec
+    specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/secrets_as_environment_variables/test/negative.yaml
+++ b/assets/queries/k8s/secrets_as_environment_variables/test/negative.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secret-env-pod
+spec:
+  containers:
+  - name: mycontainer
+    image: redis
+  restartPolicy: Never

--- a/assets/queries/k8s/secrets_as_environment_variables/test/positive.yaml
+++ b/assets/queries/k8s/secrets_as_environment_variables/test/positive.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secret-env-pod
+spec:
+  containers:
+  - name: mycontainer
+    image: redis
+    env:
+      - name: SECRET_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: mysecret
+            key: username
+      - name: SECRET_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: mysecret
+            key: password
+  restartPolicy: Never
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: envfrom-secret
+spec:
+  containers:
+  - name: envars-test-container
+    image: nginx
+    envFrom:
+    - secretRef:
+        name: test-secret

--- a/assets/queries/k8s/secrets_as_environment_variables/test/positive_expected_result.json
+++ b/assets/queries/k8s/secrets_as_environment_variables/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Secrets As Environment Variables",
+		"severity": "LOW",
+		"line": 12
+	},
+	{
+		"queryName": "Secrets As Environment Variables",
+		"severity": "LOW",
+		"line": 17
+	},
+	{
+		"queryName": "Secrets As Environment Variables",
+		"severity": "LOW",
+		"line": 30
+	}
+]


### PR DESCRIPTION
Closes #517 

This query checks if containers use secrets as environment variables.