### PR TITLE
Add query to check if AWS Support is associated to role or user. Closes #778

### DIFF
--- a/assets/queries/cloudFormation/aws_support_has_no_role/metadata.json
+++ b/assets/queries/cloudFormation/aws_support_has_no_role/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "AWS_Support_Has_No_Role_Associated",
+  "queryName": "AWS Support Has No Role Associated",
+  "severity": "LOW",
+  "category": "Identity and Access Management",
+  "descriptionText": "Check if any AWS Support policy does not have any role and users and group associated, which means that is not being managed.",
+  "descriptionUrl": "https://docs.aws.amazon.com/awssupport/latest/user/security-iam.html#security_iam_access-manage"
+}

--- a/assets/queries/cloudFormation/aws_support_has_no_role/query.rego
+++ b/assets/queries/cloudFormation/aws_support_has_no_role/query.rego
@@ -1,0 +1,54 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.PolicyName == "AWSSupportAccess"
+  resource.Type == "AWS::IAM::Policy"
+
+  not hasAttributeList(resource,"Roles")
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("'Resources.%s.Roles' is set",[name]),
+                "keyActualValue":  sprintf("'Resources.%s.Roles' is undefined",[name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.PolicyName == "AWSSupportAccess"
+  resource.Type == "AWS::IAM::Policy"
+
+  not hasAttributeList(resource,"Users")
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("'Resources.%s.Users' is set",[name]),
+                "keyActualValue":  sprintf("'Resources.%s.Users' is undefined",[name]),
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.PolicyName == "AWSSupportAccess"
+  resource.Type == "AWS::IAM::Policy"
+
+  not hasAttributeList(resource,"Groups")
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("'Resources.%s.Groups' is set",[name]),
+                "keyActualValue":  sprintf("'Resources.%s.Groups' is undefined",[name]),
+              }
+}
+
+hasAttributeList(resource,attribute) {
+  object.get(resource,attribute,"undefined") != "undefined"
+  count(resource[attribute]) > 0
+} else = false

--- a/assets/queries/cloudFormation/aws_support_has_no_role/test/negative.yaml
+++ b/assets/queries/cloudFormation/aws_support_has_no_role/test/negative.yaml
@@ -1,0 +1,16 @@
+MyPolicy:
+  Type: AWS::IAM::Policy
+  Properties:
+    PolicyName: mygrouppolicy
+    PolicyDocument:
+      Version: '2012-10-17'
+      Statement:
+      - Effect: Allow
+        Action:
+        - s3:GetObject
+        - s3:PutObject
+        - s3:PutObjectAcl
+        Resource: arn:aws:s3:::myAWSBucket/*
+    Groups:
+    - myexistinggroup1
+    - !Ref mygroup

--- a/assets/queries/cloudFormation/aws_support_has_no_role/test/positive.yaml
+++ b/assets/queries/cloudFormation/aws_support_has_no_role/test/positive.yaml
@@ -38,6 +38,4 @@ Resources:
     Roles: ["SomeRole"]
     Users: ["SomeUser"]
 
-    
-
 

--- a/assets/queries/cloudFormation/aws_support_has_no_role/test/positive.yaml
+++ b/assets/queries/cloudFormation/aws_support_has_no_role/test/positive.yaml
@@ -1,0 +1,43 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template
+Resources:
+  noRoles:
+    Type: AWS::IAM::Policy
+    Properties:
+    PolicyName: AWSSupportAccess
+    PolicyDocument:
+      Version: '2012-10-17'
+      Statement:
+      - Effect: Allow
+        Action: ["*"]
+        Resource: "*"
+    Users: ["SomeUser"]
+    Groups: ["SomeGroup"]
+  noUsers:
+    Type: AWS::IAM::Policy
+    Properties:
+    PolicyName: AWSSupportAccess
+    PolicyDocument:
+      Version: '2012-10-17'
+      Statement:
+      - Effect: Allow
+        Action: ["*"]
+        Resource: "*"
+    Roles: ["SomeRole"]
+    Groups: ["SomeGroup"]
+  noGroups:
+    Type: AWS::IAM::Policy
+    Properties:
+    PolicyName: AWSSupportAccess
+    PolicyDocument:
+      Version: '2012-10-17'
+      Statement:
+      - Effect: Allow
+        Action: ["*"]
+        Resource: "*"
+    Roles: ["SomeRole"]
+    Users: ["SomeUser"]
+
+    
+
+

--- a/assets/queries/cloudFormation/aws_support_has_no_role/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/aws_support_has_no_role/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "AWS Support Has No Role Associated",
+		"severity": "LOW",
+		"line": 4
+	},
+	{
+		"queryName": "AWS Support Has No Role Associated",
+		"severity": "LOW",
+		"line": 16
+	},
+	{
+		"queryName": "AWS Support Has No Role Associated",
+		"severity": "LOW",
+		"line": 28
+	}
+]


### PR DESCRIPTION
Check if any AWS support policy is not associated with a role, user, or group. Closes #778 