### PR TITLE
Add HPA Targets a invalid object query

### DIFF
--- a/assets/queries/k8s/HPA_targets_a_invalid_object/metadata.json
+++ b/assets/queries/k8s/HPA_targets_a_invalid_object/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "HPA_Targets_A_Invalid_Object",
+  "queryName": "HPA Targets a invalid object",
+  "severity": "LOW",
+  "category": null,
+  "descriptionText": "The Horizontal Pod Autoscale must target a valid object",
+  "descriptionUrl": "https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/"
+}

--- a/assets/queries/k8s/HPA_targets_a_invalid_object/query.rego
+++ b/assets/queries/k8s/HPA_targets_a_invalid_object/query.rego
@@ -1,0 +1,33 @@
+package Cx
+
+CxPolicy [ result ] {
+
+  resource := input.document[i].spec.metrics[index]
+   
+  resourceKind := input.document[i].kind
+
+  IsHPA(resourceKind) ;
+  not checkIsValidObject(resource) 
+            
+            result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    "spec.metrics",
+                "issueType":		  "IncorrectValue",
+                "keyExpectedValue": sprintf("spec.metrics[%d] is a valid object ", [index]),
+                "keyActualValue": 	sprintf("spec.metrics[%d] is an invalid object ", [index])
+            }
+            
+}
+
+IsHPA(resourceKind) = true {
+	resourceKind == "HorizontalPodAutoscaler"
+}
+
+checkIsValidObject(resource){
+
+	resource.type == "Object"; resource.object != null; resource.object.metric != null; resource.object.target != null;
+    resource.object.describedObject.name != null;
+    resource.object.describedObject.apiVersion != null;
+    resource.object.describedObject.kind != null
+
+}

--- a/assets/queries/k8s/HPA_targets_a_invalid_object/test/negative.yaml
+++ b/assets/queries/k8s/HPA_targets_a_invalid_object/test/negative.yaml
@@ -1,0 +1,23 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Object
+    object:
+      metric:
+        name: requests-per-second
+      describedObject:
+        apiVersion: networking.k8s.io/v1beta1
+        kind: Ingress
+        name: main-route
+      target:
+        type: Value
+        value: 10k

--- a/assets/queries/k8s/HPA_targets_a_invalid_object/test/positive.yaml
+++ b/assets/queries/k8s/HPA_targets_a_invalid_object/test/positive.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Object
+    object:
+      metric:
+        name: requests-per-second
+      target:
+        type: Value
+        value: 10k

--- a/assets/queries/k8s/HPA_targets_a_invalid_object/test/positive_expected_result.json
+++ b/assets/queries/k8s/HPA_targets_a_invalid_object/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "HPA Targets a invalid object",
+		"severity": "LOW",
+		"line": 12
+	}
+]


### PR DESCRIPTION
Added new query for Kubernetes.

Provide a HPA resource and a resource to ensure that the object is valid

Closes #524

