### PR TITLE
Add Security Group is Not Configured query for Ansible

### DIFF
--- a/assets/queries/ansible/azure/security_group_is_not_configured/metadata.json
+++ b/assets/queries/ansible/azure/security_group_is_not_configured/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Security_Group_Not_Configured",
+  "queryName": "Security Group is Not Configured",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Azure Virtual Network subnet must be configured with a Network Security Group, which means the attribute 'security_group' must be defined and not empty",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_subnet_module.html"
+}

--- a/assets/queries/ansible/azure/security_group_is_not_configured/query.rego
+++ b/assets/queries/ansible/azure/security_group_is_not_configured/query.rego
@@ -1,0 +1,72 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  subnet := task["azure_rm_subnet"]
+  subnetName := task.name
+
+  object.get(subnet, "security_group", "undefined") == "undefined"
+  object.get(subnet, "security_group_name", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_rm_subnet}}", [subnetName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "azure_rm_subnet.security_group is defined",
+                "keyActualValue":   "azure_rm_subnet.security_group is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  subnet := task["azure_rm_subnet"]
+  subnetName := task.name
+  
+  checkString(subnet.security_group)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_rm_subnet}}.security_group", [subnetName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "azure_rm_subnet.security_group is not empty or null",
+                "keyActualValue":   "azure_rm_subnet.security_group is empty or null"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  subnet := task["azure_rm_subnet"]
+  subnetName := task.name
+  
+  checkString(subnet.security_group_name)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_rm_subnet}}.security_group_name", [subnetName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "azure_rm_subnet.security_group_name is not empty or null",
+                "keyActualValue":   "azure_rm_subnet.security_group_name is empty or null"
+              }
+}
+
+checkString(string){
+  string == null
+}
+
+checkString(string){
+  count(string) == 0
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/azure/security_group_is_not_configured/test/negative.yaml
+++ b/assets/queries/ansible/azure/security_group_is_not_configured/test/negative.yaml
@@ -1,0 +1,8 @@
+#this code is a correct code for which the query should not find any result
+- name: Create a subnet
+  azure_rm_subnet:
+    resource_group: myResourceGroup
+    virtual_network_name: myVirtualNetwork
+    name: mySubnet
+    address_prefix_cidr: "10.1.0.0/24"
+    security_group: mySecurityGroup

--- a/assets/queries/ansible/azure/security_group_is_not_configured/test/positive.yaml
+++ b/assets/queries/ansible/azure/security_group_is_not_configured/test/positive.yaml
@@ -1,0 +1,35 @@
+#this is a problematic code where the query should report a result(s)
+- name: Create a subnet1
+  azure_rm_subnet:
+    resource_group: myResourceGroup1
+    virtual_network_name: myVirtualNetwork1
+    name: mySubnet1
+    address_prefix_cidr: "10.1.0.0/24"
+- name: Create a subnet2
+  azure_rm_subnet:
+    resource_group: myResourceGroup2
+    virtual_network_name: myVirtualNetwork2
+    name: mySubnet2
+    address_prefix_cidr: "10.1.0.0/24"
+    security_group: 
+- name: Create a subnet3
+  azure_rm_subnet:
+    resource_group: myResourceGroup3
+    virtual_network_name: myVirtualNetwork3
+    name: mySubnet3
+    address_prefix_cidr: "10.1.0.0/24"
+    security_group_name: 
+- name: Create a subnet4
+  azure_rm_subnet:
+    resource_group: myResourceGroup4
+    virtual_network_name: myVirtualNetwork4
+    name: mySubnet4
+    address_prefix_cidr: "10.1.0.0/24"
+    security_group: ""
+- name: Create a subnet5
+  azure_rm_subnet:
+    resource_group: myResourceGroup5
+    virtual_network_name: myVirtualNetwork5
+    name: mySubnet5
+    address_prefix_cidr: "10.1.0.0/24"
+    security_group_name: ""

--- a/assets/queries/ansible/azure/security_group_is_not_configured/test/positive.yaml
+++ b/assets/queries/ansible/azure/security_group_is_not_configured/test/positive.yaml
@@ -11,14 +11,14 @@
     virtual_network_name: myVirtualNetwork2
     name: mySubnet2
     address_prefix_cidr: "10.1.0.0/24"
-    security_group: 
+    security_group:
 - name: Create a subnet3
   azure_rm_subnet:
     resource_group: myResourceGroup3
     virtual_network_name: myVirtualNetwork3
     name: mySubnet3
     address_prefix_cidr: "10.1.0.0/24"
-    security_group_name: 
+    security_group_name:
 - name: Create a subnet4
   azure_rm_subnet:
     resource_group: myResourceGroup4

--- a/assets/queries/ansible/azure/security_group_is_not_configured/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/security_group_is_not_configured/test/positive_expected_result.json
@@ -1,0 +1,27 @@
+[
+	{
+		"queryName": "Security Group is Not Configured",
+		"severity": "MEDIUM",
+		"line": 3
+	},
+	{
+		"queryName": "Security Group is Not Configured",
+		"severity": "MEDIUM",
+		"line": 14
+	},
+	{
+		"queryName": "Security Group is Not Configured",
+		"severity": "MEDIUM",
+		"line": 21
+	},
+	{
+		"queryName": "Security Group is Not Configured",
+		"severity": "MEDIUM",
+		"line": 28
+	},
+	{
+		"queryName": "Security Group is Not Configured",
+		"severity": "MEDIUM",
+		"line": 35
+	}
+]


### PR DESCRIPTION
Adding Security Group is Not Configured query for Ansible, that checks if the attribute 'security_group' is defined and not empty.

Closes #1462