### PR TITLE
Add query to check if a Pod does not have matching network policy. closes #603

### DIFF
--- a/assets/queries/k8s/pod_network_policy_not_configured/metadata.json
+++ b/assets/queries/k8s/pod_network_policy_not_configured/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Pod_Is_Not_Targeted_By_A_Proper_Network_Policy",
+  "queryName": "Pod Is Not Targeted By A Proper Network Policy",
+  "severity": "MEDIUM",
+  "category": "Networking",
+  "descriptionText": "Check if any pod is not being targeted by a proper network policy.",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/services-networking/network-policies/"
+}

--- a/assets/queries/k8s/pod_network_policy_not_configured/query.rego
+++ b/assets/queries/k8s/pod_network_policy_not_configured/query.rego
@@ -1,0 +1,71 @@
+package Cx
+
+CxPolicy [ result ] {
+      document := input.document[i]
+      metadata := document.metadata
+
+      object.get(document,"kind","undefined") != "NetworkPolicy"
+
+      findNetworkPolicy(document.metadata.labels[key],key) == false
+   
+      result := {
+                  "documentId": 		input.document[i].id,
+                  "searchKey": 	    sprintf("metadata.name=%s.labels.%s",[metadata.name,key]),
+                  "issueType":		"MissingAttribute",
+                  "keyExpectedValue": sprintf("'metadata.labels.%s' is targeted by a network policy",[key]),
+                  "keyActualValue": sprintf("'metadata.labels.%s' is not targeted by a network policy",[key])
+               }
+}
+
+CxPolicy [ result ] {
+      document := input.document[i]
+      metadata := document.metadata
+
+      object.get(document,"kind","undefined") != "NetworkPolicy"
+		
+      findNetworkPolicy(document.metadata.labels[key],key) == true
+      properNetworkPolicy(document.metadata.labels[key],key) == false
+   
+      result := {
+                  "documentId": 		input.document[i].id,
+                  "searchKey": 	    sprintf("metadata.name=%s.labels.%s",[metadata.name,key]),
+                  "issueType":		"IncorrectValue",
+                  "keyExpectedValue": sprintf("'metadata.labels.%s' is targeted by a proper network policy (covers both ingress and egress)",[key]),
+                  "keyActualValue": sprintf("'metadata.labels.%s' is not targeted by a proper network policy (does not cover ingress and egress)",[key])
+               }
+}
+
+findNetworkPolicy(lValue,lKey) = true {
+   networkPolicy := input.document[_]
+   object.get(networkPolicy,"kind","undefined") == "NetworkPolicy"
+   spec := networkPolicy.spec
+   some key
+      key == lKey
+      spec.podSelector.matchLabels[key] == lValue
+} else = false {
+	true
+}
+
+properNetworkPolicy(lValue,lKey) = true {
+   networkPolicy := input.document[_]
+   object.get(networkPolicy,"kind","undefined") == "NetworkPolicy"
+   spec := networkPolicy.spec
+   some key
+      key == lKey
+      spec.podSelector.matchLabels[key] == lValue
+      properSpec(spec) == true
+} else = false {
+	true
+}
+
+properSpec(spec) = true {
+   object.get(spec,"policyTypes","undefined") != "undefined"
+   spec.policyTypes[_] == "Ingress"
+   spec.policyTypes[_] == "Egress"
+} else = true {
+   object.get(spec,"policyTypes","undefined") == "undefined"
+   object.get(spec,"egress","undefined") != "undefined"
+   count(spec.egress) > 0
+} else = false {
+   true
+}

--- a/assets/queries/k8s/pod_network_policy_not_configured/test/negative.yaml
+++ b/assets/queries/k8s/pod_network_policy_not_configured/test/negative.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: nginx
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 172.17.0.0/16
+        except:
+        - 172.17.1.0/24
+    - namespaceSelector:
+        matchLabels:
+          project: myproject
+    - podSelector:
+        matchLabels:
+          role: frontend
+    ports:
+    - protocol: TCP
+      port: 6379
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/24
+    ports:
+    - protocol: TCP
+      port: 5978

--- a/assets/queries/k8s/pod_network_policy_not_configured/test/positive.yaml
+++ b/assets/queries/k8s/pod_network_policy_not_configured/test/positive.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1beta1
+kind: Pod
+metadata:
+  name: nopolicy
+  labels:
+    app: nomatch
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-network-policy
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: nginx
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 172.17.0.0/16
+        except:
+        - 172.17.1.0/24
+    - namespaceSelector:
+        matchLabels:
+          project: myproject
+    - podSelector:
+        matchLabels:
+          role: frontend
+    ports:
+    - protocol: TCP
+      port: 6379
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 10.0.0.0/24
+    ports:
+    - protocol: TCP
+      port: 5978
+---
+apiVersion: apps/v1beta1
+kind: Pod
+metadata:
+  name: partialpolicy
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nomatch
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/assets/queries/k8s/pod_network_policy_not_configured/test/positive_expected_result.json
+++ b/assets/queries/k8s/pod_network_policy_not_configured/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Pod Is Not Targeted By A Proper Network Policy",
+		"severity": "MEDIUM",
+		"line": 6
+	},
+	{
+		"queryName": "Pod Is Not Targeted By A Proper Network Policy",
+		"severity": "MEDIUM",
+		"line": 62
+	}
+]


### PR DESCRIPTION
Check if any pod is not being targeted by a network policy in both ingress and egress traffic. Closes #603 