### PR TITLE
Add Shielded VM is Disabled query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/shielded_vm_is_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/shielded_vm_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Shielded_VM_Disabled",
+  "queryName": "Shielded VM is Disabled",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Compute instances must be launched with Shielded VM enabled, which means the attribute 'shielded_instance_config' must be defined and its sub attributes 'enable_secure_boot', 'enable_vtpm' and 'enable_integrity_monitoring' must be set to true",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_module.html"
+}

--- a/assets/queries/ansible/gcp/shielded_vm_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/shielded_vm_is_disabled/query.rego
@@ -1,0 +1,143 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+
+  object.get(instance, "shielded_instance_config", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}", [instanceName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.shielded_instance_config is defined",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.shielded_instance_config is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+  instance.shielded_instance_config
+  object.get(instance.shielded_instance_config, "enable_integrity_monitoring", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config", [instanceName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.shielded_instance_config.enable_integrity_monitoring is defined",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.shielded_instance_config.enable_integrity_monitoring is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+  instance.shielded_instance_config
+  object.get(instance.shielded_instance_config, "enable_secure_boot", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config", [instanceName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.shielded_instance_config.enable_secure_boot is defined",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.shielded_instance_config.enable_secure_boot is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+  instance.shielded_instance_config
+  object.get(instance.shielded_instance_config, "enable_vtpm", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config", [instanceName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.shielded_instance_config.enable_vtpm is defined",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.shielded_instance_config.enable_vtpm is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+
+  isAnsibleFalse(instance.shielded_instance_config.enable_integrity_monitoring)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_integrity_monitoring", [instanceName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.shielded_instance_config.enable_integrity_monitoring is true",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.shielded_instance_config.enable_integrity_monitoring is false"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+
+  isAnsibleFalse(instance.shielded_instance_config.enable_secure_boot)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_secure_boot", [instanceName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.shielded_instance_config.enable_secure_boot is true",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.shielded_instance_config.enable_secure_boot is false"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+
+  isAnsibleFalse(instance.shielded_instance_config.enable_vtpm)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_vtpm", [instanceName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.shielded_instance_config.enable_vtpm is true",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.shielded_instance_config.enable_vtpm is false"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+} 
+
+isAnsibleFalse(answer) {
+ 	lower(answer) == "no"
+} else {
+	lower(answer) == "false"
+} else {
+	answer == false
+}

--- a/assets/queries/ansible/gcp/shielded_vm_is_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/shielded_vm_is_disabled/test/negative.yaml
@@ -1,0 +1,34 @@
+#this code is a correct code for which the query should not find any result
+- name: create a instance
+  google.cloud.gcp_compute_instance:
+    name: test_object
+    machine_type: n1-standard-1
+    disks:
+    - auto_delete: 'true'
+      boot: 'true'
+      source: "{{ disk }}"
+    - auto_delete: 'true'
+      interface: NVME
+      type: SCRATCH
+      initialize_params:
+        disk_type: local-ssd
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    shielded_instance_config:
+      enable_integrity_monitoring: yes
+      enable_secure_boot: yes
+      enable_vtpm: yes

--- a/assets/queries/ansible/gcp/shielded_vm_is_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/shielded_vm_is_disabled/test/positive.yaml
@@ -1,0 +1,162 @@
+#this is a problematic code where the query should report a result(s)
+- name: create a instance1
+  google.cloud.gcp_compute_instance:
+    name: test_object1
+    machine_type: n1-standard-1
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a instance2
+  google.cloud.gcp_compute_instance:
+    name: test_object2
+    machine_type: n1-standard-1
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    shielded_instance_config:
+      enable_secure_boot: yes
+      enable_vtpm: yes
+- name: create a instance3
+  google.cloud.gcp_compute_instance:
+    name: test_object3
+    machine_type: n1-standard-1
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    shielded_instance_config:
+      enable_integrity_monitoring: yes
+      enable_vtpm: yes
+- name: create a instance4
+  google.cloud.gcp_compute_instance:
+    name: test_object4
+    machine_type: n1-standard-1
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    shielded_instance_config:
+      enable_integrity_monitoring: yes
+      enable_secure_boot: yes
+- name: create a instance5
+  google.cloud.gcp_compute_instance:
+    name: test_object5
+    machine_type: n1-standard-1
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    shielded_instance_config:
+      enable_integrity_monitoring: no
+      enable_secure_boot: yes
+      enable_vtpm: yes
+- name: create a instance6
+  google.cloud.gcp_compute_instance:
+    name: test_object6
+    machine_type: n1-standard-1
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    shielded_instance_config:
+      enable_integrity_monitoring: yes
+      enable_secure_boot: no
+      enable_vtpm: yes
+- name: create a instance7
+  google.cloud.gcp_compute_instance:
+    name: test_object7
+    machine_type: n1-standard-1
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    shielded_instance_config:
+      enable_integrity_monitoring: yes
+      enable_secure_boot: yes
+      enable_vtpm: no

--- a/assets/queries/ansible/gcp/shielded_vm_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/shielded_vm_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,37 @@
+[
+	{
+		"queryName": "Shielded VM is Disabled",
+		"severity": "MEDIUM",
+		"line": 3
+	},
+	{
+		"queryName": "Shielded VM is Disabled",
+		"severity": "MEDIUM",
+		"line": 42
+	},
+	{
+		"queryName": "Shielded VM is Disabled",
+		"severity": "MEDIUM",
+		"line": 65
+	},
+	{
+		"queryName": "Shielded VM is Disabled",
+		"severity": "MEDIUM",
+		"line": 88
+	},
+	{
+		"queryName": "Shielded VM is Disabled",
+		"severity": "MEDIUM",
+		"line": 112
+	},
+	{
+		"queryName": "Shielded VM is Disabled",
+		"severity": "MEDIUM",
+		"line": 137
+	},
+	{
+		"queryName": "Shielded VM is Disabled",
+		"severity": "MEDIUM",
+		"line": 162
+	}
+]


### PR DESCRIPTION
Adding Shielded VM is Disabled query for Ansible, that checks if the attribute 'shielded_instance_config' is defined and its sub attributes 'enable_secure_boot', 'enable_vtpm' and 'enable_integrity_monitoring' are set to true.

Closes #1356