### PR TITLE
Add tcp_or_udp_protocol_network_acl_entry_allows_all_ports Closes #1118

### DIFF
--- a/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/metadata.json
+++ b/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "tcp_or_udp_protocol_network_acl_entry_allows_all_ports",
+  "queryName": "TCP/UDP Protocol Network ACL Entry Allows All Ports",
+  "severity": "MEDIUM",
+  "category": "null",
+  "descriptionText": "TCP/UDP protocol AWS Network ACL Entry should not allow all ports",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-portrange"
+}

--- a/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/metadata.json
+++ b/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/metadata.json
@@ -2,7 +2,7 @@
   "id": "tcp_or_udp_protocol_network_acl_entry_allows_all_ports",
   "queryName": "TCP/UDP Protocol Network ACL Entry Allows All Ports",
   "severity": "MEDIUM",
-  "category": "null",
+  "category": "Network Security",
   "descriptionText": "TCP/UDP protocol AWS Network ACL Entry should not allow all ports",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-portrange"
 }

--- a/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/query.rego
+++ b/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/query.rego
@@ -1,0 +1,69 @@
+package Cx
+
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::EC2::NetworkAclEntry"
+
+    properties := resource.Properties
+    
+    checkProtocol(properties.Protocol)
+    
+    object.get(properties, "PortRange", "undefined") == "undefined"
+
+
+    result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey": 	      sprintf("Resources.%s.Properties", [name]),
+                "issueType":		    "MissingAttribute",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.PortRange is set", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.PortRange is undefined", [name])
+              }
+}
+
+CxPolicy [ result ] {
+	  resource := input.document[i].Resources[name]
+    resource.Type == "AWS::EC2::NetworkAclEntry"
+
+    properties := resource.Properties
+    
+    checkProtocol(properties.Protocol)
+    
+    attributes := {"From", "To"}
+    object.get(properties.PortRange, attributes[y], "undefined") == "undefined"
+
+
+    result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey": 	      sprintf("Resources.%s.Properties.PortRange", [name]),
+                "issueType":		    "MissingAttribute",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.PortRange.%s is set", [name, y]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.PortRange.%s is undefined", [name, y])
+              }
+}
+
+CxPolicy [ result ] {
+    resource := input.document[i].Resources[name]
+    resource.Type == "AWS::EC2::NetworkAclEntry"
+
+    properties := resource.Properties
+    checkProtocol(properties.Protocol)
+
+    properties.PortRange.From == 0
+    properties.PortRange.To == 65535
+
+    result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey": 	      sprintf("Resources.%s.Properties.PortRange", [name]),
+                "issueType":		    "MissingAttribute",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.PortRange does not allow all ports", [name]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.PortRange allows all ports", [name])
+              }
+}
+
+checkProtocol(protocol) = allow {
+    protocols := {6, 17}
+    protocol == protocols[x]
+    
+	allow = true
+}

--- a/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/test/negative.yaml
+++ b/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/test/negative.yaml
@@ -1,0 +1,20 @@
+Resources:
+  MyNACL9:
+    Type: AWS::EC2::NetworkAcl
+    Properties:
+       VpcId: vpc-1122334455aabbccd
+       Tags:
+       - Key: Name
+         Value: NACLforSSHTraffic
+  InboundRule9:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: 6
+       RuleAction: allow
+       CidrBlock: 172.16.0.0/24
+       PortRange:
+         From: 22
+         To: 22

--- a/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/test/positive.yaml
+++ b/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/test/positive.yaml
@@ -1,0 +1,51 @@
+Resources:
+  MyNACL:
+    Type: AWS::EC2::NetworkAcl
+    Properties:
+       VpcId: vpc-1122334455aabbccd
+       Tags:
+       - Key: Name
+         Value: NACLforSSHTraffic
+  InboundRule2:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: 6
+       RuleAction: allow
+       CidrBlock: 172.16.0.0/24
+       PortRange:
+         From: 22
+  InboundRule3:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: 6
+       RuleAction: allow
+       CidrBlock: 172.16.0.0/24
+       PortRange:
+         To: 22
+  InboundRule4:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: 6
+       RuleAction: allow
+       CidrBlock: 172.16.0.0/24
+  InboundRule5:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: 6
+       RuleAction: allow
+       CidrBlock: 172.16.0.0/24
+       PortRange:
+         From: 0
+         To: 65535

--- a/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/test/positive_expected_result.json
@@ -1,0 +1,25 @@
+[
+	{
+		"queryName": "TCP/UDP Protocol Network ACL Entry Allows All Ports",
+		"severity": "MEDIUM",
+		"line": 18
+	},
+
+	{
+		"queryName": "TCP/UDP Protocol Network ACL Entry Allows All Ports",
+		"severity": "MEDIUM",
+		"line": 29
+	},
+
+	{
+		"queryName": "TCP/UDP Protocol Network ACL Entry Allows All Ports",
+		"severity": "MEDIUM",
+		"line": 33
+	},
+
+	{
+		"queryName": "TCP/UDP Protocol Network ACL Entry Allows All Ports",
+		"severity": "MEDIUM",
+		"line": 49
+	}
+]


### PR DESCRIPTION
To check if the protocol is TCP ou UDP, it is necessary to check the attribute 'Protocol' of Properties ( TCP is represented by 6 and UDP by 17). 

Furthermore, it is necessary to check if the attribute 'PortRange' of Properties is set, as well as their attributes ('From' and 'To').

Not less important, it is necessary to check if 'From' is set to 0 and 'To' set to 65535.

Closes #1118