### PR TITLE
Add 'Unpinned Package Version in pip install' query for Docker

### DIFF
--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/metadata.json
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Unpinned_Package_Version_in_Apk_Add",
+  "queryName": "Unpinned Package Version in Apk Add",
+  "severity": "MEDIUM",
+  "category": "Package Management",
+  "descriptionText": "Package version pinning reduces the range of versions that can be installed, reducing the chances of failure due to unanticipated changes",
+  "descriptionUrl": "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/"
+}

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/query.rego
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+CxPolicy [ result ] {
+  from := input.document[i].command[j]
+  instruction := from[k]
+
+  instruction.Cmd == "run"
+
+  contains(instruction.Value[0], "pip install")
+  not contains(instruction.Value[0], " -r ")
+  not regex.match(`pip\s+install\s+(--[a-z]+\s+)*(-[a-zA-z]{1}\s+)*\s*[^- || --][A-Za-z0-9_-]+=(.+)`, instruction.Value[0])
+  searchKey := replace(instruction.Original, "     ", ".")
+
+  result := {
+    "documentId": input.document[i].id,
+    "searchKey": sprintf("%s", [searchKey]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": "RUN instruction with 'pip install <package>' should use package pinning form 'pip install <package>=<version>'",
+    "keyActualValue": sprintf("RUN instruction %s does not use package pinning form", [instruction.Value[0]])
+  } 
+}

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/negative.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/negative.dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.4
+RUN apk add --update py-pip=7.1.2-r0
+RUN sudo pip install --upgrade pip=20.3 connexion=2.7.0
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt
+COPY app.py /usr/src/app/
+COPY templates/index.html /usr/src/app/templates/
+EXPOSE 5000
+CMD ["python", "/usr/src/app/app.py"]
+
+FROM alpine:3.1
+RUN apk add py-pip=7.1.2-r0
+RUN sudo pip install --upgrade pip=20.3 connexion=2.7.0
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt
+COPY app.py /usr/src/app/
+COPY templates/index.html /usr/src/app/templates/
+EXPOSE 5000
+CMD ["python", "/usr/src/app/app.py"]

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive.dockerfile
@@ -1,0 +1,20 @@
+FROM alpine:3.9
+RUN apk add --update py-pip=7.1.2-r0
+RUN pip install --user pip
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt
+COPY app.py /usr/src/app/
+COPY templates/index.html /usr/src/app/templates/
+EXPOSE 5000
+ENV TEST="test"
+CMD ["python", "/usr/src/app/app.py"]
+
+FROM alpine:3.7
+RUN apk add --update py-pip=7.1.2-r0
+RUN pip install connexion
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt
+COPY app.py /usr/src/app/
+COPY templates/index.html /usr/src/app/templates/
+EXPOSE 5000
+CMD ["python"]

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Unpinned Package Version in Apk Add",
+		"severity": "MEDIUM",
+		"line": 3
+	},
+	{
+		"queryName": "Unpinned Package Version in Apk Add",
+		"severity": "MEDIUM",
+		"line": 14
+	}
+]


### PR DESCRIPTION
**Platform**
_Docker_

**Description**
_Package version pinning reduces the range of versions that can be installed, reducing the chances of failure due to unanticipated changes_

Closes #1010