### PR TITLE
Add Root Containers Admitted query for Kubernetes

### DIFF
--- a/assets/queries/k8s/root_containers_admitted/metadata.json
+++ b/assets/queries/k8s/root_containers_admitted/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Root_Containers_Admitted",
+  "queryName": "Root Containers Admitted",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Containers must not be allowed to run with root privileges, which means the attributes 'privileged','allowPrivilegeEscalation' and 'readOnlyRootFilesystem' must be set to false, 'runAsUser.rule' must be set to 'MustRunAsNonRoot', and adding the root group must be forbidden",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/"
+}

--- a/assets/queries/k8s/root_containers_admitted/query.rego
+++ b/assets/queries/k8s/root_containers_admitted/query.rego
@@ -1,0 +1,123 @@
+package Cx
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  input.document[i].kind == "PodSecurityPolicy"
+  spec.privileged == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.privileged", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.privileged is set to 'false'", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.privileged is set to 'true'", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  input.document[i].kind == "PodSecurityPolicy"
+  spec.allowPrivilegeEscalation == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.allowPrivilegeEscalation", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.allowPrivilegeEscalation is set to 'false'", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.allowPrivilegeEscalation is set to 'true'", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  input.document[i].kind == "PodSecurityPolicy"
+  spec.readOnlyRootFilesystem == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.readOnlyRootFilesystem", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.readOnlyRootFilesystem is set to 'false'", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.readOnlyRootFilesystem is set to 'true'", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  input.document[i].kind == "PodSecurityPolicy"
+  spec.runAsUser.rule != "MustRunAsNonRoot"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.runAsUser.rule", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.runAsUser.rule is equal to 'MustRunAsNonRoot'", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.runAsUser.rule is not equal to 'MustRunAsNonRoot'", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  input.document[i].kind == "PodSecurityPolicy"
+  spec.supplementalGroups.rule != "MustRunAs"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.supplementalGroups.rule", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.supplementalGroups limits its ranges", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.supplementalGroups does not limit its ranges", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  input.document[i].kind == "PodSecurityPolicy"
+  spec.supplementalGroups.rule == "MustRunAs"
+  spec.supplementalGroups.ranges[_].min == 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.supplementalGroups", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.supplementalGroups does not allow range '0' (root)", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.supplementalGroups allows range '0' (root)", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  input.document[i].kind == "PodSecurityPolicy"
+  spec.fsGroup.rule != "MustRunAs"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.fsGroup.rule", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.fsGroup limits its ranges", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.fsGroup does not limit its ranges", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  input.document[i].kind == "PodSecurityPolicy"
+  spec.fsGroup.rule == "MustRunAs"
+  spec.fsGroup.ranges[_].min == 0
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.fsGroup", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.fsGroup does not allow range '0'", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.fsGroup allows range '0'", [metadata.name])
+              }
+}

--- a/assets/queries/k8s/root_containers_admitted/test/negative.yaml
+++ b/assets/queries/k8s/root_containers_admitted/test/negative.yaml
@@ -1,0 +1,49 @@
+#this code is a correct code for which the query should not find any result
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/assets/queries/k8s/root_containers_admitted/test/positive.yaml
+++ b/assets/queries/k8s/root_containers_admitted/test/positive.yaml
@@ -1,0 +1,37 @@
+#this is a problematic code where the query should report a result(s)
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: true

--- a/assets/queries/k8s/root_containers_admitted/test/positive_expected_result.json
+++ b/assets/queries/k8s/root_containers_admitted/test/positive_expected_result.json
@@ -1,0 +1,32 @@
+[
+	{
+		"queryName": "Root Containers Admitted",
+		"severity": "MEDIUM",
+		"line": 12
+	},
+	{
+		"queryName": "Root Containers Admitted",
+		"severity": "MEDIUM",
+		"line": 13
+	},
+	{
+		"queryName": "Root Containers Admitted",
+		"severity": "MEDIUM",
+		"line": 27
+	},
+	{
+		"queryName": "Root Containers Admitted",
+		"severity": "MEDIUM",
+		"line": 31
+	},
+	{
+		"queryName": "Root Containers Admitted",
+		"severity": "MEDIUM",
+		"line": 32
+	},
+	{
+		"queryName": "Root Containers Admitted",
+		"severity": "MEDIUM",
+		"line": 37
+	}
+]


### PR DESCRIPTION
Adding Root Containers Admitted query for Kubernetes, that checks if the attributes 'privileged','allowPrivilegeEscalation' and 'readOnlyRootFilesystem' are set to false, 'runAsUser.rule' is set to 'MustRunAsNonRoot', and adding the root group is forbidden.

Closes #583