### PR TITLE
Add cloud_dns_without_dnssec query for Ansible #1269

### DIFF
--- a/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/metadata.json
+++ b/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "cloud_dns_without_dnssec",
+  "queryName": "Cloud DNS Without DNSSEC",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "DNSSEC must be enabled for Cloud DNS",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_dns_managed_zone_module.html#return-dnssecConfig/state"
+}

--- a/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/query.rego
+++ b/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/query.rego
@@ -1,0 +1,54 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+
+  object.get(task["google.cloud.gcp_dns_managed_zone"], "dnssec_config", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_dns_managed_zone}}", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'dnssec_config' is defined",
+                "keyActualValue": 	"'dnssec_config' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+
+  object.get(task["google.cloud.gcp_dns_managed_zone"].dnssec_config, "state", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_dns_managed_zone}}.dnssec_config", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'dnssec_config.state' is defined",
+                "keyActualValue": 	"'dnssec_config.state' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+
+  task["google.cloud.gcp_dns_managed_zone"].dnssec_config.state != "on"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_dns_managed_zone}}.dnssec_config.state", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'dnssec_config.state' is equal to 'on'",
+                "keyActualValue": 	"'dnssec_config.state' is not equal to 'on'"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/test/negative.yaml
+++ b/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/test/negative.yaml
@@ -1,0 +1,13 @@
+---
+- name: create a managed zone
+  google.cloud.gcp_dns_managed_zone:
+    name: test_object
+    dns_name: test.somewild2.example.com.
+    description: test zone
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    dnssec_config:
+      kind: some_kind
+      state: on

--- a/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/test/positive.yaml
+++ b/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/test/positive.yaml
@@ -1,0 +1,33 @@
+---
+- name: create a managed zone
+  google.cloud.gcp_dns_managed_zone:
+    name: test_object
+    dns_name: test.somewild2.example.com.
+    description: test zone
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a second managed zone
+  google.cloud.gcp_dns_managed_zone:
+    name: test_object
+    dns_name: test.somewild2.example.com.
+    description: test zone
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    dnssec_config:
+      kind: some_kind
+- name: create a third managed zone
+  google.cloud.gcp_dns_managed_zone:
+    name: test_object
+    dns_name: test.somewild2.example.com.
+    description: test zone
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    dnssec_config:
+      kind: some_kind
+      state: off

--- a/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Cloud DNS Without DNSSEC",
+		"severity": "MEDIUM",
+		"line": 3
+	},
+	{
+		"queryName": "Cloud DNS Without DNSSEC",
+		"severity": "MEDIUM",
+		"line": 20
+	},
+	{
+		"queryName": "Cloud DNS Without DNSSEC",
+		"severity": "MEDIUM",
+		"line": 33
+	}
+]

--- a/assets/queries/terraform/gcp/cloud_dns_without_dnssec/metadata.json
+++ b/assets/queries/terraform/gcp/cloud_dns_without_dnssec/metadata.json
@@ -1,8 +1,8 @@
 {
-  "id": "Cloud_DNS_without_DNNSEC",
+  "id": "cloud_dns_without_dnssec",
   "queryName": "Cloud DNS without DNSSEC",
   "severity": "MEDIUM",
-  "category": null,
+  "category": "Network Security",
   "descriptionText": "Cloud DNS without DNSSEC",
   "descriptionUrl": "https://www.terraform.io/docs/providers/google/d/dns_managed_zone.html"
 }


### PR DESCRIPTION
Closes #1269 

DNSSEC must be enabled for Cloud DNS.

Also, updated the name of the query in terraform