### PR TITLE
Add redshift_without_kms_cmk Closes #834

### DIFF
--- a/assets/queries/cloudFormation/redshift_without_kms_cmk/metadata.json
+++ b/assets/queries/cloudFormation/redshift_without_kms_cmk/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "redshift_without_kms_cmk",
+  "queryName": "AWS Redshift Cluster Without KMS CMK",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "AWS Redshift Cluster should have KMS CMK defined",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html"
+}

--- a/assets/queries/cloudFormation/redshift_without_kms_cmk/query.rego
+++ b/assets/queries/cloudFormation/redshift_without_kms_cmk/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy [ result ] {
+  	resource := input.document[i].Resources[name]
+    resource.Type == "AWS::Redshift::Cluster"
+
+    object.get(resource.Properties, "KmsKeyId", "undefined") == "undefined"
+
+
+    result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("Resources.%s.Properties", [name]),
+                "issueType":		      "MissingAttribute",
+                "keyExpectedValue":   sprintf("Resources.%s.Properties.KmsKeyId is set", [name]),
+                "keyActualValue": 	  sprintf("Resources.%s.Properties.KmsKeyId is undefined", [name])
+              }
+}

--- a/assets/queries/cloudFormation/redshift_without_kms_cmk/test/negative.yaml
+++ b/assets/queries/cloudFormation/redshift_without_kms_cmk/test/negative.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Redshift Stack
+Resources:
+  RedshiftCluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterSubnetGroupName: !Ref RedshiftClusterSubnetGroup
+      ClusterType: !If [ SingleNode, single-node, multi-node ]
+      NumberOfNodes: !If [ SingleNode, !Ref 'AWS::NoValue', !Ref RedshiftNodeCount ] #'
+      DBName: !Sub ${DatabaseName}
+      IamRoles:
+        - !GetAtt RawDataBucketAccessRole.Arn
+      MasterUserPassword: !Ref MasterUserPassword
+      MasterUsername: !Ref MasterUsername
+      PubliclyAccessible: true
+      NodeType: dc1.large
+      Port: 5439
+      VpcSecurityGroupIds:
+        - !Sub ${RedshiftSecurityGroup}
+      PreferredMaintenanceWindow: Sun:09:15-Sun:09:45
+      KmsKeyId: wewewewewefsa
+  DataBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${DataBucketName}

--- a/assets/queries/cloudFormation/redshift_without_kms_cmk/test/positive.yaml
+++ b/assets/queries/cloudFormation/redshift_without_kms_cmk/test/positive.yaml
@@ -1,0 +1,24 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Redshift Stack
+Resources:
+  RedshiftCluster:
+    Type: AWS::Redshift::Cluster
+    Properties:
+      ClusterSubnetGroupName: !Ref RedshiftClusterSubnetGroup
+      ClusterType: !If [ SingleNode, single-node, multi-node ]
+      NumberOfNodes: !If [ SingleNode, !Ref 'AWS::NoValue', !Ref RedshiftNodeCount ] #'
+      DBName: !Sub ${DatabaseName}
+      IamRoles:
+        - !GetAtt RawDataBucketAccessRole.Arn
+      MasterUserPassword: !Ref MasterUserPassword
+      MasterUsername: !Ref MasterUsername
+      PubliclyAccessible: true
+      NodeType: dc1.large
+      Port: 5439
+      VpcSecurityGroupIds:
+        - !Sub ${RedshiftSecurityGroup}
+      PreferredMaintenanceWindow: Sun:09:15-Sun:09:45
+  DataBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${DataBucketName}

--- a/assets/queries/cloudFormation/redshift_without_kms_cmk/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/redshift_without_kms_cmk/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "AWS Redshift Cluster Without KMS CMK",
+		"severity": "HIGH",
+		"line": 6
+	}
+]


### PR DESCRIPTION
In Dome9 documentation, it is recommended to check if the attribute KmsKeyId is defined and if attribute 'Encrypted' exists and is set to true. Since we already have a query redshift_instances_not_encrypted, I just checked the attribute KmsKeyId existence

Closes #834