### PR TITLE
Added query permissive_access_to_create_pods

### DIFF
--- a/assets/queries/k8s/permissive_access_to_create_pods/metadata.json
+++ b/assets/queries/k8s/permissive_access_to_create_pods/metadata.json
@@ -1,0 +1,8 @@
+{
+    "id": "permissive_access_to_create_pods",
+    "queryName": "Permissive Access to Create Pods",
+    "severity": "LOW",
+    "category": null,
+    "descriptionText": "The permission to create pods in a cluster should be restricted because it allows privilege escalation.",
+    "descriptionUrl": "https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping"
+}

--- a/assets/queries/k8s/permissive_access_to_create_pods/query.rego
+++ b/assets/queries/k8s/permissive_access_to_create_pods/query.rego
@@ -1,0 +1,83 @@
+package Cx
+create := "create"
+pods := "pods"
+
+CxPolicy [ result ] {
+	document := input.document[i]
+    rules := document.rules
+    metadata := document.metadata
+    
+    isRoleKind(document.kind)
+    rules[j].verbs[l] == create
+    rules[j].resources[k] == pods
+    
+	result := {
+                "documentId": 	  	input.document[i].id,
+                "searchKey": 	      sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, create] ),
+                "issueType":	    	"IncorrectValue",
+                "keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain the value 'create' when metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name] ),
+                "keyActualValue": 	sprintf("metadata.name=%s.rules.verbs contains the value 'create' and metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name] )
+              }
+}
+
+CxPolicy [ result ] {
+	document := input.document[i]
+    rules := document.rules
+    metadata := document.metadata
+    
+    isRoleKind(document.kind)
+    rules[j].verbs[l] == create
+    isWildCardValue(rules[j].resources[k])
+    
+	result := {
+                "documentId": 	  	input.document[i].id,
+                "searchKey": 	      sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, create] ),
+                "issueType":	    	"IncorrectValue",
+                "keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain the value 'create' when metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name] ),
+                "keyActualValue": 	sprintf("metadata.name=%s.rules.verbs contains the value 'create' and metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name] )
+              }
+}
+
+CxPolicy [ result ] {
+	document := input.document[i]
+    rules := document.rules
+    metadata := document.metadata
+    
+    isRoleKind(document.kind)
+    isWildCardValue(rules[j].verbs[l])
+    rules[j].resources[k] == pods
+    
+	result := {
+                "documentId": 	  	input.document[i].id,
+                "searchKey": 	      sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, rules[j].verbs[l]] ),
+                "issueType":		    "IncorrectValue",
+                "keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name] ),
+                "keyActualValue": 	sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name] )
+              }
+}
+
+CxPolicy [ result ] {
+	document := input.document[i]
+    rules := document.rules
+    metadata := document.metadata
+    
+    isRoleKind(document.kind)
+    isWildCardValue(rules[j].verbs[l])
+    isWildCardValue(rules[j].resources[k])
+    
+	result := {
+                "documentId": 	  	input.document[i].id,
+                "searchKey": 	      sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, rules[j].verbs[l]] ),
+                "issueType":		    "IncorrectValue",
+                "keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name] ),
+                "keyActualValue": 	sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name] )
+              }
+}
+
+
+isWildCardValue(val) {
+	 regex.match(".*\\*.*", val)
+}
+
+isRoleKind("ClusterRole")
+isRoleKind("Role")

--- a/assets/queries/k8s/permissive_access_to_create_pods/test/negative.yaml
+++ b/assets/queries/k8s/permissive_access_to_create_pods/test/negative.yaml
@@ -1,0 +1,31 @@
+#this code is a correct code for which the query should not find any result
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader
+rules:
+- apiGroups: [""]
+
+  resources: ["pod"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader2
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Pod
+metadata:
+  name: secret-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs:
+    - "get"
+    - "watch"
+    - create

--- a/assets/queries/k8s/permissive_access_to_create_pods/test/positive.yaml
+++ b/assets/queries/k8s/permissive_access_to_create_pods/test/positive.yaml
@@ -45,7 +45,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: 
+  verbs:
     - "get"
     - "watch"
     - "c*e"

--- a/assets/queries/k8s/permissive_access_to_create_pods/test/positive.yaml
+++ b/assets/queries/k8s/permissive_access_to_create_pods/test/positive.yaml
@@ -1,0 +1,60 @@
+#this is a problematic code where the query should report a result(s)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs:
+    - "get"
+    - "watch"
+    - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-reader2
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["get", "watch", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader3
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-reader4
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["get", "watch", "*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader5
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: 
+    - "get"
+    - "watch"
+    - "c*e"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: secret-reader6
+rules:
+- apiGroups: [""]
+  resources: ["p*ds"]
+  verbs: ["get", "watch", "create"]

--- a/assets/queries/k8s/permissive_access_to_create_pods/test/positive_expected_result.json
+++ b/assets/queries/k8s/permissive_access_to_create_pods/test/positive_expected_result.json
@@ -1,0 +1,31 @@
+[{
+        "queryName": "Permissive Access to Create Pods",
+        "severity": "LOW",
+        "line": 12
+    },
+    {
+        "queryName": "Permissive Access to Create Pods",
+        "severity": "LOW",
+        "line": 21
+    },
+    {
+        "queryName": "Permissive Access to Create Pods",
+        "severity": "LOW",
+        "line": 30
+    },
+    {
+        "queryName": "Permissive Access to Create Pods",
+        "severity": "LOW",
+        "line": 39
+    },
+    {
+        "queryName": "Permissive Access to Create Pods",
+        "severity": "LOW",
+        "line": 51
+    },
+    {
+        "queryName": "Permissive Access to Create Pods",
+        "severity": "LOW",
+        "line": 60
+    }
+]

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -129,7 +129,8 @@ func mergeWithMetadata(base, additional map[string]interface{}) map[string]inter
 }
 
 func detectLine(ctx QueryContext, file *model.FileMetadata, searchKey string) int {
-	lines := strings.Split(file.OriginalData, "\n")
+	text := strings.ReplaceAll(file.OriginalData, "\r", "")
+	lines := strings.Split(text, "\n")
 	foundAtLeastOne := false
 	currentLine := 0
 


### PR DESCRIPTION
Created query Permissive Access To Create Pods.

The permission to create pods in a cluster should be restricted because it allows privilege escalation.

Closes #649 