### PR TITLE
Add query volumn mount with os directory write permissions

### DIFF
--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/metadata.json
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/metadata.json
@@ -1,6 +1,6 @@
 {
-  "id": "volume_mount_with_OS_directory_write_permissions",
-  "queryName": "volume mount with OS directory write permissions",
+  "id": "Volume_Mount_with_OS_Directory_Write_Permissions",
+  "queryName": "Volume Mount with OS Directory Write Permissions",
   "severity": "MEDIUM",
   "category": null,
   "descriptionText": "Containers can mount sensitive folders from the hosts, giving them potentially dangerous access to critical host configurations and binaries.",

--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/metadata.json
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "volume_mount_with_OS_directory_write_permissions",
+  "queryName": "volume mount with OS directory write permissions",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Containers can mount sensitive folders from the hosts, giving them potentially dangerous access to critical host configurations and binaries.",
+  "descriptionUrl": "#"
+}

--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/metadata.json
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/metadata.json
@@ -2,7 +2,7 @@
   "id": "Volume_Mount_with_OS_Directory_Write_Permissions",
   "queryName": "Volume Mount with OS Directory Write Permissions",
   "severity": "MEDIUM",
-  "category": null,
+  "category": "Resources Limiting",
   "descriptionText": "Containers can mount sensitive folders from the hosts, giving them potentially dangerous access to critical host configurations and binaries.",
   "descriptionUrl": "#"
 }

--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/query.rego
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/query.rego
@@ -1,0 +1,49 @@
+package Cx
+
+CxPolicy [ result ] {
+
+  resource := input.document[i]
+  containers := resource.spec.containers
+  volumeMounts := containers[_].volumeMounts
+  is_OS_Dir(volumeMounts[v].mountPath) 
+  volumeMounts[v].readOnly == false
+   
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.volumeMounts.name=%s.readyOnly", [resource.metadata.name, volumeMounts[v].name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("spec.containers.volumeMounts[%s].readOnly is true",[volumeMounts[v].name]),
+                "keyActualValue": 	sprintf("spec.containers.volumeMounts[%s].readOnly is false",[volumeMounts[v].name])
+              }
+}
+
+CxPolicy [ result ] {
+
+  resource := input.document[i]
+  containers := resource.spec.containers
+  volumeMounts := containers[_]["volumeMounts"]
+  is_OS_Dir(volumeMounts[v]["mountPath"]) 
+  object.get(volumeMounts[v] ,"readOnly", "undefined") == "undefined"
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	     sprintf("metadata.name=%s.spec.containers.volumeMounts.name=%s", [resource.metadata.name, volumeMounts[v].name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue":	sprintf("spec.containers.volumeMounts[%s].readOnly is set",[volumeMounts[v].name]),
+                "keyActualValue": 	sprintf("spec.containers.volumeMounts[%s].readOnly is undefined",[volumeMounts[v].name])
+              }
+}
+
+
+
+is_OS_Dir(mountPath) = result {
+      hostSensitiveDir = {"/bin", "/sbin","/boot","/cdrom","/dev","/etc","/home","/lib","/media","/proc","/root","/run","/seLinux","/srv","/usr","/var"}
+   	  result  = listcontains(hostSensitiveDir, mountPath)
+} else = result {
+      result  =  mountPath == "/"
+
+}
+
+listcontains(dirs, elem) {
+  startswith(elem,dirs[_])
+}
+

--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/query.rego
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/query.rego
@@ -37,7 +37,7 @@ CxPolicy [ result ] {
 
 is_OS_Dir(mountPath) = result {
       hostSensitiveDir = {"/bin", "/sbin","/boot","/cdrom","/dev","/etc","/home","/lib","/media","/proc","/root","/run","/seLinux","/srv","/usr","/var"}
-   	  result  = listcontains(hostSensitiveDir, mountPath)
+   	  result  = startswith( mountPath,hostSensitiveDir[_])
 } else = result {
       result  =  mountPath == "/"
 

--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/test/negative.yaml
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/test/negative.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: pod-0
+    volumeMounts:
+    - mountPath: /bin
+      name: vol-0
+      readOnly: true
+  volumes:
+  - name: vol-0
+    scaleIO:
+      gateway: https://localhost:443/api
+      system: scaleio
+      protectionDomain: sd0
+      storagePool: sp1
+      volumeName: vol-0
+      secretRef:
+        name: sio-secret
+      fsType: xfs
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: pod-0
+    volumeMounts:
+    - mountPath: /project-mount
+      name: vol-0
+  volumes:
+  - name: vol-0
+    scaleIO:
+      gateway: https://localhost:443/api
+      system: scaleio
+      protectionDomain: sd0
+      storagePool: sp1
+      volumeName: vol-0
+      secretRef:
+        name: sio-secret
+      fsType: xfs
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: pod-0
+    volumeMounts:
+    - mountPath: /var/run
+      name: vol-0
+      readOnly: true
+  volumes:
+  - name: vol-0
+    scaleIO:
+      gateway: https://localhost:443/api
+      system: scaleio
+      protectionDomain: sd0
+      storagePool: sp1
+      volumeName: vol-0
+      secretRef:
+        name: sio-secret
+      fsType: xfs

--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/test/positive.yaml
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/test/positive.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-0
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: pod-0
+    volumeMounts:
+    - mountPath: /bin
+      name: vol-0
+    - mountPath: /var/run
+      name: vol-1
+      readOnly: false
+  volumes:
+  - name: vol-0
+    scaleIO:
+      gateway: https://localhost:443/api
+      system: scaleio
+      protectionDomain: sd0
+      storagePool: sp1
+      volumeName: vol-0
+      secretRef:
+        name: sio-secret
+      fsType: xfs
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-1
+spec:
+  containers:
+  - image: k8s.gcr.io/test-webserver
+    name: pod-1
+    volumeMounts:
+    - mountPath: /var/run
+      name: vol-0
+    - mountPath: /bin
+      name: vol-1
+      readOnly: false
+  volumes:
+  - name: vol-0
+    scaleIO:
+      gateway: https://localhost:443/api
+      system: scaleio
+      protectionDomain: sd0
+      storagePool: sp1
+      volumeName: vol-0
+      secretRef:
+        name: sio-secret
+      fsType: xfs

--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/test/positive_expected_result.json
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/test/positive_expected_result.json
@@ -1,21 +1,21 @@
 [
 	{
-		"queryName": "volume mount with OS directory write permissions",
+		"queryName": "Volume Mount with OS Directory Write Permissions",
 		"severity": "MEDIUM",
 		"line": 13
 	},
 	{
-		"queryName": "volume mount with OS directory write permissions",
+		"queryName": "Volume Mount with OS Directory Write Permissions",
 		"severity": "MEDIUM",
 		"line": 39
 	},
 	{
-		"queryName": "volume mount with OS directory write permissions",
+		"queryName": "Volume Mount with OS Directory Write Permissions",
 		"severity": "MEDIUM",
 		"line": 11
 	},
 	{
-		"queryName": "volume mount with OS directory write permissions",
+		"queryName": "Volume Mount with OS Directory Write Permissions",
 		"severity": "MEDIUM",
 		"line": 37
 	}

--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/test/positive_expected_result.json
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "volume_mount_with_OS_directory_write_permissions",
+		"severity": "Medium",
+		"line": 13
+	},
+	{
+		"queryName": "volume_mount_with_OS_directory_write_permissions",
+		"severity": "Medium",
+		"line": 39
+	},
+	{
+		"queryName": "volume_mount_with_OS_directory_write_permissions",
+		"severity": "Medium",
+		"line": 11
+	},
+	{
+		"queryName": "volume_mount_with_OS_directory_write_permissions",
+		"severity": "Medium",
+		"line": 37
+	}
+]

--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/test/positive_expected_result.json
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/test/positive_expected_result.json
@@ -1,22 +1,22 @@
 [
 	{
-		"queryName": "volume_mount_with_OS_directory_write_permissions",
-		"severity": "Medium",
+		"queryName": "volume mount with OS directory write permissions",
+		"severity": "MEDIUM",
 		"line": 13
 	},
 	{
-		"queryName": "volume_mount_with_OS_directory_write_permissions",
-		"severity": "Medium",
+		"queryName": "volume mount with OS directory write permissions",
+		"severity": "MEDIUM",
 		"line": 39
 	},
 	{
-		"queryName": "volume_mount_with_OS_directory_write_permissions",
-		"severity": "Medium",
+		"queryName": "volume mount with OS directory write permissions",
+		"severity": "MEDIUM",
 		"line": 11
 	},
 	{
-		"queryName": "volume_mount_with_OS_directory_write_permissions",
-		"severity": "Medium",
+		"queryName": "volume mount with OS directory write permissions",
+		"severity": "MEDIUM",
 		"line": 37
 	}
 ]

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/hcl/v2 v2.7.0
 	github.com/mailru/easyjson v0.7.6
-	github.com/moby/buildkit v0.7.2
+	github.com/moby/buildkit v0.7.2 // indirect
 	github.com/open-policy-agent/opa v0.24.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.20.0


### PR DESCRIPTION
Description: Containers can mount sensitive folders from the hosts, giving them potentially dangerous access to critical host configurations and binaries.

Query looks for volume mounts, where the path startswith a Sensitive linux folder name, and then checks if the readOnly attribute of the mount is true, otherwise returns the result as a true positive.


Closes #638