### PR TITLE
Add kinesis_not_encrypted_with_kms Closes #1357

### DIFF
--- a/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/metadata.json
+++ b/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "kinesis_not_encrypted_with_kms",
+  "queryName": "AWS Kinesis Not Encrypted with KMS",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "AWS Kinesis Streams and metadata should be protected with KMS",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/kinesis_stream_module.html"
+}

--- a/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/query.rego
+++ b/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/query.rego
@@ -1,0 +1,92 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+    object.get(task["community.aws.kinesis_stream"], "encryption_type", "undefined") == "undefined"
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name={{%s}}.{{community.aws.kinesis_stream}}", [task.name]),
+        "issueType":         "MissingAttribute",
+        "keyExpectedValue":  "community.aws.kinesis_stream.encryption_type is set",
+        "keyActualValue": 	 "community.aws.kinesis_stream.encryption_type is undefined"
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+    object.get(task["community.aws.kinesis_stream"], "encryption_state", "undefined") == "undefined"
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name={{%s}}.{{community.aws.kinesis_stream}}", [task.name]),
+        "issueType":         "MissingAttribute",
+        "keyExpectedValue":  "community.aws.kinesis_stream.encryption_state is set",
+        "keyActualValue": 	 "community.aws.kinesis_stream.encryption_state is undefined"
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+    task["community.aws.kinesis_stream"].encryption_state != "enabled"
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name={{%s}}.{{community.aws.kinesis_stream}}.encryption_state", [task.name]),
+        "issueType":         "IncorrectValue",
+        "keyExpectedValue":  "community.aws.kinesis_stream.encryption_state is set to enabled",
+        "keyActualValue": 	 "community.aws.kinesis_stream.encryption_state is not set to enabled"
+    }
+}
+
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+    task["community.aws.kinesis_stream"].encryption_type == "NONE"
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name={{%s}}.{{community.aws.kinesis_stream}}.encryption_type", [task.name]),
+        "issueType":         "IncorrectValue",
+        "keyExpectedValue":  "community.aws.kinesis_stream.encryption_type is set and not NONE",
+        "keyActualValue": 	 "community.aws.kinesis_stream.encryption_type is set but NONE"
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+    task["community.aws.kinesis_stream"].encryption_type == "KMS"
+    object.get(task["community.aws.kinesis_stream"], "key_id", "undefined") == "undefined"
+    
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name={{%s}}.{{community.aws.kinesis_stream}}", [task.name]),
+        "issueType":         "MissingAttribute",
+        "keyExpectedValue":  "community.aws.kinesis_stream.key_id is set",
+        "keyActualValue": 	 "community.aws.kinesis_stream.key_id is undefined"
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/test/negative.yaml
+++ b/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/test/negative.yaml
@@ -1,0 +1,10 @@
+- name: Encrypt Kinesis Stream test-stream. v6
+  community.aws.kinesis_stream:
+    name: test-stream
+    state: present
+    shards: 1
+    encryption_state: enabled
+    encryption_type: KMS
+    key_id: alias/aws/kinesis
+    wait: yes
+    wait_timeout: 600

--- a/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/test/positive.yaml
+++ b/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/test/positive.yaml
@@ -1,0 +1,52 @@
+- name: Encrypt Kinesis Stream test-stream.
+  community.aws.kinesis_stream:
+    name: test-stream
+    state: present
+    shards: 1
+    encryption_type: KMS
+    key_id: alias/aws/kinesis
+    wait: yes
+    wait_timeout: 600
+  register: test_stream
+- name: Encrypt Kinesis Stream test-stream. v2
+  community.aws.kinesis_stream:
+    name: test-stream
+    state: present
+    shards: 1
+    encryption_state: disabled
+    encryption_type: KMS
+    key_id: alias/aws/kinesis
+    wait: yes
+    wait_timeout: 600
+  register: test_stream
+- name: Encrypt Kinesis Stream test-stream. v3
+  community.aws.kinesis_stream:
+    name: test-stream
+    state: present
+    shards: 1
+    encryption_state: enabled
+    key_id: alias/aws/kinesis
+    wait: yes
+    wait_timeout: 600
+  register: test_stream
+- name: Encrypt Kinesis Stream test-stream. v4
+  community.aws.kinesis_stream:
+    name: test-stream
+    state: present
+    shards: 1
+    encryption_state: enabled
+    encryption_type: NONE
+    key_id: alias/aws/kinesis
+    wait: yes
+    wait_timeout: 600
+  register: test_stream
+- name: Encrypt Kinesis Stream test-stream. v5
+  community.aws.kinesis_stream:
+    name: test-stream
+    state: present
+    shards: 1
+    encryption_state: enabled
+    encryption_type: KMS
+    wait: yes
+    wait_timeout: 600
+  register: test_stream

--- a/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/test/positive_expected_result.json
@@ -1,0 +1,31 @@
+[
+	{
+		"queryName": "AWS Kinesis Not Encrypted with KMS",
+		"severity": "HIGH",
+		"line": 2
+	},
+
+	{
+		"queryName": "AWS Kinesis Not Encrypted with KMS",
+		"severity": "HIGH",
+		"line": 16
+	},
+
+	{
+		"queryName": "AWS Kinesis Not Encrypted with KMS",
+		"severity": "HIGH",
+		"line": 23
+	},
+
+	{
+		"queryName": "AWS Kinesis Not Encrypted with KMS",
+		"severity": "HIGH",
+		"line": 38
+	},
+
+	{
+		"queryName": "AWS Kinesis Not Encrypted with KMS",
+		"severity": "HIGH",
+		"line": 44
+	}
+]


### PR DESCRIPTION
For this query, it is necessary to check if the attribute 'encryption_type' is set and defined as KMS and if the attribute 'key_id' is set, as well as the attribute 'encryption_state' set to enabled.

So, I thought in five cases:

Attribute 'encryption_state' is undefined

Attribute 'encryption_state' is not set to enabled

Attribute 'encryption_type' is undefined

Attribute 'encryption_type' is set but defined as "NONE"

Attribute 'encryption_type' is "KMS" but the attribute key_id' is undefined

Closes #1357