### PR TITLE
Add kinesis_stream_without_sse Closes #849

### DIFF
--- a/assets/queries/cloudFormation/kinesis_stream_without_sse/metadata.json
+++ b/assets/queries/cloudFormation/kinesis_stream_without_sse/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "kinesis_stream_without_sse",
+  "queryName": "AWS Kinesis Stream Without SSE",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "AWS Kinesis Strem should have SSE (Server Side Encryption) defined",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html"
+}

--- a/assets/queries/cloudFormation/kinesis_stream_without_sse/metadata.json
+++ b/assets/queries/cloudFormation/kinesis_stream_without_sse/metadata.json
@@ -3,6 +3,6 @@
   "queryName": "AWS Kinesis Stream Without SSE",
   "severity": "HIGH",
   "category": "Encryption and Key Management",
-  "descriptionText": "AWS Kinesis Strem should have SSE (Server Side Encryption) defined",
+  "descriptionText": "AWS Kinesis Stream should have SSE (Server Side Encryption) defined",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-stream.html"
 }

--- a/assets/queries/cloudFormation/kinesis_stream_without_sse/query.rego
+++ b/assets/queries/cloudFormation/kinesis_stream_without_sse/query.rego
@@ -1,0 +1,49 @@
+package Cx
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::Kinesis::Stream"
+
+    object.get(resource.Properties, "StreamEncryption", "undefined") == "undefined"
+
+
+    result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey": 	      sprintf("Resources.%s.Properties", [name]),
+                "issueType":		    "MissingAttribute",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.StreamEncryption is set", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.StreamEncryption is undefined", [name])
+              }
+}
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::Kinesis::Stream"
+
+    object.get(resource.Properties.StreamEncryption, "EncryptionType", "undefined") == "undefined"
+
+
+    result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey": 	      sprintf("Resources.%s.Properties.StreamEncryption", [name]),
+                "issueType":		    "MissingAttribute",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.StreamEncryption.EncryptionType is set", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.StreamEncryption.EncryptionType is undefined", [name])
+              }
+}
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::Kinesis::Stream"
+
+    object.get(resource.Properties.StreamEncryption, "KeyId", "undefined") == "undefined"
+
+
+    result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey": 	      sprintf("Resources.%s.Properties.StreamEncryption", [name]),
+                "issueType":		    "MissingAttribute",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.StreamEncryption.KeyId is set", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.StreamEncryption.KeyId is undefined", [name])
+              }
+}

--- a/assets/queries/cloudFormation/kinesis_stream_without_sse/test/negative.yaml
+++ b/assets/queries/cloudFormation/kinesis_stream_without_sse/test/negative.yaml
@@ -6,7 +6,7 @@ Resources:
       RetentionPeriodHours: 24
       ShardCount: 1
       StreamEncryption:
-            EncryptionType: KMS 
+            EncryptionType: KMS
             KeyId: !Ref myKey
       Tags:
         - Key: Name

--- a/assets/queries/cloudFormation/kinesis_stream_without_sse/test/negative.yaml
+++ b/assets/queries/cloudFormation/kinesis_stream_without_sse/test/negative.yaml
@@ -1,0 +1,13 @@
+Resources:
+  EventStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      Name: EventStream
+      RetentionPeriodHours: 24
+      ShardCount: 1
+      StreamEncryption:
+            EncryptionType: KMS 
+            KeyId: !Ref myKey
+      Tags:
+        - Key: Name
+          Value: !Sub ${EnvironmentName}-EventStream-${AWS::Region}

--- a/assets/queries/cloudFormation/kinesis_stream_without_sse/test/positive.yaml
+++ b/assets/queries/cloudFormation/kinesis_stream_without_sse/test/positive.yaml
@@ -1,0 +1,33 @@
+Resources:
+  EventStream1:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      Name: EventStream
+      RetentionPeriodHours: 24
+      ShardCount: 1
+      StreamEncryption:
+            EncryptionType: KMS
+      Tags:
+        - Key: Name
+          Value: !Sub ${EnvironmentName}-EventStream-${AWS::Region}
+  EventStream2:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      Name: EventStream
+      RetentionPeriodHours: 24
+      ShardCount: 1
+      StreamEncryption:
+            KeyId: !Ref myKey
+      Tags:
+        - Key: Name
+          Value: !Sub ${EnvironmentName}-EventStream-${AWS::Region}
+  EventStream3:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      Name: EventStream
+      RetentionPeriodHours: 24
+      ShardCount: 1
+      Tags:
+        - Key: Name
+          Value: !Sub ${EnvironmentName}-EventStream-${AWS::Region}
+

--- a/assets/queries/cloudFormation/kinesis_stream_without_sse/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/kinesis_stream_without_sse/test/positive_expected_result.json
@@ -1,0 +1,19 @@
+[
+	{
+		"queryName": "AWS Kinesis Stream Without SSE",
+		"severity": "HIGH",
+		"line": 8
+	},
+
+	{
+		"queryName": "AWS Kinesis Stream Without SSE",
+		"severity": "HIGH",
+		"line": 19
+	},
+
+	{
+		"queryName": "AWS Kinesis Stream Without SSE",
+		"severity": "HIGH",
+		"line": 26
+	}
+]


### PR DESCRIPTION
For this query, it is necessary to check the existence of the attribute StreamEncryption and the respective attributes, since "when StreamEncryption is specified, enables or updates server-side encryption using an AWS KMS key for a specified stream. Removing this property from your stack template and updating your stack disables encryption".

Closes #849