### PR TITLE
Add Host Aliases Undefined Or Empty query for Kubernetes

### DIFF
--- a/assets/queries/k8s/host_aliases_undefined_or_empty/metadata.json
+++ b/assets/queries/k8s/host_aliases_undefined_or_empty/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Host_Aliases_Undefined_Or_Empty",
+  "queryName": "Host Aliases Undefined Or Empty",
+  "severity": "HIGH",
+  "category": null,
+  "descriptionText": "A Pod should have Host Aliases defined as to prevent the container from modifying the file after a pod's containers have already been started. This means the attribute 'spec.hostAliases' must be defined and not empty or null.",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/"
+}

--- a/assets/queries/k8s/host_aliases_undefined_or_empty/query.rego
+++ b/assets/queries/k8s/host_aliases_undefined_or_empty/query.rego
@@ -1,0 +1,48 @@
+package Cx
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  object.get(spec, "hostAliases", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec", [metadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.hostAliases is defined", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.hostAliases is undefined", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  spec.hostAliases == null
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.hostAliases", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.hostAliases is not null", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.hostAliases is null", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  spec := input.document[i].spec
+  checkAction(spec.hostAliases)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.hostAliases", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.hostAliases is not empty", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.hostAliases is empty", [metadata.name])
+              }
+}
+
+checkAction(action) = true {
+	is_array(action)
+	count(action) == 0
+}

--- a/assets/queries/k8s/host_aliases_undefined_or_empty/test/negative.yaml
+++ b/assets/queries/k8s/host_aliases_undefined_or_empty/test/negative.yaml
@@ -1,0 +1,23 @@
+#this code is a correct code for which the query should not find any result
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostaliases-pod
+spec:
+  restartPolicy: Never
+  hostAliases:
+  - ip: "127.0.0.1"
+    hostnames:
+    - "foo.local"
+    - "bar.local"
+  - ip: "10.1.2.3"
+    hostnames:
+    - "foo.remote"
+    - "bar.remote"
+  containers:
+  - name: cat-hosts
+    image: busybox
+    command:
+    - cat
+    args:
+    - "/etc/hosts"

--- a/assets/queries/k8s/host_aliases_undefined_or_empty/test/positive.yaml
+++ b/assets/queries/k8s/host_aliases_undefined_or_empty/test/positive.yaml
@@ -1,0 +1,48 @@
+#this is a problematic code where the query should report a result(s)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostaliases-pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: cat-hosts
+    image: busybox
+    command:
+    - cat
+    args:
+    - "/etc/hosts"
+    
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostaliases-pod2
+spec:
+  restartPolicy: Never
+  hostAliases: []
+  containers:
+  - name: cat-hosts
+    image: busybox
+    command:
+    - cat
+    args:
+    - "/etc/hosts"
+    
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostaliases-pod3
+spec:
+  restartPolicy: Never
+  hostAliases:
+  containers:
+  - name: cat-hosts
+    image: busybox
+    command:
+    - cat
+    args:
+    - "/etc/hosts"

--- a/assets/queries/k8s/host_aliases_undefined_or_empty/test/positive_expected_result.json
+++ b/assets/queries/k8s/host_aliases_undefined_or_empty/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Host Aliases Undefined Or Empty",
+		"severity": "HIGH",
+		"line": 6
+	},
+	{
+		"queryName": "Host Aliases Undefined Or Empty",
+		"severity": "HIGH",
+		"line": 24
+	},
+	{
+		"queryName": "Host Aliases Undefined Or Empty",
+		"severity": "HIGH",
+		"line": 41
+	}
+]


### PR DESCRIPTION
Adding Host Aliases Undefined Or Empty query for Kubernetes, that checks if the attribute 'spec.hostAliases' is defined and not empty or null.

Closes #596