### PR TITLE
Add dnssec_using_rsasha1 query for Ansible #1338

### DIFF
--- a/assets/queries/ansible/gcp/dnssec_using_rsasha1/metadata.json
+++ b/assets/queries/ansible/gcp/dnssec_using_rsasha1/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "dnssec_using_rsasha1",
+  "queryName": "DNSSEC Using RSASHA1",
+  "severity": "HIGH",
+  "category": "Encryption & Key Management",
+  "descriptionText": "DNSSEC should not use the RSASHA1 algorithm",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_dns_managed_zone_module.html#return-dnssecConfig/defaultKeySpecs/algorithm"
+}

--- a/assets/queries/ansible/gcp/dnssec_using_rsasha1/query.rego
+++ b/assets/queries/ansible/gcp/dnssec_using_rsasha1/query.rego
@@ -1,0 +1,25 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+
+  dnssec_config := task["google.cloud.gcp_dns_managed_zone"].dnssec_config
+  lower(dnssec_config.defaultKeySpecs.algorithm) == "rsasha1"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_dns_managed_zone}}.dnssec_config.defaultKeySpecs.algorithm", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'dnssec_config.defaultKeySpecs.algorithm' is not equal to 'rsasha1'",
+                "keyActualValue": 	"'dnssec_config.defaultKeySpecs.algorithm' is equal to 'rsasha1'"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/dnssec_using_rsasha1/test/negative.yaml
+++ b/assets/queries/ansible/gcp/dnssec_using_rsasha1/test/negative.yaml
@@ -1,0 +1,14 @@
+---
+- name: create a managed zone
+  google.cloud.gcp_dns_managed_zone:
+    name: test_object
+    dns_name: test.somewild2.example.com.
+    description: test zone
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    dnssec_config:
+      defaultKeySpecs:
+        algorithm: RSASHA256
+      state: off

--- a/assets/queries/ansible/gcp/dnssec_using_rsasha1/test/positive.yaml
+++ b/assets/queries/ansible/gcp/dnssec_using_rsasha1/test/positive.yaml
@@ -1,0 +1,14 @@
+---
+- name: create a managed zone
+  google.cloud.gcp_dns_managed_zone:
+    name: test_object
+    dns_name: test.somewild2.example.com.
+    description: test zone
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    dnssec_config:
+      defaultKeySpecs:
+        algorithm: RSASHA1
+      state: off

--- a/assets/queries/ansible/gcp/dnssec_using_rsasha1/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/dnssec_using_rsasha1/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "DNSSEC Using RSASHA1",
+		"severity": "HIGH",
+		"line": 13
+	}
+]


### PR DESCRIPTION
Closes #1338 

This query checks if, within the 'dnssec_config' block, the 'default_key_specs' block exists with the 'algorithm' field is 'rsasha1' which is bad.