### PR TITLE
Add VM CSEK Encryption is Disabled query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "VM_CSEK_Encryption_Disabled",
+  "queryName": "VM CSEK Encryption is Disabled",
+  "severity": "MEDIUM",
+  "category": "Encryption & Key Management",
+  "descriptionText": "VM disks for critical VMs must be encrypted with Customer Supplied Encryption Keys (CSEK), which means the attribute 'disk_encryption_key' must be defined and its sub attribute 'raw_key' must also be defined and not empty",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_disk_module.html"
+}

--- a/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/query.rego
@@ -1,0 +1,71 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  disk := task["google.cloud.gcp_compute_disk"]
+  diskName := task.name
+  
+  object.get(disk, "disk_encryption_key", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_disk}}", [diskName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_compute_disk.disk_encryption_key is defined",
+                "keyActualValue":   "google.cloud.gcp_compute_disk.disk_encryption_key is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  disk := task["google.cloud.gcp_compute_disk"]
+  diskName := task.name
+  
+  object.get(disk.disk_encryption_key, "raw_key", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_disk}}.disk_encryption_key", [diskName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_compute_disk.disk_encryption_key.raw_key is defined",
+                "keyActualValue":   "google.cloud.gcp_compute_disk.disk_encryption_key.raw_key is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  disk := task["google.cloud.gcp_compute_disk"]
+  diskName := task.name
+  
+  check(disk.disk_encryption_key.raw_key)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_disk}}.disk_encryption_key.raw_key", [diskName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_compute_disk.disk_encryption_key.raw_key is not empty or null",
+                "keyActualValue":   "google.cloud.gcp_compute_disk.disk_encryption_key.raw_key is empty or null"
+              }
+}
+
+check(key){
+  key == null
+}
+
+check(key){
+  count(key) == 0
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/test/negative.yaml
@@ -1,0 +1,12 @@
+#this code is a correct code for which the query should not find any result
+- name: create a disk
+  google.cloud.gcp_compute_disk:
+    name: test_object
+    size_gb: 50
+    disk_encryption_key:
+      raw_key: SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/test/positive.yaml
@@ -1,0 +1,43 @@
+#this is a problematic code where the query should report a result(s)
+- name: create a disk1
+  google.cloud.gcp_compute_disk:
+    name: test_object1
+    size_gb: 50
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a disk2
+  google.cloud.gcp_compute_disk:
+    name: test_object2
+    size_gb: 50
+    disk_encryption_key:
+      kms_key_name: string
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a disk3
+  google.cloud.gcp_compute_disk:
+    name: test_object3
+    size_gb: 50
+    disk_encryption_key:
+      raw_key:
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create a disk4
+  google.cloud.gcp_compute_disk:
+    name: test_object4
+    size_gb: 50
+    disk_encryption_key:
+      raw_key: ""
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "VM CSEK Encryption is Disabled",
+		"severity": "MEDIUM",
+		"line": 3
+	},
+	{
+		"queryName": "VM CSEK Encryption is Disabled",
+		"severity": "MEDIUM",
+		"line": 15
+	},
+	{
+		"queryName": "VM CSEK Encryption is Disabled",
+		"severity": "MEDIUM",
+		"line": 27
+	},
+	{
+		"queryName": "VM CSEK Encryption is Disabled",
+		"severity": "MEDIUM",
+		"line": 38
+	}
+]


### PR DESCRIPTION
Adding VM CSEK Encryption is Disabled query for Ansible, that checks if the attribute 'disk_encryption_key' is defined and its sub attribute 'raw_key' is also defined and not empty.

Closes #1455