### PR TITLE
Add ad_admin_not_configured_for_sql_server query for Ansible #1371

### DIFF
--- a/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/metadata.json
+++ b/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ad_admin_not_configured_for_sql_server",
+  "queryName": "AD Admin Not Configured For SQL Server",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "The Active Directory Administrator is not configured for a SQL server",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_sqlserver_module.html#parameter-ad_user"
+}

--- a/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/query.rego
+++ b/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/query.rego
@@ -1,0 +1,24 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]["azure_rm_sqlserver"]
+
+  object.get(task, "ad_user", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{azure_rm_sqlserver}}", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'ad_user' is defined",
+                "keyActualValue": 	"'ad_user' is undefined"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}

--- a/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/test/negative.yaml
+++ b/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/test/negative.yaml
@@ -1,0 +1,9 @@
+---
+- name: Create (or update) SQL Server
+  azure_rm_sqlserver:
+    resource_group: myResourceGroup
+    name: server_name
+    location: westus
+    admin_username: mylogin
+    admin_password: Testpasswordxyz12!
+    ad_user: sqladmin

--- a/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/test/positive.yaml
+++ b/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/test/positive.yaml
@@ -1,0 +1,8 @@
+---
+- name: Create (or update) SQL Server
+  azure_rm_sqlserver:
+    resource_group: myResourceGroup
+    name: server_name
+    location: westus
+    admin_username: mylogin
+    admin_password: Testpasswordxyz12!

--- a/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "AD Admin Not Configured For SQL Server",
+		"severity": "HIGH",
+		"line": 5
+	}
+]


### PR DESCRIPTION
Closes #1371 

This query checks if there is an SQL Server without an AD Admin configured.