### PR TITLE
Add vm_not_attached_to_network query for Ansible #1362

### DIFF
--- a/assets/queries/ansible/azure/vm_not_attached_to_network/metadata.json
+++ b/assets/queries/ansible/azure/vm_not_attached_to_network/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "vm_not_attached_to_network",
+  "queryName": "VM Not Attached To Network",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "No Network Security Group is attached to the Virtual Machine",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_virtualmachine_module.html#parameter-network_interface_names"
+}

--- a/assets/queries/ansible/azure/vm_not_attached_to_network/query.rego
+++ b/assets/queries/ansible/azure/vm_not_attached_to_network/query.rego
@@ -1,0 +1,25 @@
+package Cx
+
+CxPolicy [ result ] {
+  	document := input.document[i]
+  	task := getTasks(document)[t]["azure_rm_virtualmachine"]
+
+  	object.get(task, "network_interface_names", "undefined") == "undefined"
+    object.get(task, "network_interfaces", "undefined") == "undefined"
+    
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{azure_rm_virtualmachine}}", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'network_interface_names' is defined",
+                "keyActualValue": 	"'network_interface_names' is undefined"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/azure/vm_not_attached_to_network/test/negative.yaml
+++ b/assets/queries/ansible/azure/vm_not_attached_to_network/test/negative.yaml
@@ -1,0 +1,10 @@
+---
+- name: Create a VM with a custom image
+  azure_rm_virtualmachine:
+    resource_group: myResourceGroup
+    name: testvm001
+    vm_size: Standard_DS1_v2
+    admin_username: adminUser
+    admin_password: password01
+    image: customimage001
+    network_interfaces: testvm001

--- a/assets/queries/ansible/azure/vm_not_attached_to_network/test/positive.yaml
+++ b/assets/queries/ansible/azure/vm_not_attached_to_network/test/positive.yaml
@@ -1,0 +1,9 @@
+---
+- name: Create a VM with a custom image
+  azure_rm_virtualmachine:
+    resource_group: myResourceGroup
+    name: testvm001
+    vm_size: Standard_DS1_v2
+    admin_username: adminUser
+    admin_password: password01
+    image: customimage001

--- a/assets/queries/ansible/azure/vm_not_attached_to_network/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/vm_not_attached_to_network/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "VM Not Attached To Network",
+		"severity": "HIGH",
+		"line": 5
+	}
+]


### PR DESCRIPTION
Closes #1362 

This query detects if no Network Security Group is attached to a Virtual Machine