### PR TITLE
Add Cluster Allows Unsafe Sysctls query for Kubernetes

### DIFF
--- a/assets/queries/k8s/cluster_allows_unsafe_sysctls/metadata.json
+++ b/assets/queries/k8s/cluster_allows_unsafe_sysctls/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Cluster_Allows_Unsafe_Sysctls",
+  "queryName": "Cluster Allows Unsafe Sysctls",
+  "severity": "HIGH",
+  "category": null,
+  "descriptionText": "A Kubernetes Cluster must not allow Unsafe Sysctls, to prevent a pod from having any influence on any other pod on the node, harming the node's health or gaining CPU or memory resources outside of the resource limits of a pod. This means the 'spec.securityContext.sysctls' must not have an Unsafe Sysctls and that the atrribute 'allowedUnsafeSysctls' must be undefined.",
+  "descriptionUrl": "https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/"
+}

--- a/assets/queries/k8s/cluster_allows_unsafe_sysctls/query.rego
+++ b/assets/queries/k8s/cluster_allows_unsafe_sysctls/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  input.document[i].kind == "PodSecurityPolicy"
+  spec := input.document[i].spec
+
+  spec.allowedUnsafeSysctls
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.allowedUnsafeSysctls is undefined", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.allowedUnsafeSysctls is defined", [metadata.name])
+              }
+}
+
+CxPolicy [ result ] {
+  metadata := input.document[i].metadata
+  input.document[i].kind == "Pod"
+  spec := input.document[i].spec
+  
+  sysctl := spec.securityContext.sysctls[_].name
+  check_Unsafe(sysctl)
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.securityContext.sysctls", [metadata.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("metadata.name=%s.spec.securityContext.sysctls does not have an Unsafe Sysctl", [metadata.name]),
+                "keyActualValue": 	 sprintf("metadata.name=%s.spec.securityContext.sysctls has an Unsafe Sysctl", [metadata.name])
+              }
+}
+
+check_Unsafe(sysctl) {
+	safeSysctls = {"kernel.shm_rmid_forced", "net.ipv4.ip_local_port_range", "net.ipv4.tcp_syncookies", "net.ipv4.ping_group_range"}
+    not safeSysctls[sysctl]
+}

--- a/assets/queries/k8s/cluster_allows_unsafe_sysctls/test/negative.yaml
+++ b/assets/queries/k8s/cluster_allows_unsafe_sysctls/test/negative.yaml
@@ -1,0 +1,22 @@
+#this code is a correct code for which the query should not find any result
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctl-example
+spec:
+  securityContext:
+    sysctls:
+    - name: kernel.shm_rmid_forced
+      value: "0"
+    - name: net.ipv4.ip_local_port_range
+      value: "0"
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: sysctl-psp
+spec:
+  forbiddenSysctls:
+  - kernel.shm_rmid_forced

--- a/assets/queries/k8s/cluster_allows_unsafe_sysctls/test/positive.yaml
+++ b/assets/queries/k8s/cluster_allows_unsafe_sysctls/test/positive.yaml
@@ -1,0 +1,26 @@
+#this is a problematic code where the query should report a result(s)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sysctl-example
+spec:
+  securityContext:
+    sysctls:
+    - name: kernel.shm_rmid_forced
+      value: "0"
+    - name: net.core.somaxconn
+      value: "1024"
+    - name: kernel.msgmax
+      value: "65536"
+
+---
+
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: sysctl-psp
+spec:
+  allowedUnsafeSysctls:
+  - kernel.msg*
+  forbiddenSysctls:
+  - kernel.shm_rmid_forced

--- a/assets/queries/k8s/cluster_allows_unsafe_sysctls/test/positive_expected_result.json
+++ b/assets/queries/k8s/cluster_allows_unsafe_sysctls/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Cluster Allows Unsafe Sysctls",
+		"severity": "HIGH",
+		"line": 8
+	},
+	{
+		"queryName": "Cluster Allows Unsafe Sysctls",
+		"severity": "HIGH",
+		"line": 22
+	}
+]


### PR DESCRIPTION
Adding Cluster Allows Unsafe Sysctls query for Kubernetes, that checks if any of the 'spec.securityContext.sysctls' is an Unsafe Sysctl and if the attribute 'allowedUnsafeSysctls' is defined.

Closes #620