### PR TITLE
Feature/add new query amplify app basic auth config password rule

### DIFF
--- a/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/metadata.json
+++ b/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "amplify_app_basic_auth_config_password_rule",
+  "queryName": "Amplify App Basic Auth Config Password Rule",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Amplify App BasicAuthConfig Password must not be a plaintext string or a Ref to a Parameter with a Default value.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amplify-app-basicauthconfig.html"
+}

--- a/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/metadata.json
+++ b/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "amplify_app_basic_auth_config_password_rule",
-  "queryName": "Amplify App Basic Auth Config Password Rule",
+  "queryName": "Amplify App Basic Auth Config Password Exposed",
   "severity": "MEDIUM",
-  "category": null,
+  "category": "Identity and Access Management",
   "descriptionText": "Amplify App BasicAuthConfig Password must not be a plaintext string or a Ref to a Parameter with a Default value.",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amplify-app-basicauthconfig.html"
 }

--- a/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/query.rego
+++ b/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/query.rego
@@ -1,0 +1,58 @@
+package Cx
+
+
+CxPolicy [ result ]  {
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::Amplify::App"
+
+  properties := resource.Properties
+  properties.BasicAuthConfig.EnableBasicAuth == true
+  paramName  := properties.BasicAuthConfig.Password
+
+  defaultToken := document.Parameters[paramName].Default
+
+  regex.match(`[A-Za-z\d@$!%*"#"?&]{8,}`,defaultToken)
+  not hasSecretManager(defaultToken, document.Resources)
+
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Parameters.%s.Default", [paramName]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Parameters.%s.Default is defined",[paramName]),
+                "keyActualValue": 	sprintf("Parameters.%s.Default shouldn't be defined",[paramName])
+              }
+}
+
+
+
+CxPolicy [  result ]  {
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::Amplify::App"
+
+  properties := resource.Properties
+  properties.BasicAuthConfig.EnableBasicAuth == true
+  paramName  := properties.BasicAuthConfig.Password
+  object.get(document, "Parameters", "undefined") == "undefined"
+
+  defaultToken := paramName
+
+  regex.match(`[A-Za-z\d@$!%*"#"?&]{8,}`,defaultToken)
+  not hasSecretManager(defaultToken, document.Resources)
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.BasicAuthConfig.Password", [key]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.BasicAuthConfig.Password must not be in plain text string",[key]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.BasicAuthConfig.Password must be defined as a parameter or have a secret manager referenced",[key])
+              }
+}
+
+
+hasSecretManager(str, document) {
+	selectedSecret :=  strings.replace_n({"${":"","}":""}, regex.find_n(`\${\w+}`,str,1)[0])
+  document[selectedSecret].Type == "AWS::SecretsManager::Secret"
+}

--- a/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/query.rego
+++ b/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/query.rego
@@ -36,7 +36,8 @@ CxPolicy [  result ]  {
   properties := resource.Properties
   properties.BasicAuthConfig.EnableBasicAuth == true
   paramName  := properties.BasicAuthConfig.Password
-  object.get(document, "Parameters", "undefined") == "undefined"
+  object.get(document, "Parameters" , "undefined") != "undefined"
+  object.get(document.Parameters, paramName , "undefined") == "undefined"
 
   defaultToken := paramName
 
@@ -51,6 +52,29 @@ CxPolicy [  result ]  {
               }
 }
 
+CxPolicy [  result ]  {
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::Amplify::App"
+
+  properties := resource.Properties
+  properties.BasicAuthConfig.EnableBasicAuth == true
+  paramName  := properties.BasicAuthConfig.Password
+  object.get(document, "Parameters" , "undefined") == "undefined"
+
+  defaultToken := paramName
+
+  regex.match(`[A-Za-z\d@$!%*"#"?&]{8,}`,defaultToken)
+  not hasSecretManager(defaultToken, document.Resources)
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.BasicAuthConfig.Password", [key]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.BasicAuthConfig.Password must not be in plain text string",[key]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.BasicAuthConfig.Password must be defined as a parameter or have a secret manager referenced",[key])
+              }
+}
 
 hasSecretManager(str, document) {
 	selectedSecret :=  strings.replace_n({"${":"","}":""}, regex.find_n(`\${\w+}`,str,1)[0])

--- a/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/test/negative.yaml
+++ b/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/test/negative.yaml
@@ -1,0 +1,76 @@
+Resources:
+     NewAmpApp-2:
+        Type: AWS::Amplify::App
+        Properties:
+          BuildSpec: String
+          CustomHeaders: String
+          Description: String
+          EnableBranchAutoDeletion: true
+          IAMServiceRole: String
+          Name: NewAmpApp
+          OauthToken: String
+          Repository: String
+          BasicAuthConfig :
+            EnableBasicAuth: true
+            Password: !Sub '{{resolve:secretsmanager:${MyAmpAppSecretManagerRotater}::password}}'
+            Username: !Sub '{{resolve:secretsmanager:${MyAmpAppSecretManagerRotater}::username}}'
+     MyAmpAppSecretManagerRotater:
+        Type: AWS::SecretsManager::Secret
+        Properties:
+          Description: 'This is my amp app instance secret'
+          GenerateSecretString:
+            SecretStringTemplate: '{"username": "admin"}'
+            GenerateStringKey: 'password'
+            PasswordLength: 16
+            ExcludeCharacters: '"@/\'
+---
+Parameters:
+  ParentPassword:
+    Description: 'Password'
+    Type: String
+  ParentUsername:
+    Description: 'Username'
+    Type: String
+Resources:
+  NewAmpApp-1:
+    Type: AWS::Amplify::App
+    Properties:
+      BuildSpec: String
+      CustomHeaders: String
+      Description: String
+      EnableBranchAutoDeletion: true
+      IAMServiceRole: String
+      Name: NewAmpApp
+      OauthToken: String
+      Repository: String
+      BasicAuthConfig:
+        EnableBasicAuth: true
+        Password: !Ref ParentPassword
+        Username: !Ref ParentUsername
+
+---
+Parameters:
+  ParentPassword:
+    Description: 'Password'
+    Type: String
+    Default: ""
+  ParentUsername:
+    Description: 'Username'
+    Type: String
+    Default: ""
+Resources:
+  NewAmpApp-4:
+    Type: AWS::Amplify::App
+    Properties:
+      BuildSpec: String
+      CustomHeaders: String
+      Description: String
+      EnableBranchAutoDeletion: true
+      IAMServiceRole: String
+      Name: NewAmpApp
+      OauthToken: String
+      Repository: String
+      BasicAuthConfig:
+        EnableBasicAuth: true
+        Password: !Ref ParentPassword
+        Username: !Ref ParentUsername

--- a/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/test/positive.yaml
+++ b/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/test/positive.yaml
@@ -1,0 +1,43 @@
+Resources:
+  NewAmpApp-1:
+    Type: AWS::Amplify::App
+    Properties:
+      BuildSpec: String
+      CustomHeaders: String
+      Description: String
+      EnableBranchAutoDeletion: true
+      IAMServiceRole: String
+      Name: NewAmpApp
+      OauthToken: String
+      Repository: String
+      BasicAuthConfig:
+        EnableBasicAuth: true
+        Password: "@skdsjdk0234!AB"
+        Username: admin
+
+---
+Parameters:
+  ParentPassword:
+    Description: 'Password'
+    Type: String
+    Default: "@skdsjdk0234!AB"
+  ParentUsername:
+    Description: 'Username'
+    Type: String
+    Default: ""
+Resources:
+  NewAmpApp-4:
+    Type: AWS::Amplify::App
+    Properties:
+      BuildSpec: String
+      CustomHeaders: String
+      Description: String
+      EnableBranchAutoDeletion: true
+      IAMServiceRole: String
+      Name: NewAmpApp
+      OauthToken: String
+      Repository: String
+      BasicAuthConfig:
+        EnableBasicAuth: true
+        Password: !Ref ParentPassword
+        Username: !Ref ParentUsername

--- a/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/test/positive_expected_result.json
@@ -1,11 +1,11 @@
 [
 	{
-		"queryName": "Amplify App Basic Auth Config Password Rule",
+		"queryName": "Amplify App Basic Auth Config Password Exposed",
 		"severity": "MEDIUM",
 		"line": 23
 	},
 	{
-		"queryName": "Amplify App Basic Auth Config Password Rule",
+		"queryName": "Amplify App Basic Auth Config Password Exposed",
 		"severity": "MEDIUM",
 		"line": 15
 	}

--- a/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_rule/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Amplify App Basic Auth Config Password Rule",
+		"severity": "MEDIUM",
+		"line": 23
+	},
+	{
+		"queryName": "Amplify App Basic Auth Config Password Rule",
+		"severity": "MEDIUM",
+		"line": 15
+	}
+]


### PR DESCRIPTION
Description
Amplify App BasicAuthConfig Password must not be a plaintext string or a Ref to a Parameter with a Default value.

Close #1112