### PR TITLE
Add Using Default Service Account query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/using_default_service_account/metadata.json
+++ b/assets/queries/ansible/gcp/using_default_service_account/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Using_Default_Service_Account",
+  "queryName": "Using Default Service Account",
+  "severity": "MEDIUM",
+  "category": "Identity & Access Management",
+  "descriptionText": "Instances must not be configured to use the Default Service Account, that has full access to all Cloud APIs, which means the attribute 'service_account_email' must be defined. Additionally, it must not be empty and must also not be a default Google Compute Engine service account.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_module.html"
+}

--- a/assets/queries/ansible/gcp/using_default_service_account/query.rego
+++ b/assets/queries/ansible/gcp/using_default_service_account/query.rego
@@ -1,0 +1,91 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+  instance.auth_kind == "serviceaccount"
+
+  object.get(instance, "service_account_email", "undefined") == "undefined"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}", [instanceName]),
+                "issueType":        "MissingAttribute",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.service_account_email is defined",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.service_account_email is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+  instance.auth_kind == "serviceaccount"
+  email := instance.service_account_email
+  
+  is_string(email)
+  count(email) == 0
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.service_account_email", [instanceName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.service_account_email is not empty",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.service_account_email is empty"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+  instance.auth_kind == "serviceaccount"
+  email := instance.service_account_email
+
+  is_string(email)
+  count(email) > 0
+  not contains(email, "@")
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.service_account_email", [instanceName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.service_account_email is an email",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.service_account_email is not an email"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_compute_instance"]
+  instanceName := task.name
+  instance.auth_kind == "serviceaccount"
+  email := instance.service_account_email
+
+  contains(email, "@developer.gserviceaccount.com")
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.service_account_email", [instanceName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "google.cloud.gcp_compute_instance.service_account_email is not a default Google Compute Engine service account",
+                "keyActualValue":   "google.cloud.gcp_compute_instance.service_account_email is a default Google Compute Engine service account"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/using_default_service_account/test/negative.yaml
+++ b/assets/queries/ansible/gcp/using_default_service_account/test/negative.yaml
@@ -1,0 +1,30 @@
+#this code is a correct code for which the query should not find any result
+- name: create a instance
+  google.cloud.gcp_compute_instance:
+    name: test_object
+    machine_type: n1-standard-1
+    disks:
+    - auto_delete: 'true'
+      boot: 'true'
+      source: "{{ disk }}"
+    - auto_delete: 'true'
+      interface: NVME
+      type: SCRATCH
+      initialize_params:
+        disk_type: local-ssd
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_email: "admin@admin.com"
+    state: present

--- a/assets/queries/ansible/gcp/using_default_service_account/test/positive.yaml
+++ b/assets/queries/ansible/gcp/using_default_service_account/test/positive.yaml
@@ -1,0 +1,116 @@
+#this is a problematic code where the query should report a result(s)
+- name: create a instance1
+  google.cloud.gcp_compute_instance:
+    name: test_object1
+    machine_type: n1-standard-1
+    disks:
+    - auto_delete: 'true'
+      boot: 'true'
+      source: "{{ disk }}"
+    - auto_delete: 'true'
+      interface: NVME
+      type: SCRATCH
+      initialize_params:
+        disk_type: local-ssd
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    state: present
+- name: create a instance2
+  google.cloud.gcp_compute_instance:
+    name: test_object2
+    machine_type: n1-standard-1
+    disks:
+    - auto_delete: 'true'
+      boot: 'true'
+      source: "{{ disk }}"
+    - auto_delete: 'true'
+      interface: NVME
+      type: SCRATCH
+      initialize_params:
+        disk_type: local-ssd
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_email: ""
+    state: present
+- name: create a instance3
+  google.cloud.gcp_compute_instance:
+    name: test_object3
+    machine_type: n1-standard-1
+    disks:
+    - auto_delete: 'true'
+      boot: 'true'
+      source: "{{ disk }}"
+    - auto_delete: 'true'
+      interface: NVME
+      type: SCRATCH
+      initialize_params:
+        disk_type: local-ssd
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_email: "admin"
+    state: present
+- name: create a instance4
+  google.cloud.gcp_compute_instance:
+    name: test_object4
+    machine_type: n1-standard-1
+    disks:
+    - auto_delete: 'true'
+      boot: 'true'
+      source: "{{ disk }}"
+    - auto_delete: 'true'
+      interface: NVME
+      type: SCRATCH
+      initialize_params:
+        disk_type: local-ssd
+    metadata:
+      startup-script-url: gs:://graphite-playground/bootstrap.sh
+      cost-center: '12345'
+    labels:
+      environment: production
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_email: "admin@developer.gserviceaccount.com"
+    state: present

--- a/assets/queries/ansible/gcp/using_default_service_account/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/using_default_service_account/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "Using Default Service Account",
+		"severity": "MEDIUM",
+		"line": 3
+	},
+	{
+		"queryName": "Using Default Service Account",
+		"severity": "MEDIUM",
+		"line": 57
+	},
+	{
+		"queryName": "Using Default Service Account",
+		"severity": "MEDIUM",
+		"line": 86
+	},
+	{
+		"queryName": "Using Default Service Account",
+		"severity": "MEDIUM",
+		"line": 115
+	}
+]


### PR DESCRIPTION
Adding Using Default Service Account query for Ansible, that checks if the attribute 'service_account_email' is defined. Additionally, it must not be empty and must also not be a default Google Compute Engine service account.

Closes #1508