### PR TITLE
Add alb_is_not_integrated_with_waf query for AWS CloudFormation #821

### DIFF
--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/metadata.json
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "alb_is_not_integrated_with_waf",
+  "queryName": "ALB Is Not Integrated With WAF",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "All Application Load Balancers (ALB) must be protected with Web Application Firewall (WAF) service",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-webaclassociation.html"
+}

--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/query.rego
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/query.rego
@@ -1,0 +1,40 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  
+  isLoadBalancer(resource)
+  not internalALB(resource)
+  not associatedWAF(name)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s", [name]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": sprintf("'Resources.Type=AWS::WAFRegional::WebACLAssociation.ResourceArn.Ref=%s' is defined", [name]),
+                "keyActualValue": 	sprintf("'Resources.Type=AWS::WAFRegional::WebACLAssociation.ResourceArn.Ref=%s' is undefined", [name])
+              }
+}
+
+isLoadBalancer(resource) {
+	resource.Type == "AWS::ElasticLoadBalancing::LoadBalancer"
+}
+isLoadBalancer(resource) {
+	resource.Type == "AWS::ElasticLoadBalancingV2::LoadBalancer"
+}
+
+internalALB(resource) {
+	scheme := resource.Properties.Scheme
+  scheme == "internal"
+}
+
+associatedWAF(target_alb) {
+	resource := input.document[_].Resources[_]
+  resource.Type == "AWS::WAFRegional::WebACLAssociation"
+  resource.Properties.ResourceArn.Ref == target_alb
+}
+associatedWAF(target_alb) {
+	resource := input.document[_].Resources[_]
+  resource.Type == "AWS::WAFRegional::WebACLAssociation"
+  resource.Properties.ResourceArn == target_alb
+}

--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/negative.yaml
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/negative.yaml
@@ -1,0 +1,24 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+    MyLoadBalancer:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          AvailabilityZones:
+          - "us-east-2a"
+          CrossZone: true
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: HTTPS
+            PolicyNames:
+            - My-SSLNegotiation-Policy
+            SSLCertificateId: arn:aws:iam::123456789012:server-certificate/my-server-certificate
+          Scheme: internet-facing
+    MyWebACLAssociation:
+      Type: "AWS::WAFRegional::WebACLAssociation"
+      Properties:
+        ResourceArn:
+          Ref: MyLoadBalancer
+        WebACLId:
+          Ref: MyWebACL

--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/positive.yaml
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/positive.yaml
@@ -1,0 +1,22 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+    MyLoadBalancer:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          AvailabilityZones:
+          - "us-east-2a"
+          CrossZone: true
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTP
+            LoadBalancerPort: '443'
+            Protocol: HTTPS
+            PolicyNames:
+            - My-SSLNegotiation-Policy
+            SSLCertificateId: arn:aws:iam::123456789012:server-certificate/my-server-certificate
+          Scheme: internet-facing
+    MyLoadBalancerV2:
+        Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+        Properties:
+            Name: myloadbalancerv2
+            Scheme: internet-facing

--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "ALB Is Not Integrated With WAF",
+		"severity": "MEDIUM",
+		"line": 3
+	},
+	{
+		"queryName": "ALB Is Not Integrated With WAF",
+		"severity": "MEDIUM",
+		"line": 18
+	}
+]


### PR DESCRIPTION
Closes #821 

All Application Load Balancers (ALB) must be protected with Web Application Firewall (WAF) service.

This query checks if a public ALB ('Scheme' field not "internal") has no associated WAF resource (a "AWS::WAFRegional::WebACLAssociation" resource with "ResourceArn" field referring the ALB resource).