### PR TITLE
Add 'Use of apk upgrade' query for Docker

### DIFF
--- a/assets/queries/dockerfile/use_of_apk_upgrade/metadata.json
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Use_of_apk_upgrade",
+  "queryName": "Use of apk upgrade",
+  "severity": "HIGH",
+  "category": "Package Management",
+  "descriptionText": "Avoid usage of apk upgrade because some packages from the parent image cannot be upgraded inside an unprivileged container",
+  "descriptionUrl": "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run"
+}

--- a/assets/queries/dockerfile/use_of_apk_upgrade/query.rego
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy [ result ] {
+  instruction := input.document[i].command[name][j]
+
+  instruction.Cmd == "run"
+  regex.match(`.*apk.*upgrade`, instruction.Value[0])
+
+  result := {
+    "documentId": input.document[i].id,
+    "searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, instruction.Value[0]]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": sprintf("RUN command '%s' should not have apk upgrade instruction", [instruction.Value[0]]),
+    "keyActualValue": sprintf("RUN '%s' has apk upgrade instruction", [instruction.Value[0]])
+  }
+}

--- a/assets/queries/dockerfile/use_of_apk_upgrade/test/negative.dockerfile
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/test/negative.dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.7
+RUN apk update \
+    && apk add kubectl=1.20.0-r0 \
+    && rm -rf /var/cache/apk/*
+ENTRYPOINT [ "kubectl" ]

--- a/assets/queries/dockerfile/use_of_apk_upgrade/test/positive.dockerfile
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/test/positive.dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.7
+RUN apk update \
+    && apk upgrade \
+    && apk add kubectl=1.20.0-r0 \
+    && rm -rf /var/cache/apk/*
+ENTRYPOINT ["kubectl"]
+
+FROM alpine:3.9
+RUN apk update
+RUN apk update && apk upgrade && apk add kubectl=1.20.0-r0 \
+    && rm -rf /var/cache/apk/*
+ENTRYPOINT ["kubectl"]

--- a/assets/queries/dockerfile/use_of_apk_upgrade/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Use of apk upgrade",
+		"severity": "HIGH",
+		"line": 2
+	},
+	{
+		"queryName": "Use of apk upgrade",
+		"severity": "HIGH",
+		"line": 10
+	}
+]


### PR DESCRIPTION
### Platform
*Docker*

### Description
*Avoid usage of 'apk upgrade' because some packages from the parent image cannot be upgraded inside an unprivileged container*

Closes #987