### PR TITLE
Add Container CPU Requests Not Equal Limits query for Kubernetes 

### DIFF
--- a/assets/queries/k8s/container_cpu_requests_not_equal_limits/metadata.json
+++ b/assets/queries/k8s/container_cpu_requests_not_equal_limits/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Container_CPU_Requests_Not_Equal_Limits",
+  "queryName": "Container CPU Requests Not Equal Limits",
+  "severity": "LOW",
+  "category": null,
+  "descriptionText": "A Pod's Containers must have the same CPU requests as limits set, which is recommended to avoid resource DDOS of the node during spikes. This means the 'requests.cpu' must equal 'limits.cpu', and both be defined.",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+}

--- a/assets/queries/k8s/container_cpu_requests_not_equal_limits/query.rego
+++ b/assets/queries/k8s/container_cpu_requests_not_equal_limits/query.rego
@@ -1,0 +1,46 @@
+package Cx
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  container := input.document[i].spec.containers[c]
+  input.document[i].kind == "Pod"
+  object.get(container.resources.requests, "cpu", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources.requests", [metadata.name, container.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue":  sprintf("spec.containers[%s].resources.requests.cpu is defined", [container.name]),
+                "keyActualValue": 	 sprintf("spec.containers[%s].resources.requests.cpu is not defined", [container.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  container := input.document[i].spec.containers[c]
+  input.document[i].kind == "Pod"
+  object.get(container.resources.limits, "cpu", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources.limits", [metadata.name, container.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue":  sprintf("spec.containers[%s].resources.limits.cpu is defined", [container.name]),
+                "keyActualValue": 	 sprintf("spec.containers[%s].resources.limits.cpu is not defined", [container.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  container := input.document[i].spec.containers[c]
+  input.document[i].kind == "Pod"
+  container.resources.requests.cpu != container.resources.limits.cpu
+  
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources", [metadata.name, container.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("spec.containers[%s].resources.requests.cpu is equal to spec.containers[%s].resources.limits.cpu", [container.name, container.name]),
+                "keyActualValue": 	 sprintf("spec.containers[%s].resources.requests.cpu is not equal to spec.containers[%s].resources.limits.cpu", [container.name, container.name])
+              }
+}

--- a/assets/queries/k8s/container_cpu_requests_not_equal_limits/test/negative.yaml
+++ b/assets/queries/k8s/container_cpu_requests_not_equal_limits/test/negative.yaml
@@ -1,0 +1,25 @@
+#this code is a correct code for which the query should not find any result
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "500m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  - name: log-aggregator
+    image: images.my-company.example/log-aggregator:v6
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "500m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"

--- a/assets/queries/k8s/container_cpu_requests_not_equal_limits/test/positive.yaml
+++ b/assets/queries/k8s/container_cpu_requests_not_equal_limits/test/positive.yaml
@@ -1,0 +1,32 @@
+#this is a problematic code where the query should report a result(s)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: frontend
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "128Mi"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+  - name: log-aggregator
+    image: images.my-company.example/log-aggregator:v6
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "500m"
+      limits:
+        memory: "128Mi"
+  - name: app2
+    image: images.my-company.example/app:v4
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"

--- a/assets/queries/k8s/container_cpu_requests_not_equal_limits/test/positive_expected_result.json
+++ b/assets/queries/k8s/container_cpu_requests_not_equal_limits/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Container CPU Requests Not Equal Limits",
+		"severity": "LOW",
+		"line": 11
+	},
+	{
+		"queryName": "Container CPU Requests Not Equal Limits",
+		"severity": "LOW",
+		"line": 22
+	},
+	{
+		"queryName": "Container CPU Requests Not Equal Limits",
+		"severity": "LOW",
+		"line": 26
+	}
+]


### PR DESCRIPTION
Adding Container CPU Requests Not Equal Limits query for Kubernetes, that checks if the 'requests.cpu' is equal to 'limits.cpu', and if both are defined.

Closes #525