### PR TITLE
Add unknown_port_exposed_to_internet Closes #1214

### DIFF
--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/metadata.json
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "unknown_port_exposed_to_internet",
+  "queryName": "Unknown Port Exposed To Internet",
+  "severity": "HIGH",
+  "category": "Network Ports Security",
+  "descriptionText": "AWS Security Group should not have an unknown port exposed to the entire Internet",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_group_module.html"
+}

--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/query.rego
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/query.rego
@@ -1,0 +1,86 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+    
+    currentPort:= task["amazon.aws.ec2_group"].rules[index].from_port
+    
+    cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+    
+    not portIsKnown(currentPort)
+    isEntireNetwork(cidr)
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
+        "issueType":         "IncorrectValue",
+        "keyExpectedValue":  sprintf("amazon.aws.ec2_group.rules[%d].from_port is known", [index]),
+        "keyActualValue": 	 sprintf("amazon.aws.ec2_group.rules[%d].from_port is unknown and is exposed to the entire Internet", [index])
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+    
+    currentPort:= task["amazon.aws.ec2_group"].rules[index].from_port
+    
+    cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ipv6
+    
+    not portIsKnown(currentPort)
+    isEntireNetwork(cidr)
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
+        "issueType":         "IncorrectValue",
+        "keyExpectedValue":  sprintf("amazon.aws.ec2_group.rules[%d].from_port is known", [index]),
+        "keyActualValue": 	 sprintf("amazon.aws.ec2_group.rules[%d].from_port is unknown and is exposed to the entire Internet", [index])
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}
+
+portIsKnown(port) = allow  {
+
+    knownPorts := [0, 20, 21, 22, 23, 25, 53, 57, 80, 88, 110, 119, 123, 135, 143, 137, 138, 139,
+                 161, 162, 163, 164, 194, 318, 443, 514, 563, 636, 989, 990, 1433, 1434,
+                 2382, 2383, 2484, 3000, 3020, 3306, 3389, 4505, 4506, 5060, 5353, 5432,
+                 5500, 5900, 7001, 8000, 8080, 8140, 9000, 9200, 9300, 11214, 11215, 27017,
+                 27018, 61621]
+    
+    count({x | knownPorts[x]; knownPorts[x] == port}) != 0
+
+    allow = true
+}
+
+
+isEntireNetwork(cidr) = allow {
+   
+    isArray := is_array(cidr)
+    
+    cidrs = {"0.0.0.0/0", "::/0"}
+    
+    count({x | cidr[x]; cidr[x] == cidrs[j]}) != 0
+
+    allow = true
+}
+
+isEntireNetwork(cidr) = allow {
+   
+    isString := is_string(cidr)
+
+    cidrs = {"0.0.0.0/0", "::/0"}
+    cidr == cidrs[j]
+
+    allow = true
+}

--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/test/negative.yaml
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/test/negative.yaml
@@ -1,0 +1,15 @@
+- name: example ec2 group
+  amazon.aws.ec2_group:
+    name: example
+    description: an example EC2 group
+    vpc_id: 12345
+    region: eu-west-1
+    rules:
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: 10.0.0.0/8

--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/test/positive.yaml
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/test/positive.yaml
@@ -1,0 +1,15 @@
+- name: example ec2 group
+  amazon.aws.ec2_group:
+    name: example
+    description: an example EC2 group
+    vpc_id: 12345
+    region: eu-west-1
+    rules:
+      - proto: tcp
+        from_port: 800000000000
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 222222
+        to_port: 22
+        cidr_ipv6: ::/0

--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Unknown Port Exposed To Internet",
+		"severity": "HIGH",
+		"line": 7
+	},
+	{
+		"queryName": "Unknown Port Exposed To Internet",
+		"severity": "HIGH",
+		"line": 7
+	}
+]


### PR DESCRIPTION
For this query, I verified if the attribute 'from_port' of 'rules' is an unknown port and if is exposed to the entire Internet ("0.0.0.0/0" or "::/0")

I did not indicate from_port in searchKey because for some reason (which I did not understand) the tests failed

(P.S. I did not find the module community to satisfy this query)

Closes #1214