### PR TITLE
Add Network Policy is Disabled query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/network_policy_is_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/network_policy_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Network_Policy_Disabled",
+  "queryName": "Network Policy is Disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Kubernetes Engine Clusters must have Network Policy enabled, meaning that the attribute 'network_policy.enabled' must be true and the attribute 'addons_config.network_policy_config.disabled' must be false",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_module.html"
+}

--- a/assets/queries/ansible/gcp/network_policy_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/network_policy_is_disabled/query.rego
@@ -1,0 +1,111 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  object.get(cluster, "network_policy", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.network_policy is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.network_policy is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  object.get(cluster, "addons_config", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.addons_config is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.addons_config is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  object.get(cluster.addons_config, "network_policy_config", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.addons_config", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.addons_config.network_policy_config is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.addons_config.network_policy_config is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+  
+  isAnsibleFalse(cluster.network_policy.enabled)
+
+  result := {
+              "documentId":       input.document[i].id,
+              "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.network_policy.enabled", [clusterName]),
+              "issueType":        "IncorrectValue",
+              "keyExpectedValue": "google.cloud.gcp_container_cluster.network_policy.enabled is true",
+              "keyActualValue":   "google.cloud.gcp_container_cluster.network_policy.enabled is false"
+            }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  isAnsibleTrue(cluster.network_policy.enabled)
+  isAnsibleTrue(cluster.addons_config.network_policy_config.disabled)
+
+  result := {
+              "documentId":       input.document[i].id,
+              "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.addons_config.network_policy_config.disabled", [clusterName]),
+              "issueType":        "IncorrectValue",
+              "keyExpectedValue": "google.cloud.gcp_container_cluster.addons_config.network_policy_config.disabled is false",
+              "keyActualValue":   "google.cloud.gcp_container_cluster.addons_config.network_policy_config.disabled is true"
+            }
+}
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}
+
+isAnsibleTrue(answer) {
+ 	lower(answer) == "yes"
+} else {
+	answer == false
+}
+
+isAnsibleFalse(answer) {
+ 	lower(answer) == "no"
+} else {
+	answer == false
+}

--- a/assets/queries/ansible/gcp/network_policy_is_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/network_policy_is_disabled/test/negative.yaml
@@ -1,0 +1,21 @@
+#this code is a correct code for which the query should not find any result
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    network_policy:
+      enabled: yes
+    addons_config:
+      network_policy_config:
+        disabled: no

--- a/assets/queries/ansible/gcp/network_policy_is_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/network_policy_is_disabled/test/positive.yaml
@@ -1,0 +1,96 @@
+#this is a problematic code where the query should report a result(s)
+- name: create a cluster1
+  google.cloud.gcp_container_cluster:
+    name: my-cluster1
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    addons_config:
+      network_policy_config:
+        disabled: false
+- name: create a cluster2
+  google.cloud.gcp_container_cluster:
+    name: my-cluster2
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    network_policy:
+      enabled: yes
+- name: create a cluster3
+  google.cloud.gcp_container_cluster:
+    name: my-cluster3
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    network_policy:
+      enabled: yes
+    addons_config:
+      horizontal_pod_autoscaling:
+        disabled: yes
+- name: create a cluster4
+  google.cloud.gcp_container_cluster:
+    name: my-cluster4
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    network_policy:
+      enabled: no
+    addons_config:
+      network_policy_config:
+        disabled: no
+- name: create a cluster5
+  google.cloud.gcp_container_cluster:
+    name: my-cluster5
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    network_policy:
+      enabled: yes
+    addons_config:
+      network_policy_config:
+        disabled: yes

--- a/assets/queries/ansible/gcp/network_policy_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/network_policy_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,27 @@
+[
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 21
+	},
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 54
+	},
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 73
+	},
+	{
+		"queryName": "Network Policy is Disabled",
+		"severity": "HIGH",
+		"line": 96
+	}
+]


### PR DESCRIPTION
Adding Network Policy is Disabled query for Ansible, that checks if the attribute 'network_policy.enabled' is true and the attribute 'addons_config.network_policy_config.disabled' is false.

Closes #1280