### PR TITLE
Add ELB Using Insecure Protocols query for Ansible 

### DIFF
--- a/assets/queries/ansible/aws/elb_using_insecure_protocols/metadata.json
+++ b/assets/queries/ansible/aws/elb_using_insecure_protocols/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ELB_Using_Insecure_Protocols",
+  "queryName": "ELB Using Insecure Protocols",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "ELB Predefined or Custom Security Policies must not use weak ciphers, to reduce the risk of the SSL connection between the client and the load balancer being exploited. That means the 'SslPolicy' of 'listeners' must not coincide with any of a predefined list of insecure protocols.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/elb_application_lb_module.html"
+}

--- a/assets/queries/ansible/aws/elb_using_insecure_protocols/query.rego
+++ b/assets/queries/ansible/aws/elb_using_insecure_protocols/query.rego
@@ -1,0 +1,122 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  elb := task["community.aws.elb_application_lb"]
+  elbName := task.name
+  
+  object.get(elb, "listeners", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{community.aws.elb_application_lb}}", [elbName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "community.aws.elb_application_lb.listeners is defined",
+                "keyActualValue":   "community.aws.elb_application_lb.listeners is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  elb := task["community.aws.elb_application_lb"]
+  elbName := task.name
+  
+  object.get(elb.listeners[j], "SslPolicy", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.%s", [elbName, j]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "community.aws.elb_application_lb.listeners.SslPolicy is defined",
+                "keyActualValue":   "community.aws.elb_application_lb.listeners.SslPolicy is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  elb := task["community.aws.elb_application_lb"]
+  elbName := task.name
+  
+  check_vulnerability(elb.listeners[j].SslPolicy)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.%s", [elbName, j]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "community.aws.elb_application_lb.listeners.SslPolicy is not a weak cipher",
+                "keyActualValue":   "community.aws.elb_application_lb.listeners.SslPolicy is a weak cipher"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  elb := task["community.aws.elb_network_lb"]
+  elbName := task.name
+  
+  object.get(elb, "listeners", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{community.aws.elb_network_lb}}", [elbName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "community.aws.elb_network_lb.listeners is defined",
+                "keyActualValue":   "community.aws.elb_network_lb.listeners is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  elb := task["community.aws.elb_network_lb"]
+  elbName := task.name
+  
+  object.get(elb.listeners[j], "SslPolicy", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{community.aws.elb_network_lb}}.listeners.%s", [elbName, j]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "community.aws.elb_network_lb.listeners.SslPolicy is defined",
+                "keyActualValue":   "community.aws.elb_network_lb.listeners.SslPolicy is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  elb := task["community.aws.elb_network_lb"]
+  elbName := task.name
+  
+  check_vulnerability(elb.listeners[j].SslPolicy)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{community.aws.elb_network_lb}}.listeners.%s", [elbName, j]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "community.aws.elb_network_lb.listeners.SslPolicy is not a weak cipher",
+                "keyActualValue":   "community.aws.elb_network_lb.listeners.SslPolicy is a weak cipher"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}
+
+check_vulnerability(val) {
+	insecure_protocols = {"Protocol-SSLv2", "Protocol-SSLv3", "Protocol-TLSv1", "Protocol-TLSv1.1"}
+  val == insecure_protocols[_]
+} 

--- a/assets/queries/ansible/aws/elb_using_insecure_protocols/test/negative.yaml
+++ b/assets/queries/ansible/aws/elb_using_insecure_protocols/test/negative.yaml
@@ -1,0 +1,41 @@
+#this code is a correct code for which the query should not find any result
+- name: elb1
+  community.aws.elb_application_lb:
+    name: myelb1
+    security_groups:
+      - sg-12345678
+      - my-sec-group
+    subnets:
+      - subnet-012345678
+      - subnet-abcdef000
+    listeners:
+      - Protocol: HTTP # Required. The protocol for connections from clients to the load balancer (HTTP or HTTPS) (case-sensitive).
+        Port: 80 # Required. The port on which the load balancer is listening.
+        # The security policy that defines which ciphers and protocols are supported. The default is the current predefined security policy.
+        SslPolicy: ELBSecurityPolicy-2015-05
+        Certificates: # The ARN of the certificate (only one certficate ARN should be provided)
+          - CertificateArn: arn:aws:iam::12345678987:server-certificate/test.domain.com
+        DefaultActions:
+          - Type: forward # Required.
+            TargetGroupName: # Required. The name of the target group
+    state: present
+- name: elb2
+  community.aws.elb_network_lb:
+    name: myelb2
+    security_groups:
+      - sg-12345678
+      - my-sec-group
+    subnets:
+      - subnet-012345678
+      - subnet-abcdef000
+    listeners:
+      - Protocol: HTTP # Required. The protocol for connections from clients to the load balancer (HTTP or HTTPS) (case-sensitive).
+        Port: 80 # Required. The port on which the load balancer is listening.
+        # The security policy that defines which ciphers and protocols are supported. The default is the current predefined security policy.
+        SslPolicy: ELBSecurityPolicy-2015-05
+        Certificates: # The ARN of the certificate (only one certficate ARN should be provided)
+          - CertificateArn: arn:aws:iam::12345678987:server-certificate/test.domain.com
+        DefaultActions:
+          - Type: forward # Required.
+            TargetGroupName: # Required. The name of the target group
+    state: present

--- a/assets/queries/ansible/aws/elb_using_insecure_protocols/test/positive.yaml
+++ b/assets/queries/ansible/aws/elb_using_insecure_protocols/test/positive.yaml
@@ -1,0 +1,99 @@
+#this is a problematic code where the query should report a result(s)
+- name: elb1
+  community.aws.elb_application_lb:
+    name: myelb1
+    security_groups:
+      - sg-12345678
+      - my-sec-group
+    subnets:
+      - subnet-012345678
+      - subnet-abcdef000
+    state: present
+- name: elb2
+  community.aws.elb_application_lb:
+    name: myelb2
+    security_groups:
+      - sg-12345678
+      - my-sec-group
+    subnets:
+      - subnet-012345678
+      - subnet-abcdef000
+    listeners:
+      - Protocol: HTTP # Required. The protocol for connections from clients to the load balancer (HTTP or HTTPS) (case-sensitive).
+        Port: 80 # Required. The port on which the load balancer is listening.
+        # The security policy that defines which ciphers and protocols are supported. The default is the current predefined security policy.
+        Certificates: # The ARN of the certificate (only one certficate ARN should be provided)
+          - CertificateArn: arn:aws:iam::12345678987:server-certificate/test.domain.com
+        DefaultActions:
+          - Type: forward # Required.
+            TargetGroupName: # Required. The name of the target group
+    state: present
+- name: elb3
+  community.aws.elb_application_lb:
+    name: myelb3
+    security_groups:
+      - sg-12345678
+      - my-sec-group
+    subnets:
+      - subnet-012345678
+      - subnet-abcdef000
+    listeners:
+      - Protocol: HTTP # Required. The protocol for connections from clients to the load balancer (HTTP or HTTPS) (case-sensitive).
+        Port: 80 # Required. The port on which the load balancer is listening.
+        # The security policy that defines which ciphers and protocols are supported. The default is the current predefined security policy.
+        SslPolicy: Protocol-SSLv2
+        Certificates: # The ARN of the certificate (only one certficate ARN should be provided)
+          - CertificateArn: arn:aws:iam::12345678987:server-certificate/test.domain.com
+        DefaultActions:
+          - Type: forward # Required.
+            TargetGroupName: # Required. The name of the target group
+    state: present
+- name: elb4
+  community.aws.elb_network_lb:
+    name: myelb4
+    security_groups:
+      - sg-12345678
+      - my-sec-group
+    subnets:
+      - subnet-012345678
+      - subnet-abcdef000
+    state: present
+- name: elb5
+  community.aws.elb_network_lb:
+    name: myelb5
+    security_groups:
+      - sg-12345678
+      - my-sec-group
+    subnets:
+      - subnet-012345678
+      - subnet-abcdef000
+    listeners:
+      - Protocol: HTTP # Required. The protocol for connections from clients to the load balancer (HTTP or HTTPS) (case-sensitive).
+        Port: 80 # Required. The port on which the load balancer is listening.
+        # The security policy that defines which ciphers and protocols are supported. The default is the current predefined security policy.
+        Certificates: # The ARN of the certificate (only one certficate ARN should be provided)
+          - CertificateArn: arn:aws:iam::12345678987:server-certificate/test.domain.com
+        DefaultActions:
+          - Type: forward # Required.
+            TargetGroupName: # Required. The name of the target group
+    state: present
+- name: elb6
+  community.aws.elb_network_lb:
+    name: myelb6
+    security_groups:
+      - sg-12345678
+      - my-sec-group
+    subnets:
+      - subnet-012345678
+      - subnet-abcdef000
+    listeners:
+      - Protocol: HTTP # Required. The protocol for connections from clients to the load balancer (HTTP or HTTPS) (case-sensitive).
+        Port: 80 # Required. The port on which the load balancer is listening.
+        # The security policy that defines which ciphers and protocols are supported. The default is the current predefined security policy.
+        SslPolicy: Protocol-TLSv1.1
+        Certificates: # The ARN of the certificate (only one certficate ARN should be provided)
+          - CertificateArn: arn:aws:iam::12345678987:server-certificate/test.domain.com
+        DefaultActions:
+          - Type: forward # Required.
+            TargetGroupName: # Required. The name of the target group
+    state: present

--- a/assets/queries/ansible/aws/elb_using_insecure_protocols/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/elb_using_insecure_protocols/test/positive_expected_result.json
@@ -1,0 +1,32 @@
+[
+	{
+		"queryName": "ELB Using Insecure Protocols",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "ELB Using Insecure Protocols",
+		"severity": "HIGH",
+		"line": 21
+	},
+	{
+		"queryName": "ELB Using Insecure Protocols",
+		"severity": "HIGH",
+		"line": 40
+	},
+	{
+		"queryName": "ELB Using Insecure Protocols",
+		"severity": "HIGH",
+		"line": 52
+	},
+	{
+		"queryName": "ELB Using Insecure Protocols",
+		"severity": "HIGH",
+		"line": 70
+	},
+	{
+		"queryName": "ELB Using Insecure Protocols",
+		"severity": "HIGH",
+		"line": 89
+	}
+]


### PR DESCRIPTION
Adding ELB Using Insecure Protocols query for Ansible, that checks if the 'SslPolicy' of 'listeners' must not coincide with any of a predefined list of insecure protocols.

Closes #1339