### PR TITLE
Add query to check if root container is not readonly

### DIFF
--- a/assets/queries/k8s/root_container_filesystem_not_readonly/metadata.json
+++ b/assets/queries/k8s/root_container_filesystem_not_readonly/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Root Container Not Mounted As Read-only",
+  "queryName": "Root Container Not Mounted As Read-only",
+  "severity": "LOW",
+  "category": null,
+  "descriptionText": "Check if the root container filesystem is not being mounted as read-only.",
+  "descriptionUrl": "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+}

--- a/assets/queries/k8s/root_container_filesystem_not_readonly/query.rego
+++ b/assets/queries/k8s/root_container_filesystem_not_readonly/query.rego
@@ -1,0 +1,53 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+
+    some j
+      container := document.spec.containers[j]
+      object.get(container,"securityContext","undefined") == "undefined"
+    
+    metadata := document.metadata
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s",[metadata.name,container.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'spec.containers[%d].securityContext' is set",[j]),
+                "keyActualValue": sprintf("'spec.containers[%d].securityContext' is undefined",[j])
+              }
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+
+    some j
+      container := document.spec.containers[j]
+      securityContext := container.securityContext
+      object.get(securityContext,"readOnlyRootFilesystem","undefined") == "undefined"
+    
+    metadata := document.metadata
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.securityContext",[metadata.name,container.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is set and is true",[j]),
+                "keyActualValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is undefined",[j])
+              }
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+
+    some j
+      container := document.spec.containers[j]
+      container.securityContext.readOnlyRootFilesystem == false
+    
+    metadata := document.metadata
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.readOnlyRootFilesystem",[metadata.name,container.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is true",[j]),
+                "keyActualValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is false",[j])
+              }
+}

--- a/assets/queries/k8s/root_container_filesystem_not_readonly/test/negative.yaml
+++ b/assets/queries/k8s/root_container_filesystem_not_readonly/test/negative.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goproxy
+  labels:
+    app: goproxy
+spec:
+  containers:
+  - name: goproxy
+    image: k8s.gcr.io/goproxy:0.1
+    securityContext:
+      readOnlyRootFilesystem: true

--- a/assets/queries/k8s/root_container_filesystem_not_readonly/test/positive.yaml
+++ b/assets/queries/k8s/root_container_filesystem_not_readonly/test/positive.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rootfalse
+  labels:
+    app: goproxy
+spec:
+  containers:
+  - name: contain1_1
+    image: k8s.gcr.io/goproxy:0.1
+    securityContext:
+      readOnlyRootFilesystem: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: noroot
+  labels:
+    app: goproxy
+spec:
+  containers:
+  - name: contain1_2
+    image: k8s.gcr.io/goproxy:0.1
+    securityContext:
+      someotherthing: true

--- a/assets/queries/k8s/root_container_filesystem_not_readonly/test/positive_expected_result.json
+++ b/assets/queries/k8s/root_container_filesystem_not_readonly/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Root Container Not Mounted As Read-only",
+		"severity": "LOW",
+		"line": 12
+	},
+	{
+		"queryName": "Root Container Not Mounted As Read-only",
+		"severity": "LOW",
+		"line": 24
+	}
+]


### PR DESCRIPTION
Check if a root container filesystem is mounted as read-only. Closes #574 