### PR TITLE
Add query to check kms rotation period surpasses 365 days. Closes #1207

### DIFF
--- a/assets/queries/ansible/gcp/kms_rotation_period_higher_365_days/metadata.json
+++ b/assets/queries/ansible/gcp/kms_rotation_period_higher_365_days/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "KMS_Rotation_Period_Is_Higher_Than_365_Days",
+  "queryName": "KMS Rotation Period Is Higher Than 365 Days",
+  "severity": "HIGH",
+  "category": "Encryption & Key Management",
+  "descriptionText": "Check if any KMS rotation period surpasses 365 days.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_kms_crypto_key_module.html"
+}

--- a/assets/queries/ansible/gcp/kms_rotation_period_higher_365_days/query.rego
+++ b/assets/queries/ansible/gcp/kms_rotation_period_higher_365_days/query.rego
@@ -1,0 +1,42 @@
+package Cx
+
+CxPolicy [result] {
+  playbooks := getTasks(input.document[i])
+  kms_key := playbooks[j]
+  instance := kms_key["google.cloud.gcp_kms_crypto_key"]
+
+  rotation_period := substring(instance.rotation_period,0,count(instance.rotation_period)-1)
+  seconds_in_a_year := 315356000
+  to_number(rotation_period) > seconds_in_a_year
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_kms_crypto_key}}.rotation_period", [playbooks[j].name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_kms_crypto_key}}.rotation_period is at most '315356000s'", [playbooks[j].name]),
+                "keyActualValue": 	sprintf("name=%s.{{google.cloud.gcp_kms_crypto_key}}.rotation_period is '%ss'", [playbooks[j].name,rotation_period])
+              }
+}
+
+CxPolicy [result] {
+  playbooks := getTasks(input.document[i])
+  kms_key := playbooks[j]
+  instance := kms_key["google.cloud.gcp_kms_crypto_key"]
+
+  object.get(instance,"rotation_period","undefined") == "undefined"
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_kms_crypto_key}}", [playbooks[j].name]),
+                "issueType":		"MissingAttribute", 
+                "keyExpectedValue":  sprintf("name=%s.{{google.cloud.gcp_kms_crypto_key}}.rotation_period is set", [playbooks[j].name]),
+                "keyActualValue": 	sprintf("name=%s.{{google.cloud.gcp_kms_crypto_key}}.rotation_period is undefined", [playbooks[j].name])
+              }
+}
+
+getTasks(document) = result {
+  result := document.playbooks[0].tasks
+} else = result {
+  object.get(document.playbooks[0],"tasks","undefined") == "undefined"
+  result := document.playbooks
+}

--- a/assets/queries/ansible/gcp/kms_rotation_period_higher_365_days/test/negative.yaml
+++ b/assets/queries/ansible/gcp/kms_rotation_period_higher_365_days/test/negative.yaml
@@ -1,0 +1,9 @@
+- name: key_with_valid_rotation_period
+  google.cloud.gcp_kms_crypto_key:
+    name: test_object
+    key_ring: projects/{{ gcp_project }}/locations/us-central1/keyRings/key-key-ring
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    rotation_period: "90000s"

--- a/assets/queries/ansible/gcp/kms_rotation_period_higher_365_days/test/positive.yaml
+++ b/assets/queries/ansible/gcp/kms_rotation_period_higher_365_days/test/positive.yaml
@@ -1,0 +1,17 @@
+- name: key_with_high_rotation_period
+  google.cloud.gcp_kms_crypto_key:
+    name: test_object
+    key_ring: projects/{{ gcp_project }}/locations/us-central1/keyRings/key-key-ring
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    rotation_period: "315356001s"
+- name: key_without_rotation_period
+  google.cloud.gcp_kms_crypto_key:
+    name: test_object
+    key_ring: projects/{{ gcp_project }}/locations/us-central1/keyRings/key-key-ring
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/kms_rotation_period_higher_365_days/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/kms_rotation_period_higher_365_days/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "KMS Rotation Period Is Higher Than 365 Days",
+		"severity": "HIGH",
+		"line": 9
+	},
+	{
+		"queryName": "KMS Rotation Period Is Higher Than 365 Days",
+		"severity": "HIGH",
+		"line": 11
+	}
+]


### PR DESCRIPTION
Check GCP KMS keys rotation period to ensure that none is higher than 3153600 seconds (365 days). Closes #1207 