### PR TITLE
Add Client Certificate is Disabled query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/client_certificate_is_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/client_certificate_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Client_Certificate_Disabled",
+  "queryName": "Client Certificate is Disabled",
+  "severity": "HIGH",
+  "category": "Identity & Access Management",
+  "descriptionText": "Kubernetes Clusters must be created with Client Certificate enabled, which means 'master_auth' must have 'client_certificate_config' with the attribute 'issue_client_certificate' equal to true",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_module.html"
+}

--- a/assets/queries/ansible/gcp/client_certificate_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/client_certificate_is_disabled/query.rego
@@ -1,0 +1,71 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+  
+  object.get(cluster, "master_auth", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.master_auth is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.master_auth is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+  
+  object.get(cluster.master_auth, "client_certificate_config", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth", [clusterName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.master_auth.client_certificate_config is defined",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.master_auth.client_certificate_config is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cluster := task["google.cloud.gcp_container_cluster"]
+  clusterName := task.name
+  
+  isAnsibleFalse(cluster.master_auth.client_certificate_config.issue_client_certificate)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth.client_certificate_config.issue_client_certificate", [clusterName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_container_cluster.master_auth.password is true",
+                "keyActualValue":   "google.cloud.gcp_container_cluster.master_auth.password is false"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}
+
+isAnsibleFalse(answer) {
+ 	lower(answer) == "no"
+} else {
+	lower(answer) == "false"
+} else {
+	answer == false
+}

--- a/assets/queries/ansible/gcp/client_certificate_is_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/client_certificate_is_disabled/test/negative.yaml
@@ -1,0 +1,18 @@
+#this code is a correct code for which the query should not find any result
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+      client_certificate_config:
+        issue_client_certificate: yes
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/client_certificate_is_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/client_certificate_is_disabled/test/positive.yaml
@@ -1,0 +1,45 @@
+#this is a problematic code where the query should report a result(s)
+- name: create a cluster1
+  google.cloud.gcp_container_cluster:
+    name: my-cluster1
+    initial_node_count: 2
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a cluster2
+  google.cloud.gcp_container_cluster:
+    name: my-cluster2
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a cluster3
+  google.cloud.gcp_container_cluster:
+    name: my-cluster3
+    initial_node_count: 2
+    master_auth:
+      username: cluster_admin
+      password: my-secret-password
+      client_certificate_config:
+        issue_client_certificate: no
+    node_config:
+      machine_type: n1-standard-4
+      disk_size_gb: 500
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/client_certificate_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/client_certificate_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Client Certificate is Disabled",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "Client Certificate is Disabled",
+		"severity": "HIGH",
+		"line": 18
+	},
+	{
+		"queryName": "Client Certificate is Disabled",
+		"severity": "HIGH",
+		"line": 37
+	}
+]


### PR DESCRIPTION
Adding Client Certificate is Disabled query for Ansible, that checks if 'master_auth' has 'client_certificate_config' with the sub attribute 'issue_client_certificate' equal to true.

Closes #1315