### PR TITLE
Add cloudwatch_retention_period Closes #1236

### DIFF
--- a/assets/queries/ansible/aws/cloudwatch_retention_period/metadata.json
+++ b/assets/queries/ansible/aws/cloudwatch_retention_period/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "cloudwatch_retention_period",
+  "queryName": "AWS CloudWatch Retention Period",
+  "severity": "MEDIUM",
+  "category":"Logging",
+  "descriptionText": "AWS CloudWatch should have CloudWatch Logs enabled in order to monitor, store, and access log events",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/cloudwatchlogs_log_group_module.html"
+}

--- a/assets/queries/ansible/aws/cloudwatch_retention_period/metadata.json
+++ b/assets/queries/ansible/aws/cloudwatch_retention_period/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "cloudwatch_retention_period",
-  "queryName": "AWS CloudWatch Retention Period",
+  "queryName": "CloudWatch Retention Period",
   "severity": "MEDIUM",
   "category":"Logging",
   "descriptionText": "AWS CloudWatch should have CloudWatch Logs enabled in order to monitor, store, and access log events",

--- a/assets/queries/ansible/aws/cloudwatch_retention_period/query.rego
+++ b/assets/queries/ansible/aws/cloudwatch_retention_period/query.rego
@@ -1,0 +1,47 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+    
+    object.get(task["community.aws.cloudwatchlogs_log_group"], "retention", "undefined") == "undefined"
+
+    
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s.{{community.aws.cloudwatchlogs_log_group}}", [task.name]),
+        "issueType":         "MissingAttribute",
+        "keyExpectedValue":  "community.aws.cloudwatchlogs_log_group.retention is set",
+        "keyActualValue": 	 "community.aws.cloudwatchlogs_log_group.retention is undefined"
+    }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  
+  value := task["community.aws.cloudwatchlogs_log_group"].retention
+
+  validValues = [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+
+  count({x | validValues[x]; validValues[x] == value}) == 0
+
+  
+  result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s.{{community.aws.cloudwatchlogs_log_group}}.retention", [task.name]),
+        "issueType":         "IncorrectValue",
+        "keyExpectedValue":  "community.aws.cloudwatchlogs_log_group.retention is set and valid", 
+        "keyActualValue": 	 "community.aws.cloudwatchlogs_log_group.retention is set and invalid"
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/cloudwatch_retention_period/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudwatch_retention_period/test/negative.yaml
@@ -1,0 +1,4 @@
+- name: example3 ec2 group
+  community.aws.cloudwatchlogs_log_group:
+    log_group_name: test-log-group
+    retention: 5

--- a/assets/queries/ansible/aws/cloudwatch_retention_period/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudwatch_retention_period/test/positive.yaml
@@ -1,0 +1,7 @@
+- name: example ec2 group
+  community.aws.cloudwatchlogs_log_group:
+    log_group_name: test-log-group
+- name: example2 ec2 group
+  community.aws.cloudwatchlogs_log_group:
+    log_group_name: test-log-group
+    retention: 111111

--- a/assets/queries/ansible/aws/cloudwatch_retention_period/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudwatch_retention_period/test/positive_expected_result.json
@@ -1,0 +1,13 @@
+[
+	{
+		"queryName": "AWS CloudWatch Retention Period",
+		"severity": "MEDIUM",
+		"line": 2
+	},
+
+	{
+		"queryName": "AWS CloudWatch Retention Period",
+		"severity": "MEDIUM",
+		"line": 7
+	}
+]

--- a/assets/queries/ansible/aws/cloudwatch_retention_period/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudwatch_retention_period/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "AWS CloudWatch Retention Period",
+		"queryName": "CloudWatch Retention Period",
 		"severity": "MEDIUM",
 		"line": 2
 	},
 
 	{
-		"queryName": "AWS CloudWatch Retention Period",
+		"queryName": "CloudWatch Retention Period",
 		"severity": "MEDIUM",
 		"line": 7
 	}


### PR DESCRIPTION
AWS CloudWatch should have CloudWatch Logs enabled to monitor, store, and access log events. For that, we can specify the value of logs retention through the attribute 'retention'. This attribute should be defined and set to one of the following values: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653.

For this query, I thought in two cases:

Attribute 'retention_in_days' is undefined

Attribute 'retention_in_days' is set but not to a valid value


(P.S. I just found the module community to satisfy this query)

Closes #1236