### PR TITLE
Add SQL Server Predictable Admin Account Name query for Ansible

### DIFF
--- a/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/metadata.json
+++ b/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "SQL_Server_Predictable_Admin_Account_Name",
+  "queryName": "SQL Server Predictable Admin Account Name",
+  "severity": "MEDIUM",
+  "category": "Identity & Access Management",
+  "descriptionText": "Azure SQL Server's Admin account login must avoid using names like 'Admin', that are too predictable, which means the attribute 'admin_username' must be set to a name that is not easy to predict",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_sqlserver_module.html"
+}

--- a/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/query.rego
+++ b/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/query.rego
@@ -1,0 +1,61 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  server := task["azure_rm_sqlserver"]
+  serverName := task.name
+  
+  checkSize(server.admin_username)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_rm_sqlserver}}.admin_username", [serverName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "azure_rm_sqlserver.admin_username is not empty",
+                "keyActualValue":   "azure_rm_sqlserver.admin_username is empty"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  server := task["azure_rm_sqlserver"]
+  serverName := task.name
+  
+  is_string(server.admin_username)
+  check_predictable(server.admin_username)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_rm_sqlserver}}.admin_username", [serverName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "azure_rm_sqlserver.admin_username is not predictable",
+                "keyActualValue":   "azure_rm_sqlserver.admin_username is predictable"
+              }
+}
+
+checkSize(username){
+  is_string(username)
+  count(username) == 0
+}
+
+checkSize(username){
+  username == null
+}
+
+check_predictable(username){
+  predictable_names := {"admin", "administrator", "root", "user", "azure_admin", "azure_administrator", "guest"}
+	some i
+    	lower(username) == predictable_names[i]
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/test/negative.yaml
+++ b/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/test/negative.yaml
@@ -1,0 +1,8 @@
+#this code is a correct code for which the query should not find any result
+- name: Create (or update) SQL Server
+  azure_rm_sqlserver:
+    resource_group: myResourceGroup
+    name: server_name
+    location: westus
+    admin_username: mylogin
+    admin_password: Testpasswordxyz12!

--- a/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/test/positive.yaml
+++ b/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/test/positive.yaml
@@ -1,0 +1,22 @@
+#this is a problematic code where the query should report a result(s)
+- name: Create (or update) SQL Server1
+  azure_rm_sqlserver:
+    resource_group: myResourceGroup
+    name: server_name1
+    location: westus
+    admin_username: ""
+    admin_password: Testpasswordxyz12!
+- name: Create (or update) SQL Server2
+  azure_rm_sqlserver:
+    resource_group: myResourceGroup
+    name: server_name2
+    location: westus
+    admin_username:
+    admin_password: Testpasswordxyz12!
+- name: Create (or update) SQL Server3
+  azure_rm_sqlserver:
+    resource_group: myResourceGroup
+    name: server_name3
+    location: westus
+    admin_username: admin
+    admin_password: Testpasswordxyz12!

--- a/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "SQL Server Predictable Admin Account Name",
+		"severity": "MEDIUM",
+		"line": 7
+	},
+	{
+		"queryName": "SQL Server Predictable Admin Account Name",
+		"severity": "MEDIUM",
+		"line": 14
+	},
+	{
+		"queryName": "SQL Server Predictable Admin Account Name",
+		"severity": "MEDIUM",
+		"line": 21
+	}
+]


### PR DESCRIPTION
Adding SQL Server Predictable Admin Account Name query for Ansible, that checks if the attribute 'admin_username' is set to a name that is easy to predict.

Closes #1473