### PR TITLE
Added Query Directory Service Simple AD Password Rule

### DIFF
--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/metadata.json
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "directory_service_simple_ad_password_rule",
-  "queryName": "Directory Service Simple AD Password Rule",
+  "queryName": "Directory Service Simple AD Password Exposed",
   "severity": "MEDIUM",
-  "category": null,
+  "category": "Identity and Access Management",
   "descriptionText": "DirectoryService SimpleAD password must not be a plaintext string or a Ref to a Parameter with a Default value.",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-directoryservice-simplead.html"
 }

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/metadata.json
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "directory_service_simple_ad_password_rule",
+  "queryName": "Directory Service Simple AD Password Rule",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "DirectoryService SimpleAD password must not be a plaintext string or a Ref to a Parameter with a Default value.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-directoryservice-simplead.html"
+}

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/query.rego
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/query.rego
@@ -1,7 +1,7 @@
 package Cx
 
 
-CxPolicy [result ]  { 
+CxPolicy [result ]  {
 
   document := input.document[i]
   resource := document.Resources[key]
@@ -17,7 +17,7 @@ CxPolicy [result ]  {
   result := {
                 "documentId": 		input.document[i].id,
                 "searchKey": 	    sprintf("Parameters.%s.Default", [paramName]),
-                "issueType":		"IncorrectValue", 
+                "issueType":		"IncorrectValue",
                 "keyExpectedValue": sprintf("Parameters.%s.Default is defined",[paramName]),
                 "keyActualValue": 	sprintf("Parameters.%s.Default shouldn't be defined",[paramName])
               }
@@ -25,7 +25,7 @@ CxPolicy [result ]  {
 
 
 
-CxPolicy [result]  { 
+CxPolicy [result]  {
 
   document := input.document[i]
   resource := document.Resources[key]
@@ -33,7 +33,7 @@ CxPolicy [result]  {
 
   properties := resource.Properties
   paramName  := properties.Password
-  object.get(document, "Parameters", "undefined") == "undefined" 
+  object.get(document, "Parameters", "undefined") == "undefined"
 
   defaultToken := paramName
 
@@ -42,7 +42,31 @@ CxPolicy [result]  {
   result := {
                 "documentId": 		input.document[i].id,
                 "searchKey": 	    sprintf("Resources.%s.Properties.Password", [key]),
-                "issueType":		"IncorrectValue", 
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.Password must not be in plain text string",[key]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.Password must be defined as a parameter or have a secret manager referenced",[key])
+              }
+
+}
+CxPolicy [result]  {
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::DirectoryService::SimpleAD"
+
+  properties := resource.Properties
+  paramName  := properties.Password
+  object.get(document, "Parameters" , "undefined") != "undefined"
+  object.get(document.Parameters, paramName , "undefined") == "undefined"
+
+  defaultToken := paramName
+
+  regex.match(`[A-Za-z\d@$!%*"#"?&]{8,}`,defaultToken)
+  not hasSecretManager(defaultToken, document.Resources)
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.Password", [key]),
+                "issueType":		"IncorrectValue",
                 "keyExpectedValue": sprintf("Resources.%s.Properties.Password must not be in plain text string",[key]),
                 "keyActualValue": 	sprintf("Resources.%s.Properties.Password must be defined as a parameter or have a secret manager referenced",[key])
               }

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/query.rego
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/query.rego
@@ -1,0 +1,57 @@
+package Cx
+
+
+CxPolicy [result ]  { 
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::DirectoryService::SimpleAD"
+
+  properties := resource.Properties
+  paramName  := properties.Password
+  defaultToken := document.Parameters[paramName].Default
+
+   regex.match(`[A-Za-z\d@$!%*"#"?&]{8,}`,defaultToken)
+   not hasSecretManager(defaultToken, document.Resources)
+
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Parameters.%s.Default", [paramName]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("Parameters.%s.Default is defined",[paramName]),
+                "keyActualValue": 	sprintf("Parameters.%s.Default shouldn't be defined",[paramName])
+              }
+}
+
+
+
+CxPolicy [result]  { 
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::DirectoryService::SimpleAD"
+
+  properties := resource.Properties
+  paramName  := properties.Password
+  object.get(document, "Parameters", "undefined") == "undefined" 
+
+  defaultToken := paramName
+
+  regex.match(`[A-Za-z\d@$!%*"#"?&]{8,}`,defaultToken)
+  not hasSecretManager(defaultToken, document.Resources)
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.Password", [key]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("Resources.%s.Properties.Password must not be in plain text string",[key]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.Password must be defined as a parameter or have a secret manager referenced",[key])
+              }
+
+}
+
+
+hasSecretManager(str, document) {
+	selectedSecret :=  strings.replace_n({"${":"","}":""}, regex.find_n(`\${\w+}`,str,1)[0])
+  document[selectedSecret].Type == "AWS::SecretsManager::Secret"
+}
+

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/negative.yaml
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/negative.yaml
@@ -1,5 +1,3 @@
-AWSTemplateFormatVersion: 2010-09-09
-Description: Creating DBCluster
 Parameters:
   ParentMasterPassword:
     Description: 'Password'
@@ -21,8 +19,6 @@ Resources:
           ShortName: String
           Size: String
 ---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Creating DBCluster
 Parameters:
   ParentMasterPassword:
     Description: 'Password'
@@ -43,8 +39,6 @@ Resources:
           ShortName: String
           Size: String
 ---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Creating Amplify App
 Resources:
     NewAmpApp-2:
         Type: AWS::DirectoryService::SimpleAD

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/negative.yaml
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/negative.yaml
@@ -1,0 +1,67 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creating DBCluster
+Parameters:
+  ParentMasterPassword:
+    Description: 'Password'
+    Type: String
+    Default: ''
+  ParentMasterUsername:
+    Description: 'username'
+    Type: String
+    Default: 'username!'
+Resources:
+  NewAmpApp-1:
+      Type: AWS::DirectoryService::SimpleAD
+      Properties: 
+          CreateAlias: true
+          Description: String
+          EnableSso: true
+          Name: String
+          Password: !Ref ParentMasterPassword
+          ShortName: String
+          Size: String
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creating DBCluster
+Parameters:
+  ParentMasterPassword:
+    Description: 'Password'
+    Type: String
+  ParentMasterUsername:
+    Description: 'username'
+    Type: String
+    Default: 'username'
+Resources:
+  NewAmpApp-1:
+     Type: AWS::DirectoryService::SimpleAD
+        Properties: 
+          CreateAlias: true
+          Description: String
+          EnableSso: true
+          Name: String
+          Password: !Ref ParentMasterPassword
+          ShortName: String
+          Size: String
+---      
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creating Amplify App
+Resources:
+    NewAmpApp-2:
+        Type: AWS::DirectoryService::SimpleAD
+        Properties: 
+            CreateAlias: true
+            Description: String
+            EnableSso: true
+            Name: String
+            Password:  !Sub '{{resolve:secretsmanager:${MyAmpAppSecretManagerRotater}::password}}'
+            ShortName: String
+            Size: String
+    MyAmpAppSecretManagerRotater:
+        Type: AWS::SecretsManager::Secret
+        Properties:
+          Description: 'This is my amp app instance secret'
+          GenerateSecretString:
+            SecretStringTemplate: '{"username": "admin"}'
+            GenerateStringKey: 'password'
+            PasswordLength: 16
+            ExcludeCharacters: '"@/\'

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/negative.yaml
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/negative.yaml
@@ -12,7 +12,7 @@ Parameters:
 Resources:
   NewAmpApp-1:
       Type: AWS::DirectoryService::SimpleAD
-      Properties: 
+      Properties:
           CreateAlias: true
           Description: String
           EnableSso: true
@@ -34,7 +34,7 @@ Parameters:
 Resources:
   NewAmpApp-1:
      Type: AWS::DirectoryService::SimpleAD
-        Properties: 
+        Properties:
           CreateAlias: true
           Description: String
           EnableSso: true
@@ -42,13 +42,13 @@ Resources:
           Password: !Ref ParentMasterPassword
           ShortName: String
           Size: String
----      
+---
 AWSTemplateFormatVersion: 2010-09-09
 Description: Creating Amplify App
 Resources:
     NewAmpApp-2:
         Type: AWS::DirectoryService::SimpleAD
-        Properties: 
+        Properties:
             CreateAlias: true
             Description: String
             EnableSso: true

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive.yaml
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive.yaml
@@ -1,0 +1,60 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creating DBCluster
+Parameters:
+  ParentMasterPassword:
+    Description: 'Password'
+    Type: String
+    Default: ''
+  ParentMasterUsername:
+    Description: 'username'
+    Type: String
+    Default: 'username!'
+Resources:
+  NewAmpApp-1:
+      Type: AWS::DirectoryService::SimpleAD
+      Properties: 
+          CreateAlias: true
+          Description: String
+          EnableSso: true
+          Name: String
+          Password: !Ref ParentMasterPassword
+          ShortName: String
+          Size: String
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creating DBCluster
+Resources:
+  NewAmpApp:
+      Type: AWS::DirectoryService::SimpleAD
+      Properties: 
+          CreateAlias: true
+          Description: String
+          EnableSso: true
+          Name: String
+          Password: 'asDjskjs73!!'
+          ShortName: String
+          Size: String
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creating DBCluster
+Parameters:
+  ParentMasterPassword:
+    Description: 'Password'
+    Type: String
+    Default: 'asDjskjs73!'
+  ParentMasterUsername:
+    Description: 'username'
+    Type: String
+    Default: 'username!'
+Resources:
+  NewAmpApp-1:
+      Type: AWS::DirectoryService::SimpleAD
+      Properties: 
+          CreateAlias: true
+          Description: String
+          EnableSso: true
+          Name: String
+          Password: !Ref ParentMasterPassword
+          ShortName: String
+          Size: String
+

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive.yaml
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive.yaml
@@ -1,5 +1,3 @@
-AWSTemplateFormatVersion: 2010-09-09
-Description: Creating DBCluster
 Parameters:
   ParentMasterPassword:
     Description: 'Password'
@@ -17,12 +15,10 @@ Resources:
           Description: String
           EnableSso: true
           Name: String
-          Password: !Ref ParentMasterPassword
+          Password:  'asDjskjs73!!'
           ShortName: String
           Size: String
 ---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Creating DBCluster
 Resources:
   NewAmpApp:
       Type: AWS::DirectoryService::SimpleAD
@@ -35,8 +31,6 @@ Resources:
           ShortName: String
           Size: String
 ---
-AWSTemplateFormatVersion: 2010-09-09
-Description: Creating DBCluster
 Parameters:
   ParentMasterPassword:
     Description: 'Password'

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive.yaml
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive.yaml
@@ -12,7 +12,7 @@ Parameters:
 Resources:
   NewAmpApp-1:
       Type: AWS::DirectoryService::SimpleAD
-      Properties: 
+      Properties:
           CreateAlias: true
           Description: String
           EnableSso: true
@@ -26,7 +26,7 @@ Description: Creating DBCluster
 Resources:
   NewAmpApp:
       Type: AWS::DirectoryService::SimpleAD
-      Properties: 
+      Properties:
           CreateAlias: true
           Description: String
           EnableSso: true
@@ -49,7 +49,7 @@ Parameters:
 Resources:
   NewAmpApp-1:
       Type: AWS::DirectoryService::SimpleAD
-      Properties: 
+      Properties:
           CreateAlias: true
           Description: String
           EnableSso: true

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive_expected_result.json
@@ -2,11 +2,17 @@
 	{
 		"queryName": "Directory Service Simple AD Password Rule",
 		"severity": "MEDIUM",
-		"line": 7
+		"line": 5
 	},
 	{
 		"queryName": "Directory Service Simple AD Password Rule",
 		"severity": "MEDIUM",
-		"line":34
+		"line":30
+	},
+	{
+		"queryName": "Directory Service Simple AD Password Rule",
+		"severity": "MEDIUM",
+		"line":18
 	}
+	
 ]

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Directory Service Simple AD Password Rule",
+		"severity": "MEDIUM",
+		"line": 7
+	},
+	{
+		"queryName": "Directory Service Simple AD Password Rule",
+		"severity": "MEDIUM",
+		"line":34
+	}
+]

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_rule/test/positive_expected_result.json
@@ -1,16 +1,16 @@
 [
 	{
-		"queryName": "Directory Service Simple AD Password Rule",
+		"queryName": "Directory Service Simple AD Password Exposed",
 		"severity": "MEDIUM",
 		"line": 5
 	},
 	{
-		"queryName": "Directory Service Simple AD Password Rule",
+		"queryName": "Directory Service Simple AD Password Exposed",
 		"severity": "MEDIUM",
 		"line":30
 	},
 	{
-		"queryName": "Directory Service Simple AD Password Rule",
+		"queryName": "Directory Service Simple AD Password Exposed",
 		"severity": "MEDIUM",
 		"line":18
 	}


### PR DESCRIPTION
Description:
 Directory Service Microsoft AD password must not be a plaintext string or a Ref to a Parameter with a Default value.   Can be Ref to a NoEcho Parameter without a Default, or a dynamic reference to a secretsmanager/ssm-secure value.

close #1025 