### PR TITLE
Add query to check if metadata labels are invalid. Closes #607

### DIFF
--- a/assets/queries/k8s/metadata_label_is_invalid/metadata.json
+++ b/assets/queries/k8s/metadata_label_is_invalid/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Metadata_Label_Is_Invalid",
+  "queryName": "Metadata Label Is Invalid",
+  "severity": "LOW",
+  "category": null,
+  "descriptionText": "Check if any label in the metadata is invalid.",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/"
+}

--- a/assets/queries/k8s/metadata_label_is_invalid/query.rego
+++ b/assets/queries/k8s/metadata_label_is_invalid/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    metadata := document.metadata
+    labels := metadata.labels
+
+    some key
+      value := labels[key]
+      regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", value) == false
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.labels.%s",[metadata.name,key]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'metadata.labels.%s' has valid label %s",[key,value]),
+                "keyActualValue": sprintf("'metadata.labels.%s' has invalid label %s",[key,value])
+              }
+}

--- a/assets/queries/k8s/metadata_label_is_invalid/test/negative.yaml
+++ b/assets/queries/k8s/metadata_label_is_invalid/test/negative.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goproxy
+  labels:
+    app: goproxy
+spec:
+  containers:
+  - name: goproxy
+    image: k8s.gcr.io/goproxy:0.1
+    ports:
+    - containerPort: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 5
+      periodSeconds: 10
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 15
+      periodSeconds: 20

--- a/assets/queries/k8s/metadata_label_is_invalid/test/positive.yaml
+++ b/assets/queries/k8s/metadata_label_is_invalid/test/positive.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goproxy
+  labels:
+    app: g**dy.l+bel.
+spec:
+  containers:
+  - name: goproxy
+    image: k8s.gcr.io/goproxy:0.1
+    ports:
+    - containerPort: 8080
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 15
+      periodSeconds: 20

--- a/assets/queries/k8s/metadata_label_is_invalid/test/positive_expected_result.json
+++ b/assets/queries/k8s/metadata_label_is_invalid/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Metadata Label Is Invalid",
+		"severity": "LOW",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Check if any object metadata contains an invalid label (e.g, with /+*!?, etc). Closes #607