### PR TITLE
Add S3 Bucket Allows Get Action From All Principals query for CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/s3_bucket_allows_get_actions_from_all_principals/metadata.json
+++ b/assets/queries/cloudFormation/s3_bucket_allows_get_actions_from_all_principals/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "S3_Bucket_Allows_Get_Action_From_All_Principals",
+  "queryName": "S3 Bucket Allows Get Action From All Principals",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "S3 Buckets must not allow Get Actions From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion. This means the 'Effect' must not be 'Allow' when the 'Action' is Get, for all Principals.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html"
+}

--- a/assets/queries/cloudFormation/s3_bucket_allows_get_actions_from_all_principals/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_allows_get_actions_from_all_principals/query.rego
@@ -1,0 +1,74 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+  resource.Type == "AWS::IAM::Role"
+  statement := resource.Properties.AssumeRolePolicyDocument.Statement[j]
+	statement.Effect == "Allow"
+  statement.Principal == "*"
+	check_action(statement.Action[k])
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement does not allow a 'Get' action from all principals", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement allows a 'Get' action from all principals", [name])
+              }
+}
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+  resource.Type == "AWS::IAM::Role"
+  statement := resource.Properties.AssumeRolePolicyDocument.Statement[j]
+	statement.Effect == "Allow"
+  statement.Principal == "*"
+	check_action(statement.Action)
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement does not allow a 'Get' action from all principals", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement allows a 'Get' action from all principals", [name])
+              }
+}
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+  resource.Type == "AWS::IAM::Policy"
+  statement := resource.Properties.PolicyDocument.Statement[j]
+	statement.Effect == "Allow"
+  statement.Resource == "*"
+	check_action(statement.Action[k])
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.PolicyDocument.Statement", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.PolicyDocument.Statement does not allow a 'Get' action from all principals", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.PolicyDocument.Statement allows a 'Get' action from all principals", [name])
+              }
+}
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+  resource.Type == "AWS::IAM::Policy"
+  statement := resource.Properties.PolicyDocument.Statement[j]
+	statement.Effect == "Allow"
+  statement.Resource == "*"
+	check_action(statement.Action)
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.PolicyDocument.Statement", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.PolicyDocument.Statement does not allow a 'Get' action from all principals", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.PolicyDocument.Statement allows a 'Get' action from all principals", [name])
+              }
+}
+
+check_action(action){
+	  is_string(action)
+    contains(lower(action), "get")
+}

--- a/assets/queries/cloudFormation/s3_bucket_allows_get_actions_from_all_principals/test/negative.yaml
+++ b/assets/queries/cloudFormation/s3_bucket_allows_get_actions_from_all_principals/test/negative.yaml
@@ -1,0 +1,80 @@
+#this code is a correct code for which the query should not find any result
+Resources:
+  RecordServiceS3Bucket:
+    Type: 'AWS::S3::Bucket'
+    DeletionPolicy: Retain
+    Properties:
+      ReplicationConfiguration:
+        Role:
+          'Fn::GetAtt':
+            - WorkItemBucketBackupRole
+            - Arn
+        Rules:
+          - Destination:
+              Bucket:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - 'Fn::Join':
+                        - '-'
+                        - - Ref: 'AWS::Region'
+                          - Ref: 'AWS::StackName'
+                          - replicationbucket
+              StorageClass: STANDARD
+            Id: Backup
+            Prefix: ''
+            Status: Enabled
+      VersioningConfiguration:
+        Status: Enabled
+  WorkItemBucketBackupRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service:
+                - s3.amazonaws.com
+  BucketBackupPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 's3:GetReplicationConfiguration'
+              - 's3:ListBucket'
+            Effect: Allow
+            Resource:
+              - 'Fn::Join':
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - Ref: RecordServiceS3Bucket
+          - Action:
+              - 's3:GetObjectVersion'
+              - 's3:GetObjectVersionAcl'
+            Effect: Allow
+            Resource:
+              - 'Fn::Join':
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - Ref: RecordServiceS3Bucket
+                    - /*
+          - Action:
+              - 's3:ReplicateObject'
+              - 's3:ReplicateDelete'
+            Effect: Allow
+            Resource:
+              - 'Fn::Join':
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - 'Fn::Join':
+                        - '-'
+                        - - Ref: 'AWS::Region'
+                          - Ref: 'AWS::StackName'
+                          - replicationbucket
+                    - /*
+      PolicyName: BucketBackupPolicyABC
+      Roles:
+        - Ref: WorkItemBucketBackupRole

--- a/assets/queries/cloudFormation/s3_bucket_allows_get_actions_from_all_principals/test/positive.yaml
+++ b/assets/queries/cloudFormation/s3_bucket_allows_get_actions_from_all_principals/test/positive.yaml
@@ -1,0 +1,117 @@
+#this is a problematic code where the query should report a result(s)
+Resources:
+  RecordServiceS3Bucket:
+    Type: 'AWS::S3::Bucket'
+    DeletionPolicy: Retain
+    Properties:
+      ReplicationConfiguration:
+        Role:
+          'Fn::GetAtt':
+            - WorkItemBucketBackupRole
+            - Arn
+        Rules:
+          - Destination:
+              Bucket:
+                'Fn::Join':
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - 'Fn::Join':
+                        - '-'
+                        - - Ref: 'AWS::Region'
+                          - Ref: 'AWS::StackName'
+                          - replicationbucket
+              StorageClass: STANDARD
+            Id: Backup
+            Prefix: ''
+            Status: Enabled
+      VersioningConfiguration:
+        Status: Enabled
+  WorkItemBucketBackupRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - 's3:GetObject'
+            Effect: Allow
+            Principal: "*"
+  AnotherRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: "s3:GetObject"
+            Effect: Allow
+            Principal: "*"
+  BucketBackupPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 's3:GetObject'
+              - 's3:RestoreBucket'
+            Effect: Allow
+            Resource: "*"
+          - Action:
+              - 's3:PutObjectVersion'
+              - 's3:PutObjectVersionAcl'
+            Effect: Allow
+            Resource:
+              - 'Fn::Join':
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - Ref: RecordServiceS3Bucket
+                    - /*
+          - Action:
+              - 's3:ReplicateObject'
+              - 's3:ReplicateDelete'
+            Effect: Allow
+            Resource:
+              - 'Fn::Join':
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - 'Fn::Join':
+                        - '-'
+                        - - Ref: 'AWS::Region'
+                          - Ref: 'AWS::StackName'
+                          - replicationbucket
+                    - /*
+      PolicyName: BucketBackupPolicyABC
+      Roles:
+        - Ref: WorkItemBucketBackupRole
+  AnotherPolicy:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: 's3:GetObject'
+            Effect: Allow
+            Resource: "*"
+          - Action:
+              - 's3:PutObjectVersion'
+              - 's3:PutObjectVersionAcl'
+            Effect: Allow
+            Resource:
+              - 'Fn::Join':
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - Ref: RecordServiceS3Bucket
+                    - /*
+          - Action:
+              - 's3:ReplicateObject'
+              - 's3:ReplicateDelete'
+            Effect: Allow
+            Resource:
+              - 'Fn::Join':
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - 'Fn::Join':
+                        - '-'
+                        - - Ref: 'AWS::Region'
+                          - Ref: 'AWS::StackName'
+                          - replicationbucket
+                    - /*
+      PolicyName: AnotherPolicyABC
+      Roles:
+        - Ref: WorkItemBucketBackupRole

--- a/assets/queries/cloudFormation/s3_bucket_allows_get_actions_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/s3_bucket_allows_get_actions_from_all_principals/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "S3 Bucket Allows Get Action From All Principals",
+		"severity": "HIGH",
+		"line": 33
+	},
+	{
+		"queryName": "S3 Bucket Allows Get Action From All Principals",
+		"severity": "HIGH",
+		"line": 42
+	},
+	{
+		"queryName": "S3 Bucket Allows Get Action From All Principals",
+		"severity": "HIGH",
+		"line": 50
+	},
+	{
+		"queryName": "S3 Bucket Allows Get Action From All Principals",
+		"severity": "HIGH",
+		"line": 87
+	}
+]


### PR DESCRIPTION
Adding S3 Bucket Allows Get Action From All Principals query for CloudFormation, that checks if the 'Effect' is 'Allow' when the 'Action' is Get, for all Principals.

Closes #720