### PR TITLE
Add query to check if redis cache firewall rule allows too many hosts. Closes #1394

### DIFF
--- a/assets/queries/ansible/azure/redis_firewall_allows_too_many_users/metadata.json
+++ b/assets/queries/ansible/azure/redis_firewall_allows_too_many_users/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Firewall_Rule_Allows_Too_Many_Hosts_To_Access_Redis_Cache",
+  "queryName": "Firewall Rule Allows Too Many Hosts To Access Redis Cache",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Check if any firewall rule allows too many hosts to access Redis Cache.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_rediscachefirewallrule_module.html"
+}

--- a/assets/queries/ansible/azure/redis_firewall_allows_too_many_users/query.rego
+++ b/assets/queries/ansible/azure/redis_firewall_allows_too_many_users/query.rego
@@ -1,0 +1,35 @@
+package Cx
+
+CxPolicy [result] {
+  playbooks := getTasks(input.document[i])
+  redis_cache := playbooks[j]
+  instance := redis_cache["azure_rm_rediscachefirewallrule"]
+  occupied_hosts := getHosts(instance.start_ip_address)
+  all_hosts := getHosts(instance.end_ip_address)
+  available := abs(all_hosts-occupied_hosts)
+
+  available > 255
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address", [playbooks[j].name]),
+                "issueType":		"IncorrectValue", 
+                "keyExpectedValue": sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address and end_ip_address allows up to 255 hosts", [playbooks[j].name]),
+                "keyActualValue": 	sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address and end_ip_address allow %s", [playbooks[j].name,available])
+              }
+}
+
+getHosts(ip) = nhosts {
+  nums := split(ip,".")
+  # ip = x.y.z.w
+  # hosts = x * 2^24 + y * 2^16 + z * 2^8 + w 
+  # 2^24 = 16777216  2^16 = 65536  2^8 = 256
+  nhosts := (to_number(nums[0]) * 16777216) + (to_number(nums[1]) * 65536) + (to_number(nums[2]) * 256) + to_number(nums[3])
+} 
+
+getTasks(document) = result {
+  result := document.playbooks[0].tasks
+} else = result {
+  object.get(document.playbooks[0],"tasks","undefined") == "undefined"
+  result := document.playbooks
+}

--- a/assets/queries/ansible/azure/redis_firewall_allows_too_many_users/test/negative.yaml
+++ b/assets/queries/ansible/azure/redis_firewall_allows_too_many_users/test/negative.yaml
@@ -1,0 +1,7 @@
+- name: reduced_hosts
+  azure_rm_rediscachefirewallrule:
+      resource_group: myResourceGroup
+      cache_name: myRedisCache
+      name: myRule
+      start_ip_address: 192.168.1.1
+      end_ip_address: 192.168.1.4

--- a/assets/queries/ansible/azure/redis_firewall_allows_too_many_users/test/positive.yaml
+++ b/assets/queries/ansible/azure/redis_firewall_allows_too_many_users/test/positive.yaml
@@ -1,0 +1,7 @@
+- name: too_many_hosts
+  azure_rm_rediscachefirewallrule:
+      resource_group: myResourceGroup
+      cache_name: myRedisCache
+      name: myRule
+      start_ip_address: 192.168.1.1
+      end_ip_address: 192.169.1.4

--- a/assets/queries/ansible/azure/redis_firewall_allows_too_many_users/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/redis_firewall_allows_too_many_users/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Firewall Rule Allows Too Many Hosts To Access Redis Cache",
+		"severity": "MEDIUM",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Check firewall rules for Redis Cache if more than 255 hosts are allowed by it. Closes #1394 