### PR TITLE
Add query to check if EC2 instance don't have IAM roles associated. Closes #658

### DIFF
--- a/assets/queries/cloudFormation/ec2_instance_no_iam_role/metadata.json
+++ b/assets/queries/cloudFormation/ec2_instance_no_iam_role/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "AWS EC2 Instance Has No IAM Role",
+  "queryName": "AWS EC2 Instance Has No IAM Role",
+  "severity": "MEDIUM",
+  "category": "Identity and Access Management",
+  "descriptionText": "Check if an EC2 instance refers to an IAM profile, which represents an IAM Role.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html"
+}

--- a/assets/queries/cloudFormation/ec2_instance_no_iam_role/query.rego
+++ b/assets/queries/cloudFormation/ec2_instance_no_iam_role/query.rego
@@ -1,0 +1,79 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::EC2::Instance"
+  
+  object.get(resource.Properties,"IamInstanceProfile","undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties", [name]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.IamInstanceProfile' is set",[name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.IamInstanceProfile' is undefined",[name])
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::EC2::Instance"
+  
+  object.get(resource.Properties,"IamInstanceProfile","undefined") != "undefined"
+
+  iamProfile := getIAMProfile(resource.Properties.IamInstanceProfile)
+
+  emptyProfile(iamProfile)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.IamInstanceProfile",[name]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.IamInstanceProfile' has matching IamInstanceProfile resource",[name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.IamInstanceProfile' does not have matching IamInstanceProfile resource",[name])
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::EC2::Instance"
+  
+  object.get(resource.Properties,"IamInstanceProfile","undefined") != "undefined"
+
+  iamProfile := getIAMProfile(resource.Properties.IamInstanceProfile)
+
+  emptyProfile(iamProfile) == false
+
+  object.get(iamProfile[_].Properties,"Roles","undefined") == "undefined"
+
+  some key
+  iamProfile[key]
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties",[key]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.Roles' is set",[key]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.Roles' is undefined",[key])
+              }
+}
+
+getIAMProfile(profileRef) = profile {
+  is_string(profileRef)
+  profile := {
+    profileRef: object.get(input.document[_].Resources,profileRef,"undefined")
+  }
+} else = profile {
+  is_object(profileRef)
+  object.get(profileRef,"Ref","undefined") != "undefined"
+  ref := object.get(profileRef,"Ref","undefined")
+  profile := {
+    ref: object.get(input.document[_].Resources, ref, "undefined")
+  }
+} else = {}
+
+emptyProfile(iamProfile) = true {
+  is_null(iamProfile)
+} else = true {
+  iamProfile[_] == "undefined"
+} else = false

--- a/assets/queries/cloudFormation/ec2_instance_no_iam_role/test/negative.yaml
+++ b/assets/queries/cloudFormation/ec2_instance_no_iam_role/test/negative.yaml
@@ -1,0 +1,40 @@
+---
+Resources:
+  Test:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType:
+        Ref: InstanceType
+      ImageId:
+        Fn::FindInMap:
+        - AMIs
+        - Ref: AWS::Region
+        - Name
+      KeyName:
+        Ref: KeyName
+      IamInstanceProfile:
+        Ref: ListS3BucketsInstanceProfile
+      SecurityGroupIds:
+      - Ref: SSHAccessSG
+      Tags:
+      - Key: Name
+        Value: Test
+  ListS3BucketsInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: "/"
+      Roles:
+      - Ref: ListS3BucketsRole
+  ListS3BucketsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: "/"

--- a/assets/queries/cloudFormation/ec2_instance_no_iam_role/test/positive.yaml
+++ b/assets/queries/cloudFormation/ec2_instance_no_iam_role/test/positive.yaml
@@ -1,0 +1,57 @@
+---
+Resources:
+  NoIAM:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType:
+        Ref: InstanceType
+      ImageId:
+        Fn::FindInMap:
+        - AMIs
+        - Ref: AWS::Region
+        - Name
+      KeyName:
+        Ref: KeyName
+      Tags:
+      - Key: Name
+        Value: Test
+  IAM_Missing:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType:
+        Ref: InstanceType
+      ImageId:
+        Fn::FindInMap:
+        - AMIs
+        - Ref: AWS::Region
+        - Name
+      KeyName:
+        Ref: KeyName
+      IamInstanceProfile:
+        Ref: NonExistantProfile
+      SecurityGroupIds:
+      - Ref: SSHAccessSG
+      Tags:
+      - Key: Name
+        Value: Test
+  IAMNoRoles:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType:
+        Ref: InstanceType
+      ImageId:
+        Fn::FindInMap:
+        - AMIs
+        - Ref: AWS::Region
+        - Name
+      KeyName:
+        Ref: KeyName
+      IamInstanceProfile:
+        Ref: NoRolesProfile
+      Tags:
+      - Key: Name
+        Value: Test
+  NoRolesProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: "/"

--- a/assets/queries/cloudFormation/ec2_instance_no_iam_role/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ec2_instance_no_iam_role/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "AWS EC2 Instance Has No IAM Role",
+		"severity": "MEDIUM",
+		"line": 5
+	},
+	{
+		"queryName": "AWS EC2 Instance Has No IAM Role",
+		"severity": "MEDIUM",
+		"line": 30
+	},
+	{
+		"queryName": "AWS EC2 Instance Has No IAM Role",
+		"severity": "MEDIUM",
+		"line": 56
+	}
+]


### PR DESCRIPTION
Check EC2 instances in search of IAM profiles, that have roles associated, which control access. Flag if they are not found. Closes #658 