### PR TITLE
Feature/add new query dynamo db with aws owned cmk

### DIFF
--- a/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/metadata.json
+++ b/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/metadata.json
@@ -2,7 +2,7 @@
   "id": "DynamoDB_with_AWS_Owned_CMK",
   "queryName": "DynamoDB with AWS Owned CMK",
   "severity": "HIGH",
-  "category": null,
+  "category":  "Encryption and Key Management",
   "descriptionText": "AWS DynamoDb should be encrypted using AWS Managed CMK, instead of AWS-owned CMK. To verify this, SSEEnabled must be verified if false for AWS-owned CMK or true for AWS-Managed CMK. Default value is false.",
-  "descriptionUrl": "#"
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html"
 }

--- a/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/metadata.json
+++ b/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "DynamoDB_with_AWS_Owned_CMK",
+  "queryName": "DynamoDB with AWS Owned CMK",
+  "severity": "HIGH",
+  "category": null,
+  "descriptionText": "AWS DynamoDb should be encrypted using AWS Managed CMK, instead of AWS-owned CMK. To verify this, SSEEnabled must be verified if false for AWS-owned CMK or true for AWS-Managed CMK. Default value is false.",
+  "descriptionUrl": "#"
+}

--- a/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/query.rego
+++ b/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].resource
+  resource == "<VALUE>"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("%s", [resource]),
+                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
+                "keyExpectedValue": "<RESOURCE>",
+                "keyActualValue": 	resource
+              }
+}

--- a/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/query.rego
+++ b/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/query.rego
@@ -1,14 +1,74 @@
 package Cx
 
 CxPolicy [ result ] {
-  resource := input.document[i].resource
-  resource == "<VALUE>"
 
-	result := {
+  document := input.document[i]
+  resource := document.resources[key]
+  resource.Type == "AWS::DynamoDB::Table"
+  properties := resource.Properties
+  properties.SSESpecification.SSEType == "KMS"
+  properties.SSESpecification.SSEEnabled == false
+   
+   
+  result := {
                 "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("%s", [resource]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "<RESOURCE>",
-                "keyActualValue": 	resource
+                "searchKey": 	    sprintf("resources.%s.properties;", [key]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("resources[%s].properties.SSESpecification.SSEEnabled is true",[key]),
+                "keyActualValue": 	sprintf("resources[%s].properties.SSESpecification.SSEEnabled is false",[key])
               }
 }
+
+CxPolicy [ result ] {
+
+  document := input.document[i]
+  resource := document.resources[key]
+  resource.Type == "AWS::DynamoDB::Table"
+  properties := resource.Properties
+  object.get( properties ,"SSESpecification", "undefined") == "undefined"
+  
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("resources.%s.properties;", [key]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue":	sprintf("resources.%s.properties.SSESpecification is set",[key]),
+                "keyActualValue": 	sprintf("resources.%s.properties.SSESpecification is undefined",[key])
+              }
+}
+
+CxPolicy [ result ] {
+
+  document := input.document[i]
+  resource := document.resources[key]
+  resource.Type == "AWS::DynamoDB::Table"
+  properties := resource.Properties
+  object.get( properties.SSESpecification ,"SSEType", "undefined") == "undefined"
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("resources.%s.properties;", [key]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue":	sprintf("resources.%s.properties.SSESpecification.SSEType is set",[key]),
+                "keyActualValue": 	sprintf("resources.%s.properties.SSESpecification.SSEType is undefined",[key])
+              }
+}
+CxPolicy [ result ] {
+
+  document := input.document[i]
+  resource := document.resources[key]
+  resource.Type == "AWS::DynamoDB::Table"
+  properties := resource.Properties
+  
+  object.get( properties.SSESpecification ,"SSEEnabled", "undefined") == "undefined"
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("resources.%s.properties;", [key]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue":	sprintf("resources.%s.properties.SSESpecification.SSEEnabled is set",[key]),
+                "keyActualValue": 	sprintf("resources.%s.properties.SSESpecification.SSEEnabled is undefined",[key])
+              }
+}
+
+
+
+
+

--- a/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/negative.yaml
+++ b/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/negative.yaml
@@ -42,7 +42,7 @@ resources:
               - "kms:GenerateDataKeyWithoutPlaintext"
             Resource: "*"
 
-  DynamoDBOnDemandTable:
+  DynamoDBOnDemandTable1:
     Type: "AWS::DynamoDB::Table"
     Properties:
       TableName: "dynamodb-kms"

--- a/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/negative.yaml
+++ b/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/negative.yaml
@@ -1,0 +1,61 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Sample CloudFormation template for DynamoDB with customer managed CMK
+resources:
+  dynamodbKMSKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: "An example CMK"
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: "key-default-1"
+        Statement:
+         -
+            Sid: "Allow administration of the key"
+            Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::123456789012:user/ana"
+            Action:
+              - "kms:Create*"
+              - "kms:Describe*"
+              - "kms:Enable*"
+              - "kms:List*"
+              - "kms:Put*"
+              - "kms:Update*"
+              - "kms:Revoke*"
+              - "kms:Disable*"
+              - "kms:Get*"
+              - "kms:Delete*"
+              - "kms:ScheduleKeyDeletion"
+              - "kms:CancelKeyDeletion"
+            Resource: "*"
+         -
+            Sid: "Allow use of the key"
+            Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::123456789012:user/ana"
+            Action:
+              - "kms:DescribeKey"
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey"
+              - "kms:GenerateDataKeyWithoutPlaintext"
+            Resource: "*"
+
+  DynamoDBOnDemandTable:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      TableName: "dynamodb-kms"
+      AttributeDefinitions:
+        -
+          AttributeName: pk
+          AttributeType: S
+      KeySchema:
+        -
+          AttributeName: pk
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        KMSMasterKeyId: !Ref dynamodbKMSKey
+        SSEEnabled: true
+        SSEType: "KMS"

--- a/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/positive.yaml
+++ b/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/positive.yaml
@@ -1,10 +1,10 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Description: Sample CloudFormation template for DynamoDB with customer managed CMK
+Description: Sample CloudFormation template for DynamoDB with AWS-Owned CMK
 resources:
-  DynamoDBOnDemandTable:
+  DynamoDBOnDemandTable2:
     Type: "AWS::DynamoDB::Table"
     Properties:
-      TableName: "dynamodb-kms"
+      TableName: "dynamodb-kms-0"
       AttributeDefinitions:
         -
           AttributeName: pk
@@ -17,3 +17,58 @@ resources:
       SSESpecification:
         SSEEnabled: false
         SSEType: "KMS"
+---
+AWSTemplateFormatVersion: "2010-09-12"
+Description: Sample CloudFormation template for DynamoDB with AWS-Owned CMK
+resources:
+  DynamoDBOnDemandTable3:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      TableName: "dynamodb-kms-1"
+      AttributeDefinitions:
+        -
+          AttributeName: pk
+          AttributeType: S
+      KeySchema:
+        -
+          AttributeName: pk
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: false
+---
+AWSTemplateFormatVersion: "2010-09-11"
+Description: Sample CloudFormation template for DynamoDB with AWS-Owned CMK
+resources:
+  DynamoDBOnDemandTable4:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      TableName: "dynamodb-kms-2"
+      AttributeDefinitions:
+        -
+          AttributeName: pk
+          AttributeType: S
+      KeySchema:
+        -
+          AttributeName: pk
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEType: "KMS"
+---
+AWSTemplateFormatVersion: "2010-09-10"
+Description: Sample CloudFormation template for DynamoDB with AWS-Owned CMK
+resources:
+  DynamoDBOnDemandTable5:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      TableName: "dynamodb-kms-3"
+      AttributeDefinitions:
+        -
+          AttributeName: pk
+          AttributeType: S
+      KeySchema:
+        -
+          AttributeName: pk
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST

--- a/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/positive.yaml
+++ b/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/positive.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Sample CloudFormation template for DynamoDB with customer managed CMK
+resources:
+  DynamoDBOnDemandTable:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      TableName: "dynamodb-kms"
+      AttributeDefinitions:
+        -
+          AttributeName: pk
+          AttributeType: S
+      KeySchema:
+        -
+          AttributeName: pk
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: false
+        SSEType: "KMS"

--- a/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/positive_expected_result.json
@@ -2,6 +2,21 @@
 	{
 		"queryName": "DynamoDB with AWS Owned CMK",
 		"severity": "HIGH",
-		"line": 0
+		"line": 4
+	},
+	{
+		"queryName": "DynamoDB with AWS Owned CMK",
+		"severity": "HIGH",
+		"line": 62
+	},
+	{
+		"queryName": "DynamoDB with AWS Owned CMK",
+		"severity": "HIGH",
+		"line": 24
+	},
+	{
+		"queryName": "DynamoDB with AWS Owned CMK",
+		"severity": "HIGH",
+		"line": 43
 	}
 ]

--- a/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/DynamoDB_with_AWS_Owned_CMK/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "DynamoDB with AWS Owned CMK",
+		"severity": "HIGH",
+		"line": 0
+	}
+]


### PR DESCRIPTION
Description: 
AWS DynamoDb should be encrypted using AWS Managed CMK, instead of AWS-owned CMK. To verify this, SSEType should be CMK and SSEEnabled must be verified if false for AWS-owned CMK or true for AWS-Managed CMK. Default value is false.


Closes #761