### PR TITLE
Add non_kube_system_pod_with_host_mount query for Kubernetes

### DIFF
--- a/assets/queries/k8s/non_kube_system_pod_with_host_mount/metadata.json
+++ b/assets/queries/k8s/non_kube_system_pod_with_host_mount/metadata.json
@@ -3,6 +3,6 @@
   "queryName": "Non Kube System Pod With Host Mount",
   "severity": "MEDIUM",
   "category": null,
-  "descriptionText": "Ensure pods outside of kube-system do not have access to node volume",
-  "descriptionUrl": "#"
+  "descriptionText": "A non kube-system workload should not have hostPath mounted",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/"
 }

--- a/assets/queries/k8s/non_kube_system_pod_with_host_mount/metadata.json
+++ b/assets/queries/k8s/non_kube_system_pod_with_host_mount/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Non_Kube_System_Pod_With_Host_Mount",
+  "queryName": "Non Kube System Pod With Host Mount",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Ensure pods outside of kube-system do not have access to node volume",
+  "descriptionUrl": "#"
+}

--- a/assets/queries/k8s/non_kube_system_pod_with_host_mount/query.rego
+++ b/assets/queries/k8s/non_kube_system_pod_with_host_mount/query.rego
@@ -1,0 +1,74 @@
+package Cx
+
+CxPolicy [result] {
+  resource := input.document[i]
+  metadata := resource.metadata
+  not metadata.namespace
+  kind := resource.kind
+  kind == "Pod"
+  volumes := resource.spec.volumes
+  volumes[_]["hostPath"]
+  result := {
+    "documentId": input.document[i].id,
+    "searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath", [metadata.name, volumes[_].name]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": "Ensure pods outside of kube-system do not have access to node volume",
+    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' should not have hostPath mounted", [resource.metadata.name, kind, "default"])
+  } 
+}
+
+CxPolicy [result] {
+  resource := input.document[i]
+  metadata := resource.metadata
+  namespace := metadata.namespace
+  namespace != "kube-system"
+  kind := resource.kind
+  kind == "Pod"
+  volumes := resource.spec.volumes
+  volumes[_]["hostPath"]
+  result := {
+    "documentId": input.document[i].id,
+    "searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath", [metadata.name, volumes[_].name]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": "Ensure pods outside of kube-system do not have access to node volume",
+    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' should not have hostPath mounted", [resource.metadata.name, kind, namespace])
+  } 
+}
+
+
+CxPolicy [result] {
+  resource := input.document[i]
+  metadata := resource.metadata
+  namespace := metadata.namespace
+  namespace != "kube-system"
+  kind := resource.kind
+  kind != "Pod"
+  spec := resource.spec.template.spec
+  volumes := spec.volumes
+  volumes[_]["hostPath"]
+  result := {
+    "documentId": input.document[i].id,
+    "searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath", [metadata.name, volumes[_].name]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": "Ensure pods outside of kube-system do not have access to node volume",
+    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace actual '%s' should not have hostPath mounted", [resource.metadata.name, kind, namespace])
+  }
+}
+
+CxPolicy [result] {
+  resource := input.document[i]
+  metadata := resource.metadata
+  not metadata.namespace
+  kind := resource.kind
+  kind != "Pod"
+  spec := resource.spec.template.spec
+  volumes := spec.volumes
+  volumes[_]["hostPath"]
+  result := {
+    "documentId": input.document[i].id,
+    "searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath", [metadata.name, volumes[_].name]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": "Ensure pods outside of kube-system do not have access to node volume",
+    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace actual '%s' should not have hostPath mounted", [resource.metadata.name, kind, "default"])
+  }
+}

--- a/assets/queries/k8s/non_kube_system_pod_with_host_mount/query.rego
+++ b/assets/queries/k8s/non_kube_system_pod_with_host_mount/query.rego
@@ -4,16 +4,15 @@ CxPolicy [result] {
   resource := input.document[i]
   metadata := resource.metadata
   not metadata.namespace
-  kind := resource.kind
-  kind == "Pod"
+  resource.kind == "Pod"
   volumes := resource.spec.volumes
   volumes[_]["hostPath"]
   result := {
     "documentId": input.document[i].id,
     "searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath", [metadata.name, volumes[_].name]),
     "issueType": "IncorrectValue",
-    "keyExpectedValue": "Ensure pods outside of kube-system do not have access to node volume",
-    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' should not have hostPath mounted", [resource.metadata.name, kind, "default"])
+    "keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' should not have hostPath mounted", [resource.metadata.name, resource.kind, "default"]),
+    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' has a hostPath mounted", [resource.metadata.name, resource.kind, "default"])
   } 
 }
 
@@ -22,16 +21,15 @@ CxPolicy [result] {
   metadata := resource.metadata
   namespace := metadata.namespace
   namespace != "kube-system"
-  kind := resource.kind
-  kind == "Pod"
+  resource.kind == "Pod"
   volumes := resource.spec.volumes
   volumes[_]["hostPath"]
   result := {
     "documentId": input.document[i].id,
     "searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath", [metadata.name, volumes[_].name]),
     "issueType": "IncorrectValue",
-    "keyExpectedValue": "Ensure pods outside of kube-system do not have access to node volume",
-    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' should not have hostPath mounted", [resource.metadata.name, kind, namespace])
+    "keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' should not have hostPath mounted", [resource.metadata.name, resource.kind, "default"]),
+    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' has a hostPath mounted", [resource.metadata.name, resource.kind, "default"])
   } 
 }
 
@@ -41,8 +39,7 @@ CxPolicy [result] {
   metadata := resource.metadata
   namespace := metadata.namespace
   namespace != "kube-system"
-  kind := resource.kind
-  kind != "Pod"
+  resource.kind != "Pod"
   spec := resource.spec.template.spec
   volumes := spec.volumes
   volumes[_]["hostPath"]
@@ -50,8 +47,8 @@ CxPolicy [result] {
     "documentId": input.document[i].id,
     "searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath", [metadata.name, volumes[_].name]),
     "issueType": "IncorrectValue",
-    "keyExpectedValue": "Ensure pods outside of kube-system do not have access to node volume",
-    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace actual '%s' should not have hostPath mounted", [resource.metadata.name, kind, namespace])
+    "keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' should not have hostPath mounted", [resource.metadata.name, resource.kind, "default"]),
+    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' has a hostPath mounted", [resource.metadata.name, resource.kind, "default"])
   }
 }
 
@@ -59,8 +56,7 @@ CxPolicy [result] {
   resource := input.document[i]
   metadata := resource.metadata
   not metadata.namespace
-  kind := resource.kind
-  kind != "Pod"
+  resource.kind != "Pod"
   spec := resource.spec.template.spec
   volumes := spec.volumes
   volumes[_]["hostPath"]
@@ -68,7 +64,7 @@ CxPolicy [result] {
     "documentId": input.document[i].id,
     "searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath", [metadata.name, volumes[_].name]),
     "issueType": "IncorrectValue",
-    "keyExpectedValue": "Ensure pods outside of kube-system do not have access to node volume",
-    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace actual '%s' should not have hostPath mounted", [resource.metadata.name, kind, "default"])
+    "keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' should not have hostPath mounted", [resource.metadata.name, resource.kind, "default"]),
+    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' has a hostPath mounted", [resource.metadata.name, resource.kind, "default"])
   }
 }

--- a/assets/queries/k8s/non_kube_system_pod_with_host_mount/test/negative.yaml
+++ b/assets/queries/k8s/non_kube_system_pod_with_host_mount/test/negative.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd-elasticsearch
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
+spec:
+  selector:
+    matchLabels:
+      name: fluentd-elasticsearch
+  template:
+    metadata:
+      labels:
+        name: fluentd-elasticsearch
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - name: fluentd-elasticsearch
+          image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
+          resources:
+            limits:
+              cpu: 500m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis
+  namespace: kube-system
+spec:
+  containers:
+    - name: redis
+      image: redis
+      volumeMounts:
+        - name: redis-storage
+          mountPath: /data/redis
+  volumes:
+    - name: redis-storage
+      hostPath: /var/redis/data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: kube-system
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: static-page-dir
+              mountPath: /var/www/app/static
+      volumes:
+        - name: static-page-dir
+          hostPath:
+            path: /var/local/static
+            type: DirectoryOrCreate

--- a/assets/queries/k8s/non_kube_system_pod_with_host_mount/test/positive.yaml
+++ b/assets/queries/k8s/non_kube_system_pod_with_host_mount/test/positive.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd-elasticsearch
+  namespace: logs
+  labels:
+    k8s-app: fluentd-logging
+spec:
+  selector:
+    matchLabels:
+      name: fluentd-elasticsearch
+  template:
+    metadata:
+      labels:
+        name: fluentd-elasticsearch
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - name: fluentd-elasticsearch
+          image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
+          resources:
+            limits:
+              cpu: 500m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis
+spec:
+  containers:
+    - name: redis
+      image: redis
+      volumeMounts:
+        - name: redis-storage
+          mountPath: /data/redis
+  volumes:
+    - name: redis-storage
+      hostPath: /var/redis/data
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis-memcache
+  namespace: memcache
+spec:
+  containers:
+    - name: redis
+      image: redis
+      volumeMounts:
+        - name: redis-storage
+          mountPath: /data/redis
+  volumes:
+    - name: redis-storage
+      hostPath: /var/redis/data
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: default
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: static-page-dir
+              mountPath: /var/www/app/static
+      volumes:
+        - name: static-page-dir
+          hostPath:
+            path: /var/local/static
+            type: DirectoryOrCreate
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-undefined-ns
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: static-page-dir
+              mountPath: /var/www/app/static
+      volumes:
+        - name: static-page-dir
+          hostPath:
+            path: /var/local/static
+            type: DirectoryOrCreate

--- a/assets/queries/k8s/non_kube_system_pod_with_host_mount/test/positive_expected_result.json
+++ b/assets/queries/k8s/non_kube_system_pod_with_host_mount/test/positive_expected_result.json
@@ -1,0 +1,32 @@
+[
+	{
+		"queryName": "Non Kube System Pod With Host Mount",
+		"severity": "MEDIUM",
+		"line": 39
+	},
+	{
+		"queryName": "Non Kube System Pod With Host Mount",
+		"severity": "MEDIUM",
+		"line": 42
+	},
+	{
+		"queryName": "Non Kube System Pod With Host Mount",
+		"severity": "MEDIUM",
+		"line": 58
+	},
+	{
+		"queryName": "Non Kube System Pod With Host Mount",
+		"severity": "MEDIUM",
+		"line": 74
+	},
+	{
+		"queryName": "Non Kube System Pod With Host Mount",
+		"severity": "MEDIUM",
+		"line": 103
+	},
+	{
+		"queryName": "Non Kube System Pod With Host Mount",
+		"severity": "MEDIUM",
+		"line": 133
+	}
+]


### PR DESCRIPTION
Ensure pods outside of kube-system do not have access to node volume (Deployments, DaemonSets and other templated types too)

Closes #622