### PR TITLE
Added Restart Policy With 5 Retries query #559

### DIFF
--- a/assets/queries/k8s/resource_with_allow_privilege_escalation/restart_policy_with_5_retries/metadata.json
+++ b/assets/queries/k8s/resource_with_allow_privilege_escalation/restart_policy_with_5_retries/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "restart_policy_with_5_retries",
+  "queryName": "Restart Policy With 5 Retries",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "It's important that the restart policy is 'on-failure' up to 5 attempts",
+  "descriptionUrl": "https://docs.docker.com/engine/reference/commandline/run/#restart-policies---restart"
+}

--- a/assets/queries/k8s/resource_with_allow_privilege_escalation/restart_policy_with_5_retries/query.rego
+++ b/assets/queries/k8s/resource_with_allow_privilege_escalation/restart_policy_with_5_retries/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy [ result ] {
+   services := input.document[i].services[name] 
+   restart_policy := services.deploy.restart_policy
+   restart_policy.condition != "on-failure:5"
+   
+   result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("services[%s].deploy.restart_policy.condition", [name]),
+                "issueType":		   "IncorrectValue",
+                "keyExpectedValue": sprintf("services[%s].deploy.restart_policy.condition", [name]),
+                "keyActualValue": 	sprintf("services[%s].deploy.restart_policy.condition", [name])
+              }
+}

--- a/assets/queries/k8s/resource_with_allow_privilege_escalation/restart_policy_with_5_retries/test/negative.yaml
+++ b/assets/queries/k8s/resource_with_allow_privilege_escalation/restart_policy_with_5_retries/test/negative.yaml
@@ -1,0 +1,13 @@
+version: "3.8"
+services:
+  redis:
+    image: redis:alpine
+    deploy:
+      replicas: 6
+      placement:
+        max_replicas_per_node: 1
+      update_config:
+        parallelism: 2
+        delay: 10s
+      restart_policy:
+        condition: on-failure:5

--- a/assets/queries/k8s/resource_with_allow_privilege_escalation/restart_policy_with_5_retries/test/positive.yaml
+++ b/assets/queries/k8s/resource_with_allow_privilege_escalation/restart_policy_with_5_retries/test/positive.yaml
@@ -1,0 +1,13 @@
+version: "3.8"
+services:
+  redis:
+    image: redis:alpine
+    deploy:
+      replicas: 6
+      placement:
+        max_replicas_per_node: 1
+      update_config:
+        parallelism: 2
+        delay: 10s
+      restart_policy:
+        condition: no

--- a/assets/queries/k8s/resource_with_allow_privilege_escalation/restart_policy_with_5_retries/test/positive_expected_result.json
+++ b/assets/queries/k8s/resource_with_allow_privilege_escalation/restart_policy_with_5_retries/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Restart Policy With 5 Retries",
+		"severity": "MEDIUM",
+		"line": 13
+	}
+]


### PR DESCRIPTION
It's important that the restart policy is 'on-failure' up to 5 attempts.

Closes #559 