### PR TITLE
Add query to check if seccomp profile is not configured. Closes #587

### DIFF
--- a/assets/queries/k8s/seccomp_is_not_configured/metadata.json
+++ b/assets/queries/k8s/seccomp_is_not_configured/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Seccomp_Profile_Is_Not_Configured",
+  "queryName": "Seccomp Profile Is Not Configured",
+  "severity": "MEDIUM",
+  "category": "Privileges",
+  "descriptionText": "Check if any resource does not configure Seccomp default profile properly",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp"
+}

--- a/assets/queries/k8s/seccomp_is_not_configured/query.rego
+++ b/assets/queries/k8s/seccomp_is_not_configured/query.rego
@@ -1,0 +1,197 @@
+package Cx
+
+#pods
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "Pod"
+
+    metadata := document.metadata
+    object.get(metadata,"annotations","undefined") != "undefined"
+
+    annotations := metadata.annotations
+    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") == "undefined"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s",[metadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is set",
+                "keyActualValue": 	"'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "Pod"
+
+    metadata := document.metadata
+    object.get(metadata,"annotations","undefined") != "undefined"
+    annotations := metadata.annotations
+
+    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") != "undefined"
+
+    seccomp := annotations["seccomp.security.alpha.kubernetes.io/defaultProfileName"]
+
+    seccomp != "runtime/default"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s",[metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is 'runtime/default'",
+                "keyActualValue": 	sprintf("'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is '%s'",[seccomp])
+              }
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "Pod"
+
+    metadata := document.metadata
+    object.get(metadata,"annotations","undefined") == "undefined"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s",[metadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'metadata.annotations' is set",
+                "keyActualValue": 	"'metadata.annotations' is undefined"
+              }
+}
+
+###################################################################
+
+#cronjob
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "CronJob"
+
+    metadata := document.spec.jobTemplate.spec.template.metadata
+
+    parentMetadata := document.metadata
+    object.get(metadata,"annotations","undefined") == "undefined"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.jobTemplate.spec.template.metadata",[parentMetadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'spec.jobTemplate.spec.template.metadata.annotations' is set",
+                "keyActualValue": 	"'spec.jobTemplate.spec.template.metadata.annotations' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "CronJob"
+
+    metadata := document.spec.jobTemplate.spec.template.metadata
+
+    parentMetadata := document.metadata
+    object.get(metadata,"annotations","undefined") != "undefined"
+
+    annotations := metadata.annotations
+    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") == "undefined"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.jobTemplate.spec.template.metadata.annotations",[parentMetadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is set",
+                "keyActualValue": 	"'spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") == "CronJob"
+
+    metadata := document.spec.jobTemplate.spec.template.metadata
+
+    parentMetadata := document.metadata
+    object.get(metadata,"annotations","undefined") != "undefined"
+    annotations := metadata.annotations
+
+    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") != "undefined"
+
+    seccomp := annotations["seccomp.security.alpha.kubernetes.io/defaultProfileName"]
+
+    seccomp != "runtime/default"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName",[parentMetadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is 'runtime/default'",
+                "keyActualValue": 	sprintf("'spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is '%s'",[seccomp])
+              }
+}
+
+###################################################################
+
+#general
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") != "Pod"
+    object.get(document,"kind","undefined") != "CronJob"
+
+    metadata := document.spec.template.metadata
+
+    parentMetadata := document.metadata
+    object.get(metadata,"annotations","undefined") == "undefined"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.template.metadata",[parentMetadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'spec.template.metadata.annotations' is set",
+                "keyActualValue": 	"'spec.template.metadata.annotations' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") != "Pod"
+    object.get(document,"kind","undefined") != "CronJob"
+
+    metadata := document.spec.template.metadata
+
+    parentMetadata := document.metadata
+    object.get(metadata,"annotations","undefined") != "undefined"
+
+    annotations := metadata.annotations
+    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") == "undefined"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.template.metadata.annotations",[parentMetadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is set",
+                "keyActualValue": 	"'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    object.get(document,"kind","undefined") != "Pod"
+    object.get(document,"kind","undefined") != "CronJob"
+
+    metadata := document.spec.template.metadata
+
+    parentMetadata := document.metadata
+    object.get(metadata,"annotations","undefined") != "undefined"
+    annotations := metadata.annotations
+
+    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") != "undefined"
+
+    seccomp := annotations["seccomp.security.alpha.kubernetes.io/defaultProfileName"]
+
+    seccomp != "runtime/default"
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName",[parentMetadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is 'runtime/default'",
+                "keyActualValue": 	sprintf("'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is '%s'",[seccomp]),
+              }
+}

--- a/assets/queries/k8s/seccomp_is_not_configured/test/negative.yaml
+++ b/assets/queries/k8s/seccomp_is_not_configured/test/negative.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:latest

--- a/assets/queries/k8s/seccomp_is_not_configured/test/positive.yaml
+++ b/assets/queries/k8s/seccomp_is_not_configured/test/positive.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-1
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:latest
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-2
+  annotations:
+    some-annotation: true
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:latest
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-test-3
+  annotations: 
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'rntim/dfl'
+spec:
+  containers:
+  - name: foobar
+    image: foo/bar:latest
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            seccomp.security.alpha.kubernetes.io/defaultProfileName: 'rntim/dfl'
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            imagePullPolicy: IfNotPresent
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/assets/queries/k8s/seccomp_is_not_configured/test/positive.yaml
+++ b/assets/queries/k8s/seccomp_is_not_configured/test/positive.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-test-3
-  annotations: 
+  annotations:
     seccomp.security.alpha.kubernetes.io/defaultProfileName: 'rntim/dfl'
 spec:
   containers:

--- a/assets/queries/k8s/seccomp_is_not_configured/test/positive_expected_result.json
+++ b/assets/queries/k8s/seccomp_is_not_configured/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "Seccomp Profile Is Not Configured",
+		"severity": "MEDIUM",
+		"line": 4
+	},
+	{
+		"queryName": "Seccomp Profile Is Not Configured",
+		"severity": "MEDIUM",
+		"line": 13
+	},
+	{
+		"queryName": "Seccomp Profile Is Not Configured",
+		"severity": "MEDIUM",
+		"line": 24
+	},
+	{
+		"queryName": "Seccomp Profile Is Not Configured",
+		"severity": "MEDIUM",
+		"line": 43
+	}
+]


### PR DESCRIPTION
Check if any service does not use the default profile for Seccomp. Closes #587 