### PR TITLE
Add query to check if ECS Cluster has services  without TaskDefinition with roles. Closes #708

### DIFF
--- a/assets/queries/cloudFormation/ecs_service_in_cluster_no_task_definition/metadata.json
+++ b/assets/queries/cloudFormation/ecs_service_in_cluster_no_task_definition/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Empty_Roles_For_ECS_Cluster_Task_Definitions",
+  "queryName": "Empty Roles For ECS Cluster Task Definitions",
+  "severity": "MEDIUM",
+  "category": "Identity and Access Management",
+  "descriptionText": "Check if any ECS cluster has not defined proper roles for services' task definitions.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html"
+}

--- a/assets/queries/cloudFormation/ecs_service_in_cluster_no_task_definition/query.rego
+++ b/assets/queries/cloudFormation/ecs_service_in_cluster_no_task_definition/query.rego
@@ -1,0 +1,85 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::ECS::Service"
+  
+  isInCluster(resource)
+
+  object.get(resource.Properties,"TaskDefinition","undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties", [name]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.TaskDefinition' is set",[name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.TaskDefinition' is undefined",[name])
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::ECS::Service"
+  
+  isInCluster(resource)
+
+  object.get(resource.Properties,"TaskDefinition","undefined") != "undefined"
+  taskDefinition := resource.Properties.TaskDefinition
+  
+  existsTaskDefinition(taskDefinition) == null
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.TaskDefinition", [name]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.Taskdefinition' refers to a valid TaskDefinition",[name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.Taskdefinition' does not refers to a valid TaskDefinition",[name])
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::ECS::Service"
+  
+  isInCluster(resource)
+
+  object.get(resource.Properties,"TaskDefinition","undefined") != "undefined"
+  taskDefinition := resource.Properties.TaskDefinition
+  
+  taskDef:= existsTaskDefinition(taskDefinition)
+  taskDef != null
+
+  hasTaskRole(taskDef) == false
+  
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.TaskDefinition", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.TaskDefinition' refers to a TaskDefinition with Role",[name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.TaskDefinition' does not refer to a TaskDefinition with Role",[name])
+              }
+}
+
+isInCluster(service) = true {
+  cluster := service.Properties.Cluster
+  is_string(cluster)
+  input.document[_].Resources[cluster]
+} else = true {
+  cluster := service.Properties.Cluster
+  is_object(cluster)
+  object.get(cluster,"Ref","undefined") != "undefined"
+} else = false
+
+existsTaskDefinition(taskDefName) = taskDef {
+  is_string(taskDefName)
+  taskDef := input.document[_].Resource[taskDefName]
+} else = taskDef {
+  is_object(taskDefName)
+  object.get(taskDefName,"Ref","undefined") != "undefined"
+  ref := object.get(taskDefName,"Ref","undefined")
+  taskDef := object.get(input.document[_].Resources, ref, null)
+} else = null
+
+hasTaskRole(taskDef) = true {
+  object.get(taskDef.Properties,"TaskRoleArn","undefined") != "undefined"
+} else = false

--- a/assets/queries/cloudFormation/ecs_service_in_cluster_no_task_definition/test/negative.yaml
+++ b/assets/queries/cloudFormation/ecs_service_in_cluster_no_task_definition/test/negative.yaml
@@ -1,0 +1,43 @@
+---
+Resources:
+  ECSService:
+    Type: AWS::ECS::Service
+    DependsOn:
+    - Listener
+    Properties:
+      Role:
+        Ref: ECSServiceRole
+      TaskDefinition:
+        Ref: ECSTaskDefinition
+      DesiredCount: 1
+      LoadBalancers:
+      - TargetGroupArn:
+          Ref: TargetGroup
+        ContainerPort: 80
+        ContainerName: sample-app
+      Cluster:
+        Ref: ECSCluster
+  ECSTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Ref 'ServiceName'
+      Cpu: !Ref 'ContainerCpu'
+      Memory: !Ref 'ContainerMemory'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'ECSTaskExecutionRole']]
+      TaskRoleArn:
+        Fn::If:
+          - 'HasCustomRole'
+          - !Ref 'Role'
+          - !Ref "AWS::NoValue"
+      ContainerDefinitions:
+        - Name: !Ref 'ServiceName'
+          Cpu: !Ref 'ContainerCpu'
+          Memory: !Ref 'ContainerMemory'
+          Image: !Ref 'ImageUrl'
+          PortMappings:
+            - ContainerPort: !Ref 'ContainerPort

--- a/assets/queries/cloudFormation/ecs_service_in_cluster_no_task_definition/test/positive.yaml
+++ b/assets/queries/cloudFormation/ecs_service_in_cluster_no_task_definition/test/positive.yaml
@@ -1,0 +1,70 @@
+---
+Resources:
+  NoTaskDefinition:
+    Type: AWS::ECS::Service
+    DependsOn:
+    - Listener
+    Properties:
+      Role:
+        Ref: ECSServiceRole
+      DesiredCount: 1
+      LoadBalancers:
+      - TargetGroupArn:
+          Ref: TargetGroup
+        ContainerPort: 80
+        ContainerName: sample-app
+      Cluster:
+        Ref: ECSCluster
+  InvalidTaskDefinition:
+    Type: AWS::ECS::Service
+    DependsOn:
+    - Listener
+    Properties:
+      Role:
+        Ref: ECSServiceRole
+      TaskDefinition:
+        Ref: MissingTaskDefinition
+      DesiredCount: 1
+      LoadBalancers:
+      - TargetGroupArn:
+          Ref: TargetGroup
+        ContainerPort: 80
+        ContainerName: sample-app
+      Cluster:
+        Ref: ECSCluster
+  TaskNoRole:
+    Type: AWS::ECS::Service
+    DependsOn:
+    - Listener
+    Properties:
+      Role:
+        Ref: ECSServiceRole
+      TaskDefinition:
+        Ref: ECSTaskDefinition
+      DesiredCount: 1
+      LoadBalancers:
+      - TargetGroupArn:
+          Ref: TargetGroup
+        ContainerPort: 80
+        ContainerName: sample-app
+      Cluster:
+        Ref: ECSCluster
+  ECSTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Ref 'ServiceName'
+      Cpu: !Ref 'ContainerCpu'
+      Memory: !Ref 'ContainerMemory'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn:
+        Fn::ImportValue:
+          !Join [':', [!Ref 'StackName', 'ECSTaskExecutionRole']]
+      ContainerDefinitions:
+        - Name: !Ref 'ServiceName'
+          Cpu: !Ref 'ContainerCpu'
+          Memory: !Ref 'ContainerMemory'
+          Image: !Ref 'ImageUrl'
+          PortMappings:
+            - ContainerPort: !Ref 'ContainerPort'

--- a/assets/queries/cloudFormation/ecs_service_in_cluster_no_task_definition/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ecs_service_in_cluster_no_task_definition/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Empty Roles For ECS Cluster Task Definitions",
+		"severity": "MEDIUM",
+		"line": 7
+	},
+	{
+		"queryName": "Empty Roles For ECS Cluster Task Definitions",
+		"severity": "MEDIUM",
+		"line": 25
+	},
+	{
+		"queryName": "Empty Roles For ECS Cluster Task Definitions",
+		"severity": "MEDIUM",
+		"line": 42
+	}
+]


### PR DESCRIPTION
Check if the ECS cluster has services that don't have Task Definitions Roles associated. Closes #708 