### PR TITLE
Add instance_with_no_vpc Closes #1194

### DIFF
--- a/assets/queries/ansible/aws/instance_with_no_vpc/metadata.json
+++ b/assets/queries/ansible/aws/instance_with_no_vpc/metadata.json
@@ -4,5 +4,5 @@
   "severity": "MEDIUM",
   "category": "Network Security",
   "descriptionText": "Instance should be configured in VPC (Virtual Private Cloud)",
-  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance"
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_module.html"
 }

--- a/assets/queries/ansible/aws/instance_with_no_vpc/query.rego
+++ b/assets/queries/ansible/aws/instance_with_no_vpc/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+    
+    modules := {"community.aws.ec2_instance", "amazon.aws.ec2"}
+    
+    object.get(task[modules[index]], "vpc_subnet_id", "undefined") == "undefined"
+
+    
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
+        "issueType":         "MissingAttribute",
+        "keyExpectedValue":  sprintf("%s.vpc_subnet_id is set", [modules[index]]),
+        "keyActualValue": 	 sprintf("%s.vpc_subnet_id is undefined", [modules[index]])
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/instance_with_no_vpc/test/negative.yaml
+++ b/assets/queries/ansible/aws/instance_with_no_vpc/test/negative.yaml
@@ -1,0 +1,27 @@
+- name: Start an instance and have it begin a Tower callback on boot v3
+  community.aws.ec2_instance:
+    name: "tower-callback-test"
+    key_name: "prod-ssh-key"
+    vpc_subnet_id: subnet-5ca1ab1e
+    security_group: default
+    tower_callback:
+      # IP or hostname of tower server
+      tower_address: 1.2.3.4
+      job_template_id: 876
+      host_config_key: '[secret config key goes here]'
+    network:
+      assign_public_ip: true
+    image_id: ami-123456
+    cpu_credit_specification: unlimited
+    tags:
+      SomeThing: "A value"
+- name: Start an instance and have it begin a Tower callback on boot v4
+  amazon.aws.ec2:
+    key_name: mykey
+    instance_type: t2.micro
+    image: ami-123456
+    wait: yes
+    group: webserver
+    count: 3
+    vpc_subnet_id: subnet-29e63245
+    assign_public_ip: yes

--- a/assets/queries/ansible/aws/instance_with_no_vpc/test/positive.yaml
+++ b/assets/queries/ansible/aws/instance_with_no_vpc/test/positive.yaml
@@ -1,0 +1,25 @@
+- name: Start an instance and have it begin a Tower callback on boot
+  community.aws.ec2_instance:
+    name: "tower-callback-test"
+    key_name: "prod-ssh-key"
+    security_group: default
+    tower_callback:
+      # IP or hostname of tower server
+      tower_address: 1.2.3.4
+      job_template_id: 876
+      host_config_key: '[secret config key goes here]'
+    network:
+      assign_public_ip: true
+    image_id: ami-123456
+    cpu_credit_specification: unlimited
+    tags:
+      SomeThing: "A value"
+- name: Start an instance and have it begin a Tower callback on boot v2
+  amazon.aws.ec2:
+    key_name: mykey
+    instance_type: t2.micro
+    image: ami-123456
+    wait: yes
+    group: webserver
+    count: 3
+    assign_public_ip: yes

--- a/assets/queries/ansible/aws/instance_with_no_vpc/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/instance_with_no_vpc/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+	{
+		"queryName": "Instance With No VPC",
+		"severity": "MEDIUM",
+		"line": 2
+	},
+
+    {
+		"queryName": "Instance With No VPC",
+		"severity": "MEDIUM",
+		"line": 18
+	}
+
+]

--- a/assets/queries/terraform/aws/instance_with_no_vpc/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/instance_with_no_vpc/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Instance With No Vpc",
+		"queryName": "Instance With No VPC",
 		"severity": "MEDIUM",
 		"line": 1
 	}


### PR DESCRIPTION
For this query, it is necessary to check if 'vpc_subnet_id' exists in modules community.aws.ec2_instance and amazon.aws.ec2, when they are defined

Closes #1194