### PR TITLE
Add alb_listeners_accept_http query for AWS CloudFormation #842

### DIFF
--- a/assets/queries/cloudFormation/alb_listeners_accept_http/metadata.json
+++ b/assets/queries/cloudFormation/alb_listeners_accept_http/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "alb_listeners_accept_http",
+  "queryName": "ALB Listeners Accept HTTP",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "All Application Load Balancers (ALB) should block connection requests over HTTP",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-listener.html#cfn-ec2-elb-listener-protocol"
+}

--- a/assets/queries/cloudFormation/alb_listeners_accept_http/query.rego
+++ b/assets/queries/cloudFormation/alb_listeners_accept_http/query.rego
@@ -1,0 +1,32 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::ElasticLoadBalancing::LoadBalancer"
+  
+  resource.Properties.Listeners[_].Protocol == "HTTP"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.Listeners.Protocol=HTTP", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("'Resources.%s.Listeners.Protocol' not equal to 'HTTP'", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Listeners.Protocol' equals to 'HTTP'", [name])
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::ElasticLoadBalancingV2::Listener"
+  
+  protocol := resource.Properties.Protocol
+  protocol == "HTTP"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.Protocol", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("'Resources.%s.Protocol' not equal to 'HTTP'", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Protocol' equals to 'HTTP'", [name])
+              }
+}

--- a/assets/queries/cloudFormation/alb_listeners_accept_http/test/negative.yaml
+++ b/assets/queries/cloudFormation/alb_listeners_accept_http/test/negative.yaml
@@ -1,0 +1,17 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+    MyLoadBalancer:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          AvailabilityZones:
+          - "us-east-2a"
+          CrossZone: true
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTPS
+            LoadBalancerPort: '443'
+            Protocol: HTTPS
+            PolicyNames:
+            - My-SSLNegotiation-Policy
+            SSLCertificateId: arn:aws:iam::123456789012:server-certificate/my-server-certificate
+          Scheme: internal

--- a/assets/queries/cloudFormation/alb_listeners_accept_http/test/positive.yaml
+++ b/assets/queries/cloudFormation/alb_listeners_accept_http/test/positive.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+    MyLoadBalancer:
+        Type: AWS::ElasticLoadBalancing::LoadBalancer
+        Properties:
+          AvailabilityZones:
+          - "us-east-2a"
+          CrossZone: true
+          Listeners:
+          - InstancePort: '80'
+            InstanceProtocol: HTTPS
+            LoadBalancerPort: '443'
+            Protocol: HTTP
+            PolicyNames:
+            - My-SSLNegotiation-Policy
+            SSLCertificateId: arn:aws:iam::123456789012:server-certificate/my-server-certificate
+          Scheme: internal
+    HTTPlistener:
+        Type: "AWS::ElasticLoadBalancingV2::Listener"
+        Properties:
+            DefaultActions:
+            - Type: redirect
+            LoadBalancerArn: !Ref myLoadBalancer
+            Port: 80
+            Protocol: HTTP

--- a/assets/queries/cloudFormation/alb_listeners_accept_http/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/alb_listeners_accept_http/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "ALB Listeners Accept HTTP",
+		"severity": "MEDIUM",
+		"line": 13
+	},
+	{
+		"queryName": "ALB Listeners Accept HTTP",
+		"severity": "MEDIUM",
+		"line": 25
+	}
+]


### PR DESCRIPTION
Closes #842 

All Application Load Balancers (ALB) should block connection requests over HTTP.

This query checks two resources:
- "AWS::ElasticLoadBalancing::LoadBalancer": if one of the elements inside the 'Listeners' list has 'Protocol' field equals to 'HTTP';
- "AWS::ElasticLoadBalancingV2::Listener": if 'Protocol' field equals to 'HTTP'.