### PR TITLE
Add Legacy Authorization is Enabled query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/legacy_authorization_is_enabled/metadata.json
+++ b/assets/queries/ansible/gcp/legacy_authorization_is_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Legacy_Authorization_Enabled",
+  "queryName": "Legacy Authorization is Enabled",
+  "severity": "HIGH",
+  "category": "Identity & Access Management",
+  "descriptionText": "Kubernetes Engine Clusters must have Legacy Authorization set to disabled, which means the attribute 'legacy_abac.enabled' must be false.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_module.html"
+}

--- a/assets/queries/ansible/gcp/legacy_authorization_is_enabled/query.rego
+++ b/assets/queries/ansible/gcp/legacy_authorization_is_enabled/query.rego
@@ -1,0 +1,33 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+  
+  isAnsibleTrue(cluster.legacy_abac.enabled)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.legacy_abac.enabled", [clusterName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.legacy_abac.enabled is false",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.legacy_abac.enabled is true"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}
+
+isAnsibleTrue(answer) {
+ 	lower(answer) == "yes"
+} else {
+	answer == true
+}

--- a/assets/queries/ansible/gcp/legacy_authorization_is_enabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/legacy_authorization_is_enabled/test/negative.yaml
@@ -1,0 +1,18 @@
+#this code is a correct code for which the query should not find any result
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    legacy_abac:
+      enabled: no

--- a/assets/queries/ansible/gcp/legacy_authorization_is_enabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/legacy_authorization_is_enabled/test/positive.yaml
@@ -1,0 +1,18 @@
+#this is a problematic code where the query should report a result(s)
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    legacy_abac:
+      enabled: yes

--- a/assets/queries/ansible/gcp/legacy_authorization_is_enabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/legacy_authorization_is_enabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Legacy Authorization is Enabled",
+		"severity": "HIGH",
+		"line": 18
+	}
+]


### PR DESCRIPTION
Adding Legacy Authorization is Enabled query for Ansible, that checks if the attribute 'legacy_abac.enabled' is false.

Closes #1293