### PR TITLE
Add ingress_has_cidr_not_recommended Closes #952

### DIFF
--- a/assets/queries/cloudFormation/ingress_has_cidr_not_recommended/metadata.json
+++ b/assets/queries/cloudFormation/ingress_has_cidr_not_recommended/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ingress_has_cidr_not_recommended",
+  "queryName": "AWS Security Group Ingress Has CIDR Not Recommended",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "AWS Security Group Ingress CIDR should not be /32 in case of IPV4 or /128 in case of IPV6",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html"
+}

--- a/assets/queries/cloudFormation/ingress_has_cidr_not_recommended/query.rego
+++ b/assets/queries/cloudFormation/ingress_has_cidr_not_recommended/query.rego
@@ -1,0 +1,73 @@
+package Cx
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::EC2::SecurityGroupIngress"
+    
+    properties := resource.Properties
+    
+    contains(properties.CidrIp, "/32")
+
+
+    result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("Resources.%s.Properties.CidrIp", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   sprintf("Resources.%s.Properties.CidrIp is not /32", [name]),
+                "keyActualValue": 	  sprintf("Resources.%s.Properties.CidrIp is /32", [name])
+              }
+}
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::EC2::SecurityGroupIngress"
+    
+    properties := resource.Properties
+    
+    contains(properties.CidrIpv6, "/128")
+
+
+    result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("Resources.%s.Properties.CidrIpv6", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   sprintf("Resources.%s.Properties.CidrIpv6 is not /128", [name]),
+                "keyActualValue": 	  sprintf("Resources.%s.Properties.CidrIpv6 is /128", [name])
+              }
+}
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::EC2::SecurityGroup"
+    
+    properties := resource.Properties
+    
+    contains(properties["SecurityGroupIngress"][index].CidrIp, "/32")
+
+
+    result := {
+                "documentId": 		    input.document[i].id,
+                "searchKey": 	        sprintf("Resources.%s.Properties.SecurityGroupIngress.CidrIp", [name]),
+                "issueType":		      "IncorrectValue",
+                "keyExpectedValue":   sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIp is not /32", [name, index]),
+                "keyActualValue": 	  sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIp is /32", [name, index])
+              }
+}
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::EC2::SecurityGroup"
+    
+    properties := resource.Properties
+    
+    contains(properties["SecurityGroupIngress"][index].CidrIpv6, "/128")
+
+
+    result := {
+                "documentId": 		   input.document[i].id,
+                "searchKey": 	       sprintf("Resources.%s.Properties.SecurityGroupIngress.CidrIpv6", [name]),
+                "issueType":		     "IncorrectValue",
+                "keyExpectedValue":   sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIpv6 is not /128", [name, index]),
+                "keyActualValue": 	  sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIpv6 is /128", [name, index])
+              }
+}

--- a/assets/queries/cloudFormation/ingress_has_cidr_not_recommended/test/negative.yaml
+++ b/assets/queries/cloudFormation/ingress_has_cidr_not_recommended/test/negative.yaml
@@ -1,0 +1,51 @@
+Resources:
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow http to client host
+      VpcId:
+         Ref: myVPC
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        Description: TCP
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 192.0.2.0/24
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        Description: TCP
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 192.0.2.0/24
+  OutboundRule:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      Description: TCP
+      IpProtocol: tcp
+      FromPort: 0
+      ToPort: 0
+      CidrIp: 192.0.2.0/24
+      DestinationSecurityGroupId:
+        Fn::GetAtt:
+        - TargetSG
+        - GroupId
+      GroupId:
+        Fn::GetAtt:
+        - SourceSG
+        - GroupId
+  InboundRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: TCP
+      IpProtocol: tcp
+      FromPort: 0
+      ToPort: 0
+      CidrIpv6: 2001:0DB8:1234::/48
+      SourceSecurityGroupId:
+        Fn::GetAtt:
+        - SourceSG
+        - GroupId
+      GroupId:
+        Fn::GetAtt:
+        - TargetSG
+        - GroupId

--- a/assets/queries/cloudFormation/ingress_has_cidr_not_recommended/test/positive.yaml
+++ b/assets/queries/cloudFormation/ingress_has_cidr_not_recommended/test/positive.yaml
@@ -1,0 +1,51 @@
+Resources:
+  InstanceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow http to client host
+      VpcId:
+         Ref: myVPC
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        Description: TCP
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 122.24.0.0/32
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        Description: TCP
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 192.0.2.0/24
+  OutboundRule:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      Description: TCP
+      IpProtocol: tcp
+      FromPort: 0
+      ToPort: 65535
+      CidrIp: 192.0.2.0/24
+      DestinationSecurityGroupId:
+        Fn::GetAtt:
+        - TargetSG
+        - GroupId
+      GroupId:
+        Fn::GetAtt:
+        - SourceSG
+        - GroupId
+  InboundRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: TCP
+      IpProtocol: tcp
+      FromPort: 0
+      ToPort: 65535
+      CidrIpv6: ::/128
+      SourceSecurityGroupId:
+        Fn::GetAtt:
+        - SourceSG
+        - GroupId
+      GroupId:
+        Fn::GetAtt:
+        - TargetSG
+        - GroupId

--- a/assets/queries/cloudFormation/ingress_has_cidr_not_recommended/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ingress_has_cidr_not_recommended/test/positive_expected_result.json
@@ -1,0 +1,13 @@
+[
+	{
+		"queryName": "AWS Security Group Ingress Has CIDR Not Recommended",
+		"severity": "MEDIUM",
+		"line": 13
+	},
+
+	{
+		"queryName": "AWS Security Group Ingress Has CIDR Not Recommended",
+		"severity": "MEDIUM",
+		"line": 43
+	}
+]


### PR DESCRIPTION
For this query, it is necessary to check if AWS Security Group Ingress CIDR is /32 in case of IPV4 or /128 in case of IPV6

Closes #952