### PR TITLE
Add copy_from_references_current_from_alias query Closes #1172

### DIFF
--- a/assets/queries/dockerfile/copy_from_references_current_from_alias/metadata.json
+++ b/assets/queries/dockerfile/copy_from_references_current_from_alias/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "copy_from_references_current_from_alias",
+  "queryName": "COPY --from References Current FROM Alias",
+  "severity": "HIGH",
+  "category": "Multi-stage",
+  "descriptionText": "COPY --from should not mention the current FROM alias, since it is impossible to copy from itself",
+  "descriptionUrl": "https://docs.docker.com/develop/develop-images/multistage-build/"
+}

--- a/assets/queries/dockerfile/copy_from_references_current_from_alias/metadata.json
+++ b/assets/queries/dockerfile/copy_from_references_current_from_alias/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "copy_from_references_current_from_alias",
-  "queryName": "COPY --from References Current FROM Alias",
+  "queryName": "COPY '--from' References Current FROM Alias",
   "severity": "HIGH",
   "category": "Multi-stage",
-  "descriptionText": "COPY --from should not mention the current FROM alias, since it is impossible to copy from itself",
+  "descriptionText": "COPY '--from' should not mention the current FROM alias, since it is impossible to copy from itself",
   "descriptionUrl": "https://docs.docker.com/develop/develop-images/multistage-build/"
 }

--- a/assets/queries/dockerfile/copy_from_references_current_from_alias/query.rego
+++ b/assets/queries/dockerfile/copy_from_references_current_from_alias/query.rego
@@ -1,0 +1,32 @@
+package Cx
+
+CxPolicy [ result ] {
+
+  resource := input.document[i].command[name][_]
+  resource.Cmd == "copy"
+  
+  contains(resource.Flags[x],"--from=")
+  aux_split := split(resource.Flags[x], "=")
+  
+  isAliasCurrentFromAlias(name, aux_split[1])
+
+  result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey":        sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+                "issueType":		    "IncorrectValue",
+                "keyExpectedValue": "COPY --from does not reference the current FROM alias",
+                "keyActualValue": 	"COPY --from references the current FROM alias"
+              }
+}
+
+isAliasCurrentFromAlias(currentName, currentAlias) = allow {
+  resource := input.document[i].command[name][_]
+  currentName == name
+  
+  resource.Cmd == "from"
+  previousAlias := resource.Value[2]
+  
+  previousAlias == currentAlias
+  
+  allow = true
+}

--- a/assets/queries/dockerfile/copy_from_references_current_from_alias/test/negative.dockerfile
+++ b/assets/queries/dockerfile/copy_from_references_current_from_alias/test/negative.dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.7.3 AS builder
+WORKDIR /go/src/github.com/alexellis/href-counter/
+RUN go get -d -v golang.org/x/net/html
+COPY app.go    .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+
+---
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app .
+CMD ["./app"]

--- a/assets/queries/dockerfile/copy_from_references_current_from_alias/test/positive.dockerfile
+++ b/assets/queries/dockerfile/copy_from_references_current_from_alias/test/positive.dockerfile
@@ -1,0 +1,3 @@
+FROM myimage:tag as dep
+COPY --from=dep /binary /
+RUN dir c:\ 

--- a/assets/queries/dockerfile/copy_from_references_current_from_alias/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/copy_from_references_current_from_alias/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "COPY --from References Current FROM Alias",
+		"severity": "HIGH",
+		"line": 2
+	}
+]

--- a/assets/queries/dockerfile/copy_from_references_current_from_alias/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/copy_from_references_current_from_alias/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "COPY --from References Current FROM Alias",
+		"queryName": "COPY '--from' References Current FROM Alias",
 		"severity": "HIGH",
 		"line": 2
 	}


### PR DESCRIPTION
For this query, it is necessary to check if COPY --from references the current FROM alias. To do that, we need to check if the cmd copy has an attribute 'flags' like "--from=" and keep the alias. Next, we need to check if this current alias is equal to the current FROM alias ( through attribute Values of cmd from)

Closes #1172