### PR TITLE
Add ECS No Load Balancer Attached query for AWS CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/ecs_no_load_balancer_attached/metadata.json
+++ b/assets/queries/cloudFormation/ecs_no_load_balancer_attached/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ECS_No_Load_Balancer_Attached",
+  "queryName": "ECS No Load Balancer Attached",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Amazon ECS service should be configured to use Load Balancing to distribute traffic evenly across the tasks, which means there must exist at least one LoadBalancer.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html"
+}

--- a/assets/queries/cloudFormation/ecs_no_load_balancer_attached/query.rego
+++ b/assets/queries/cloudFormation/ecs_no_load_balancer_attached/query.rego
@@ -1,0 +1,49 @@
+package Cx
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::ECS::Service"
+    not resource.Properties.LoadBalancers
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties",  [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.LoadBalancers' is defined", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.LoadBalancers' is not defined", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::ECS::Service"
+    resource.Properties.LoadBalancers == null
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.LoadBalancers",  [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.LoadBalancers' is null", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.LoadBalancers' is not null", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::ECS::Service"
+    resource.Properties.LoadBalancers
+    check_size(resource.Properties.LoadBalancers)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.Policies.LoadBalancers",  [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.Policies.LoadBalancers' is not empty", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.Policies.LoadBalancers' is empty", [name]),
+              }
+}
+
+check_size(array) {
+	  is_array(array)
+    count(array) == 0
+}

--- a/assets/queries/cloudFormation/ecs_no_load_balancer_attached/test/negative.yaml
+++ b/assets/queries/cloudFormation/ecs_no_load_balancer_attached/test/negative.yaml
@@ -1,0 +1,19 @@
+#this code is a correct code for which the query should not find any result
+Resources:
+  ECSService:
+    Type: AWS::ECS::Service
+    DependsOn:
+    - Listener
+    Properties:
+      Role:
+        Ref: ECSServiceRole
+      TaskDefinition:
+        Ref: ECSTaskDefinition
+      DesiredCount: 1
+      LoadBalancers:
+      - TargetGroupArn:
+          Ref: TargetGroup
+        ContainerPort: 80
+        ContainerName: sample-app
+      Cluster:
+        Ref: ECSCluster

--- a/assets/queries/cloudFormation/ecs_no_load_balancer_attached/test/positive.yaml
+++ b/assets/queries/cloudFormation/ecs_no_load_balancer_attached/test/positive.yaml
@@ -1,0 +1,27 @@
+#this is a problematic code where the query should report a result(s)
+Resources:
+  ECSService:
+    Type: AWS::ECS::Service
+    DependsOn:
+    - Listener
+    Properties:
+      Role:
+        Ref: ECSServiceRole
+      TaskDefinition:
+        Ref: ECSTaskDefinition
+      DesiredCount: 1
+      Cluster:
+        Ref: ECSCluster
+  ECSService2:
+    Type: AWS::ECS::Service
+    DependsOn:
+    - Listener
+    Properties:
+      Role:
+        Ref: ECSServiceRole
+      TaskDefinition:
+        Ref: ECSTaskDefinition
+      DesiredCount: 1
+      LoadBalancers:
+      Cluster:
+        Ref: ECSCluster

--- a/assets/queries/cloudFormation/ecs_no_load_balancer_attached/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ecs_no_load_balancer_attached/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "ECS No Load Balancer Attached",
+		"severity": "HIGH",
+		"line": 7
+	},
+	{
+		"queryName": "ECS No Load Balancer Attached",
+		"severity": "HIGH",
+		"line": 25
+	}
+]


### PR DESCRIPTION
Adding ECS No Load Balancer Attached query for AWS CloudFormation, that checks if there exists at least one LoadBalancer.

Closes #829