### PR TITLE
Add query to check if there are containers running w/ low UID. Closes #552

### DIFF
--- a/assets/queries/k8s/containers_run_with_low_uid/metadata.json
+++ b/assets/queries/k8s/containers_run_with_low_uid/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Container_Running_With_Low_UID",
+  "queryName": "Container Running With Low UID",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Check if containers are running with low UID, which might cause conflicts with the host's user table.",
+  "descriptionUrl": "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+}

--- a/assets/queries/k8s/containers_run_with_low_uid/query.rego
+++ b/assets/queries/k8s/containers_run_with_low_uid/query.rego
@@ -1,0 +1,157 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "Pod"
+
+    spec := document.spec
+
+    isLowUID(spec)
+
+    metadata := document.metadata
+    result := checkContainersOverride(spec,"",metadata)
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "Pod"
+
+    spec := document.spec
+
+    isSetUID(spec) != true
+
+    metadata := document.metadata
+    result := checkContainersSet(spec,"",metadata)
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "CronJob"
+
+    spec := document.spec.jobTemplate.spec.template.spec
+
+    isLowUID(spec)
+
+    metadata := document.metadata
+    result := checkContainersOverride(spec,"spec.jobTemplate.spec.template.",metadata)
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "CronJob"
+
+    spec := document.spec.jobTemplate.spec.template.spec
+
+    isSetUID(spec) != true
+
+    metadata := document.metadata
+    result := checkContainersSet(spec,"spec.jobTemplate.spec.template.",metadata)
+}
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") != "Pod"
+    object.get(document,"kind","undefined") != "CronJob"
+
+    spec := document.spec.template.spec
+
+    isSetUID(spec) != true
+
+    metadata := document.metadata
+    result := checkContainersSet(spec,"spec.template.",metadata)
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") != "Pod"
+    object.get(document,"kind","undefined") != "CronJob"
+
+    spec := document.spec.template.spec
+
+    isLowUID(spec)
+
+    metadata := document.metadata
+    result := checkContainersOverride(spec,"spec.template.",metadata)
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") != "Pod"
+    object.get(document,"kind","undefined") != "CronJob"
+
+    spec := document.spec.template.spec
+
+    isSetUID(spec) != true
+
+    metadata := document.metadata
+    result := checkContainersSet(spec,"spec.template.",metadata)
+}
+
+#if there are no containers to override low UID setting
+checkContainersOverride(spec,path,metadata) = result {
+    object.get(spec,"containers","undefined") == "undefined"
+    
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.%sspec.securityContext.runAsUser",[metadata.name,path]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'%sspec.securityContext.runAsUser' is higher or equal to 10000",[path]),
+                "keyActualValue": 	sprintf("'%sspec.securityContext.runAsUser' is less than 10000",[path]),
+              }
+}
+
+#if there are containers and one of them has also low UID setting
+checkContainersOverride(spec,path,metadata) = result {
+    containers := object.get(spec,"containers","undefined")
+    containers != "undefined"
+
+    some j
+      isLowUID(containers[j])
+      result := {
+                  "documentId": 		input.document[i].id,
+                  "searchKey": 	    sprintf("metadata.name=%s.%sspec.containers",[metadata.name,path]),
+                  "issueType":		"IncorrectValue",
+                  "keyExpectedValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is higher or equal to 10000",[path,j]),
+                  "keyActualValue": 	sprintf("'%sspec.containers[%d].securityContext.runAsUser' is less than 10000",[path,j]),
+                }
+}
+
+#if there are containers and one of them doesn't override low UID setting
+checkContainersSet(spec,path,metadata) = result {
+    containers := object.get(spec,"containers","undefined")
+    containers != "undefined"
+    some j
+      isSetUID(containers[j]) != true
+      result := {
+                  "documentId": 		input.document[i].id,
+                  "searchKey": 	    sprintf("metadata.name=%s.%sspec.containers",[metadata.name,path]),
+                  "issueType":		"MissingAttribute",
+                  "keyExpectedValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is set and higher or equal to 10000",[path,j]),
+                  "keyActualValue": 	sprintf("'$sspec.containers[%d].securityContext.runAsUser' is undefined",[path,j]),
+                }
+}
+
+#if there are containers and one of them doesn't override low UID setting
+checkContainersSet(spec,path,metadata) = result {
+    containers := object.get(spec,"containers","undefined")
+    containers != "undefined"
+
+    some j
+      isSetUID(containers[j]) != true
+      result := {
+                  "documentId": 		input.document[i].id,
+                  "searchKey": 	    sprintf("metadata.name=%s.%sspec.containers",[metadata.name,path]),
+                  "issueType":		"MissingAttribute",
+                  "keyExpectedValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is set and higher or equal to 10000",[path,j]),
+                  "keyActualValue": 	sprintf("'%sspec.containers[%d].securityContext.runAsUser' is undefined",[path,j]),
+                }
+}
+
+isLowUID(spec) {
+  to_number(spec.securityContext.runAsUser) < 10000  
+}
+
+isSetUID(spec) = true {
+  object.get(spec.securityContext,"runAsUser","undefined") != "undefined"
+} else = false {
+  true
+}

--- a/assets/queries/k8s/containers_run_with_low_uid/test/negative.yaml
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/negative.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo-2
+spec:
+  securityContext:
+    runAsUser: 10000
+  containers:
+  - name: sec-ctx-demo-2
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      runAsUser: 10100
+      allowPrivilegeEscalation: false
+      

--- a/assets/queries/k8s/containers_run_with_low_uid/test/positive.yaml
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/positive.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo-2
+spec:
+  securityContext:
+    runAsUser: 1000
+  containers:
+  - name: sec-ctx-demo-2
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      runAsUser: 2000
+      allowPrivilegeEscalation: false
+      

--- a/assets/queries/k8s/containers_run_with_low_uid/test/positive_expected_result.json
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Container Running With Low UID",
+		"severity": "MEDIUM",
+		"line": 8
+	}
+]


### PR DESCRIPTION
Check if any container has a low UID or if not set, the parent specification sets a low UID as well. Closes #552 