### PR TITLE
Add Redshift Cluster Publicly Accessible query for CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/metadata.json
+++ b/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Redshift_Cluster_Publicly_Accessible",
+  "queryName": "Redshift Cluster Publicly Accessible",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "AWS Redshift Clusters must not be publicly accessible, which means the attribute 'PubliclyAccessible' must be set to false",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html"
+}

--- a/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/query.rego
+++ b/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+    resource.Type == "AWS::Redshift::Cluster"
+    object.get(resource.Properties, "PubliclyAccessible", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties",  [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.PubliclyAccessible' is defined", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.PubliclyAccessible' is not defined", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+    resource.Type == "AWS::Redshift::Cluster"
+    resource.Properties.PubliclyAccessible == true
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.PubliclyAccessible",  [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.PubliclyAccessible' is false", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.PubliclyAccessible' is true", [name]),
+              }
+}

--- a/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/test/negative.yaml
+++ b/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/test/negative.yaml
@@ -1,12 +1,12 @@
 #this code is a correct code for which the query should not find any result
 Resources:
-  myCluster: 
+  myCluster:
     Type: "AWS::Redshift::Cluster"
     Properties:
       PubliclyAccessible: false
       DBName: "mydb"
       MasterUsername: "master"
-      MasterUserPassword: 
+      MasterUserPassword:
         Ref: "MasterUserPassword"
       NodeType: "ds2.xlarge"
       ClusterType: "single-node"

--- a/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/test/negative.yaml
+++ b/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/test/negative.yaml
@@ -1,0 +1,15 @@
+#this code is a correct code for which the query should not find any result
+Resources:
+  myCluster: 
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      PubliclyAccessible: false
+      DBName: "mydb"
+      MasterUsername: "master"
+      MasterUserPassword: 
+        Ref: "MasterUserPassword"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"
+      Tags:
+        - Key: foo
+          Value: bar

--- a/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/test/positive.yaml
+++ b/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/test/positive.yaml
@@ -1,0 +1,27 @@
+#this is a problematic code where the query should report a result(s)
+Resources:
+  myCluster: 
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      DBName: "mydb"
+      MasterUsername: "master"
+      MasterUserPassword: 
+        Ref: "MasterUserPassword"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"
+      Tags:
+        - Key: foo
+          Value: bar
+  myCluster2: 
+    Type: "AWS::Redshift::Cluster"
+    Properties:
+      PubliclyAccessible: true
+      DBName: "mydb"
+      MasterUsername: "master"
+      MasterUserPassword: 
+        Ref: "MasterUserPassword"
+      NodeType: "ds2.xlarge"
+      ClusterType: "single-node"
+      Tags:
+        - Key: foo
+          Value: bar

--- a/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/test/positive.yaml
+++ b/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/test/positive.yaml
@@ -1,24 +1,24 @@
 #this is a problematic code where the query should report a result(s)
 Resources:
-  myCluster: 
+  myCluster:
     Type: "AWS::Redshift::Cluster"
     Properties:
       DBName: "mydb"
       MasterUsername: "master"
-      MasterUserPassword: 
+      MasterUserPassword:
         Ref: "MasterUserPassword"
       NodeType: "ds2.xlarge"
       ClusterType: "single-node"
       Tags:
         - Key: foo
           Value: bar
-  myCluster2: 
+  myCluster2:
     Type: "AWS::Redshift::Cluster"
     Properties:
       PubliclyAccessible: true
       DBName: "mydb"
       MasterUsername: "master"
-      MasterUserPassword: 
+      MasterUserPassword:
         Ref: "MasterUserPassword"
       NodeType: "ds2.xlarge"
       ClusterType: "single-node"

--- a/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/redshift_cluster_publicly_accessible/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Redshift Cluster Publicly Accessible",
+		"severity": "MEDIUM",
+		"line": 5
+	},
+	{
+		"queryName": "Redshift Cluster Publicly Accessible",
+		"severity": "MEDIUM",
+		"line": 18
+	}
+]


### PR DESCRIPTION
Adding Redshift Cluster Publicly Accessible query for CloudFormation, that checks if the attribute 'PubliclyAccessible' is set to false and defined.

Closes #844