### PR TITLE
Add Service Account Name Undefined Or Empty query for Kubernetes

### DIFF
--- a/assets/queries/k8s/service_account_name_undefined_or_empty/metadata.json
+++ b/assets/queries/k8s/service_account_name_undefined_or_empty/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Service_Account_Name_Undefined_Or_Empty",
+  "queryName": "Service Account Name Undefined Or Empty",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "A Pod should have a Service Account defined so to restrict Kubernetes API access, which means the attribute 'serviceAccountName' should be defined and not empty.",
+  "descriptionUrl": "https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/"
+}

--- a/assets/queries/k8s/service_account_name_undefined_or_empty/query.rego
+++ b/assets/queries/k8s/service_account_name_undefined_or_empty/query.rego
@@ -1,0 +1,48 @@
+package Cx
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  object.get(spec, "serviceAccountName", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec", [metadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.serviceAccountName is defined", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.serviceAccountName is undefined", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  spec.serviceAccountName == null
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.serviceAccountName", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.serviceAccountName is not null", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.serviceAccountName is null", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  checkAction(spec.serviceAccountName)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.serviceAccountName", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.serviceAccountName is not empty", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.serviceAccountName is empty", [metadata.name])
+              }
+}
+
+checkAction(action) = true {
+	is_string(action)
+	count(action) == 0
+}

--- a/assets/queries/k8s/service_account_name_undefined_or_empty/test/negative.yaml
+++ b/assets/queries/k8s/service_account_name_undefined_or_empty/test/negative.yaml
@@ -1,0 +1,21 @@
+#this code is a correct code for which the query should not find any result
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - image: nginx
+    name: nginx
+    volumeMounts:
+    - mountPath: /var/run/secrets/tokens
+      name: vault-token
+  serviceAccountName: build-robot
+  volumes:
+  - name: vault-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: vault-token
+          expirationSeconds: 7200
+          audience: vault

--- a/assets/queries/k8s/service_account_name_undefined_or_empty/test/positive.yaml
+++ b/assets/queries/k8s/service_account_name_undefined_or_empty/test/positive.yaml
@@ -1,0 +1,67 @@
+#this is a problematic code where the query should report a result(s)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - image: nginx
+    name: nginx
+    volumeMounts:
+    - mountPath: /var/run/secrets/tokens
+      name: vault-token
+  volumes:
+  - name: vault-token
+    projected:
+      sources:
+      - serviceAccountToken:  
+          path: vault-token
+          expirationSeconds: 7200
+          audience: vault
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx2
+spec:
+  containers:
+  - image: nginx2
+    name: nginx2
+    volumeMounts:
+    - mountPath: /var/run/secrets/tokens
+      name: vault-token
+  serviceAccountName: 
+  volumes:
+  - name: vault-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: vault-token
+          expirationSeconds: 7200
+          audience: vault
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx3
+spec:
+  containers:
+  - image: nginx3
+    name: nginx3
+    volumeMounts:
+    - mountPath: /var/run/secrets/tokens
+      name: vault-token
+  serviceAccountName: ""
+  volumes:
+  - name: vault-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: vault-token
+          expirationSeconds: 7200
+          audience: vault
+

--- a/assets/queries/k8s/service_account_name_undefined_or_empty/test/positive_expected_result.json
+++ b/assets/queries/k8s/service_account_name_undefined_or_empty/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Service Account Name Undefined Or Empty",
+		"severity": "MEDIUM",
+		"line": 6
+	},
+	{
+		"queryName": "Service Account Name Undefined Or Empty",
+		"severity": "MEDIUM",
+		"line": 35
+	},
+	{
+		"queryName": "Service Account Name Undefined Or Empty",
+		"severity": "MEDIUM",
+		"line": 58
+	}
+]


### PR DESCRIPTION
Adding Service Account Name Undefined Or Empty query for Kubernetes, that checks if the attribute 'serviceAccountName' is defined and not empty or null.

Closes #594