### PR TITLE
Add IP Forwarding is Enabled query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/ip_forwarding_is_enabled/metadata.json
+++ b/assets/queries/ansible/gcp/ip_forwarding_is_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "IP_Forwarding_Enabled",
+  "queryName": "IP Forwarding is Enabled",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Instances must not have IP forwarding enabled, which means the attribute 'can_ip_forward' must not be true",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_module.html"
+}

--- a/assets/queries/ansible/gcp/ip_forwarding_is_enabled/query.rego
+++ b/assets/queries/ansible/gcp/ip_forwarding_is_enabled/query.rego
@@ -1,0 +1,35 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+
+  isAnsibleTrue(instance.can_ip_forward)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.can_ip_forward", [instanceName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.can_ip_forward is false",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.can_ip_forward is true"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+} 
+
+isAnsibleTrue(answer) {
+ 	lower(answer) == "yes"
+} else {
+	lower(answer) == "true"
+} else {
+	answer == true
+}

--- a/assets/queries/ansible/gcp/ip_forwarding_is_enabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/ip_forwarding_is_enabled/test/negative.yaml
@@ -1,0 +1,22 @@
+#this code is a correct code for which the query should not find any result
+- name: create a instance
+  google.cloud.gcp_compute_instance:
+    name: test_object
+    machine_type: n1-standard-1
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    can_ip_forward: no

--- a/assets/queries/ansible/gcp/ip_forwarding_is_enabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/ip_forwarding_is_enabled/test/positive.yaml
@@ -1,0 +1,22 @@
+#this is a problematic code where the query should report a result(s)
+- name: create a instance
+  google.cloud.gcp_compute_instance:
+    name: test_object
+    machine_type: n1-standard-1
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    can_ip_forward: yes

--- a/assets/queries/ansible/gcp/ip_forwarding_is_enabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/ip_forwarding_is_enabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "IP Forwarding is Enabled",
+		"severity": "MEDIUM",
+		"line": 22
+	}
+]


### PR DESCRIPTION
Adding IP Forwarding is Enabled query for Ansible, that checks if the attribute 'can_ip_forward' is true.

Closes #1361