### PR TITLE
Add ELB Using Insecure Protocols query for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/elb_using_insecure_protocols/metadata.json
+++ b/assets/queries/cloudFormation/elb_using_insecure_protocols/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ELB_Using_Insecure_Protocols",
+  "queryName": "ELB Using Insecure Protocols",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "ELB Predefined or Custom Security Policies must not use insecure protocols, to reduce the risk of the SSL connection between the client and the load balancer being exploited. That means the ELB Listeners must not have Policies that coincide with any of a predefined list of insecure protocols.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html"
+}

--- a/assets/queries/cloudFormation/elb_using_insecure_protocols/metadata.json
+++ b/assets/queries/cloudFormation/elb_using_insecure_protocols/metadata.json
@@ -3,6 +3,6 @@
   "queryName": "ELB Using Insecure Protocols",
   "severity": "HIGH",
   "category": "Encryption and Key Management",
-  "descriptionText": "ELB Predefined or Custom Security Policies must not use insecure protocols, to reduce the risk of the SSL connection between the client and the load balancer being exploited. That means the ELB Listeners must not have Policies that coincide with any of a predefined list of insecure protocols.",
+  "descriptionText": "ELB Predefined or Custom Security Policies must not use insecure protocols, to reduce the risk of the SSL connection between the client and the load balancer being exploited. That means the ELB Listeners must not have Policies that posses Protocols that coincide with any of a predefined list of insecure protocols.",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html"
 }

--- a/assets/queries/cloudFormation/elb_using_insecure_protocols/query.rego
+++ b/assets/queries/cloudFormation/elb_using_insecure_protocols/query.rego
@@ -1,0 +1,22 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+    resource.Type == "AWS::ElasticLoadBalancing::LoadBalancer"
+    policyName := resource.Properties.Policies[j].PolicyName
+  	protocol := resource.Properties.Policies[j].Attributes[k].Name
+  	check_vulnerability(protocol)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.Policies.PolicyName=%s.Attributes.Name=%s",  [name, policyName, protocol]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.Policies.%s.Attributes.%s' is not an insecure protocol", [name, policyName, protocol]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.Policies.%s.Attributes.%s' is an insecure protocol", [name, policyName, protocol]),
+              }
+}
+
+check_vulnerability(protocol) {
+	insecure_protocols = {"Protocol-SSLv2", "Protocol-SSLv3", "Protocol-TLSv1", "Protocol-TLSv1.1"}
+  	protocol == insecure_protocols[_]
+}

--- a/assets/queries/cloudFormation/elb_using_insecure_protocols/test/negative.yaml
+++ b/assets/queries/cloudFormation/elb_using_insecure_protocols/test/negative.yaml
@@ -11,7 +11,7 @@ Resources:
             InstanceProtocol: HTTP
             LoadBalancerPort: '443'
             Protocol: HTTPS
-            PolicyNames: 
+            PolicyNames:
             - My-SSLNegotiation-Policy
             SSLCertificateId: arn:aws:iam::123456789012:server-certificate/my-server-certificate
           HealthCheck:

--- a/assets/queries/cloudFormation/elb_using_insecure_protocols/test/negative.yaml
+++ b/assets/queries/cloudFormation/elb_using_insecure_protocols/test/negative.yaml
@@ -1,0 +1,28 @@
+#this code is a correct code for which the query should not find any result
+Resources:
+    MyLoadBalancer:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          AvailabilityZones:
+          - "us-east-2a"
+          CrossZone: true
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: HTTPS
+            PolicyNames: 
+            - My-SSLNegotiation-Policy
+            SSLCertificateId: arn:aws:iam::123456789012:server-certificate/my-server-certificate
+          HealthCheck:
+            Target: HTTP:80/
+            HealthyThreshold: '2'
+            UnhealthyThreshold: '3'
+            Interval: '10'
+            Timeout: '5'
+          Policies:
+          - PolicyName: My-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01

--- a/assets/queries/cloudFormation/elb_using_insecure_protocols/test/positive.yaml
+++ b/assets/queries/cloudFormation/elb_using_insecure_protocols/test/positive.yaml
@@ -11,7 +11,7 @@ Resources:
             InstanceProtocol: HTTP
             LoadBalancerPort: '443'
             Protocol: HTTPS
-            PolicyNames: 
+            PolicyNames:
             - My-SSLNegotiation-Policy
             SSLCertificateId: arn:aws:iam::123456789012:server-certificate/my-server-certificate
           HealthCheck:
@@ -27,7 +27,7 @@ Resources:
             - Name: Protocol-SSLv2
               Value: ELBSecurityPolicy-TLS-1-2-2017-01
             - Name: Reference-Security-Policy
-              Value: ELBSecurityPolicy-TLS-1-2-2017-01 
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01
           - PolicyName: My-SSLNegotiation-Policy2
             PolicyType: SSLNegotiationPolicyType
             Attributes:

--- a/assets/queries/cloudFormation/elb_using_insecure_protocols/test/positive.yaml
+++ b/assets/queries/cloudFormation/elb_using_insecure_protocols/test/positive.yaml
@@ -1,0 +1,35 @@
+#this is a problematic code where the query should report a result(s)
+Resources:
+    MyLoadBalancer:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          AvailabilityZones:
+          - "us-east-2a"
+          CrossZone: true
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: HTTPS
+            PolicyNames: 
+            - My-SSLNegotiation-Policy
+            SSLCertificateId: arn:aws:iam::123456789012:server-certificate/my-server-certificate
+          HealthCheck:
+            Target: HTTP:80/
+            HealthyThreshold: '2'
+            UnhealthyThreshold: '3'
+            Interval: '10'
+            Timeout: '5'
+          Policies:
+          - PolicyName: My-SSLNegotiation-Policy
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Protocol-SSLv2
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01
+            - Name: Reference-Security-Policy
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01 
+          - PolicyName: My-SSLNegotiation-Policy2
+            PolicyType: SSLNegotiationPolicyType
+            Attributes:
+            - Name: Protocol-TLSv1
+              Value: ELBSecurityPolicy-TLS-1-2-2017-01

--- a/assets/queries/cloudFormation/elb_using_insecure_protocols/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/elb_using_insecure_protocols/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "ELB Using Insecure Protocols",
+		"severity": "HIGH",
+		"line": 27
+	},
+	{
+		"queryName": "ELB Using Insecure Protocols",
+		"severity": "HIGH",
+		"line": 34
+	}
+]


### PR DESCRIPTION
Adding ELB Using Insecure Protocols query for AWS CloudFormation, that checks if ELB Listeners have Policies that possess Protocols that coincide with any of a predefined list of insecure protocols.

Closes #805