### PR TITLE
Add api_gateway_exposed_to_the_public_internet query for AWS CloudFormation #859

### DIFF
--- a/assets/queries/cloudFormation/api_gateway_exposed_to_the_public_internet/metadata.json
+++ b/assets/queries/cloudFormation/api_gateway_exposed_to_the_public_internet/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "api_gateway_exposed_to_the_public_internet",
+  "queryName": "API Gateway Exposed To The Public Internet",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "The API Endpoint type in API Gateway should be set to PRIVATE so it's not exposed to the public internet",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-restapi-endpointconfiguration.html#cfn-apigateway-restapi-endpointconfiguration-types"
+}

--- a/assets/queries/cloudFormation/api_gateway_exposed_to_the_public_internet/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_exposed_to_the_public_internet/query.rego
@@ -1,0 +1,52 @@
+package Cx
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::ApiGateway::RestApi"
+  
+  object.get(resource.Properties, "EndpointConfiguration", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties", [name]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": sprintf("'Resources.%s.EndpointConfiguration' is defined", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.EndpointConfiguration' is undefined", [name])
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::ApiGateway::RestApi"
+  endpointConfig := resource.Properties.EndpointConfiguration
+  
+  object.get(endpointConfig, "Types", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.EndpointConfiguration", [name]),
+                "issueType":		"MissingAttribute",  
+                "keyExpectedValue": sprintf("'Resources.%s.EndpointConfiguration.Types' is defined", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.EndpointConfiguration.Types' is undefined", [name])
+              }
+}
+
+CxPolicy [ result ] {
+  resource := input.document[i].Resources[name]
+  resource.Type == "AWS::ApiGateway::RestApi"
+  endpointConfig := resource.Properties.EndpointConfiguration
+  
+  not containsPrivate(endpointConfig.Types)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.EndpointConfiguration.Types", [name]),
+                "issueType":		"IncorrectValue",  
+                "keyExpectedValue": sprintf("'Resources.%s.EndpointConfiguration.Types' contains 'PRIVATE'", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.EndpointConfiguration.Types' does not contain 'PRIVATE'", [name])
+              }
+}
+
+containsPrivate(types) {
+	types[_] == "PRIVATE"
+}

--- a/assets/queries/cloudFormation/api_gateway_exposed_to_the_public_internet/test/negative.yaml
+++ b/assets/queries/cloudFormation/api_gateway_exposed_to_the_public_internet/test/negative.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+    MyRestApi:
+        Type: AWS::ApiGateway::RestApi
+        Properties:
+          EndpointConfiguration:
+            Types:
+              - PRIVATE
+          Name: myRestApi

--- a/assets/queries/cloudFormation/api_gateway_exposed_to_the_public_internet/test/positive.yaml
+++ b/assets/queries/cloudFormation/api_gateway_exposed_to_the_public_internet/test/positive.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+    MyRestApi:
+        Type: AWS::ApiGateway::RestApi
+        Properties:
+          Name: myRestApi
+    MyRestApi2:
+        Type: AWS::ApiGateway::RestApi
+        Properties:
+          EndpointConfiguration:
+            Types:
+              - EDGE
+          Name: myRestApi2

--- a/assets/queries/cloudFormation/api_gateway_exposed_to_the_public_internet/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/api_gateway_exposed_to_the_public_internet/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "API Gateway Exposed To The Public Internet",
+		"severity": "HIGH",
+		"line": 5
+	},
+	{
+		"queryName": "API Gateway Exposed To The Public Internet",
+		"severity": "HIGH",
+		"line": 11
+	}
+]


### PR DESCRIPTION
Closes #859 

The API Endpoint type in API Gateway should be set to PRIVATE so it's not exposed to the public internet.

This query checks, within an "AWS::ApiGateway::RestApi" resource, if:
- 'EndpointConfiguration' is undefined or
- 'EndpointConfiguration.Types' is undefined or
- 'EndpointConfiguration.Types' does not contain 'PRIVATE'