### PR TITLE
Add SQL Server Accessibility Is Not Minimal query for Ansible

### DIFF
--- a/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/metadata.json
+++ b/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "SQL_Server_Accessibility_Not_Minimal",
+  "queryName": "SQL Server Accessibility is Not Minimal",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Azure SQL Server Accessibility must be set to a minimal address range, which means the difference between the values of the 'end_ip_address' and 'start_ip_address' must be lesser than 256. Additionally, both ips must be different from '0.0.0.0'",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_sqlfirewallrule_module.html"
+}

--- a/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/query.rego
+++ b/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/query.rego
@@ -1,0 +1,57 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  rule := task["azure_rm_sqlfirewallrule"]
+  ruleName := task.name
+
+  rule.start_ip_address == "0.0.0.0"
+  rule.end_ip_address == "0.0.0.0"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_rm_sqlfirewallrule}}", [ruleName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "azure_rm_sqlfirewallrule.start_ip_address is different from '0.0.0.0' and azure_rm_sqlfirewallrule.end_ip_address is different from '0.0.0.0'",
+                "keyActualValue":   "azure_rm_sqlfirewallrule.start_ip_address is '0.0.0.0' and azure_rm_sqlfirewallrule.end_ip_address is '0.0.0.0'"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  rule := task["azure_rm_sqlfirewallrule"]
+  ruleName := task.name
+  startIP_value := calcValue(rule.start_ip_address)
+  endIP_value := calcValue(rule.end_ip_address)
+  
+  abs(endIP_value - startIP_value) >= 256
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_rm_sqlfirewallrule}}", [ruleName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "The difference between the value of 'azure_rm_sqlfirewallrule.end_ip_address' and 'azure_rm_sqlfirewallrule.start_ip_address' is lesser than 256",
+                "keyActualValue":   "The difference between the value of 'azure_rm_sqlfirewallrule.end_ip_address' and 'azure_rm_sqlfirewallrule.start_ip_address' is greater than or equal to 256"
+              }
+}
+
+calcValue (val) = result {
+	ips := split(val, ".")
+
+    #calculate the value of an ip
+    #a.b.c.d
+    #a*16777216 + b*65536 + c*256 + d
+    result = (to_number(ips[0]) * 16777216) + (to_number(ips[1]) * 65536) + (to_number(ips[2]) * 256) + to_number(ips[3])
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/test/negative.yaml
+++ b/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/test/negative.yaml
@@ -1,0 +1,8 @@
+#this code is a correct code for which the query should not find any result
+- name: Create (or update) Firewall Rule
+  azure_rm_sqlfirewallrule:
+    resource_group: myResourceGroup
+    server_name: firewallrulecrudtest-6285
+    name: firewallrulecrudtest-5370
+    start_ip_address: 172.28.10.136
+    end_ip_address: 172.28.10.138

--- a/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/test/positive.yaml
+++ b/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/test/positive.yaml
@@ -1,0 +1,15 @@
+#this is a problematic code where the query should report a result(s)
+- name: Create (or update) Firewall Rule1
+  azure_rm_sqlfirewallrule:
+    resource_group: myResourceGroup1
+    server_name: firewallrulecrudtest-6285
+    name: firewallrulecrudtest-5370
+    start_ip_address: 0.0.0.0
+    end_ip_address: 0.0.0.0
+- name: Create (or update) Firewall Rule2
+  azure_rm_sqlfirewallrule:
+    resource_group: myResourceGroup2
+    server_name: firewallrulecrudtest-6285
+    name: firewallrulecrudtest-5370
+    start_ip_address: 172.28.10.136
+    end_ip_address: 172.28.11.138

--- a/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "SQL Server Accessibility is Not Minimal",
+		"severity": "MEDIUM",
+		"line": 3
+	},
+	{
+		"queryName": "SQL Server Accessibility is Not Minimal",
+		"severity": "MEDIUM",
+		"line": 10
+	}
+]


### PR DESCRIPTION
Adding SQL Server Accessibility Is Not Minimal query for Ansible, that checks if the difference between the values of the 'end_ip_address' and 'start_ip_address' is lesser than 256. Additionally, both ips must be different from '0.0.0.0'.

Closes #1497