### PR TITLE
Add 'Use of apk upgrade' query for Docker

### DIFF
--- a/assets/queries/dockerfile/use_of_apk_upgrade/metadata.json
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Use_of_apk_upgrade",
+  "queryName": "Use of apk upgrade",
+  "severity": "HIGH",
+  "category": "Package Management",
+  "descriptionText": "Avoid usage of apk upgrade because some packages from the parent image cannot be upgraded inside an unprivileged container",
+  "descriptionUrl": "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run"
+}

--- a/assets/queries/dockerfile/use_of_apk_upgrade/query.rego
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/query.rego
@@ -1,0 +1,55 @@
+package Cx
+
+CxPolicy [ result ] {
+  command := input.document[i].command[_]
+
+  from := splitFrom(input.document[i].command)
+  fromCommand := from[w]
+
+  fromCommand[j].Cmd == "run"
+  arrCmds := split(fromCommand[j].Value[0], " ")
+  contains(fromCommand[j].Value[0], "apk upgrade")
+
+  result := {
+    "documentId": input.document[i].id,
+    "searchKey": sprintf("FROM=%s.RUN=%s.apk[upgrade]", [fromCommand[0].Value[0], arrCmds[0]]),
+    "issueType": "InvalidAttribute",
+    "keyExpectedValue": sprintf("RUN command '%s' should not have apk upgrade instruction", [fromCommand[j].Value[0]]),
+    "keyActualValue": sprintf("RUN '%s' has apk upgrade instruction", [fromCommand[j].Value[0]])
+  }
+}
+
+splitFrom(cmdList) = sliceCmdList {
+    fromIte :=  [x | x := checkFrom(cmdList[i], i)]
+    sliceCmdList := [x | x := slice(cmdList, fromIte, fromIte[j], j, count(fromIte))]
+}
+
+checkFrom(cmd, i) = x {
+    cmd.Cmd == "from"
+    x := i
+}
+
+slice(cmdList, fromIte, s, i, countIte) = cmdListSlice {
+    countIte == 1
+    cmdListSlice := cmdList
+}
+
+slice(cmdList, fromIte, s, i, countIte) = cmdListSlice {
+    not countIte == 1
+    i == 0
+    cmdListSlice := array.slice(cmdList, s, fromIte[1])
+}
+
+slice(cmdList, fromIte, s, i, countIte) = cmdListSlice {
+    not countIte == 1
+    not i == 0
+    i == (countIte-1)
+    cmdListSlice := array.slice(cmdList, s, count(cmdList))
+}
+
+slice(cmdList, fromIte, s, i, countIte) = cmdListSlice {
+    not countIte == 1
+    not i == 0
+    not i == (countIte-1)
+    cmdListSlice := array.slice(cmdList, s, fromIte[i+1])
+}

--- a/assets/queries/dockerfile/use_of_apk_upgrade/test/negative.dockerfile
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/test/negative.dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.7
+RUN apk update \
+    && apk add kubectl=1.20.0-r0 \
+    && rm -rf /var/cache/apk/*
+ENTRYPOINT [ "kubectl" ]

--- a/assets/queries/dockerfile/use_of_apk_upgrade/test/positive.dockerfile
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/test/positive.dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.7
+RUN apk update \
+    && apk upgrade \
+    && apk add kubectl=1.20.0-r0 \
+    && rm -rf /var/cache/apk/*
+ENTRYPOINT ["kubectl"]
+
+FROM alpine:3.9
+RUN apk update
+RUN apk update && apk upgrade && apk add kubectl=1.20.0-r0 \
+    && rm -rf /var/cache/apk/*
+ENTRYPOINT ["kubectl"]

--- a/assets/queries/dockerfile/use_of_apk_upgrade/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Use of apk upgrade",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "Use of apk upgrade",
+		"severity": "HIGH",
+		"line": 10
+	}
+]


### PR DESCRIPTION
### Platform
*Docker*

### Description
*Avoid usage of 'apk upgrade' because some packages from the parent image cannot be upgraded inside an unprivileged container*

Closes #987