### PR TITLE
Add query to check if policy grants full permissions unduly. Closes #772

### DIFF
--- a/assets/queries/cloudFormation/iam_policy_full_permissions/metadata.json
+++ b/assets/queries/cloudFormation/iam_policy_full_permissions/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "IAM_Policy_Grants_Full_Permissions",
+  "queryName": "IAM Policy Grants Full Permissions",
+  "severity": "LOW",
+  "category": "Identity and Access Management",
+  "descriptionText": "Check if an IAM policy is granting full permissions to resources from the get-go, instead of granting permissions gradually as necessary.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html"
+}

--- a/assets/queries/cloudFormation/iam_policy_full_permissions/query.rego
+++ b/assets/queries/cloudFormation/iam_policy_full_permissions/query.rego
@@ -1,0 +1,31 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::IAM::Policy"
+
+  statements := resource.PolicyDocument.Statement
+  checkPolicy(statements[i])
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.PolicyDocument.Statement.Resource=%s", [name,statements[i].Resource]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("'Resources.%s.PolicyDocument.Statement.Resource=%s' does not have full permissions or is Admin",[name,statements[i].Resource]),
+                "keyActualValue": 	sprintf("'Resources.%s.PolicyDocument.Statement.Resource=%s' has full permissions and is not Admin.",[name,statements[i].Resource])
+              }
+}
+
+checkPolicy(pol) {
+    pol.Effect == "Allow"
+    pol.Resource != "arn:aws:iam::aws:policy/AdministratorAccess"
+    checkAction(pol.Action)
+}
+
+checkAction(act) {
+	act == "*"
+}
+
+checkAction(act) {
+	act[_] == "*"
+}

--- a/assets/queries/cloudFormation/iam_policy_full_permissions/test/negative.yaml
+++ b/assets/queries/cloudFormation/iam_policy_full_permissions/test/negative.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template
+Resources:
+  adminPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+    PolicyName: mygrouppolicy
+    PolicyDocument:
+      Version: '2012-10-17'
+      Statement:
+      - Effect: Allow
+        Action: ["*"]
+        Resource: arn:aws:iam::aws:policy/AdministratorAccess
+    Groups:
+    - myexistinggroup1
+    - !Ref mygroup

--- a/assets/queries/cloudFormation/iam_policy_full_permissions/test/positive.yaml
+++ b/assets/queries/cloudFormation/iam_policy_full_permissions/test/positive.yaml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template
+Resources:
+  mypolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+    PolicyName: mygrouppolicy
+    PolicyDocument:
+      Version: '2012-10-17'
+      Statement:
+      - Effect: Allow
+        Action: ["*"]
+        Resource: "*"
+    Groups:
+    - myexistinggroup1
+    - !Ref mygroup
+  mypolicy2:
+    Type: AWS::IAM::Policy
+    Properties:
+    PolicyName: mygrouppolicy
+    PolicyDocument:
+      Version: '2012-10-17'
+      Statement:
+      - Effect: Allow
+        Action: "*"
+        Resource: "*"
+    Groups:
+    - myexistinggroup1
+    - !Ref mygroup
+
+
+

--- a/assets/queries/cloudFormation/iam_policy_full_permissions/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/iam_policy_full_permissions/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "IAM Policy Grants Full Permissions",
+		"severity": "LOW",
+		"line": 13
+	},
+	{
+		"queryName": "IAM Policy Grants Full Permissions",
+		"severity": "LOW",
+		"line": 26
+	}
+]


### PR DESCRIPTION
Check if an IAM policy is granting full permissions to a Resource that is not Admin, which should not happen, the resource should only have the necessary permissions. Closes #772 