### PR TITLE
Add query to check if apt-get not installing additional packages. Closes #1064

### DIFF
--- a/assets/queries/dockerfile/apt-get_without_no_recommends_flag/metadata.json
+++ b/assets/queries/dockerfile/apt-get_without_no_recommends_flag/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "APT-GET_Not_Avoiding_Additional_Packages",
+  "queryName": "APT-GET Not Avoiding Additional Packages",
+  "severity": "INFO",
+  "category": "Package Management",
+  "descriptionText": "Check if any apt-get installs don't use '--no-install-recommends' flag to avoid installing additional packages.",
+  "descriptionUrl": "https://docs.docker.com/engine/reference/builder/#run"
+}

--- a/assets/queries/dockerfile/apt-get_without_no_recommends_flag/query.rego
+++ b/assets/queries/dockerfile/apt-get_without_no_recommends_flag/query.rego
@@ -1,0 +1,91 @@
+package Cx
+
+CxPolicy [ result ] {
+  runCmd := input.document[i].command[name][_]
+  isRunCmd(runCmd) 
+  
+  value := runCmd.Value
+  count(value) == 1 #command is in a single string
+
+  cmd := value[0]
+
+  searchIndex := indexof(cmd,"apt-get")
+
+  searchIndex != -1
+
+  aptGetCmd := trimCmdEnd(substring(cmd,searchIndex+8,count(cmd)-searchIndex-8))
+
+  not hasNoRecommendsFlag(aptGetCmd)
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name,runCmd.Original]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'%s' uses '--no-install-recommends' flag to avoid installing additional packages", [runCmd.Original]),
+                "keyActualValue": 	sprintf("'%s' does not use '--no-install-recommends' flag to avoid installing additional packages", [runCmd.Original])
+              }
+}
+
+CxPolicy [ result ] {
+  runCmd := input.document[i].command[name][_]
+  isRunCmd(runCmd) 
+  
+  value := runCmd.Value
+  count(value) > 1 #command is in several tokens
+  
+  aptGetIdx := getAptGetIdx(value)
+  aptGetIdx != -1
+  aptGetCmdLastIdx := getCmdLastIdx(value,aptGetIdx)
+
+  not checkRecommendsFlag(value,aptGetIdx,aptGetCmdLastIdx)
+
+  cmdFormatted := replace(runCmd.Original,"\"","'")
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name,runCmd.Original]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'%s' uses '--no-install-recommends' flag to avoid installing additional packages", [cmdFormatted]),
+                "keyActualValue": 	sprintf("'%s' does not use '--no-install-recommends' flag to avoid installing additional packages", [cmdFormatted])
+              }
+}
+
+isRunCmd(com) = true{
+  com.Cmd == "run"
+} else = false
+
+trimCmdEnd(cmd) = trimmed {
+  termOps := ["&&","||","|","&",";"]
+
+  splitStr := split(cmd," ")
+  some i, j
+      splitStr[i] == termOps[j] 
+      indexTerm := indexof(cmd,termOps[j])
+      trimmed := substring(cmd,0,count(cmd) - indexTerm)
+} else = cmd
+
+hasNoRecommendsFlag(arg) {
+  flags := ["--no-install-recommends","apt::install-recommends=false"]
+  contains(arg,flags[_])
+} else = false
+
+getAptGetIdx(value) = idx {
+  some i
+    value[i] == "apt-get"
+    idx := i+1
+} else = -1
+
+getCmdLastIdx(arr,initCmdIdx) = idx {
+  termOps := ["&&","||","|","&",";"]
+  some i
+    i > initCmdIdx
+    arr[i] == termOps[i]
+    idx := i-1
+} else = count(arr)-1
+
+checkRecommendsFlag(cmd,start,end) {
+  some i
+    i >= start 
+    i <= end
+    hasNoRecommendsFlag(cmd[i])
+} else = false

--- a/assets/queries/dockerfile/apt-get_without_no_recommends_flag/test/negative.dockerfile
+++ b/assets/queries/dockerfile/apt-get_without_no_recommends_flag/test/negative.dockerfile
@@ -1,0 +1,4 @@
+FROM node:12
+RUN apt-get --no-install-recommends install apt-utils
+RUN ["apt-get", "apt::install-recommends=false", "install", "apt-utils"]
+

--- a/assets/queries/dockerfile/apt-get_without_no_recommends_flag/test/positive.dockerfile
+++ b/assets/queries/dockerfile/apt-get_without_no_recommends_flag/test/positive.dockerfile
@@ -1,0 +1,3 @@
+FROM node:12
+RUN apt-get install apt-utils
+RUN ["apt-get", "install", "apt-utils"]

--- a/assets/queries/dockerfile/apt-get_without_no_recommends_flag/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/apt-get_without_no_recommends_flag/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "APT-GET Not Avoiding Additional Packages",
+		"severity": "INFO",
+		"line": 2
+	},
+	{
+		"queryName": "APT-GET Not Avoiding Additional Packages",
+		"severity": "INFO",
+		"line": 3
+	}
+]


### PR DESCRIPTION
Check if any apt-get install commands use no install recommendations to avoid installing additional packages. Closes #1064 