### PR TITLE
Add iam_user_with_inline_policies query for AWS CloudFormation #689

### DIFF
--- a/assets/queries/cloudFormation/iam_user_with_inline_policies/metadata.json
+++ b/assets/queries/cloudFormation/iam_user_with_inline_policies/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "iam_user_wih_inline_policies",
+  "queryName": "IAM User With Inline Policies",
+  "severity": "MEDIUM",
+  "category": "Identity and Access Management",
+  "descriptionText": "IAM User should embed managed policies instead of inline policies",
+  "descriptionUrl": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html"
+}

--- a/assets/queries/cloudFormation/iam_user_with_inline_policies/query.rego
+++ b/assets/queries/cloudFormation/iam_user_with_inline_policies/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::IAM::User"
+  policies := resource.Properties.Policies
+  policies != []
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.Policies", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": "'Resources.Properties.Policies' is undefined or empty",
+                "keyActualValue": 	"'Resources.Properties.Policies' is not empty"
+              }
+}

--- a/assets/queries/cloudFormation/iam_user_with_inline_policies/test/negative.yaml
+++ b/assets/queries/cloudFormation/iam_user_with_inline_policies/test/negative.yaml
@@ -1,0 +1,5 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template
+Resources:
+    myuser:
+      Type: AWS::IAM::User

--- a/assets/queries/cloudFormation/iam_user_with_inline_policies/test/positive.yaml
+++ b/assets/queries/cloudFormation/iam_user_with_inline_policies/test/positive.yaml
@@ -1,0 +1,24 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template
+Resources:
+    myuser:
+      Type: AWS::IAM::User
+      Properties:
+        Path: "/"
+        LoginProfile:
+          Password: myP@ssW0rd
+        Policies:
+        - PolicyName: giveaccesstoqueueonly
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - sqs:*
+              Resource:
+              - !GetAtt myqueue.Arn
+            - Effect: Deny
+              Action:
+              - sqs:*
+              NotResource:
+              - !GetAtt myqueue.Arn

--- a/assets/queries/cloudFormation/iam_user_with_inline_policies/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/iam_user_with_inline_policies/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "IAM User With Inline Policies",
+		"severity": "MEDIUM",
+		"line": 10
+	}
+]


### PR DESCRIPTION
Closes #689

IAM User should embed managed policies instead of inline policies