### PR TITLE
Add query to check if containers run as root unduly. Closes #566

### DIFF
--- a/assets/queries/k8s/containers_run_as_root/metadata.json
+++ b/assets/queries/k8s/containers_run_as_root/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Containers_Running_As_Root",
+  "queryName": "Containers Running As Root",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Check if containers are running as root unduly.",
+  "descriptionUrl": "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+}

--- a/assets/queries/k8s/containers_run_as_root/query.rego
+++ b/assets/queries/k8s/containers_run_as_root/query.rego
@@ -1,0 +1,120 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "Pod"
+
+    spec := document.spec
+
+    metadata := document.metadata
+    result := checkRootParent(spec,"spec",metadata)
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "CronJob"
+
+    spec := document.spec.jobTemplate.spec.template.spec
+
+    metadata := document.metadata
+    result := checkRootParent(spec,"spec.jobTemplate.spec.template.spec",metadata)
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") != "Pod"
+    object.get(document,"kind","undefined") != "CronJob"
+
+    spec := document.spec.template.spec
+
+    metadata := document.metadata
+    result := checkRootParent(spec,"spec.template.spec",metadata)
+}
+
+checkRootParent(spec,path,metadata) = result {
+  nonRootParent := object.get(spec.securityContext,"runAsNonRoot","undefined")
+  is_boolean(nonRootParent)
+
+  nonRootParent == true
+
+  result := checkRootContainer(spec,path,metadata)
+
+}
+
+checkRootParent(spec,path,metadata) = result {
+  nonRootParent := object.get(spec.securityContext,"runAsNonRoot","undefined")
+  is_boolean(nonRootParent)
+
+  nonRootParent == false
+
+  userParent := object.get(spec.securityContext,"runAsUser","undefined")
+  is_number(userParent)
+
+  userParent > 0
+
+  result := checkUserContainer(spec,path,metadata)
+}
+
+checkRootParent(spec,path,metadata) = result {
+  object.get(spec.securityContext,"runAsNonRoot","undefined") == "undefined"
+  object.get(spec.securityContext,"runAsUser","undefined") == "undefined"
+
+  result := checkRootContainer(spec,path,metadata)
+}
+
+checkRootContainer(spec,path,metadata) = result {
+  some j
+    container := spec.containers[j]
+    not container.securityContext.runAsNonRoot
+    uid := container.securityContext.runAsUser
+    to_number(uid) <= 0
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("%s.containers",[path]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is higher than 0 and/or 'runAsNonRoot' is true",[path,j]),
+                "keyActualValue": 	sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true",[path,j]),
+              }
+}
+
+checkRootContainer(spec,path,metadata) = result {
+  some j
+    container := spec.containers[j]
+    not container.securityContext.runAsNonRoot
+    object.get(container.securityContext,"runAsUser","undefined") == "undefined"
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.%s.containers",[metadata.name,path]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is set to higher than 0 and/or 'runAsNonRoot' is true",[path,j]),
+                "keyActualValue": 	sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true",[path,j]),
+              }
+}
+
+checkUserContainer(spec,path,metadata) = result {
+  some j
+    container := spec.containers[j]
+    uid := container.securityContext.runAsUser
+    to_number(uid) <= 0
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.%s.containers",[metadata.name,path]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is higher than 0 and/or 'runAsNonRoot' is true",[path,j]),
+                "keyActualValue": 	sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true",[path,j]),
+              }
+}
+
+checkUserContainer(spec,path,metadata) = result {
+  some j
+    container := spec.containers[j]
+    not container.securityContext.runAsNonRoot
+    object.get(container.securityContext,"runAsUser","undefined") == "undefined"
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.%s.containers",[metadata.name,path]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is set to higher than 0 and/or 'runAsNonRoot' is true",[path,j]),
+                "keyActualValue": 	sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true",[path,j]),
+              }
+}

--- a/assets/queries/k8s/containers_run_as_root/test/negative.yaml
+++ b/assets/queries/k8s/containers_run_as_root/test/negative.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo-2
+spec:
+  securityContext:
+    runAsUser: 10000
+    runAsNonRoot: true
+  containers:
+  - name: sec-ctx-demo-2
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      runAsUser: 10100
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      

--- a/assets/queries/k8s/containers_run_as_root/test/positive.yaml
+++ b/assets/queries/k8s/containers_run_as_root/test/positive.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-context-demo-2
+spec:
+  securityContext:
+    runAsUser: 1000
+    runAsNonRoot: false
+  containers:
+  - name: sec-ctx-demo-2
+    image: gcr.io/google-samples/node-hello:1.0
+    securityContext:
+      runAsUser: 0
+      allowPrivilegeEscalation: false
+      runAsNonRoot: false
+      

--- a/assets/queries/k8s/containers_run_as_root/test/positive_expected_result.json
+++ b/assets/queries/k8s/containers_run_as_root/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Containers Running As Root",
+		"severity": "MEDIUM",
+		"line": 9
+	}
+]


### PR DESCRIPTION
Check if containers run as root, either by their own settings or default parent settings. Closes #566 