### PR TITLE
Add Auto Scaling Group With No Associated ELB query for AWS CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/metadata.json
+++ b/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Auto_Scaling_Group_With_No_Associated_ELB",
+  "queryName": "Auto Scaling Group With No Associated ELB",
+  "severity": "MEDIUM",
+  "category": "Operational",
+  "descriptionText": "AWS Auto Scaling Groups must have associated ELBs to ensure high availability and improve application performance. This means the attribute 'LoadBalancerNames' must be defined and not empty.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html"
+}

--- a/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/query.rego
+++ b/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/query.rego
@@ -1,0 +1,49 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+    resource.Type == "AWS::AutoScaling::AutoScalingGroup"
+    object.get(resource.Properties, "LoadBalancerNames", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties",  [name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.LoadBalancerNames' is defined", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.LoadBalancerNames' is not defined", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+    resource.Type == "AWS::AutoScaling::AutoScalingGroup"
+    resource.Properties.LoadBalancerNames == null
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.LoadBalancerNames",  [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.LoadBalancerNames' is not null", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.LoadBalancerNames' is null", [name]),
+              }
+}
+
+CxPolicy [ result ] {
+	resource := input.document[i].Resources[name]
+    resource.Type == "AWS::AutoScaling::AutoScalingGroup"
+    elbs := resource.Properties.LoadBalancerNames
+    check_size(elbs)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.LoadBalancerNames",  [name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.LoadBalancerNames' is not empty", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.LoadBalancerNames' is empty", [name]),
+              }
+}
+
+check_size(array) {
+	is_array(array)
+    count(array) == 0
+}

--- a/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/test/negative.yaml
+++ b/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/test/negative.yaml
@@ -3,24 +3,24 @@ AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   myLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
-    Properties: 
+    Properties:
       LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
-      LaunchTemplateData: 
-        BlockDeviceMappings: 
+      LaunchTemplateData:
+        BlockDeviceMappings:
           - Ebs:
               VolumeSize: 22
               VolumeType: gp2
               DeleteOnTermination: true
               Encrypted: true
             DeviceName: /dev/xvdcz
-        CreditSpecification: 
+        CreditSpecification:
           CpuCredits: Unlimited
         ImageId: ami-02354e95b39ca8dec
         InstanceType: t2.micro
         KeyName: my-key-pair-useast1
-        Monitoring: 
+        Monitoring:
           Enabled: true
-        SecurityGroupIds: 
+        SecurityGroupIds:
           - sg-7c227019
           - sg-903004f8
   myASG:
@@ -40,9 +40,9 @@ Resources:
       VPCZoneIdentifier:
         - !Ref myPublicSubnet1
         - !Ref myPublicSubnet2
-      MetricsCollection: 
+      MetricsCollection:
         - Granularity: "1Minute"
-          Metrics: 
+          Metrics:
             - "GroupMinSize"
             - "GroupMaxSize"
       Tags:

--- a/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/test/negative.yaml
+++ b/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/test/negative.yaml
@@ -1,0 +1,54 @@
+#this code is a correct code for which the query should not find any result
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  myLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties: 
+      LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
+      LaunchTemplateData: 
+        BlockDeviceMappings: 
+          - Ebs:
+              VolumeSize: 22
+              VolumeType: gp2
+              DeleteOnTermination: true
+              Encrypted: true
+            DeviceName: /dev/xvdcz
+        CreditSpecification: 
+          CpuCredits: Unlimited
+        ImageId: ami-02354e95b39ca8dec
+        InstanceType: t2.micro
+        KeyName: my-key-pair-useast1
+        Monitoring: 
+          Enabled: true
+        SecurityGroupIds: 
+          - sg-7c227019
+          - sg-903004f8
+  myASG:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      AutoScalingGroupName: myASG
+      MinSize: "1"
+      MaxSize: "6"
+      DesiredCapacity: "2"
+      HealthCheckGracePeriod: 300
+      LoadBalancerNames:
+        - elb_1
+        - elb_2
+      LaunchTemplate:
+        LaunchTemplateId: !Ref myLaunchTemplate
+        Version: !GetAtt myLaunchTemplate.LatestVersionNumber
+      VPCZoneIdentifier:
+        - !Ref myPublicSubnet1
+        - !Ref myPublicSubnet2
+      MetricsCollection: 
+        - Granularity: "1Minute"
+          Metrics: 
+            - "GroupMinSize"
+            - "GroupMaxSize"
+      Tags:
+        - Key: Environment
+          Value: Production
+          PropagateAtLaunch: "true"
+        - Key: Purpose
+          Value: WebServerGroup
+          PropagateAtLaunch: "false"

--- a/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/test/positive.yaml
+++ b/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/test/positive.yaml
@@ -1,0 +1,105 @@
+#this is a problematic code where the query should report a result(s)
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  myLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties: 
+      LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
+      LaunchTemplateData: 
+        BlockDeviceMappings: 
+          - Ebs:
+              VolumeSize: 22
+              VolumeType: gp2
+              DeleteOnTermination: true
+              Encrypted: true
+            DeviceName: /dev/xvdcz
+        CreditSpecification: 
+          CpuCredits: Unlimited
+        ImageId: ami-02354e95b39ca8dec
+        InstanceType: t2.micro
+        KeyName: my-key-pair-useast1
+        Monitoring: 
+          Enabled: true
+        SecurityGroupIds: 
+          - sg-7c227019
+          - sg-903004f8
+  myASG:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      AutoScalingGroupName: myASG
+      MinSize: "1"
+      MaxSize: "6"
+      DesiredCapacity: "2"
+      HealthCheckGracePeriod: 300
+      LaunchTemplate:
+        LaunchTemplateId: !Ref myLaunchTemplate
+        Version: !GetAtt myLaunchTemplate.LatestVersionNumber
+      VPCZoneIdentifier:
+        - !Ref myPublicSubnet1
+        - !Ref myPublicSubnet2
+      MetricsCollection: 
+        - Granularity: "1Minute"
+          Metrics: 
+            - "GroupMinSize"
+            - "GroupMaxSize"
+      Tags:
+        - Key: Environment
+          Value: Production
+          PropagateAtLaunch: "true"
+        - Key: Purpose
+          Value: WebServerGroup
+          PropagateAtLaunch: "false"
+  myASG2:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      AutoScalingGroupName: myASG2
+      MinSize: "1"
+      MaxSize: "6"
+      DesiredCapacity: "2"
+      HealthCheckGracePeriod: 300
+      LoadBalancerNames: 
+      LaunchTemplate:
+        LaunchTemplateId: !Ref myLaunchTemplate
+        Version: !GetAtt myLaunchTemplate.LatestVersionNumber
+      VPCZoneIdentifier:
+        - !Ref myPublicSubnet1
+        - !Ref myPublicSubnet2
+      MetricsCollection: 
+        - Granularity: "1Minute"
+          Metrics: 
+            - "GroupMinSize"
+            - "GroupMaxSize"
+      Tags:
+        - Key: Environment
+          Value: Production
+          PropagateAtLaunch: "true"
+        - Key: Purpose
+          Value: WebServerGroup
+          PropagateAtLaunch: "false"
+  myASG3:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      AutoScalingGroupName: myASG
+      MinSize: "1"
+      MaxSize: "6"
+      DesiredCapacity: "2"
+      HealthCheckGracePeriod: 300
+      LoadBalancerNames: []
+      LaunchTemplate:
+        LaunchTemplateId: !Ref myLaunchTemplate
+        Version: !GetAtt myLaunchTemplate.LatestVersionNumber
+      VPCZoneIdentifier:
+        - !Ref myPublicSubnet1
+        - !Ref myPublicSubnet2
+      MetricsCollection: 
+        - Granularity: "1Minute"
+          Metrics: 
+            - "GroupMinSize"
+            - "GroupMaxSize"
+      Tags:
+        - Key: Environment
+          Value: Production
+          PropagateAtLaunch: "true"
+        - Key: Purpose
+          Value: WebServerGroup
+          PropagateAtLaunch: "false"

--- a/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/test/positive.yaml
+++ b/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/test/positive.yaml
@@ -3,24 +3,24 @@ AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   myLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
-    Properties: 
+    Properties:
       LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
-      LaunchTemplateData: 
-        BlockDeviceMappings: 
+      LaunchTemplateData:
+        BlockDeviceMappings:
           - Ebs:
               VolumeSize: 22
               VolumeType: gp2
               DeleteOnTermination: true
               Encrypted: true
             DeviceName: /dev/xvdcz
-        CreditSpecification: 
+        CreditSpecification:
           CpuCredits: Unlimited
         ImageId: ami-02354e95b39ca8dec
         InstanceType: t2.micro
         KeyName: my-key-pair-useast1
-        Monitoring: 
+        Monitoring:
           Enabled: true
-        SecurityGroupIds: 
+        SecurityGroupIds:
           - sg-7c227019
           - sg-903004f8
   myASG:
@@ -37,9 +37,9 @@ Resources:
       VPCZoneIdentifier:
         - !Ref myPublicSubnet1
         - !Ref myPublicSubnet2
-      MetricsCollection: 
+      MetricsCollection:
         - Granularity: "1Minute"
-          Metrics: 
+          Metrics:
             - "GroupMinSize"
             - "GroupMaxSize"
       Tags:
@@ -57,16 +57,16 @@ Resources:
       MaxSize: "6"
       DesiredCapacity: "2"
       HealthCheckGracePeriod: 300
-      LoadBalancerNames: 
+      LoadBalancerNames:
       LaunchTemplate:
         LaunchTemplateId: !Ref myLaunchTemplate
         Version: !GetAtt myLaunchTemplate.LatestVersionNumber
       VPCZoneIdentifier:
         - !Ref myPublicSubnet1
         - !Ref myPublicSubnet2
-      MetricsCollection: 
+      MetricsCollection:
         - Granularity: "1Minute"
-          Metrics: 
+          Metrics:
             - "GroupMinSize"
             - "GroupMaxSize"
       Tags:
@@ -91,9 +91,9 @@ Resources:
       VPCZoneIdentifier:
         - !Ref myPublicSubnet1
         - !Ref myPublicSubnet2
-      MetricsCollection: 
+      MetricsCollection:
         - Granularity: "1Minute"
-          Metrics: 
+          Metrics:
             - "GroupMinSize"
             - "GroupMaxSize"
       Tags:

--- a/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Auto Scaling Group With No Associated ELB",
+		"severity": "MEDIUM",
+		"line": 28
+	},
+	{
+		"queryName": "Auto Scaling Group With No Associated ELB",
+		"severity": "MEDIUM",
+		"line": 60
+	},
+	{
+		"queryName": "Auto Scaling Group With No Associated ELB",
+		"severity": "MEDIUM",
+		"line": 87
+	}
+]


### PR DESCRIPTION
Adding Auto Scaling Group With No Associated ELB query for AWS CloudFormation, that checks if the attribute 'LoadBalancerNames' is defined and not empty.

Closes #883