### PR TITLE
Add object_versioning_not_enabled query for Ansible #1262

### DIFF
--- a/assets/queries/ansible/gcp/object_versioning_not_enabled/metadata.json
+++ b/assets/queries/ansible/gcp/object_versioning_not_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "object_versioning_not_enabled",
+  "queryName": "Object Versioning Not Enabled",
+  "severity": "HIGH",
+  "category": "Logging",
+  "descriptionText": "Object Versioning not fully enabled on Cloud Storage Bucket",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_storage_bucket_module.html#parameter-versioning"
+}

--- a/assets/queries/ansible/gcp/object_versioning_not_enabled/query.rego
+++ b/assets/queries/ansible/gcp/object_versioning_not_enabled/query.rego
@@ -1,0 +1,47 @@
+package Cx
+
+CxPolicy [ result ] {
+	document := input.document[i]
+  	task := getTasks(document)[t]
+
+	object.get(task["google.cloud.gcp_storage_bucket"], "versioning", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_storage_bucket}}", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'versioning' is defined",
+                "keyActualValue": 	"'versioning' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  	document := input.document[i]
+  	task := getTasks(document)[t]
+
+  	not isAnsibleTrue(task["google.cloud.gcp_storage_bucket"].versioning.enabled)
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_storage_bucket}}.versioning.enabled", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'versioning.enabled' is true",
+                "keyActualValue": 	"'versioning.enabled' is false"
+              }
+}
+
+getTasks(document) = result {
+ 	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+  	count(result) != 0
+} else = result {
+  	result := [body | playbook := document.playbooks[_]; body := playbook ]  
+  	count(result) != 0
+}
+
+isAnsibleTrue(answer) {
+ 	lower(answer) == "yes"
+} else {
+	lower(answer) == "true"
+} else {
+	answer == true
+}

--- a/assets/queries/ansible/gcp/object_versioning_not_enabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/object_versioning_not_enabled/test/negative.yaml
@@ -1,0 +1,10 @@
+---
+- name: create a bucket
+  google.cloud.gcp_storage_bucket:
+    name: ansible-storage-module
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    versioning:
+      enabled: yes

--- a/assets/queries/ansible/gcp/object_versioning_not_enabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/object_versioning_not_enabled/test/positive.yaml
@@ -1,0 +1,17 @@
+---
+- name: create a bucket
+  google.cloud.gcp_storage_bucket:
+    name: ansible-storage-module
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a second bucket
+  google.cloud.gcp_storage_bucket:
+    name: ansible-storage-module
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    versioning:
+      enabled: no

--- a/assets/queries/ansible/gcp/object_versioning_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/object_versioning_not_enabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Object Versioning Not Enabled",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "Object Versioning Not Enabled",
+		"severity": "HIGH",
+		"line": 17
+	}
+]


### PR DESCRIPTION
Closes #1262 

This query ensures that object versioning is enabled on a Google Storage Bucket by checking if the 'versioning' block exists within the 'google_storage_bucket' resource and with the 'enabled' field equal to 'true'.