### PR TITLE
Add query to check if apt-get is called without yes flag. Closes #1059

### DIFF
--- a/assets/queries/dockerfile/apt-get_without_yes_flag/metadata.json
+++ b/assets/queries/dockerfile/apt-get_without_yes_flag/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "APT-GET_Missing_'-y'_To_Avoid_Manual_Input",
+  "queryName": "APT-GET Missing '-y' To Avoid Manual Input",
+  "severity": "MEDIUM",
+  "category": "Package Management",
+  "descriptionText": "Check if apt-get calls use the flag -y to avoid user manual input.",
+  "descriptionUrl": "https://docs.docker.com/engine/reference/builder/#run"
+}

--- a/assets/queries/dockerfile/apt-get_without_yes_flag/query.rego
+++ b/assets/queries/dockerfile/apt-get_without_yes_flag/query.rego
@@ -1,0 +1,91 @@
+package Cx
+
+CxPolicy [ result ] {
+  runCmd := input.document[i].command[name][_]
+  isRunCmd(runCmd) 
+  
+  value := runCmd.Value
+  count(value) == 1 #command is in a single string
+
+  cmd := value[0]
+
+  searchIndex := indexof(cmd,"apt-get")
+
+  searchIndex != -1
+
+  aptGetCmd := trimCmdEnd(substring(cmd,searchIndex+8,count(cmd)-searchIndex-8))
+
+  not hasYesFlag(aptGetCmd)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'%s' uses '-y' flag to avoid user manual input", [runCmd.Original]),
+                "keyActualValue": 	sprintf("'%s' does not use '-y' flag to avoid user manual input", [runCmd.Original])
+              }
+}
+
+CxPolicy [ result ] {
+  runCmd := input.document[i].command[name][_]
+  isRunCmd(runCmd) 
+  
+  value := runCmd.Value
+  count(value) > 1 #command is in several tokens
+  
+  aptGetIdx := getAptGetIdx(value)
+  aptGetIdx != -1
+  aptGetCmdLastIdx := getCmdLastIdx(value,aptGetIdx)
+
+  not checkYesFlag(value,aptGetIdx,aptGetCmdLastIdx)
+
+  cmdFormatted := replace(runCmd.Original,"\"","'")
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'%s' uses '-y' flag to avoid user manual input", [cmdFormatted]),
+                "keyActualValue": 	sprintf("'%s' does not use '-y' flag to avoid user manual input", [cmdFormatted])
+              }
+}
+
+isRunCmd(com) = true{
+  com.Cmd == "run"
+} else = false
+
+trimCmdEnd(cmd) = trimmed {
+  termOps := ["&&","||","|","&",";"]
+
+  splitStr := split(cmd," ")
+  some i, j
+      splitStr[i] == termOps[j] 
+      indexTerm := indexof(cmd,termOps[j])
+      trimmed := substring(cmd,0,count(cmd) - indexTerm)
+} else = cmd
+
+hasYesFlag(arg) {
+  flags := ["-y","-yes","--assume-yes"]
+  contains(arg,flags[_])
+} else = false
+
+getAptGetIdx(value) = idx {
+  some i
+    value[i] == "apt-get"
+    idx := i+1
+} else = -1
+
+getCmdLastIdx(arr,initCmdIdx) = idx {
+  termOps := ["&&","||","|","&",";"]
+  some i
+    i > initCmdIdx
+    arr[i] == termOps[i]
+    idx := i-1
+} else = count(arr)-1
+
+checkYesFlag(cmd,start,end) {
+  some i
+    i >= start 
+    i <= end
+    hasYesFlag(cmd[i])
+} else = false

--- a/assets/queries/dockerfile/apt-get_without_yes_flag/test/negative.dockerfile
+++ b/assets/queries/dockerfile/apt-get_without_yes_flag/test/negative.dockerfile
@@ -1,0 +1,4 @@
+FROM node:12
+RUN apt-get -y install apt-utils
+RUN ["apt-get", "-y", "install", "apt-utils"]
+

--- a/assets/queries/dockerfile/apt-get_without_yes_flag/test/positive.dockerfile
+++ b/assets/queries/dockerfile/apt-get_without_yes_flag/test/positive.dockerfile
@@ -1,0 +1,3 @@
+FROM node:12
+RUN apt-get install apt-utils
+RUN ["apt-get", "install", "apt-utils"]

--- a/assets/queries/dockerfile/apt-get_without_yes_flag/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/apt-get_without_yes_flag/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "APT-GET Missing '-y' To Avoid Manual Input",
+		"severity": "MEDIUM",
+		"line": 2
+	},
+	{
+		"queryName": "APT-GET Missing '-y' To Avoid Manual Input",
+		"severity": "MEDIUM",
+		"line": 3
+	}
+]


### PR DESCRIPTION
Check if any apt-get call does not use "-y" flag to avoid manual user input. Closes #1059 