### PR TITLE
Add Cluster Labels are Disabled for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/cluster_labels_are_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/cluster_labels_are_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Cluster_Labels_Disabled",
+  "queryName": "Cluster Labels are Disabled",
+  "severity": "HIGH",
+  "category": "Operational Efficiency",
+  "descriptionText": "Kubernetes Clusters must be configured with labels, which means the attribute 'resource_labels' must be defined",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_module.html"
+}

--- a/assets/queries/ansible/gcp/cluster_labels_are_disabled/query.rego
+++ b/assets/queries/ansible/gcp/cluster_labels_are_disabled/query.rego
@@ -11,10 +11,46 @@ CxPolicy [ result ] {
 
     result := {
                 "documentId":       input.document[i].id,
-                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.resource_labels", [clusterName]),
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [clusterName]),
                 "issueType":        "MissingAttribute",
-                "keyExpectedValue": "google.cloud.gcp_container_cluster.resource_labels is defined",
-                "keyActualValue":   "google.cloud.gcp_container_cluster.resource_labels is undefined"
+                "keyExpectedValue": sprintf("google.cloud.gcp_container_cluster[%s].resource_labels is defined", [clusterName]),
+                "keyActualValue":   sprintf("google.cloud.gcp_container_cluster[%s].resource_labels is undefined", [clusterName])
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  cluster.resource_labels == null
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.resource_labels", [clusterName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": sprintf("google.cloud.gcp_container_cluster[%s].resource_labels is not null", [clusterName]),
+                "keyActualValue":   sprintf("google.cloud.gcp_container_cluster[%s].resource_labels is null", [clusterName])
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  count(cluster.resource_labels) == 0
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.resource_labels", [clusterName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": sprintf("google.cloud.gcp_container_cluster[%s].resource_labels is not empty", [clusterName]),
+                "keyActualValue":   sprintf("google.cloud.gcp_container_cluster[%s].resource_labels is empty", [clusterName])
               }
 }
 
@@ -24,10 +60,4 @@ getTasks(document) = result {
 } else = result {
     result := [body | playbook := document.playbooks[_]; body := playbook ]  
     count(result) != 0
-}
-
-isAnsibleTrue(answer) {
- 	lower(answer) == "yes"
-} else {
-	answer == true
 }

--- a/assets/queries/ansible/gcp/cluster_labels_are_disabled/query.rego
+++ b/assets/queries/ansible/gcp/cluster_labels_are_disabled/query.rego
@@ -1,0 +1,33 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  object.get(cluster, "resource_labels", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.resource_labels", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.resource_labels is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.resource_labels is undefined"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}
+
+isAnsibleTrue(answer) {
+ 	lower(answer) == "yes"
+} else {
+	answer == true
+}

--- a/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/negative.yaml
@@ -1,0 +1,16 @@
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    resource_labels:

--- a/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/negative.yaml
@@ -13,4 +13,4 @@
     auth_kind: serviceaccount
     service_account_file: "/tmp/auth.pem"
     state: present
-    resource_labels:
+    resource_labels: label1

--- a/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/positive.yaml
@@ -1,0 +1,15 @@
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/positive.yaml
@@ -1,6 +1,6 @@
-- name: create a cluster
+- name: create a cluster1
   google.cloud.gcp_container_cluster:
-    name: my-cluster
+    name: my-cluster1
     initial_node_count: 2
     master_auth:
       username: cluster_admin
@@ -13,3 +13,35 @@
     auth_kind: serviceaccount
     service_account_file: "/tmp/auth.pem"
     state: present
+- name: create a cluster2
+  google.cloud.gcp_container_cluster:
+    name: my-cluster3
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    resource_labels:
+- name: create a cluster3
+  google.cloud.gcp_container_cluster:
+    name: my-cluster3
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    resource_labels: ""

--- a/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/positive_expected_result.json
@@ -3,5 +3,15 @@
 		"queryName": "Cluster Labels are Disabled",
 		"severity": "HIGH",
 		"line": 2
+	},
+	{
+		"queryName": "Cluster Labels are Disabled",
+		"severity": "HIGH",
+		"line": 31
+	},
+	{
+		"queryName": "Cluster Labels are Disabled",
+		"severity": "HIGH",
+		"line": 47
 	}
 ]

--- a/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/cluster_labels_are_disabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Cluster Labels are Disabled",
+		"severity": "HIGH",
+		"line": 2
+	}
+]


### PR DESCRIPTION
Adding Cluster Labels are Disabled for Ansible, that checks if the attribute 'resource_labels' is defined.

Closes  #1219