### PR TITLE
Add cos_node_image_not_used query for Ansible #1343

### DIFF
--- a/assets/queries/ansible/gcp/cos_node_image_not_used/metadata.json
+++ b/assets/queries/ansible/gcp/cos_node_image_not_used/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "cos_node_image_not_used",
+  "queryName": "COS Node Image Not Used",
+  "severity": "HIGH",
+  "category": "Operational Efficiency",
+  "descriptionText": "A node image, that is not Container-Optimized OS (COS), is used for Kubernetes Engine Clusters Node image",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_node_pool_module.html#parameter-config/image_type"
+}

--- a/assets/queries/ansible/gcp/cos_node_image_not_used/query.rego
+++ b/assets/queries/ansible/gcp/cos_node_image_not_used/query.rego
@@ -1,0 +1,25 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+
+  image_type := task["google.cloud.gcp_container_node_pool"].config.image_type
+  lower(image_type) != "cos"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_container_node_pool}}.config.image_type", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'config.image_type' is equal to 'COS'",
+                "keyActualValue": 	"'config.image_type' is not equal to 'COS'"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/cos_node_image_not_used/test/negative.yaml
+++ b/assets/queries/ansible/gcp/cos_node_image_not_used/test/negative.yaml
@@ -1,0 +1,13 @@
+---
+- name: create a node pool
+  google.cloud.gcp_container_node_pool:
+    name: my-pool
+    initial_node_count: 4
+    cluster: "{{ cluster }}"
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    config:
+        image_type: COS

--- a/assets/queries/ansible/gcp/cos_node_image_not_used/test/positive.yaml
+++ b/assets/queries/ansible/gcp/cos_node_image_not_used/test/positive.yaml
@@ -1,0 +1,13 @@
+---
+- name: create a node pool
+  google.cloud.gcp_container_node_pool:
+    name: my-pool
+    initial_node_count: 4
+    cluster: "{{ cluster }}"
+    location: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    config:
+        image_type: WINDOWS_LTSC

--- a/assets/queries/ansible/gcp/cos_node_image_not_used/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/cos_node_image_not_used/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "COS Node Image Not Used",
+		"severity": "HIGH",
+		"line": 13
+	}
+]


### PR DESCRIPTION
Closes #1343 

This query detects if a node image that is not COS (Container-Optimized OS) is used for Kubernetes Engine Clusters Node image.