### PR TITLE
Add cloudfront_distribution_without_waf query for AWS CloudFormation #731

### DIFF
--- a/assets/queries/cloudFormation/cloudfront_distribution_without_waf/metadata.json
+++ b/assets/queries/cloudFormation/cloudfront_distribution_without_waf/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "cloudfront_distribution_without_waf",
+  "queryName": "CloudFront Distribution Without WAF",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "All AWS CloudFront distributions should be integrated with the Web Application Firewall (AWS WAF) service",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-distributionconfig.html#cfn-cloudfront-distribution-distributionconfig-webaclid"
+}

--- a/assets/queries/cloudFormation/cloudfront_distribution_without_waf/query.rego
+++ b/assets/queries/cloudFormation/cloudfront_distribution_without_waf/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::CloudFront::Distribution"
+  distributionConfig := resource.Properties.DistributionConfig
+  
+  object.get(distributionConfig, "WebACLId", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.DistributionConfig", [name]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": "'Resources.Properties.DistributionConfig.WebACLId' is defined",
+                "keyActualValue": 	"'Resources.Properties.DistributionConfig.WebACLId' is undefined"
+              }
+}

--- a/assets/queries/cloudFormation/cloudfront_distribution_without_waf/test/negative.yaml
+++ b/assets/queries/cloudFormation/cloudfront_distribution_without_waf/test/negative.yaml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  cloudfrontdistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        CacheBehaviors:
+          - LambdaFunctionAssociations:
+              - EventType: string-value
+                LambdaFunctionARN: string-value
+        DefaultCacheBehavior:
+          LambdaFunctionAssociations:
+            - EventType: string-value
+              LambdaFunctionARN: string-value
+        IPV6Enabled: boolean-value
+        Origins:
+          - CustomOriginConfig:
+              OriginKeepaliveTimeout: integer-value
+              OriginReadTimeout: integer-value
+        WebACLId: string-value
+      Tags:
+        - Key: string-value
+          Value: string-value

--- a/assets/queries/cloudFormation/cloudfront_distribution_without_waf/test/positive.yaml
+++ b/assets/queries/cloudFormation/cloudfront_distribution_without_waf/test/positive.yaml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  cloudfrontdistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        CacheBehaviors:
+          - LambdaFunctionAssociations:
+              - EventType: string-value
+                LambdaFunctionARN: string-value
+        DefaultCacheBehavior:
+          LambdaFunctionAssociations:
+            - EventType: string-value
+              LambdaFunctionARN: string-value
+        IPV6Enabled: boolean-value
+        Origins:
+          - CustomOriginConfig:
+              OriginKeepaliveTimeout: integer-value
+              OriginReadTimeout: integer-value
+      Tags:
+        - Key: string-value
+          Value: string-value

--- a/assets/queries/cloudFormation/cloudfront_distribution_without_waf/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/cloudfront_distribution_without_waf/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "CloudFront Distribution Without WAF",
+		"severity": "MEDIUM",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Closes #731 

All AWS CloudFront distributions should be integrated with the Web Application Firewall (AWS WAF) service.

This query checks if a "CloudFront::Distribution" resource isn't defining the "Properties.DistributionConfig.WebACLId" field.