### PR TITLE
Added Query Amplify App OAuth Token Rule

### DIFF
--- a/assets/queries/cloudFormation/amplify_app_oauth_token_rule/metadata.json
+++ b/assets/queries/cloudFormation/amplify_app_oauth_token_rule/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "amplify_app_basic_auth_config_password_rule",
-  "queryName": "Amplify App OAuth Token Rule",
+  "queryName": "Amplify App OAuth Token Exposed",
   "severity": "MEDIUM",
-  "category": null,
+  "category": "Identity and Access Management",
   "descriptionText": "Amplify App OAuth Token must not be a plaintext string or a Ref to a Parameter with a Default value.",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amplify-app-basicauthconfig.html"
 }

--- a/assets/queries/cloudFormation/amplify_app_oauth_token_rule/metadata.json
+++ b/assets/queries/cloudFormation/amplify_app_oauth_token_rule/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "amplify_app_basic_auth_config_password_rule",
+  "queryName": "Amplify App OAuth Token Rule",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "Amplify App OAuth Token must not be a plaintext string or a Ref to a Parameter with a Default value.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amplify-app-basicauthconfig.html"
+}

--- a/assets/queries/cloudFormation/amplify_app_oauth_token_rule/query.rego
+++ b/assets/queries/cloudFormation/amplify_app_oauth_token_rule/query.rego
@@ -1,0 +1,81 @@
+package Cx
+
+
+CxPolicy [ result ]  {
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::Amplify::App"
+
+  properties := resource.Properties
+  paramName  := properties.OauthToken
+
+  defaultToken := document.Parameters[paramName].Default
+
+  regex.match(`[A-Za-z0-9\-\._~\+\/]+=*`,defaultToken)
+  not hasSecretManager(defaultToken, document.Resources)
+
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Parameters.%s.Default", [paramName]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Parameters.%s.Default is defined",[paramName]),
+                "keyActualValue": 	sprintf("Parameters.%s.Default shouldn't be defined",[paramName])
+              }
+}
+
+
+
+CxPolicy [  result ]  {
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::Amplify::App"
+
+  properties := resource.Properties
+  paramName  := properties.OauthToken
+  count(paramName)>=50
+  defaultToken := paramName
+  object.get(document, "Parameters" , "undefined") != "undefined"
+  object.get(document.Parameters, paramName , "undefined") == "undefined"
+
+  regex.match(`[A-Za-z0-9\-\._~\+\/]+=*`,defaultToken)
+  not hasSecretManager(defaultToken, document.Resources)
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.BasicAuthConfig.Password", [key]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.BasicAuthConfig.Password must not be in plain text string",[key]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.BasicAuthConfig.Password must be defined as a parameter or have a secret manager referenced",[key])
+              }
+}
+
+
+CxPolicy [  result ]  {
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::Amplify::App"
+
+  properties := resource.Properties
+  paramName  := properties.OauthToken
+  object.get(document, "Parameters" , "undefined") == "undefined"
+  count(paramName)>=50
+  defaultToken := paramName
+
+
+  regex.match(`[A-Za-z0-9\-\._~\+\/]+=*`,defaultToken)
+  not hasSecretManager(defaultToken, document.Resources)
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.BasicAuthConfig.Password", [key]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.BasicAuthConfig.Password must not be in plain text string",[key]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.BasicAuthConfig.Password must be defined as a parameter or have a secret manager referenced",[key])
+              }
+}
+
+hasSecretManager(str, document) {
+	selectedSecret :=  strings.replace_n({"${":"","}":""}, regex.find_n(`\${\w+}`,str,1)[0])
+  document[selectedSecret].Type == "AWS::SecretsManager::Secret"
+}

--- a/assets/queries/cloudFormation/amplify_app_oauth_token_rule/test/negative.yaml
+++ b/assets/queries/cloudFormation/amplify_app_oauth_token_rule/test/negative.yaml
@@ -8,7 +8,6 @@ Resources:
           EnableBranchAutoDeletion: true
           IAMServiceRole: String
           Name: NewAmpApp
-          OauthToken: String
           Repository: String
           OauthToken: !Sub '{{resolve:secretsmanager:${MyAmpAppSecretManagerRotater}::password}}'
      MyAmpAppSecretManagerRotater:
@@ -38,7 +37,6 @@ Resources:
       EnableBranchAutoDeletion: true
       IAMServiceRole: String
       Name: NewAmpApp
-      OauthToken: String
       Repository: String
       OauthToken: !Ref ParentPassword
 
@@ -62,6 +60,5 @@ Resources:
       EnableBranchAutoDeletion: true
       IAMServiceRole: String
       Name: NewAmpApp
-      OauthToken: String
       Repository: String
       OauthToken: !Ref ParentPassword

--- a/assets/queries/cloudFormation/amplify_app_oauth_token_rule/test/negative.yaml
+++ b/assets/queries/cloudFormation/amplify_app_oauth_token_rule/test/negative.yaml
@@ -1,0 +1,67 @@
+Resources:
+     NewAmpApp-2:
+        Type: AWS::Amplify::App
+        Properties:
+          BuildSpec: String
+          CustomHeaders: String
+          Description: String
+          EnableBranchAutoDeletion: true
+          IAMServiceRole: String
+          Name: NewAmpApp
+          OauthToken: String
+          Repository: String
+          OauthToken: !Sub '{{resolve:secretsmanager:${MyAmpAppSecretManagerRotater}::password}}'
+     MyAmpAppSecretManagerRotater:
+        Type: AWS::SecretsManager::Secret
+        Properties:
+          Description: 'This is my amp app instance secret'
+          GenerateSecretString:
+            SecretStringTemplate: '{"username": "admin"}'
+            GenerateStringKey: 'password'
+            PasswordLength: 16
+            ExcludeCharacters: '"@/\'
+---
+Parameters:
+  ParentPassword:
+    Description: 'Password'
+    Type: String
+  ParentUsername:
+    Description: 'Username'
+    Type: String
+Resources:
+  NewAmpApp-1:
+    Type: AWS::Amplify::App
+    Properties:
+      BuildSpec: String
+      CustomHeaders: String
+      Description: String
+      EnableBranchAutoDeletion: true
+      IAMServiceRole: String
+      Name: NewAmpApp
+      OauthToken: String
+      Repository: String
+      OauthToken: !Ref ParentPassword
+
+---
+Parameters:
+  ParentPassword:
+    Description: 'Password'
+    Type: String
+    Default: ""
+  ParentUsername:
+    Description: 'Username'
+    Type: String
+    Default: ""
+Resources:
+  NewAmpApp-4:
+    Type: AWS::Amplify::App
+    Properties:
+      BuildSpec: String
+      CustomHeaders: String
+      Description: String
+      EnableBranchAutoDeletion: true
+      IAMServiceRole: String
+      Name: NewAmpApp
+      OauthToken: String
+      Repository: String
+      OauthToken: !Ref ParentPassword

--- a/assets/queries/cloudFormation/amplify_app_oauth_token_rule/test/positive.yaml
+++ b/assets/queries/cloudFormation/amplify_app_oauth_token_rule/test/positive.yaml
@@ -1,0 +1,39 @@
+Resources:
+  NewAmpApp-1:
+    Type: AWS::Amplify::App
+    Properties:
+      BuildSpec: String
+      CustomHeaders: String
+      Description: String
+      EnableBranchAutoDeletion: true
+      IAMServiceRole: String
+      Name: NewAmpApp
+      Repository: String
+      OauthToken: 'CqGZthigPO55H3fi1_6wrP9jmdivueS7lYd7Lg2styBfjsK5eQ5C2qg_gONQgzyvvVojXY0JyMkRdm71y3nTFl1ZYOgJSNLshvWnm9QoEJrInp_xr-o-9RgZHhrGp5X9dCZVYsYF1WHqj5p75O37IKc8Rv6yO9kGw1flCbT4xbeLTDItX71jRzuAHYNKGPKkxrhIuQ-w9MyKYZ0a3pYT4lWZzWVFoMu9G-smC4qrww5grWCUevE9LuNEZgSijFgRK9QPo8PxMt427lGyK-FkoB8x4qllQ1aCG9_mz2t6A1nRxXY7-Jq9ONkmNoUHiTenEUUaPQcz4RFzrkTE-GaUNP_yK2tNR2i5-TQ4tcI8hQW0aaAsWBPoxd_ZXNty9AhRpshU9WUy32yIHj47jMYCpA'
+
+---
+Parameters:
+  ParentPassword:
+    Description: 'Password'
+    Type: String
+    Default: 'CqGZthigPO55H3fi1_6wrP9jmdivueS7lYd7Lg2styBfjsK5eQ5C2qg_gONQgzyvvVojXY0JyMkRdm71y3nTFl1ZYOgJSNLshvWnm9QoEJrInp_xr-o-9RgZHhrGp5X9dCZVYsYF1WHqj5p75O37IKc8Rv6yO9kGw1flCbT4xbeLTDItX71jRzuAHYNKGPKkxrhIuQ-w9MyKYZ0a3pYT4lWZzWVFoMu9G-smC4qrww5grWCUevE9LuNEZgSijFgRK9QPo8PxMt427lGyK-FkoB8x4qllQ1aCG9_mz2t6A1nRxXY7-Jq9ONkmNoUHiTenEUUaPQcz4RFzrkTE-GaUNP_yK2tNR2i5-TQ4tcI8hQW0aaAsWBPoxd_ZXNty9AhRpshU9WUy32yIHj47jMYCpA'
+  ParentUsername:
+    Description: 'Username'
+    Type: String
+    Default: ""
+Resources:
+  NewAmpApp-4:
+    Type: AWS::Amplify::App
+    Properties:
+      BuildSpec: String
+      CustomHeaders: String
+      Description: String
+      EnableBranchAutoDeletion: true
+      IAMServiceRole: String
+      Name: NewAmpApp
+      OauthToken: !Ref ParentPassword
+      Repository: String
+      BasicAuthConfig:
+        EnableBasicAuth: true
+        Password: !Ref ParentPassword
+        Username: !Ref ParentUsername

--- a/assets/queries/cloudFormation/amplify_app_oauth_token_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/amplify_app_oauth_token_rule/test/positive_expected_result.json
@@ -1,11 +1,11 @@
 [
 	{
-		"queryName": "Amplify App OAuth Token Rule",
+		"queryName": "Amplify App OAuth Token Exposed",
 		"severity": "MEDIUM",
 		"line": 19
 	},
 	{
-		"queryName": "Amplify App OAuth Token Rule",
+		"queryName": "Amplify App OAuth Token Exposed",
 		"severity": "MEDIUM",
 		"line": 38
 	}

--- a/assets/queries/cloudFormation/amplify_app_oauth_token_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/amplify_app_oauth_token_rule/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Amplify App OAuth Token Rule",
+		"severity": "MEDIUM",
+		"line": 19
+	},
+	{
+		"queryName": "Amplify App OAuth Token Rule",
+		"severity": "MEDIUM",
+		"line": 38
+	}
+]


### PR DESCRIPTION
Description
Amplify App OAuth Token must not be a plaintext string or a Ref to a Parameter with a Default value.

Close  #1114