### PR TITLE
 Add no_password_policy_enabled query Closes #1472

### DIFF
--- a/assets/queries/ansible/aws/no_password_policy_enabled/metadata.json
+++ b/assets/queries/ansible/aws/no_password_policy_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "no_password_policy_enabled",
+  "queryName": "No Password Policy Enabled",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "IAM password policies should be set",
+  "descriptionUrl": "https://docs.ansible.com/ansible/2.9_ja/modules/iam_password_policy_module.html"
+} 

--- a/assets/queries/ansible/aws/no_password_policy_enabled/query.rego
+++ b/assets/queries/ansible/aws/no_password_policy_enabled/query.rego
@@ -6,9 +6,8 @@ CxPolicy[result] {
     tasks := getTasks(document)
     task := tasks[t]
 
-    modules := {"community.aws.iam_password_policy", "iam_password_policy"}
-    
-    count({index | object.get(task, modules[index], "undefined") == "undefined"}) == 2
+    object.get(task, "community.aws.iam_password_policy", "undefined") == "undefined"
+    object.get(task, "iam_password_policy", "undefined") == "undefined"
 
 
     result := {

--- a/assets/queries/ansible/aws/no_password_policy_enabled/query.rego
+++ b/assets/queries/ansible/aws/no_password_policy_enabled/query.rego
@@ -1,0 +1,80 @@
+package Cx
+
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+    modules := {"community.aws.iam_password_policy", "iam_password_policy"}
+    
+    count({index | object.get(task, modules[index], "undefined") == "undefined"}) == 2
+
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s", [task.name]),
+        "issueType":         "MissingAttribute",
+        "keyExpectedValue":  "community.aws.iam_password_policy or iam_password_policy is set",
+        "keyActualValue": 	 "community.aws.iam_password_policy or iam_password_policy is not set",
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+    modules := {"community.aws.iam_password_policy", "iam_password_policy"}
+    
+    attributes := {"require_lowercase", "require_numbers", "require_symbols", "require_uppercase"}
+
+    object.get(task[modules[index]], attributes[j], "undefined") == "undefined"
+
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
+        "issueType":         "MissingAttribute",
+        "keyExpectedValue":  sprintf("%s.%s is set", [modules[index], attributes[j]]),
+        "keyActualValue": 	 sprintf("%s.%s is undefined", [modules[index], attributes[j]])
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+    modules := {"community.aws.iam_password_policy", "iam_password_policy"}
+    
+    attributes := {"require_lowercase", "require_numbers", "require_symbols", "require_uppercase"}
+
+    attribute := object.get(task[modules[index]], attributes[j], "undefined")
+    attribute != "undefined"
+    
+    not isTrueOrYes(attribute)
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s.{{%s}}.%s", [task.name, modules[index], attributes[j]]),
+        "issueType":         "IncorrectValue",
+        "keyExpectedValue":  sprintf("%s.%s is set to true or yes", [modules[index], attributes[j]]),
+        "keyActualValue": 	 sprintf("%s.%s is not set to true or yes", [modules[index], attributes[j]])
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}
+
+isTrueOrYes(attribute) = allow {
+    possibilities := {"yes", true}
+    attribute == possibilities[j]
+    
+	allow = true
+}

--- a/assets/queries/ansible/aws/no_password_policy_enabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/no_password_policy_enabled/test/negative.yaml
@@ -1,0 +1,24 @@
+- name: Password policy for AWS account v3
+  community.aws.iam_password_policy:
+    state: present
+    min_pw_length: 14
+    require_symbols: true
+    require_numbers: true
+    require_uppercase: true
+    require_lowercase: true
+    allow_pw_change: true
+    pw_max_age: 60
+    pw_reuse_prevent: 5
+    pw_expire: true
+- name: Password policy for AWS account v4
+  iam_password_policy:
+    state: present
+    min_pw_length: 14
+    require_symbols: true
+    require_numbers: true
+    require_uppercase: true
+    require_lowercase: true
+    allow_pw_change: true
+    pw_max_age: 60
+    pw_reuse_prevent: 5
+    pw_expire: true

--- a/assets/queries/ansible/aws/no_password_policy_enabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/no_password_policy_enabled/test/positive.yaml
@@ -1,0 +1,23 @@
+- name: Password policy for AWS account
+  community.aws.iam_password_policy:
+    state: present
+    min_pw_length: 8
+    require_numbers: true
+    require_uppercase: true
+    require_lowercase: true
+    allow_pw_change: true
+    pw_max_age: 60
+    pw_reuse_prevent: 5
+    pw_expire: false
+- name: Password policy for AWS account v2
+  community.aws.iam_password_policy:
+    state: present
+    min_pw_length: 8
+    require_symbols: false
+    require_numbers: true
+    require_uppercase: true
+    require_lowercase: true
+    allow_pw_change: true
+    pw_max_age: 60
+    pw_reuse_prevent: 5
+    pw_expire: false

--- a/assets/queries/ansible/aws/no_password_policy_enabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/no_password_policy_enabled/test/positive_expected_result.json
@@ -1,0 +1,13 @@
+[
+	{
+		"queryName": "No Password Policy Enabled",
+		"severity": "HIGH",
+		"line": 2
+	},
+
+	{
+		"queryName": "No Password Policy Enabled",
+		"severity": "HIGH",
+		"line": 16
+	}
+]


### PR DESCRIPTION
For this query, it is necessary to check if module 'community.aws.iam_password_policy' or 'iam_password_policy' is set. So, if both are not set, no password policy is enabled.

I added other attributes verification like 'require_lowercase', 'require_numbers',' require_symbols ", and 'require_uppercase' because there is no query for that check, as far as I see

Closes #1472