### PR TITLE
Add authentication_without_mfa Closes #711

### DIFF
--- a/assets/queries/terraform/aws/authentication_without_mfa/metadata.json
+++ b/assets/queries/terraform/aws/authentication_without_mfa/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "authentication_without_mfa",
+  "queryName": "Authentication Without MFA",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "Users should authenticate with MFA (Multi-factor Authentication)",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy"
+}

--- a/assets/queries/terraform/aws/authentication_without_mfa/query.rego
+++ b/assets/queries/terraform/aws/authentication_without_mfa/query.rego
@@ -1,0 +1,123 @@
+package Cx
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_iam_user_policy[name]
+ 
+  poli := resource.policy
+  output := json.unmarshal(poli)
+  
+  statement := output.Statement
+ 
+  checkShortTermCredentials(input.document)
+
+  mfa := existsMFA(statement)
+  mfa == "undefined"
+  
+  result := {
+                "documentId":        input.document[i].id,
+                "searchKey":         sprintf("resource.aws_iam_user_policy[%s].policy", [name]),
+                "issueType":         "MissingAttribute",
+                "keyExpectedValue":  "Attribute 'aws:MultiFactorAuthPresent' is set",
+                "keyActualValue":    "Attribute 'aws:MultiFactorAuthPresent' is undefined"
+            }
+}
+
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource.aws_iam_user_policy[name]
+ 
+  poli := resource.policy
+  output := json.unmarshal(poli)
+  
+  statement := output.Statement
+ 
+  checkShortTermCredentials(input.document)
+
+  mfa := existsMFA(statement)
+  mfa == "false"
+  
+  result := {
+                "documentId":        input.document[i].id,
+                "searchKey":         sprintf("resource.aws_iam_user_policy[%s].policy", [name]),
+                "issueType":         "IncorrectValue",
+                "keyExpectedValue":  "Attribute 'aws:MultiFactorAuthPresent' is set a true",
+                "keyActualValue":    "Attribute 'aws:MultiFactorAuthPresent' is set a false"
+            }
+}
+
+
+existsMFA(statement) = mfa {
+  isArray := is_array(statement)
+  
+  object.get(statement[index]["Condition"]["BoolIfExists"],"aws:MultiFactorAuthPresent", "undefined") == "undefined"
+  
+  mfa := "undefined"
+}
+
+existsMFA(statement) = mfa {
+  isArray := is_array(statement)
+  
+  object.get(statement[index]["Condition"],"BoolIfExists", "undefined") == "undefined"
+  
+  mfa := "undefined"
+}
+
+existsMFA(statement) = mfa {
+  isArray := is_array(statement)
+  
+  object.get(statement[index],"Condition", "undefined") == "undefined"
+  
+  mfa := "undefined"
+}
+
+
+existsMFA(statement) = mfa {
+  isObject := is_object(statement)
+ 
+  object.get(statement["Condition"]["BoolIfExists"],"aws:MultiFactorAuthPresent", "undefined") == "undefined"
+
+  mfa := "undefined"
+}
+
+existsMFA(statement) = mfa {
+  isObject := is_object(statement)
+ 
+  object.get(statement["Condition"],"BoolIfExists", "undefined") == "undefined"
+
+  mfa := "undefined"
+}
+
+
+existsMFA(statement) = mfa {
+  isObject := is_object(statement)
+ 
+  object.get(statement,"Condition", "undefined") == "undefined"
+
+  mfa := "undefined"
+}
+
+
+existsMFA(statement) = mfa {
+  isObject := is_object(statement)
+ 
+  object.get(statement["Condition"]["BoolIfExists"],"aws:MultiFactorAuthPresent", "undefined") != "undefined"
+
+  mfa := statement["Condition"]["BoolIfExists"]["aws:MultiFactorAuthPresent"]
+}
+
+existsMFA(statement) = mfa {
+  isArray := is_array(statement)
+ 
+  object.get(statement[index]["Condition"]["BoolIfExists"],"aws:MultiFactorAuthPresent", "undefined") != "undefined"
+  
+  mfa := statement[index]["Condition"]["BoolIfExists"]["aws:MultiFactorAuthPresent"]
+}
+
+checkShortTermCredentials(documents) = allow {
+  resource := documents[x].provider["aws"]
+
+  resource.token
+
+  allow = true
+}

--- a/assets/queries/terraform/aws/authentication_without_mfa/test/negative.tf
+++ b/assets/queries/terraform/aws/authentication_without_mfa/test/negative.tf
@@ -1,0 +1,32 @@
+resource "aws_iam_user_policy" "lb_ro" {
+  name = "test"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "arn:aws:iam::111122223333:root"
+       },
+       "Action": "sts:AssumeRole",
+       "Condition": {
+         "BoolIfExists": {
+           "aws:MultiFactorAuthPresent" : "true"
+         }
+       }
+     }
+   ]
+}
+EOF
+}
+
+
+
+provider "aws" {
+  region                  = "us-west-2"
+  profile                 = "customprofile"
+  token                   = "sddssdsddertweteetwt"
+}

--- a/assets/queries/terraform/aws/authentication_without_mfa/test/positive.tf
+++ b/assets/queries/terraform/aws/authentication_without_mfa/test/positive.tf
@@ -1,0 +1,51 @@
+resource "aws_iam_user_policy" "lb_ro" {
+  name = "test"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "arn:aws:iam::111122223333:root"
+       },
+       "Action": "sts:AssumeRole",
+       "Condition": {
+         "BoolIfExists": {
+           "aws:MultiFactorAuthPresent" : "false"
+         }
+       }
+     }
+   ]
+}
+EOF
+}
+
+
+resource "aws_iam_user_policy" "lb_ro2" {
+  name = "test"
+  user = aws_iam_user.lb.name
+
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Effect": "Allow",
+       "Principal": {
+         "AWS": "arn:aws:iam::111122223333:root"
+       },
+       "Action": "sts:AssumeRole"
+     }
+   ]
+}
+EOF
+}
+
+provider "aws" {
+  region                  = "us-west-2"
+  profile                 = "customprofile"
+  token                   = "sddssdsddertweteetwt"
+}

--- a/assets/queries/terraform/aws/authentication_without_mfa/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/authentication_without_mfa/test/positive_expected_result.json
@@ -1,0 +1,15 @@
+[
+	{
+		"queryName": "Authentication Without MFA",
+		"severity": "HIGH",
+		"line": 5
+	},
+
+
+	{
+		"queryName": "Authentication Without MFA",
+		"severity": "HIGH",
+		"line": 31
+	}
+
+]


### PR DESCRIPTION
For this query, it is necessary to check if the user did authenticate with MFA through the aws:MultiFactorAuthPresent key set a true in a Bool condition. For that, it is necessary to verify if the aws:MultiFactorAuthPresent is undefined or set a false.

However, the key is only present when the user authenticates with short-term credentials. So, I thought checking the existence of a token, since session token is used for validating temporary credentials. I did not find another alternative.
Closes #711