### PR TITLE
Add Default Network Access is Allowed query for Ansible

### DIFF
--- a/assets/queries/ansible/azure/default_network_access_allowed/metadata.json
+++ b/assets/queries/ansible/azure/default_network_access_allowed/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Default_Network_Access_Allowed",
+  "queryName": "Default Network Access is Allowed",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Default Network Access rule for Storage Accounts must be set to deny, which means the attribute 'default_action' must be 'Deny'",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_storageaccount_module.html"
+}

--- a/assets/queries/ansible/azure/default_network_access_allowed/query.rego
+++ b/assets/queries/ansible/azure/default_network_access_allowed/query.rego
@@ -1,0 +1,30 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  storageAccount := task["azure_rm_storageaccount"]
+  storageAccountName := task.name
+  
+  default_action := storageAccount.network_acls.default_action
+
+  is_string(default_action)
+  lower(default_action) == "allow"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_rm_storageaccount}}.network_acls.default_action", [storageAccountName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "azure_rm_storageaccount.network_acls.default_action is 'Deny'",
+                "keyActualValue":   "azure_rm_storageaccount.network_acls.default_action is 'Allow'"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/azure/default_network_access_allowed/test/negative.yaml
+++ b/assets/queries/ansible/azure/default_network_access_allowed/test/negative.yaml
@@ -1,0 +1,17 @@
+#this code is a correct code for which the query should not find any result
+- name: configure firewall and virtual networks
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0002
+    type: Standard_RAGRS
+    network_acls:
+      bypass: AzureServices,Metrics
+      default_action: Deny
+      virtual_network_rules:
+        - id: /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet
+          action: Allow
+      ip_rules:
+        - value: 1.2.3.4
+          action: Allow
+        - value: 123.234.123.0/24
+          action: Allow

--- a/assets/queries/ansible/azure/default_network_access_allowed/test/positive.yaml
+++ b/assets/queries/ansible/azure/default_network_access_allowed/test/positive.yaml
@@ -1,0 +1,17 @@
+#this is a problematic code where the query should report a result(s)
+- name: configure firewall and virtual networks
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0002
+    type: Standard_RAGRS
+    network_acls:
+      bypass: AzureServices,Metrics
+      default_action: Allow
+      virtual_network_rules:
+        - id: /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet
+          action: Allow
+      ip_rules:
+        - value: 1.2.3.4
+          action: Allow
+        - value: 123.234.123.0/24
+          action: Allow

--- a/assets/queries/ansible/azure/default_network_access_allowed/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/default_network_access_allowed/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Default Network Access is Allowed",
+		"severity": "MEDIUM",
+		"line": 9
+	}
+]


### PR DESCRIPTION
Adding Default Network Access is Allowed query for Ansible, that checks if the attribute 'default_action' is 'Deny'.

Closes #1467