### PR TITLE
Add missing_dnf_clean_all query for Docker

### DIFF
--- a/assets/queries/dockerfile/missing_dnf_clean_all/metadata.json
+++ b/assets/queries/dockerfile/missing_dnf_clean_all/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "missing_dnf_clean_all",
+  "queryName": "Missing dnf clean all",
+  "severity": "MEDIUM",
+  "category": "Package Management",
+  "descriptionText": "Cached package data should be cleaned after installation to reduce image size",
+  "descriptionUrl": "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/"
+}

--- a/assets/queries/dockerfile/missing_dnf_clean_all/query.rego
+++ b/assets/queries/dockerfile/missing_dnf_clean_all/query.rego
@@ -1,0 +1,57 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].command[name][_]
+ 	resource.Cmd == "run"
+ 	command := resource.Value[0]
+
+  containsInstallCommand(command)
+
+  not containsCleanAfterInstall(command)
+    
+	result := {
+    			      "documentId": 		input.document[i].id,
+              	"searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+              	"issueType":		 "IncorrectValue",
+              	"keyExpectedValue": "After installing a package with dnf, command 'dnf clean all' is run.",
+              	"keyActualValue": 	 "Command `dnf clean all` should be run after installing packages.",
+            }
+}
+
+containsInstallCommand(command){
+  installCommands = [
+        "dnf install",
+        "dnf in",
+        "dnf reinstall",
+        "dnf rei",
+        "dnf install-n",
+        "dnf install-na",
+        "dnf install-nevra"      
+        ]
+  contains(command, installCommands[_])    
+}
+
+# `dnf clean all` should come after `dnf install`
+containsCleanAfterInstall(command) {
+
+	contains(command, "dnf clean all")
+    
+  installCommands = [
+        	"dnf install",
+          "dnf in",
+          "dnf reinstall",
+          "dnf rei",
+          "dnf install-n",
+          "dnf install-na",
+          "dnf install-nevra"      
+        ]
+         
+    some cmd 
+    install := indexof(command, installCommands[cmd])
+    install != -1
+    
+    clean := indexof(command, "dnf clean")
+    clean != -1
+    
+    install<clean
+}

--- a/assets/queries/dockerfile/missing_dnf_clean_all/test/negative.dockerfile
+++ b/assets/queries/dockerfile/missing_dnf_clean_all/test/negative.dockerfile
@@ -1,0 +1,7 @@
+FROM fedora:27
+RUN set -uex && \
+    dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo && \
+    sed -i 's/\$releasever/26/g' /etc/yum.repos.d/docker-ce.repo && \
+    dnf install -vy docker-ce && \
+    dnf clean all
+HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1

--- a/assets/queries/dockerfile/missing_dnf_clean_all/test/positive.dockerfile
+++ b/assets/queries/dockerfile/missing_dnf_clean_all/test/positive.dockerfile
@@ -1,0 +1,6 @@
+FROM fedora:27
+RUN set -uex && \
+    dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo && \
+    sed -i 's/\$releasever/26/g' /etc/yum.repos.d/docker-ce.repo && \
+    dnf install -vy docker-ce
+HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1

--- a/assets/queries/dockerfile/missing_dnf_clean_all/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/missing_dnf_clean_all/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Missing dnf clean all",
+		"severity": "MEDIUM",
+		"line": 1
+	}
+]


### PR DESCRIPTION
Cached package data should be cleaned after installation to reduce image size. This can be achieved by executing the `dnf clean all command` in the same `RUN` step, after installing the packages. Closes #1069 