### PR TITLE
Add Filter&Alarm !Exists S3 Bucket Policy Changes

### DIFF
--- a/assets/queries/cloudFormation/filter_and_alarm_exist_for_S3_bucket_policy_changes/metadata.json
+++ b/assets/queries/cloudFormation/filter_and_alarm_exist_for_S3_bucket_policy_changes/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Filter_And_Alarm_Exist_For_S3_Bucket_Policy_Changes",
+  "queryName": "Filter And Alarm Not Exists For S3 Bucket Policy Changes",
+  "severity": "MEDIUM",
+  "category": "Monitoring",
+  "descriptionText": "A log metric filter and alarm should exist for S3 Bucket Policy Changes",
+  "descriptionUrl": "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudwatch-alarms-for-cloudtrail.html"
+}

--- a/assets/queries/cloudFormation/filter_and_alarm_exist_for_S3_bucket_policy_changes/query.rego
+++ b/assets/queries/cloudFormation/filter_and_alarm_exist_for_S3_bucket_policy_changes/query.rego
@@ -1,0 +1,74 @@
+package Cx
+
+CxPolicy [ result ] {
+
+	resourceMetricFilter := input.document[i].Resources
+    some name
+    resourceMetricFilter[name].Type == "AWS::Logs::MetricFilter"
+    
+    resourceAlarm := input.document[i].Resources
+    some nameAlarm
+    resourceAlarm[nameAlarm].Type == "AWS::CloudWatch::Alarm"
+   
+    checkAlarm(resourceMetricFilter[name].Properties.MetricTransformations[index].MetricNamespace, resourceAlarm[nameAlarm].Properties)
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	     sprintf("Resources.%s.Properties.MetricTransformations.MetricNamespace", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("'Resources.%s.Properties.MetricTransformations[%d].MetricNamespace' should have a valid Namespace in 'AWS::CloudWatch::Alarm')", [name, index]),
+                "keyActualValue": 	sprintf("'Resources.%s.FilterPattern.MetricTransformations[%d].MetricNamespace' doesn't have a valid Namespace in 'AWS::CloudWatch::Alarm')", [name, index]),
+            }
+}
+CxPolicy [ result ] {
+
+	resourceMetricFilter := input.document[i].Resources
+   
+    resourceAlarm := input.document[i].Resources
+    some nameAlarm
+    resourceAlarm[nameAlarm].Type == "AWS::CloudWatch::Alarm"
+   
+    resourceSNS := input.document[i].Resources
+    some nameSNS
+    resourceSNS[nameSNS].Type == "AWS::SNS::Topic"
+   
+    checkTopic(resourceAlarm[nameAlarm].Properties.AlarmActions[index], nameSNS)
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	     sprintf("Resources.%s.Properties.AlarmActions.Ref", [nameAlarm]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("'Resources.%s.Properties.AlarmActions[%d].Ref' should have a valid resource with 'AWS::SNS::Topic' type)", [nameAlarm, index]),
+                "keyActualValue": 	sprintf("'Resources.%s.FilterPattern.AlarmActions[%d].Ref' doesn't have a valid resource with 'AWS::SNS::Topic' type)", [nameAlarm, index]),
+            }
+}
+CxPolicy [ result ] {
+
+	resourceMetricFilter := input.document[i].Resources
+    some name
+    resourceMetricFilter[name].Type == "AWS::Logs::MetricFilter"
+    
+    resourceAlarm := input.document[i].Resources
+    some nameAlarm
+    resourceAlarm[nameAlarm].Type == "AWS::CloudWatch::Alarm"
+    
+    
+	not regex.match("{ *\\(\\$\\.eventSource *= *s3\\.amazonaws\\.com\\) *&& *\\(\\(\\$\\.eventName *= *PutBucketAcl\\) *\\|\\| *\\(\\$\\.eventName *= *PutBucketPolicy\\) *\\|\\| *\\(\\$\\.eventName *= *PutBucketCors\\) *\\|\\| *\\(\\$\\.eventName *= *PutBucketLifecycle\\) *\\|\\| *\\(\\$\\.eventName *= *PutBucketReplication\\) *\\|\\| *\\(\\$\\.eventName *= *DeleteBucketPolicy\\) *\\|\\| *\\(\\$\\.eventName *= *DeleteBucketCors\\) *\\|\\| *\\(\\$\\.eventName *= *DeleteBucketLifecycle\\) *\\|\\| *\\(\\$\\.eventName *= *DeleteBucketReplication\\)\\) *}",
+    	resourceMetricFilter[name].Properties.FilterPattern)
+
+
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	     sprintf("Resources.%s.Properties.FilterPattern", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue":  sprintf("'Resources.%s.Properties.FilterPattern' should have the right specification')", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s.FilterPattern' does not have the right specification", [name])
+            }
+}
+checkAlarm(metricFilter, resourceAlarm) = true {
+    resourceAlarm.Namespace != metricFilter
+}
+
+checkTopic(resourceAlarm, nameSNS) = true {
+    resourceAlarm.Ref != nameSNS
+}

--- a/assets/queries/cloudFormation/filter_and_alarm_exist_for_S3_bucket_policy_changes/test/negative.yaml
+++ b/assets/queries/cloudFormation/filter_and_alarm_exist_for_S3_bucket_policy_changes/test/negative.yaml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ''
+Resources:
+  SnsTopic:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      Subscription:
+        - Endpoint: email@example.com
+          Protocol: email
+      TopicName: alarm-action
+  CloudWatchAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmName: iam_policy_changes
+      AlarmDescription: >-
+        A CloudWatch Alarm that triggers when changes are made to IAM policies.
+        Events include IAM policy creation/deletion/update operations as well as
+        attaching/detaching policies from IAM users, roles or groups.
+      MetricName: IAMPolicyEventCount
+      Namespace: CloudTrailMetrics
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - Ref: SnsTopic
+      TreatMissingData: notBreaching
+  MetricFilter:
+    Type: 'AWS::Logs::MetricFilter'
+    Properties:
+      LogGroupName: ''
+      FilterPattern: >-
+        { ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) ||($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) ||($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName= DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: CloudTrailMetrics
+          MetricName: IAMPolicyEventCount

--- a/assets/queries/cloudFormation/filter_and_alarm_exist_for_S3_bucket_policy_changes/test/positive.yaml
+++ b/assets/queries/cloudFormation/filter_and_alarm_exist_for_S3_bucket_policy_changes/test/positive.yaml
@@ -1,0 +1,109 @@
+Resources:
+  SnsTopic:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      Subscription:
+        - Endpoint: email@example.com
+          Protocol: email
+      TopicName: alarm-action
+  CloudWatchAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmName: iam_policy_changes
+      AlarmDescription: >-
+        A CloudWatch Alarm that triggers when changes are made to IAM policies.
+        Events include IAM policy creation/deletion/update operations as well as
+        attaching/detaching policies from IAM users, roles or groups.
+      MetricName: IAMPolicyEventCount
+      Namespace: CloudTrailMetrics
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - Ref: SnsTopic
+      TreatMissingData: notBreaching
+  MetricFilter:
+    Type: 'AWS::Logs::MetricFilter'
+    Properties:
+      LogGroupName: ''
+      FilterPattern: 'A'
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: CloudTrailMetrics
+          MetricName: IAMPolicyEventCount
+---
+Resources:
+  SnsTopic2:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      Subscription:
+        - Endpoint: email@example.com
+          Protocol: email
+      TopicName: alarm-action
+  CloudWatchAlarm2:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmName: iam_policy_changes
+      AlarmDescription: >-
+        A CloudWatch Alarm that triggers when changes are made to IAM policies.
+        Events include IAM policy creation/deletion/update operations as well as
+        attaching/detaching policies from IAM users, roles or groups.
+      MetricName: IAMPolicyEventCount
+      Namespace: CloudTrailMetrics2
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - Ref: SnsTopic2
+      TreatMissingData: notBreaching
+  MetricFilter2:
+    Type: 'AWS::Logs::MetricFilter'
+    Properties:
+      LogGroupName: ''
+      FilterPattern: >-
+        { ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) ||($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) ||($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName= DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: CloudTrailMetricsFake
+          MetricName: IAMPolicyEventCount
+---
+Resources:
+  SnsTopic3:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      Subscription:
+        - Endpoint: email@example.com
+          Protocol: email
+      TopicName: alarm-action
+  CloudWatchAlarm3:
+    Type: 'AWS::CloudWatch::Alarm'
+    Properties:
+      AlarmName: iam_policy_changes
+      AlarmDescription: >-
+        A CloudWatch Alarm that triggers when changes are made to IAM policies.
+        Events include IAM policy creation/deletion/update operations as well as
+        attaching/detaching policies from IAM users, roles or groups.
+      MetricName: IAMPolicyEventCount
+      Namespace: CloudTrailMetrics
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - Ref: SnsTopicFake
+      TreatMissingData: notBreaching
+  MetricFilter3:
+    Type: 'AWS::Logs::MetricFilter'
+    Properties:
+      LogGroupName: ''
+      FilterPattern: >-
+        { ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) ||($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) ||($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName= DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: CloudTrailMetrics
+          MetricName: IAMPolicyEventCount

--- a/assets/queries/cloudFormation/filter_and_alarm_exist_for_S3_bucket_policy_changes/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/filter_and_alarm_exist_for_S3_bucket_policy_changes/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Filter And Alarm Not Exists For S3 Bucket Policy Changes",
+  		"severity": "MEDIUM",
+		"line": 31
+	},
+	{
+		"queryName": "Filter And Alarm Not Exists For S3 Bucket Policy Changes",
+  		"severity": "MEDIUM",
+		"line": 71
+	},
+	{
+		"queryName": "Filter And Alarm Not Exists For S3 Bucket Policy Changes",
+  		"severity": "MEDIUM",
+		"line": 98
+	}
+]


### PR DESCRIPTION
Added new query for AWS CloudFormation.

Provide a CloudFormation resource and a resource to ensure that changes in S3 Bucket Policy are configured in an alarm and a metric filter

Closes #1147