### PR TITLE
Add secure_ciphers_disabled query Closes #732

### DIFF
--- a/assets/queries/cloudFormation/secure_ciphers_disabled/metadata.json
+++ b/assets/queries/cloudFormation/secure_ciphers_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "secure_ciphers_disabled",
+  "queryName": "Secure Ciphers Disabled",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "Check if secure ciphers aren't used in CloudFront",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution"
+}

--- a/assets/queries/cloudFormation/secure_ciphers_disabled/query.rego
+++ b/assets/queries/cloudFormation/secure_ciphers_disabled/query.rego
@@ -1,0 +1,25 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Properties.ViewerCertificate.CloudFrontDefaultCertificate == false
+  not checkMinPortocolVersion(resource.Properties.ViewerCertificate.MinimumProtocolVersion)
+	
+	result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("Resources.%s.Properties.ViewerCertificate.MinimumProtocolVersion", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   sprintf("Resources.%s.Properties.ViewerCertificate.MinimumProtocolVersion is TLSv1.1 or TLSv1.2", [name]),
+                "keyActualValue": 	  sprintf("Resources.%s.Properties.ViewerCertificate.MinimumProtocolVersion isn't TLSv1.1 or TLSv1.2", [name])
+              }
+}
+
+checkMinPortocolVersion(version)
+{
+	version == "TLSv1.1"
+}
+
+checkMinPortocolVersion(version)
+{
+	version == "TLSv1.2"
+}

--- a/assets/queries/cloudFormation/secure_ciphers_disabled/test/negative.yaml
+++ b/assets/queries/cloudFormation/secure_ciphers_disabled/test/negative.yaml
@@ -1,0 +1,25 @@
+#this code is a correct code for which the query should not find any result
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  cloudfrontdistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        CacheBehaviors:
+          - LambdaFunctionAssociations:
+              - EventType: viewer-request
+                LambdaFunctionARN: examp
+        DefaultCacheBehavior:
+          LambdaFunctionAssociations:
+            - EventType: viewer-request
+              LambdaFunctionARN: examp
+        IPV6Enabled: true
+        Origins:
+          - CustomOriginConfig:
+              OriginKeepaliveTimeout: 60
+              OriginReadTimeout: 30
+      Tags:
+        - Key: name
+          Value: example 
+      ViewerCertificate:
+        CloudFrontDefaultCertificate: true

--- a/assets/queries/cloudFormation/secure_ciphers_disabled/test/negative.yaml
+++ b/assets/queries/cloudFormation/secure_ciphers_disabled/test/negative.yaml
@@ -20,6 +20,6 @@ Resources:
               OriginReadTimeout: 30
       Tags:
         - Key: name
-          Value: example 
+          Value: example
       ViewerCertificate:
         CloudFrontDefaultCertificate: true

--- a/assets/queries/cloudFormation/secure_ciphers_disabled/test/positive.yaml
+++ b/assets/queries/cloudFormation/secure_ciphers_disabled/test/positive.yaml
@@ -20,8 +20,7 @@ Resources:
               OriginReadTimeout: 30
       Tags:
         - Key: name
-          Value: example 
+          Value: example
       ViewerCertificate:
         CloudFrontDefaultCertificate: false
         MinimumProtocolVersion: SSLv3
-      

--- a/assets/queries/cloudFormation/secure_ciphers_disabled/test/positive.yaml
+++ b/assets/queries/cloudFormation/secure_ciphers_disabled/test/positive.yaml
@@ -1,0 +1,27 @@
+#this is a problematic code where the query should report a result(s)
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  cloudfrontdistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        CacheBehaviors:
+          - LambdaFunctionAssociations:
+              - EventType: viewer-request
+                LambdaFunctionARN: examp
+        DefaultCacheBehavior:
+          LambdaFunctionAssociations:
+            - EventType: viewer-request
+              LambdaFunctionARN: examp
+        IPV6Enabled: true
+        Origins:
+          - CustomOriginConfig:
+              OriginKeepaliveTimeout: 60
+              OriginReadTimeout: 30
+      Tags:
+        - Key: name
+          Value: example 
+      ViewerCertificate:
+        CloudFrontDefaultCertificate: false
+        MinimumProtocolVersion: SSLv3
+      

--- a/assets/queries/cloudFormation/secure_ciphers_disabled/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/secure_ciphers_disabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Secure Ciphers Disabled",
+		"severity": "HIGH",
+		"line": 26
+	}
+]


### PR DESCRIPTION
Closes #732 

Check if secure ciphers aren't used in CloudFront