### PR TITLE
Add Master Authentication is Disabled query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/master_authentication_is_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/master_authentication_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Master_Authentication_Disabled",
+  "queryName": "Master Authentication is Disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Kubernetes Engine Clusters must have Master Authentication set to enabled, which means the attribute 'master_auth' must have the subattributes 'username' and 'password' defined and not empty",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_module.html"
+}

--- a/assets/queries/ansible/gcp/master_authentication_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/master_authentication_is_disabled/query.rego
@@ -1,0 +1,107 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  object.get(cluster, "master_auth", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.master_auth is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.master_auth is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  object.get(cluster.master_auth, "username", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.master_auth.username is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.master_auth.username is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  object.get(cluster.master_auth, "password", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.master_auth.password is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.master_auth.password is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  check_size(cluster.master_auth.username)
+
+  result := {
+              "documentId":       input.document[i].id,
+              "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth.username", [clusterName]),
+              "issueType":        "IncorrectValue",
+              "keyExpectedValue": "google.cloud.gcp_container_cluster.master_auth.username is not empty",
+              "keyActualValue":   "google.cloud.gcp_container_cluster.master_auth.username is empty"
+            }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  check_size(cluster.master_auth.password)
+
+  result := {
+              "documentId":       input.document[i].id,
+              "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth.password", [clusterName]),
+              "issueType":        "IncorrectValue",
+              "keyExpectedValue": "google.cloud.gcp_container_cluster.master_auth.password is not empty",
+              "keyActualValue":   "google.cloud.gcp_container_cluster.master_auth.password is empty"
+            }
+}
+
+check_size(val){
+  count(val) == 0
+}
+
+check_size(val){
+  val == null
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/master_authentication_is_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/master_authentication_is_disabled/test/negative.yaml
@@ -1,0 +1,16 @@
+#this code is a correct code for which the query should not find any result
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/master_authentication_is_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/master_authentication_is_disabled/test/positive.yaml
@@ -1,0 +1,71 @@
+#this is a problematic code where the query should report a result(s)
+- name: create a cluster1
+  google.cloud.gcp_container_cluster:
+    name: my-cluster1
+    initial_node_count: 2
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a cluster2
+  google.cloud.gcp_container_cluster:
+    name: my-cluster2
+    initial_node_count: 2
+    master_auth:
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a cluster3
+  google.cloud.gcp_container_cluster:
+    name: my-cluster3
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a cluster4
+  google.cloud.gcp_container_cluster:
+    name: my-cluster4
+    initial_node_count: 2
+    master_auth:
+      username:
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a cluster5
+  google.cloud.gcp_container_cluster:
+    name: my-cluster5
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password:
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/master_authentication_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/master_authentication_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,27 @@
+[
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 18
+	},
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 32
+	},
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 47
+	},
+	{
+		"queryName": "Master Authentication is Disabled",
+		"severity": "HIGH",
+		"line": 63
+	}
+]


### PR DESCRIPTION
Adding Master Authentication is Disabled query for Ansible, that checks if the attribute 'master_auth' has the subattributes 'username' and 'password' defined and not empty.

Closes #1232