### PR TITLE
Add Sec. Groups Allows egress access query #748

### DIFF
--- a/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/metadata.json
+++ b/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "security_groups_allows_unrestricted_outbound_traffic",
+  "queryName": "Security Groups Allows Unrestricted Outbound Traffic",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "It is important that no security group allows unrestricted egress access",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html"
+}

--- a/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/query.rego
+++ b/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/query.rego
@@ -3,6 +3,9 @@ package Cx
 CxPolicy [ result ] {
    document := input.document
    resources := document[i].Resources[name]
+   
+   resources.Type == "AWS::EC2::SecurityGroup"
+   
    properties := resources.Properties
    properties.SecurityGroupEgress[j].IpProtocol == "ALL"
    properties.SecurityGroupEgress[j].CidrIp == "0.0.0.0/0"

--- a/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/query.rego
+++ b/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy [ result ] {
+   document := input.document
+   resources := document[i].Resources[name]
+   properties := resources.Properties
+   properties.SecurityGroupEgress[j].IpProtocol == "ALL"
+   properties.SecurityGroupEgress[j].CidrIp == "0.0.0.0/0"
+     
+      result := {
+                "documentId": 		input.document[i].id,
+                "searchKey":        sprintf("Resources.%s.Properties.SecurityGroupEgress[%d]", [name, j]),
+                "issueType":		   "IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.SecurityGroupEgress[%d] must have different IpProtocol from 'ALL' and CidrIp from '0.0.0.0/0'.", [name, j]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.SecurityGroupEgress[%d] must not have IpProtocol as 'ALL' and CidrIp as '0.0.0.0/0'.", [name, j])
+              }
+}

--- a/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/test/negative.yaml
+++ b/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/test/negative.yaml
@@ -1,0 +1,27 @@
+Parameters:
+  KeyName:
+    Description: The EC2 Key Pair to allow SSH access to the instance
+    Type: 'AWS::EC2::KeyPair::KeyName'
+Resources:
+  Ec2Instance:
+    Type: 'AWS::EC2::Instance'
+    Properties:
+      SecurityGroups:
+        - !Ref InstanceSecurityGroup
+        - MyExistingSecurityGroup
+      KeyName: !Ref KeyName
+      ImageId: ami-7a11e213
+  InstanceSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Enable SSH access via port 22
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: '22'
+          ToPort: '22'
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: '22'
+          ToPort: '22'
+          CidrIp: 0.0.0.0/0

--- a/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/test/positive.yaml
+++ b/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/test/positive.yaml
@@ -1,0 +1,27 @@
+Parameters:
+  KeyName:
+    Description: The EC2 Key Pair to allow SSH access to the instance
+    Type: 'AWS::EC2::KeyPair::KeyName'
+Resources:
+  Ec2Instance:
+    Type: 'AWS::EC2::Instance'
+    Properties:
+      SecurityGroups:
+        - !Ref InstanceSecurityGroup
+        - MyExistingSecurityGroup
+      KeyName: !Ref KeyName
+      ImageId: ami-7a11e213
+  InstanceSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Enable SSH access via port 22
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: '22'
+          ToPort: '22'
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: ALL
+          FromPort: '22'
+          ToPort: '22'
+          CidrIp: 0.0.0.0/0

--- a/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/security_groups_allows_unrestricted_outbound_traffic/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Security Groups Allows Unrestricted Outbound Traffic",
+		"severity": "HIGH",
+		"line": 16
+	}
+]


### PR DESCRIPTION
It is important that no security group allows unrestricted egress access.

Closes #748 