### PR TITLE
Feature/add new query ec2 instance under vpc

### DIFF
--- a/assets/queries/cloudFormation/ec2_instance_under_vpc/metadata.json
+++ b/assets/queries/cloudFormation/ec2_instance_under_vpc/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ec2_instance_under_vpc",
+  "queryName": "Ec2 Instance Under VPC",
+  "severity": "MEDIUM",
+  "category": null,
+  "descriptionText": "EC2 Instances should be configured under a vpc network. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-vpc.html"
+}

--- a/assets/queries/cloudFormation/ec2_instance_under_vpc/metadata.json
+++ b/assets/queries/cloudFormation/ec2_instance_under_vpc/metadata.json
@@ -2,7 +2,7 @@
   "id": "ec2_instance_under_vpc",
   "queryName": "Ec2 Instance Under VPC",
   "severity": "MEDIUM",
-  "category": null,
+  "category": "Compute",
   "descriptionText": "EC2 Instances should be configured under a vpc network. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations.",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-vpc.html"
 }

--- a/assets/queries/cloudFormation/ec2_instance_under_vpc/query.rego
+++ b/assets/queries/cloudFormation/ec2_instance_under_vpc/query.rego
@@ -1,0 +1,42 @@
+package Cx
+
+
+CxPolicy [result ]  {
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::EC2::Instance"
+
+  properties := resource.Properties
+  subnetName  := properties.NetworkInterfaces[j].SubnetId
+  subNetObj := document.Resources[subnetName]
+   object.get(subNetObj.Properties, "VpcId", "undefined") == "undefined"
+
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties", [subnetName]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.VpcId should be defined",[subnetName]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.VpcId is undefined",[subnetName])
+              }
+}
+
+
+CxPolicy [result ]  {
+
+  document := input.document[i]
+  resource := document.Resources[key]
+  resource.Type == "AWS::EC2::Instance"
+
+  properties := resource.Properties
+   object.get(properties, "NetworkInterfaces", "undefined") == "undefined"
+
+
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties", [key]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("Resources.%s.Properties.NetworkInterfaces should be defined",[key]),
+                "keyActualValue": 	sprintf("Resources.%s.Properties.NetworkInterfaces is undefined",[key])
+              }
+}

--- a/assets/queries/cloudFormation/ec2_instance_under_vpc/test/negative.yaml
+++ b/assets/queries/cloudFormation/ec2_instance_under_vpc/test/negative.yaml
@@ -1,0 +1,41 @@
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.1.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+          - Key: Name
+            Value:  !Join ['', [!Ref "AWS::StackName", "-VPC" ]]
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    DependsOn: VPC
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+  PublicSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.1.10.0/24
+      AvailabilityZone: !Select [ 0, !GetAZs ]    # Obtenha o primeiro AZ na lista
+      Tags:
+          - Key: Name
+            Value: !Sub ${AWS::StackName}-Public-A
+  Ec2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId:
+      Fn::FindInMap:
+            - "RegionMap"
+            - Ref: "AWS::Region"
+            - "AMI"
+      KeyName:
+      Ref: "KeyName"
+      NetworkInterfaces:
+        -   AssociatePublicIpAddress: "true"
+            DeviceIndex: 0
+            SubnetId: !Ref PublicSubnetA

--- a/assets/queries/cloudFormation/ec2_instance_under_vpc/test/positive.yaml
+++ b/assets/queries/cloudFormation/ec2_instance_under_vpc/test/positive.yaml
@@ -1,0 +1,52 @@
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.1.0.0/16
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+          - Key: Name
+            Value:  !Join ['', [!Ref "AWS::StackName", "-VPC" ]]
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    DependsOn: VPC
+  AttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+  PublicSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.1.10.0/24
+      AvailabilityZone: !Select [ 0, !GetAZs ]    # Obtenha o primeiro AZ na lista
+      Tags:
+          - Key: Name
+            Value: !Sub ${AWS::StackName}-Public-A
+  Ec2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId:
+      Fn::FindInMap:
+            - "RegionMap"
+            - Ref: "AWS::Region"
+            - "AMI"
+      KeyName:
+      Ref: "KeyName"
+      NetworkInterfaces:
+        -   AssociatePublicIpAddress: "true"
+            DeviceIndex: 0
+            SubnetId: !Ref PublicSubnetA
+---
+Resources:
+  Ec2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId:
+      Fn::FindInMap:
+            - "RegionMap"
+            - Ref: "AWS::Region"
+            - "AMI"
+      KeyName:
+      Ref: "KeyName"

--- a/assets/queries/cloudFormation/ec2_instance_under_vpc/test/positive.yaml
+++ b/assets/queries/cloudFormation/ec2_instance_under_vpc/test/positive.yaml
@@ -24,7 +24,7 @@ Resources:
       Tags:
           - Key: Name
             Value: !Sub ${AWS::StackName}-Public-A
-  Ec2Instance:
+  Ec2Instance-01:
     Type: AWS::EC2::Instance
     Properties:
       ImageId:
@@ -40,7 +40,7 @@ Resources:
             SubnetId: !Ref PublicSubnetA
 ---
 Resources:
-  Ec2Instance:
+  Ec2Instance-02:
     Type: AWS::EC2::Instance
     Properties:
       ImageId:

--- a/assets/queries/cloudFormation/ec2_instance_under_vpc/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ec2_instance_under_vpc/test/positive_expected_result.json
@@ -7,6 +7,6 @@
 	{
 		"queryName": "Ec2 Instance Under VPC",
 		"severity": "MEDIUM",
-		"line": 29
+		"line": 45
 	}
 ]

--- a/assets/queries/cloudFormation/ec2_instance_under_vpc/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ec2_instance_under_vpc/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Ec2 Instance Under VPC",
+		"severity": "MEDIUM",
+		"line": 21
+	},
+	{
+		"queryName": "Ec2 Instance Under VPC",
+		"severity": "MEDIUM",
+		"line": 29
+	}
+]


### PR DESCRIPTION
Description
EC2 Instances should be configured under a vpc network. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations.


Close #1200