### PR TITLE
Add RDS Public Interface Open To Public Scope query for AWS CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/rds_public_interface_open_to_public_scope/metadata.json
+++ b/assets/queries/cloudFormation/rds_public_interface_open_to_public_scope/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "RDS_Public_Interface_Open_To_Public_Scope",
+  "queryName": "RDS Public Interface Open To Public Scope",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Amazon RDS must not have a public interface open to a public scope, which means the IP Address in its Security Group must not be '0.0.0.0/0' (IPv4) or '::/0' (IPv6).",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html"
+}

--- a/assets/queries/cloudFormation/rds_public_interface_open_to_public_scope/query.rego
+++ b/assets/queries/cloudFormation/rds_public_interface_open_to_public_scope/query.rego
@@ -1,0 +1,65 @@
+package Cx
+
+CxPolicy [ result ] {
+	not input.document[i].Resources[name].Type == "AWS::RDS::DBSecurityGroup"
+	resource := input.document[i].Resources[name]
+  check_public(resource)
+  some j
+    res := input.document[i].Resources[j]
+  	res.Type == "AWS::EC2::SecurityGroup"
+  	not res.Properties.SecurityGroupIngress[x].CidrIpv6
+  	ipv4 := res.Properties.SecurityGroupIngress[x].CidrIp
+  	ipv4 == "0.0.0.0/0"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.SecurityGroupIngress",  [j]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.SecurityGroupIngress' should not be '0.0.0.0/0'.", [j]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.SecurityGroupIngress' is '0.0.0.0/0'.", [j]),
+              }
+}
+
+CxPolicy [ result ] {
+	not input.document[i].Resources[name].Type == "AWS::RDS::DBSecurityGroup"
+	resource := input.document[i].Resources[name]
+  check_public(resource)
+  some j
+    res := input.document[i].Resources[j]
+  	res.Type == "AWS::EC2::SecurityGroup"
+  	not res.Properties.SecurityGroupIngress[x].CidrIp
+  	ipv6 := res.Properties.SecurityGroupIngress[x].CidrIpv6
+  	ipv6 == "::/0"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.SecurityGroupIngress",  [j]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.SecurityGroupIngress' should not be '0.0.0.0/0'.", [j]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.SecurityGroupIngress' is '0.0.0.0/0'.", [j]),
+              }
+}
+
+CxPolicy [ result ] {
+	not input.document[i].Resources[name].Type == "AWS::EC2::SecurityGroup"
+	resource := input.document[i].Resources[name]
+  check_public(resource)
+  some j
+    res := input.document[i].Resources[j]
+  	res.Type == "AWS::RDS::DBSecurityGroup"
+  	ipv4 := res.Properties.DBSecurityGroupIngress[x].CIDRIP
+  	ipv4 == "0.0.0.0/0"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.DBSecurityGroupIngress",  [j]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("'Resources.%s.Properties.DBSecurityGroupIngress' should not be '0.0.0.0/0'.", [j]),
+                "keyActualValue": 	sprintf("'Resources.%s.Properties.DBSecurityGroupIngress' is '0.0.0.0/0'.", [j]),
+              }
+}
+
+check_public(resource){
+  resource.Type == "AWS::RDS::DBInstance"
+  resource.Properties.PubliclyAccessible == true
+}

--- a/assets/queries/cloudFormation/rds_public_interface_open_to_public_scope/test/negative.yaml
+++ b/assets/queries/cloudFormation/rds_public_interface_open_to_public_scope/test/negative.yaml
@@ -1,0 +1,63 @@
+#this code is a correct code for which the query should not find any result
+Resources:
+  DBEC2SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Open database for access
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 1.2.3.4/24
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIpv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 0.0.0.0/0
+  DBInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      PubliclyAccessible: true
+      DBName:
+        Ref: DBName
+      Engine: MySQL
+      MultiAZ:
+        Ref: MultiAZDatabase
+      MasterUsername:
+        Ref: DBUser
+      DBInstanceClass:
+        Ref: DBClass
+      AllocatedStorage:
+        Ref: DBAllocatedStorage
+      MasterUserPassword:
+        Ref: DBPassword
+      VPCSecurityGroups:
+      - !GetAtt DBEC2SecurityGroup.GroupId
+
+---
+
+Resources:
+  DBinstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      PubliclyAccessible: true
+      DBSecurityGroups:
+        -
+          Ref: "DbSecurityByEC2SecurityGroup"
+      AllocatedStorage: "5"
+      DBInstanceClass: "db.t3.small"
+      Engine: "MySQL"
+      MasterUsername: "YourName"
+      MasterUserPassword: "YourPassword"
+    DeletionPolicy: "Snapshot"
+  DbSecurityByEC2SecurityGroup:
+    Type: AWS::RDS::DBSecurityGroup
+    Properties:
+      GroupDescription: "Ingress for Amazon EC2 security group"
+      DBSecurityGroupIngress:
+        -
+          CIDRIP: 1.2.3.4/24

--- a/assets/queries/cloudFormation/rds_public_interface_open_to_public_scope/test/positive.yaml
+++ b/assets/queries/cloudFormation/rds_public_interface_open_to_public_scope/test/positive.yaml
@@ -1,0 +1,92 @@
+#this is a problematic code where the query should report a result(s)
+Resources:
+  DBEC2SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Open database for access
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 0.0.0.0/0
+  DBInstance:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      PubliclyAccessible: true
+      DBName:
+        Ref: DBName
+      Engine: MySQL
+      MultiAZ:
+        Ref: MultiAZDatabase
+      MasterUsername:
+        Ref: DBUser
+      DBInstanceClass:
+        Ref: DBClass
+      AllocatedStorage:
+        Ref: DBAllocatedStorage
+      MasterUserPassword:
+        Ref: DBPassword
+      VPCSecurityGroups:
+      - !GetAtt DBEC2SecurityGroup.GroupId
+---
+Resources:
+  DBinstance2:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      PubliclyAccessible: true
+      DBSecurityGroups:
+        -
+          Ref: "DbSecurityByEC2SecurityGroup"
+      AllocatedStorage: "5"
+      DBInstanceClass: "db.t3.small"
+      Engine: "MySQL"
+      MasterUsername: "YourName"
+      MasterUserPassword: "YourPassword"
+    DeletionPolicy: "Snapshot"
+  DbSecurityByEC2SecurityGroup:
+    Type: AWS::RDS::DBSecurityGroup
+    Properties:
+      GroupDescription: "Ingress for Amazon EC2 security group"
+      DBSecurityGroupIngress:
+        -
+          CIDRIP: 0.0.0.0/0
+---
+Resources:
+  DBEC2SecurityGroup2:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Open database for access
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIpv6: ::/0
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 80
+        ToPort: 80
+        CidrIp: 0.0.0.0/0
+  DBInstance3:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      PubliclyAccessible: true
+      DBName:
+        Ref: DBName
+      Engine: MySQL
+      MultiAZ:
+        Ref: MultiAZDatabase
+      MasterUsername:
+        Ref: DBUser
+      DBInstanceClass:
+        Ref: DBClass
+      AllocatedStorage:
+        Ref: DBAllocatedStorage
+      MasterUserPassword:
+        Ref: DBPassword
+      VPCSecurityGroups:
+      - !GetAtt DBEC2SecurityGroup2.GroupId

--- a/assets/queries/cloudFormation/rds_public_interface_open_to_public_scope/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/rds_public_interface_open_to_public_scope/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "RDS Public Interface Open To Public Scope",
+		"severity": "HIGH",
+		"line": 7
+	},
+	{
+		"queryName": "RDS Public Interface Open To Public Scope",
+		"severity": "HIGH",
+		"line": 55
+	},
+	{
+		"queryName": "RDS Public Interface Open To Public Scope",
+		"severity": "HIGH",
+		"line": 64
+	}
+]


### PR DESCRIPTION
Adding RDS Public Interface Open To Public Scope query for AWS CloudFormation, that checks if the IP Address in its Security Group is '0.0.0.0/0' (IPv4) or '::/0' (IPv6) when it has a public interface.

Closes #1126