### PR TITLE
Add Cloud Storage Anonymous or Publicly Accessible query for Ansible 

### DIFF
--- a/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/metadata.json
+++ b/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Cloud_Storage_Anonymous_Or_Publicly_Accessible",
+  "queryName": "Cloud Storage Anonymous or Publicly Accessible",
+  "severity": "MEDIUM",
+  "category": "Identity & Access Management",
+  "descriptionText": "Cloud Storage Buckets must not be anonymously or publicly accessible, which means the attribute 'entity' must not be 'allUsers' or 'allAuthenticatedUsers'",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_storage_bucket_module.html"
+}

--- a/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/query.rego
+++ b/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/query.rego
@@ -1,0 +1,75 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  bucket := task["google.cloud.gcp_storage_bucket"]
+  bucketName := task.name
+
+  object.get(bucket, "acl", "undefined") == "undefined"
+  object.get(bucket, "default_object_acl", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_storage_bucket}}", [bucketName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_storage_bucket.default_object_acl is defined",
+                "keyActualValue":   "google.cloud.gcp_storage_bucket.default_object_acl is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  bucket := task["google.cloud.gcp_storage_bucket"]
+  bucketName := task.name
+  bucket.acl
+  check(bucket.acl.entity)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_storage_bucket}}.acl.entity", [bucketName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_storage_bucket.acl.entity isn't 'allUsers' or 'allAuthenticatedUsers'",
+                "keyActualValue":   "google.cloud.gcp_storage_bucket.acl.entity is 'allUsers' or 'allAuthenticatedUsers'"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  bucket := task["google.cloud.gcp_storage_bucket"]
+  bucketName := task.name
+  object.get(bucket, "acl", "undefined") == "undefined"
+  bucket.default_object_acl
+  check(bucket.default_object_acl.entity)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_storage_bucket}}.default_object_acl.entity", [bucketName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_storage_bucket.default_object_acl.entity isn't 'allUsers' or 'allAuthenticatedUsers'",
+                "keyActualValue":   "google.cloud.gcp_storage_bucket.default_object_acl.entity is 'allUsers' or 'allAuthenticatedUsers'"
+              }
+}
+
+check(entity){
+  is_string(entity)
+  lower(entity) == "allusers"
+}
+
+check(entity){
+  is_string(entity)
+  lower(entity) == "allauthenticatedusers"
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/test/negative.yaml
+++ b/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/test/negative.yaml
@@ -1,0 +1,11 @@
+#this code is a correct code for which the query should not find any result
+- name: create a bucket
+  google.cloud.gcp_storage_bucket:
+    name: ansible-storage-module
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    acl:
+      bucket: bucketName
+      entity: group-example@googlegroups.com

--- a/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/test/positive.yaml
+++ b/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/test/positive.yaml
@@ -1,0 +1,33 @@
+#this is a problematic code where the query should report a result(s)
+- name: create a bucket1
+  google.cloud.gcp_storage_bucket:
+    name: ansible-storage-module1
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    default_object_acl:
+      bucket: bucketName1
+      entity: allUsers
+      role: READER
+- name: create a bucket2
+  google.cloud.gcp_storage_bucket:
+    name: ansible-storage-module2
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    acl:
+      bucket: bucketName2
+      entity: allAuthenticatedUsers
+    default_object_acl:
+      bucket: bucketName2
+      entity: allUsers
+      role: READER
+- name: create a bucket3
+  google.cloud.gcp_storage_bucket:
+    name: ansible-storage-module3
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Cloud Storage Anonymous or Publicly Accessible",
+		"severity": "MEDIUM",
+		"line": 11
+	},
+	{
+		"queryName": "Cloud Storage Anonymous or Publicly Accessible",
+		"severity": "MEDIUM",
+		"line": 22
+	},
+	{
+		"queryName": "Cloud Storage Anonymous or Publicly Accessible",
+		"severity": "MEDIUM",
+		"line": 28
+	}
+]


### PR DESCRIPTION
Adding Cloud Storage Anonymous or Publicly Accessible query for Ansible, that checks if the attribute 'entity' must not be 'allUsers' or 'allAuthenticatedUsers'.

Closes #1349