### PR TITLE
Add query to check if Access Keys are not being rotated within 90 days. Closes #934

### DIFF
--- a/assets/queries/cloudFormation/accessKey_not_rotated_within_90_days/metadata.json
+++ b/assets/queries/cloudFormation/accessKey_not_rotated_within_90_days/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Access_Key_Is_Not_Rotated_Within_90_Days",
+  "queryName": "Access Key Is Not Rotated Within 90 Days",
+  "severity": "MEDIUM",
+  "category": "Identity and Access Management",
+  "descriptionText": "Check if there isn't a rule that enforces access keys to be rotated within 90 days.",
+  "descriptionUrl": "https://docs.amazonaws.cn/en_us/config/latest/developerguide/access-keys-rotated.html"
+}

--- a/assets/queries/cloudFormation/accessKey_not_rotated_within_90_days/query.rego
+++ b/assets/queries/cloudFormation/accessKey_not_rotated_within_90_days/query.rego
@@ -1,0 +1,56 @@
+package Cx
+
+CxPolicy [ result ] {
+	document := input.document[i]
+  not hasAccessKeyRotationRule(document)
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    "Resources",
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": "Resources has a ConfigRule defining rotation period on AccessKeys.",
+                "keyActualValue": 	"Resources doesn't have a ConfigRule defining rotation period on AccessKeys."
+              }
+}
+
+CxPolicy [ result ] {
+	document := input.document[i]
+  configRule := document.Resources[name]
+  configRule.Type == "AWS::Config::ConfigRule"
+  configRule.Properties.Source.SourceIdentifier == "ACCESS_KEYS_ROTATED"
+
+  object.get(configRule.Properties,"InputParameters","undefined") == "undefined"
+	
+  result := {
+                "documentId": 		document.id,
+                "searchKey": 	    "Resources.%s.Properties",
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue": sprintf("Resources.%s.InputParameters is defined and contains 'maxAccessKeyAge' key.",[name]),
+                "keyActualValue": 	sprintf("Resources.%s.InputParameters is undefined.",[name])
+              }
+}
+
+CxPolicy [ result ] {
+	document := input.document[i]
+  configRule := document.Resources[name]
+  configRule.Type == "AWS::Config::ConfigRule"
+  configRule.Properties.Source.SourceIdentifier == "ACCESS_KEYS_ROTATED"
+
+  maxDays := configRule.Properties.InputParameters.maxAccessKeyAge
+
+  to_number(maxDays) > 90
+	
+  result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.InputParameters.maxAccessKeyAge",[name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("Resources.%s.InputParameters.maxAccessKeyAge is less or equal to 90 (days)",[name]),
+                "keyActualValue": 	sprintf("Resources.%s.InputParameters.maxAccessKeyAge is more than 90 (days).",[name])
+              }
+}
+
+hasAccessKeyRotationRule(document) {
+    configRule := document.Resources[_]
+    configRule.Type == "AWS::Config::ConfigRule"
+    configRule.Properties.Source.SourceIdentifier == "ACCESS_KEYS_ROTATED"
+} else = false

--- a/assets/queries/cloudFormation/accessKey_not_rotated_within_90_days/test/negative.yaml
+++ b/assets/queries/cloudFormation/accessKey_not_rotated_within_90_days/test/negative.yaml
@@ -1,0 +1,11 @@
+Resources:
+  ConfigRule:
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: access-keys-rotated
+      InputParameters:
+        maxAccessKeyAge: 90
+      Source:
+        Owner: AWS
+        SourceIdentifier: ACCESS_KEYS_ROTATED
+      MaximumExecutionFrequency: TwentyFour_Hours

--- a/assets/queries/cloudFormation/accessKey_not_rotated_within_90_days/test/positive.yaml
+++ b/assets/queries/cloudFormation/accessKey_not_rotated_within_90_days/test/positive.yaml
@@ -1,0 +1,11 @@
+Resources:
+  ConfigRule:
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: access-keys-rotated
+      InputParameters:
+        maxAccessKeyAge: 100
+      Source:
+        Owner: AWS
+        SourceIdentifier: ACCESS_KEYS_ROTATED
+      MaximumExecutionFrequency: TwentyFour_Hours

--- a/assets/queries/cloudFormation/accessKey_not_rotated_within_90_days/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/accessKey_not_rotated_within_90_days/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Access Key Is Not Rotated Within 90 Days",
+		"severity": "MEDIUM",
+		"line": 7
+	}
+]


### PR DESCRIPTION
Check if there is not a ConfigRule that enforces AccessKeys to be rotated within 90 days. Closes #934 