### PR TITLE
Add missing_version_specification_in_dnf_install query for Docker

### DIFF
--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/metadata.json
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "missing_version_specification_in_dnf_install",
+  "queryName": "Missing Version Specification In dnf install",
+  "severity": "MEDIUM",
+  "category": "Package Management",
+  "descriptionText": "Specifying a package version allows to reduce failures due to unanticipated changes in required packages.",
+  "descriptionUrl": "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/"
+}

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/query.rego
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/query.rego
@@ -1,0 +1,37 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].command[name][_]
+ 	
+  resource.Cmd == "run"
+ 	
+  command := resource.Value[0]
+    
+  containsCommand(command)
+  not regex.match(`dnf\s+(-*[a-zA-Z]+\s*)*(in|rei)n?(stall)?(-*[a-z]+\s*)*\s*\w*(-|_|~|=)(\d+\.)(.+)`, command)
+    
+	result := {
+    			    "documentId": 		input.document[i].id,
+              "searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+              "issueType":		 "IncorrectValue",
+              "keyExpectedValue": "Package version is specified when using 'dnf install'",
+              "keyActualValue": 	 "Package version should be pinned when running ´dnf install´",
+            }
+}
+	
+containsCommand(command) {
+	instructions := split(command,"&& ")
+
+  installCommands = [
+        "install",
+        "in",
+        "reinstall",
+        "rei",     
+      ]
+        
+  some i        
+	  contains(instructions[i], "dnf")
+  some j
+  	contains(instructions[i], installCommands[j]) 
+}
+

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/negative.dockerfile
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/negative.dockerfile
@@ -1,0 +1,5 @@
+FROM fedora:latest
+RUN dnf -y update && dnf -y install httpd-2.24.2 && dnf clean all
+COPY index.html /var/www/html/index.html
+EXPOSE 80
+ENTRYPOINT /usr/sbin/httpd -DFOREGROUND

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive.dockerfile
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive.dockerfile
@@ -1,0 +1,5 @@
+FROM fedora:latest
+RUN dnf -y update && dnf -y install httpd && dnf clean all
+COPY index.html /var/www/html/index.html
+EXPOSE 80
+ENTRYPOINT /usr/sbin/httpd -DFOREGROUND

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Missing Version Specification In dnf install",
+		"severity": "MEDIUM",
+		"line": 2
+	}
+]


### PR DESCRIPTION
Package versions should be pinned when running `dnf install`,  as it allows to reduce failures due to unanticipated changes in required packages. Closes #1068 