### PR TITLE
Add redshift_instances_not_encrypted Closes #801

### DIFF
--- a/assets/queries/cloudFormation/redshift_instances_not_encrypted/metadata.json
+++ b/assets/queries/cloudFormation/redshift_instances_not_encrypted/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "redshift_instances_not_encrypted",
-  "queryName": "Redshift Instances Not Encrypted",
+  "queryName": "AWS Redshift Cluster Not Encrypted",
   "severity": "HIGH",
   "category": "Encryption and Key Management",
-  "descriptionText": "AWS Redshift instances should be encrypted",
+  "descriptionText": "AWS Redshift Cluster should be encrypted",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html"
 }

--- a/assets/queries/cloudFormation/redshift_instances_not_encrypted/metadata.json
+++ b/assets/queries/cloudFormation/redshift_instances_not_encrypted/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "redshift_instances_not_encrypted",
+  "queryName": "Redshift Instances Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "AWS Redshift instances should be encrypted",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html"
+}

--- a/assets/queries/cloudFormation/redshift_instances_not_encrypted/query.rego
+++ b/assets/queries/cloudFormation/redshift_instances_not_encrypted/query.rego
@@ -1,0 +1,38 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+    resource.Type == "AWS::Redshift::Cluster"
+
+    object.get(resource.Properties, "Encrypted", "undefined") == "undefined"
+
+
+    result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey": 	      sprintf("Resources.%s.Properties", [name]),
+                "issueType":		    "MissingAttribute",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.Encrypted is set", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.Encrypted is undefined", [name])
+              }
+}
+
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+    resource.Type == "AWS::Redshift::Cluster"
+    
+    properties := resource.Properties
+
+    object.get(properties, "Encrypted", "undefined") != "undefined"
+    
+    properties.Encrypted == false
+
+
+    result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey": 	      sprintf("Resources.%s.Properties.Encrypted", [name]),
+                "issueType":		    "IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.Encrypted is set to true", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.Encryped is set to false", [name])
+              }
+}

--- a/assets/queries/cloudFormation/redshift_instances_not_encrypted/test/negative.yaml
+++ b/assets/queries/cloudFormation/redshift_instances_not_encrypted/test/negative.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: 2010-09-11
+Description: Redshift Stack2
+Resources:
+  RedshiftCluster2:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterSubnetGroupName: !Ref RedshiftClusterSubnetGroup
+      ClusterType: !If [ SingleNode, single-node, multi-node ]
+      NumberOfNodes: !If [ SingleNode, !Ref 'AWS::NoValue', !Ref RedshiftNodeCount ] #'
+      DBName: !Sub ${DatabaseName}
+      IamRoles:
+        - !GetAtt RawDataBucketAccessRole.Arn
+      MasterUserPassword: !Ref MasterUserPassword
+      MasterUsername: !Ref MasterUsername
+      PubliclyAccessible: true
+      NodeType: dc1.large
+      Port: 5439
+      VpcSecurityGroupIds:
+        - !Sub ${RedshiftSecurityGroup}
+      PreferredMaintenanceWindow: Sun:09:15-Sun:09:45
+      Encrypted: true
+  DataBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${DataBucketName}

--- a/assets/queries/cloudFormation/redshift_instances_not_encrypted/test/positive.yaml
+++ b/assets/queries/cloudFormation/redshift_instances_not_encrypted/test/positive.yaml
@@ -1,0 +1,52 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Redshift Stack
+Resources:
+  RedshiftCluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterSubnetGroupName: !Ref RedshiftClusterSubnetGroup
+      ClusterType: !If [ SingleNode, single-node, multi-node ]
+      NumberOfNodes: !If [ SingleNode, !Ref 'AWS::NoValue', !Ref RedshiftNodeCount ] #'
+      DBName: !Sub ${DatabaseName}
+      IamRoles:
+        - !GetAtt RawDataBucketAccessRole.Arn
+      MasterUserPassword: !Ref MasterUserPassword
+      MasterUsername: !Ref MasterUsername
+      PubliclyAccessible: true
+      NodeType: dc1.large
+      Port: 5439
+      VpcSecurityGroupIds:
+        - !Sub ${RedshiftSecurityGroup}
+      PreferredMaintenanceWindow: Sun:09:15-Sun:09:45
+  DataBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${DataBucketName}
+
+
+---
+AWSTemplateFormatVersion: 2010-09-11
+Description: Redshift Stack2
+Resources:
+  RedshiftCluster2:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterSubnetGroupName: !Ref RedshiftClusterSubnetGroup
+      ClusterType: !If [ SingleNode, single-node, multi-node ]
+      NumberOfNodes: !If [ SingleNode, !Ref 'AWS::NoValue', !Ref RedshiftNodeCount ] #'
+      DBName: !Sub ${DatabaseName}
+      IamRoles:
+        - !GetAtt RawDataBucketAccessRole.Arn
+      MasterUserPassword: !Ref MasterUserPassword
+      MasterUsername: !Ref MasterUsername
+      PubliclyAccessible: true
+      NodeType: dc1.large
+      Port: 5439
+      VpcSecurityGroupIds:
+        - !Sub ${RedshiftSecurityGroup}
+      PreferredMaintenanceWindow: Sun:09:15-Sun:09:45
+      Encrypted: false
+  DataBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${DataBucketName}

--- a/assets/queries/cloudFormation/redshift_instances_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/redshift_instances_not_encrypted/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Redshift Instances Not Encrypted",
+		"queryName": "AWS Redshift Cluster Not Encrypted",
 		"severity": "HIGH",
 		"line": 6
 	},
 
 	{
-		"queryName": "Redshift Instances Not Encrypted",
+		"queryName": "AWS Redshift Cluster Not Encrypted",
 		"severity": "HIGH",
 		"line": 48
 	}

--- a/assets/queries/cloudFormation/redshift_instances_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/redshift_instances_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,13 @@
+[
+	{
+		"queryName": "Redshift Instances Not Encrypted",
+		"severity": "HIGH",
+		"line": 6
+	},
+
+	{
+		"queryName": "Redshift Instances Not Encrypted",
+		"severity": "HIGH",
+		"line": 48
+	}
+]


### PR DESCRIPTION
For this query, it necessary to check if the attribute 'Encrypted' not exists in 'Properties' or if exists in 'Properties' and is set to false, since if set to true, the data in the cluster is encrypted at rest.


Closes #801