### PR TITLE
Add query to check if ReadinessProbe is not configured in container. Closes #568

### DIFF
--- a/assets/queries/k8s/readiness_probe_not_configured/metadata.json
+++ b/assets/queries/k8s/readiness_probe_not_configured/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Readiness_Probe_Is_Not_Configured",
+  "queryName": "Readiness Probe Is Not Configured",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Check if Readiness Probe is not configured.",
+  "descriptionUrl": "https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes"
+}

--- a/assets/queries/k8s/readiness_probe_not_configured/query.rego
+++ b/assets/queries/k8s/readiness_probe_not_configured/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") != "Job"
+    object.get(document,"kind","undefined") != "CronJob"
+
+
+    some j
+      container := document.spec.containers[j]
+      object.get(container,"readinessProbe","undefined") == "undefined"
+    
+    metadata := document.metadata
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.containers",[metadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'spec.containers[%d].readinessProbe' is set",[j]),
+                "keyActualValue": sprintf("'spec.containers[%d].readinessProbe' is undefined",[j])
+              }
+}

--- a/assets/queries/k8s/readiness_probe_not_configured/test/negative.yaml
+++ b/assets/queries/k8s/readiness_probe_not_configured/test/negative.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goproxy
+  labels:
+    app: goproxy
+spec:
+  containers:
+  - name: goproxy
+    image: k8s.gcr.io/goproxy:0.1
+    ports:
+    - containerPort: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 15
+      periodSeconds: 20

--- a/assets/queries/k8s/readiness_probe_not_configured/test/positive.yaml
+++ b/assets/queries/k8s/readiness_probe_not_configured/test/positive.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goproxy
+  labels:
+    app: goproxy
+spec:
+  containers:
+  - name: goproxy
+    image: k8s.gcr.io/goproxy:0.1
+    ports:
+    - containerPort: 8080
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 15
+      periodSeconds: 20

--- a/assets/queries/k8s/readiness_probe_not_configured/test/positive_expected_result.json
+++ b/assets/queries/k8s/readiness_probe_not_configured/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Readiness Probe Is Not Configured",
+		"severity": "MEDIUM",
+		"line": 8
+	}
+]


### PR DESCRIPTION
Check if any container, that is not part of a Job or CronJob, configures the readinessProbe. Closes #568 

Their utility, as mentioned in the Kubernetes [docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes), is:

> Sometimes, applications are temporarily unable to serve traffic. For example, an application might need to load large data or configuration files during startup, or depend on external services after startup. In such cases, you don't want to kill the application, but you don't want to send it requests either. Kubernetes provides readiness probes to detect and mitigate these situations.