### PR TITLE
Add vm_with_full_cloud_access query for Ansible #1353

### DIFF
--- a/assets/queries/ansible/gcp/vm_with_full_cloud_access/metadata.json
+++ b/assets/queries/ansible/gcp/vm_with_full_cloud_access/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "vm_with_full_cloud_access",
-  "queryName": "VM with Full Cloud Access",
+  "queryName": "VM With Full Cloud Access",
   "severity": "HIGH",
   "category": "Access Control",
   "descriptionText": "A VM instance is configured to use the default service account with full access to all Cloud APIs",
-  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#scopes"
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_module.html#parameter-service_accounts/scopes"
 }

--- a/assets/queries/ansible/gcp/vm_with_full_cloud_access/query.rego
+++ b/assets/queries/ansible/gcp/vm_with_full_cloud_access/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy [ result ] {
+  	document := input.document[i]
+  	task := getTasks(document)[t]
+
+  	service_accounts := task["google.cloud.gcp_compute_instance"].service_accounts
+	some s
+    	scopes := service_accounts[s].scopes
+        lower(scopes[_]) == "cloud-platform"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_compute_instance}}.service_accounts", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'service_accounts.scopes' does not contain 'cloud-platform'",
+                "keyActualValue": 	"'service_accounts.scopes' contains 'cloud-platform'"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/vm_with_full_cloud_access/test/negative.yaml
+++ b/assets/queries/ansible/gcp/vm_with_full_cloud_access/test/negative.yaml
@@ -1,0 +1,8 @@
+---
+- name: create a instance
+  google.cloud.gcp_compute_instance:
+    name: test_object
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    state: present

--- a/assets/queries/ansible/gcp/vm_with_full_cloud_access/test/positive.yaml
+++ b/assets/queries/ansible/gcp/vm_with_full_cloud_access/test/positive.yaml
@@ -1,0 +1,11 @@
+---
+- name: create a instance
+  google.cloud.gcp_compute_instance:
+    name: test_object
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_accounts:
+        - scopes:
+            - cloud-platform
+    state: present

--- a/assets/queries/ansible/gcp/vm_with_full_cloud_access/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/vm_with_full_cloud_access/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "VM With Full Cloud Access",
+		"severity": "HIGH",
+		"line": 8
+	}
+]


### PR DESCRIPTION
Closes #1353 

This query detects if a VM instance is configured to use the default service account with full access to all Cloud APIs.
Checks if, within a 'google_compute_instance' resource, the list 'service_accounts.scopes' contains 'cloud_platform'.