### PR TITLE
Add Private Cluster is Disabled query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/public_cluster_is_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/public_cluster_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Private_Cluster_Disabled",
+  "queryName": "Private Cluster is Disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Kubernetes Clusters must be created with Private Clusters enabled, meaning the 'private_cluster_config' must be defined and the attributes 'enable_private_endpoint' and 'enable_private_nodes' must be true.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_module.html"
+}

--- a/assets/queries/ansible/gcp/public_cluster_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/public_cluster_is_disabled/query.rego
@@ -1,0 +1,103 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+	
+  object.get(cluster, "private_cluster_config", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.private_cluster_config is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.private_cluster_config is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+	
+  object.get(cluster.private_cluster_config, "enable_private_nodes", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.private_cluster_config", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.private_cluster_config.enable_private_nodes is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.private_cluster_config.enable_private_nodes is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+	
+  object.get(cluster.private_cluster_config, "enable_private_endpoint", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.private_cluster_config", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.private_cluster_config.enable_private_endpoint is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.private_cluster_config.enable_private_endpoint is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+  not isAnsibleTrue(cluster.private_cluster_config.enable_private_endpoint)
+
+  result := {
+              "documentId":       input.document[i].id,
+              "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.private_cluster_config.enable_private_endpoint", [clusterName]),
+              "issueType":        "IncorrectValue",
+              "keyExpectedValue": "google.cloud.gcp_container_cluster.private_cluster_config.enable_private_endpoint is true",
+              "keyActualValue":   "google.cloud.gcp_container_cluster.private_cluster_config.enable_private_endpoint is false"
+            }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+  not isAnsibleTrue(cluster.private_cluster_config.enable_private_nodes)
+
+  result := {
+              "documentId":       input.document[i].id,
+              "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.private_cluster_config.enable_private_nodes", [clusterName]),
+              "issueType":        "IncorrectValue",
+              "keyExpectedValue": "google.cloud.gcp_container_cluster.private_cluster_config.enable_private_nodes is true",
+              "keyActualValue":   "google.cloud.gcp_container_cluster.private_cluster_config.enable_private_nodes is false"
+            }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}
+
+isAnsibleTrue(answer) {
+ 	lower(answer) == "yes"
+} else {
+	answer == true
+}

--- a/assets/queries/ansible/gcp/public_cluster_is_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/public_cluster_is_disabled/test/negative.yaml
@@ -1,0 +1,18 @@
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    private_cluster_config:
+      enable_private_endpoint: yes
+      enable_private_nodes: yes

--- a/assets/queries/ansible/gcp/public_cluster_is_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/public_cluster_is_disabled/test/positive.yaml
@@ -1,0 +1,85 @@
+- name: create a cluster1
+  google.cloud.gcp_container_cluster:
+    name: my-cluster1
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a cluster2
+  google.cloud.gcp_container_cluster:
+    name: my-cluster2
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    private_cluster_config:
+      enable_private_endpoint: yes
+- name: create a cluster3
+  google.cloud.gcp_container_cluster:
+    name: my-cluster3
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    private_cluster_config:
+      enable_private_nodes: yes
+- name: create a cluster4
+  google.cloud.gcp_container_cluster:
+    name: my-cluster4
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    private_cluster_config:
+      enable_private_endpoint: no
+      enable_private_nodes: yes
+- name: create a cluster5
+  google.cloud.gcp_container_cluster:
+    name: my-cluster5
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    private_cluster_config:
+      enable_private_endpoint: yes
+      enable_private_nodes: no

--- a/assets/queries/ansible/gcp/public_cluster_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/public_cluster_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,27 @@
+[
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 2
+	},
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 31
+	},
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 48
+	},
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 66
+	},
+	{
+		"queryName": "Private Cluster is Disabled",
+		"severity": "HIGH",
+		"line": 85
+	}
+]


### PR DESCRIPTION
Adding Private Cluster is Disabled query for Ansible, that checks if the 'private_cluster_config' is defined and the attributes 'enable_private_endpoint' and 'enable_private_nodes' are true.

Closes  #1225