### PR TITLE
Add query to check if PSP allows containers to share  host network. Closes #432

### DIFF
--- a/assets/queries/k8s/psp_containers_share_host_network_namespace/metadata.json
+++ b/assets/queries/k8s/psp_containers_share_host_network_namespace/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "PSP_Allows_Containers_To_Share_The_Host_Network_Namespace",
+  "queryName": "PSP Allows Containers To Share The Host Network Namespace",
+  "severity": "HIGH",
+  "category": "Networking",
+  "descriptionText": "Check if Pod Security Policies allow containers to share the host network namespace.",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/"
+}

--- a/assets/queries/k8s/psp_containers_share_host_network_namespace/query.rego
+++ b/assets/queries/k8s/psp_containers_share_host_network_namespace/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    metadata := document.metadata
+    object.get(document,"kind","undefined") == "PodSecurityPolicy"
+
+    object.get(document.spec,"hostNetwork","undefined") == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.hostNetwork",[metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'spec.hostNetwork' is false or undefined",
+                "keyActualValue": 	"'spec.hostNetwork' is true"
+              }
+}

--- a/assets/queries/k8s/psp_containers_share_host_network_namespace/test/negative.yaml
+++ b/assets/queries/k8s/psp_containers_share_host_network_namespace/test/negative.yaml
@@ -1,0 +1,27 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: false
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'

--- a/assets/queries/k8s/psp_containers_share_host_network_namespace/test/positive.yaml
+++ b/assets/queries/k8s/psp_containers_share_host_network_namespace/test/positive.yaml
@@ -1,0 +1,27 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'

--- a/assets/queries/k8s/psp_containers_share_host_network_namespace/test/positive_expected_result.json
+++ b/assets/queries/k8s/psp_containers_share_host_network_namespace/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "PSP Allows Containers To Share The Host Network Namespace",
+		"severity": "HIGH",
+		"line": 14
+	}
+]


### PR DESCRIPTION
Check if Pod Security Policy enables the host network to be shared by the containers. Closes #432 