### PR TITLE
Add query to check if user has too many access keys. closes #804

### DIFF
--- a/assets/queries/cloudFormation/iam_user_too_many_access_keys/metadata.json
+++ b/assets/queries/cloudFormation/iam_user_too_many_access_keys/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "IAM_User_Has_Too_Many_Access_Keys",
+  "queryName": "IAM User Has Too Many Access Keys",
+  "severity": "MEDIUM",
+  "category": "Identity and Access Management",
+  "descriptionText": "Check if any user has more than one access key, which increases the risk of unauthorized access and compromise of credentials.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-accesskey.html"
+}

--- a/assets/queries/cloudFormation/iam_user_too_many_access_keys/query.rego
+++ b/assets/queries/cloudFormation/iam_user_too_many_access_keys/query.rego
@@ -1,0 +1,22 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::IAM::AccessKey"
+  user := resource.Properties.UserName
+  findAnotherAccessKey(name,user)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("'Resources.%s' is the only AccessKey of user '%s'",[name,user]),
+                "keyActualValue": 	sprintf("'Resources.%s' is not the only AccessKey of user '%s'",[name,user])
+              }
+}
+
+findAnotherAccessKey(firstKey,userName) {
+  key := input.document[_].Resources[secondKey]
+  firstKey != secondKey
+  key.Properties.UserName == userName
+} else = false

--- a/assets/queries/cloudFormation/iam_user_too_many_access_keys/test/negative.yaml
+++ b/assets/queries/cloudFormation/iam_user_too_many_access_keys/test/negative.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template
+Resources:
+    myuser:
+      Type: AWS::IAM::User
+      Properties:
+        Path: "/"
+        LoginProfile:
+          Password: myP@ssW0rd
+    firstKey:
+      Type: AWS::IAM::AccessKey
+      Properties:
+        UserName:
+          Ref: myuser

--- a/assets/queries/cloudFormation/iam_user_too_many_access_keys/test/positive.yaml
+++ b/assets/queries/cloudFormation/iam_user_too_many_access_keys/test/positive.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template
+Resources:
+    myuser:
+      Type: AWS::IAM::User
+      Properties:
+        Path: "/"
+        LoginProfile:
+          Password: myP@ssW0rd
+    firstKey:
+      Type: AWS::IAM::AccessKey
+      Properties:
+        UserName: !Ref myuser
+    secondKey:
+      Type: AWS::IAM::AccessKey
+      Properties:
+        UserName: !Ref myuser

--- a/assets/queries/cloudFormation/iam_user_too_many_access_keys/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/iam_user_too_many_access_keys/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "IAM User Has Too Many Access Keys",
+		"severity": "MEDIUM",
+		"line": 10
+	},
+	{
+		"queryName": "IAM User Has Too Many Access Keys",
+		"severity": "MEDIUM",
+		"line": 14
+	}
+]


### PR DESCRIPTION
Check if an IAM user has more than one access key associated, which increases the risk of unauthorized access. closes #804 