### PR TITLE
Add Incorrect Volume Claim Access Mode Read Write Once query for Kubernetes 

### DIFF
--- a/assets/queries/k8s/incorrect_volume_claim_access_mode_readWriteOnce/metadata.json
+++ b/assets/queries/k8s/incorrect_volume_claim_access_mode_readWriteOnce/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Incorrect_Volume_Claim_Access_Mode_ReadWriteOnce",
+  "queryName": "Incorrect Volume Claim Access Mode ReadWriteOnce",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Stateful Sets must have one Volume Claim template with the access mode 'ReadWriteOnce'",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/"
+}

--- a/assets/queries/k8s/incorrect_volume_claim_access_mode_readWriteOnce/query.rego
+++ b/assets/queries/k8s/incorrect_volume_claim_access_mode_readWriteOnce/query.rego
@@ -1,0 +1,37 @@
+package Cx
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  volumeClaims := input.document[i].spec.volumeClaimTemplates
+     
+  vClaimsWitReadWriteOnce := [ vClaims | contains(volumeClaims[v].spec.accessModes, "ReadWriteOnce") == true; vClaims := volumeClaims[v].metadata.name]
+  count(vClaimsWitReadWriteOnce) == 0
+    
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.volumeClaimTemplates", [metadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.volumeClaimTemplates has one template with a 'ReadWriteOnce'", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.volumeClaimTemplates does not have a template with a 'ReadWriteOnce'", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  volumeClaims := input.document[i].spec.volumeClaimTemplates
+     
+  vClaimsWitReadWriteOnce := [ vClaims | contains(volumeClaims[v].spec.accessModes, "ReadWriteOnce") == true; vClaims := volumeClaims[v].metadata.name]
+  count(vClaimsWitReadWriteOnce) > 1
+       
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.volumeClaimTemplates", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.volumeClaimTemplates has only one template with a 'ReadWriteOnce'", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.volumeClaimTemplates has multiple templates with 'ReadWriteOnce'", [metadata.name])
+              }
+}
+
+contains(array, string) = true{
+    array[_] == string
+}

--- a/assets/queries/k8s/incorrect_volume_claim_access_mode_readWriteOnce/test/negative.yaml
+++ b/assets/queries/k8s/incorrect_volume_claim_access_mode_readWriteOnce/test/negative.yaml
@@ -1,0 +1,35 @@
+#this code is a correct code for which the query should not find any result
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: nginx # has to match .spec.template.metadata.labels
+  serviceName: "nginx"
+  replicas: 3 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: nginx # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: k8s.gcr.io/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "my-storage-class"
+      resources:
+        requests:
+          storage: 1Gi

--- a/assets/queries/k8s/incorrect_volume_claim_access_mode_readWriteOnce/test/positive.yaml
+++ b/assets/queries/k8s/incorrect_volume_claim_access_mode_readWriteOnce/test/positive.yaml
@@ -1,0 +1,88 @@
+#this is a problematic code where the query should report a result(s)
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: nginx # has to match .spec.template.metadata.labels
+  serviceName: "nginx"
+  replicas: 3 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: nginx # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: k8s.gcr.io/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "my-storage-class"
+      resources:
+        requests:
+          storage: 1Gi
+  - metadata:
+      name: aaa
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "my-storage-class"
+      resources:
+        requests:
+          storage: 1Gi
+
+---
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web2
+spec:
+  selector:
+    matchLabels:
+      app: nginx # has to match .spec.template.metadata.labels
+  serviceName: "nginx"
+  replicas: 3 # by default is 1
+  template:
+    metadata:
+      labels:
+        app: nginx # has to match .spec.selector.matchLabels
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: k8s.gcr.io/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes: [ "ReadWrite" ]
+      storageClassName: "my-storage-class"
+      resources:
+        requests:
+          storage: 1Gi
+  - metadata:
+      name: aaa
+    spec:
+      accessModes: [ "ReadWrite" ]
+      storageClassName: "my-storage-class"
+      resources:
+        requests:
+          storage: 1Gi

--- a/assets/queries/k8s/incorrect_volume_claim_access_mode_readWriteOnce/test/positive_expected_result.json
+++ b/assets/queries/k8s/incorrect_volume_claim_access_mode_readWriteOnce/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Incorrect Volume Claim Access Mode ReadWriteOnce",
+		"severity": "MEDIUM",
+		"line": 27
+	},
+	{
+		"queryName": "Incorrect Volume Claim Access Mode ReadWriteOnce",
+		"severity": "MEDIUM",
+		"line": 72
+	}
+]


### PR DESCRIPTION
Adding Incorrect Volume Claim Access Mode Read Write Once query for Kubernetes, that verifies Stateful Sets have one Volume Claim template with the access mode 'ReadWriteOnce'.

Closes #617