### PR TITLE
Add Stackdriver Monitoring Is Disabled query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Stackdriver_Monitoring_Disabled",
+  "queryName": "Stackdriver Monitoring is Disabled",
+  "severity": "HIGH",
+  "category": "Monitoring",
+  "descriptionText": "Kubernetes Engine Clusters must have Stackdriver Monitoring enabled, which means the attribute 'monitoring_service' must be defined and different than 'none'",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_module.html"
+}

--- a/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/query.rego
@@ -1,0 +1,45 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+
+  object.get(cluster, "monitoring_service", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.monitoring_service is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.monitoring_service is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+  is_string(cluster.monitoring_service)
+  lower(cluster.monitoring_service) == "none"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.monitoring_service", [clusterName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.monitoring_service is different from 'none'",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.monitoring_service is 'none'"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/test/negative.yaml
@@ -1,0 +1,17 @@
+#this code is a correct code for which the query should not find any result
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    monitoring_service: monitoring.googleapis.com

--- a/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/test/positive.yaml
@@ -1,0 +1,32 @@
+#this is a problematic code where the query should report a result(s)
+- name: create a cluster1
+  google.cloud.gcp_container_cluster:
+    name: my-cluster1
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a cluster2
+  google.cloud.gcp_container_cluster:
+    name: my-cluster2
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    monitoring_service: none

--- a/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Stackdriver Monitoring is Disabled",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "Stackdriver Monitoring is Disabled",
+		"severity": "HIGH",
+		"line": 32
+	}
+]


### PR DESCRIPTION
Adding Stackdriver Monitoring Is Disabled query for Ansible, that checks if the attribute 'monitoring_service' is defined and different than 'none'.

Closes #1286