### PR TITLE
Add Google Compute SSL Policy Weak Cipher Suits is Enabled query for Ansible #1453

### DIFF
--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/metadata.json
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "google_compute_ssl_policy",
+  "queryName": "Google Compute SSL Policy Weak Cipher Suits is Enabled",
+  "severity": "MEDIUM",
+  "category": "Encryption & Key Management",
+  "descriptionText": "This query confirms if Google Compute SSL Policy Weak Chyper Suits is Enabled, to do so we need to check if TLS is TLS_1_2, because other version have Weak Chypers",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_ssl_policy_module.html"
+} 

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/query.rego
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/query.rego
@@ -1,0 +1,45 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  policy := task["google.cloud.gcp_compute_ssl_policy"]
+  policyName := task.name
+
+  object.get(policy, "min_tls_version", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_ssl_policy}}", [policyName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_compute_ssl_policy should have a min_tls_version 'TLS_1_2'",
+                "keyActualValue":   "google.cloud.gcp_compute_ssl_policy does not have min_tls_version 'TLS_1_2'"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  policy := task["google.cloud.gcp_compute_ssl_policy"]
+  policyName := task.name
+  policy.min_tls_version != "TLS_1_2"
+  
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_ssl_policy}}.min_tls_version", [policyName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_compute_ssl_policy.min_tls_version should have min_tls_version 'TLS_1_2'",
+                "keyActualValue":   "google.cloud.gcp_compute_ssl_policy.min_tls_version does not have min_tls_version 'TLS_1_2'"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/test/negative.yaml
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/test/negative.yaml
@@ -1,4 +1,3 @@
----
 - name: create a SSL policy
   google.cloud.gcp_compute_ssl_policy:
     name: test_object

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/test/negative.yaml
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/test/negative.yaml
@@ -1,0 +1,14 @@
+---
+- name: create a SSL policy
+  google.cloud.gcp_compute_ssl_policy:
+    name: test_object
+    profile: CUSTOM
+    min_tls_version: TLS_1_2
+    custom_features:
+    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive.yaml
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive.yaml
@@ -10,8 +10,6 @@
     service_account_file: "/tmp/auth.pem"
     state: present
 
----
-
 - name: create a SSL policy2
   google.cloud.gcp_compute_ssl_policy:
     name: test_object2

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive.yaml
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive.yaml
@@ -1,0 +1,26 @@
+- name: create a SSL policy
+  google.cloud.gcp_compute_ssl_policy:
+    name: test_object
+    profile: CUSTOM
+    min_tls_version: TLS_1_1
+    custom_features:
+    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+
+---
+
+- name: create a SSL policy2
+  google.cloud.gcp_compute_ssl_policy:
+    name: test_object
+    profile: CUSTOM
+    custom_features:
+    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive.yaml
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive.yaml
@@ -2,7 +2,6 @@
   google.cloud.gcp_compute_ssl_policy:
     name: test_object
     profile: CUSTOM
-    min_tls_version: TLS_1_1
     custom_features:
     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
     - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -15,8 +14,9 @@
 
 - name: create a SSL policy2
   google.cloud.gcp_compute_ssl_policy:
-    name: test_object
+    name: test_object2
     profile: CUSTOM
+    min_tls_version: TLS_1_1
     custom_features:
     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
     - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
@@ -24,3 +24,4 @@
     auth_kind: serviceaccount
     service_account_file: "/tmp/auth.pem"
     state: present
+

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive_expected_result.json
@@ -2,11 +2,16 @@
 	{
 		"queryName": "Google Compute SSL Policy Weak Cipher Suits is Enabled",
 		"severity": "MEDIUM",
-		"line": 5
+		"line": 2
 	},
 	{
 		"queryName": "Google Compute SSL Policy Weak Cipher Suits is Enabled",
 		"severity": "MEDIUM",
-		"line": 17
+		"line": 2
+	},
+	{
+		"queryName": "Google Compute SSL Policy Weak Cipher Suits is Enabled",
+		"severity": "MEDIUM",
+		"line": 19
 	}
 ]

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive_expected_result.json
@@ -7,11 +7,6 @@
 	{
 		"queryName": "Google Compute SSL Policy Weak Cipher Suits is Enabled",
 		"severity": "MEDIUM",
-		"line": 2
-	},
-	{
-		"queryName": "Google Compute SSL Policy Weak Cipher Suits is Enabled",
-		"severity": "MEDIUM",
 		"line": 19
 	}
 ]

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive_expected_result.json
@@ -7,6 +7,6 @@
 	{
 		"queryName": "Google Compute SSL Policy Weak Cipher Suits is Enabled",
 		"severity": "MEDIUM",
-		"line": 19
+		"line": 17
 	}
 ]

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Google Compute SSL Policy Weak Cipher Suits is Enabled",
+		"severity": "MEDIUM",
+		"line": 5
+	},
+	{
+		"queryName": "Google Compute SSL Policy Weak Cipher Suits is Enabled",
+		"severity": "MEDIUM",
+		"line": 17
+	}
+]


### PR DESCRIPTION
This query confirms if Google Compute SSL Policy Weak Chyper Suits is Enabled, to do so we need to check if TLS is TLS_1_2, because other version have Weak Chypers #1453 