### PR TITLE
ingress_controller_exposes_workload Closes #676

### DIFF
--- a/assets/queries/k8s/ingress_controller_exposes_workload/metadata.json
+++ b/assets/queries/k8s/ingress_controller_exposes_workload/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ingress_controller_exposes_workload",
+  "queryName": "Ingress Controller Exposes Workload",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Ingress Controllers should not expose workload in order to avoid vulnerabilities and DoS attacks",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/"
+}

--- a/assets/queries/k8s/ingress_controller_exposes_workload/metadata.json
+++ b/assets/queries/k8s/ingress_controller_exposes_workload/metadata.json
@@ -2,7 +2,7 @@
   "id": "ingress_controller_exposes_workload",
   "queryName": "Ingress Controller Exposes Workload",
   "severity": "MEDIUM",
-  "category": null,
+  "category": "Networking",
   "descriptionText": "Ingress Controllers should not expose workload in order to avoid vulnerabilities and DoS attacks",
   "descriptionUrl": "https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/"
 }

--- a/assets/queries/k8s/ingress_controller_exposes_workload/query.rego
+++ b/assets/queries/k8s/ingress_controller_exposes_workload/query.rego
@@ -1,0 +1,53 @@
+package Cx
+
+CxPolicy [ result ] {
+    document := input.document[i]
+    document.kind == "Ingress"
+    specInfo := getSpecInfo(document)
+    metadata := document.metadata
+    annotations := metadata.annotations
+
+    object.get(annotations,"kubernetes.io/ingress.class", "undefined") != "undefined"
+    
+    spec := document.spec
+    
+    backend := spec["rules"][x]["http"]["paths"][j]["backend"]
+    
+    serviceName := backend["serviceName"]
+    servicePort := backend["servicePort"]
+    
+    ingressControllerExposesWorload(serviceName, servicePort)
+    
+	result := {
+                "documentId": 		  input.document[i].id,
+                "issueType":		  "IncorrectValue",
+                "searchKey":          sprintf("metadata.name=%s.%s.rules.http.paths.backend", [metadata.name, specInfo.path]),
+                "keyExpectedValue":   sprintf("metadata.name=%s is not exposing the workload", [metadata.name]),
+                "keyActualValue":     sprintf("metadata.name=%s is exposing the workload", [metadata.name])
+              }
+}
+
+getSpecInfo(document) = specInfo {
+    templates := {"job_template", "jobTemplate"}
+    spec := document.spec[templates[t]].spec.template.spec
+    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+} else = specInfo {
+    spec := document.spec.template.spec
+    specInfo := {"spec": spec, "path": "spec.template.spec"}
+} else = specInfo {
+    spec := document.spec
+    specInfo := {"spec": spec, "path": "spec"}
+} 
+
+
+ingressControllerExposesWorload(serviceName, servicePort) = allow {
+  documents := input.document
+
+  services := [service | documents[index].kind == "Service"; service = documents[index]]
+  
+  services[x]["spec"]["ports"][j]["targetPort"] == servicePort
+
+  services[x]["metadata"]["name"] == serviceName
+
+  allow = true
+}

--- a/assets/queries/k8s/ingress_controller_exposes_workload/test/negative.yaml
+++ b/assets/queries/k8s/ingress_controller_exposes_workload/test/negative.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+  labels:
+    app: app
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    targetPort: 3000
+  selector:
+    app: app
+
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+  labels:
+    app: app
+spec:
+  rules:
+  - host: app.acme.org
+    http:
+      paths:
+      - backend:
+          serviceName: app2
+          servicePort: 3000

--- a/assets/queries/k8s/ingress_controller_exposes_workload/test/positive.yaml
+++ b/assets/queries/k8s/ingress_controller_exposes_workload/test/positive.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+  labels:
+    app: app
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    targetPort: 3000
+  selector:
+    app: app
+
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+  labels:
+    app: app
+spec:
+  rules:
+  - host: app.acme.org
+    http:
+      paths:
+      - backend:
+          serviceName: app
+          servicePort: 3000

--- a/assets/queries/k8s/ingress_controller_exposes_workload/test/positive_expected_result.json
+++ b/assets/queries/k8s/ingress_controller_exposes_workload/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Ingress Controller Exposes Workload",
+		"severity": "MEDIUM",
+		"line": 31
+	}
+]


### PR DESCRIPTION
For this query, it is necessary to check if the service name and service port of the ingress are associated with some service defined. I came across this solution through the following documents: https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/ and https://blog.cloud66.com/setting-up-secure-endpoints-in-kubernetes/. I have to give credits to @fabioGoncalvesCx since he did a similar query and helped me.

Closes #676