### PR TITLE
Add sql_database_backup_configuration_disabled query for Ansible #1268

### DIFF
--- a/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "sql_database_backup_configuration_disabled",
+  "queryName": "SQL Database Backup Configuration Disabled",
+  "severity": "HIGH",
+  "category": "Backup & Disaster Recovery",
+  "descriptionText": "Checks if backup configuration is enabled for all Cloud SQL Database instances",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_instance_module.html#parameter-settings/backup_configuration/enabled"
+}

--- a/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/query.rego
+++ b/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/query.rego
@@ -1,0 +1,60 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+
+  path := getPathDefinitions(task["google.cloud.gcp_sql_instance"])
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_sql_instance}}%s", [task.name, path.defined]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("'%s' is defined", [path.undefined]),
+                "keyActualValue": 	sprintf("'%s' is undefined", [path.undefined])
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+
+  not isAnsibleTrue(task["google.cloud.gcp_sql_instance"].settings.backup_configuration.enabled)
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.backup_configuration.enabled", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'settings.backup_configuration.require_ssl' is true",
+                "keyActualValue": 	"'settings.backup_configuration.require_ssl' is false"
+              }
+}
+
+getPathDefinitions(instance) = result {
+	object.get(instance, "settings", "undefined") == "undefined"
+    result = { "defined": "", "undefined": "settings" }
+}
+getPathDefinitions(instance) = result {
+	object.get(instance.settings, "backup_configuration", "undefined") == "undefined"
+    result = { "defined": ".settings", "undefined": "settings.backup_configuration" }
+}
+getPathDefinitions(instance) = result {
+	object.get(instance.settings.backup_configuration, "enabled", "undefined") == "undefined"
+    result = { "defined": ".settings.backup_configuration", "undefined": "settings.backup_configuration.enabled" }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}
+
+isAnsibleTrue(answer) {
+ 	lower(answer) == "yes"
+} else {
+  lower(answer) == "true"
+} else {
+	answer == true
+}

--- a/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/test/negative.yaml
@@ -1,0 +1,14 @@
+---
+- name: create a instance
+  google.cloud.gcp_sql_instance:
+    name: "{{resource_name}}-2"
+    settings:
+      backup_configuration:
+        binary_log_enabled: yes
+        enabled: yes
+      tier: db-n1-standard-1
+    region: us-central1
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/test/positive.yaml
@@ -1,0 +1,44 @@
+---
+- name: create a instance
+  google.cloud.gcp_sql_instance:
+    name: "{{resource_name}}-2"
+    region: us-central1
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a second instance
+  google.cloud.gcp_sql_instance:
+    name: "{{resource_name}}-2"
+    settings:
+      tier: db-n1-standard-1
+    region: us-central1
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a third instance
+  google.cloud.gcp_sql_instance:
+    name: "{{resource_name}}-2"
+    settings:
+      backup_configuration:
+        binary_log_enabled: yes
+      tier: db-n1-standard-1
+    region: us-central1
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a forth instance
+  google.cloud.gcp_sql_instance:
+    name: "{{resource_name}}-2"
+    settings:
+      backup_configuration:
+        binary_log_enabled: yes
+        enabled: no
+      tier: db-n1-standard-1
+    region: us-central1
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "SQL Database Backup Configuration Disabled",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "SQL Database Backup Configuration Disabled",
+		"severity": "HIGH",
+		"line": 13
+	},
+	{
+		"queryName": "SQL Database Backup Configuration Disabled",
+		"severity": "HIGH",
+		"line": 24
+	},
+	{
+		"queryName": "SQL Database Backup Configuration Disabled",
+		"severity": "HIGH",
+		"line": 38
+	}
+]


### PR DESCRIPTION
Closes #1268 

This query detects Cloud SQL Database instances with backup_configuration disabled. Checks if, within the 'settings' block, the 'backup_configuration' block exists with the 'enable' field equal to 'false'.