### PR TITLE
Cloudfront configuration allow http

### DIFF
--- a/assets/queries/ansible/aws/cloudfront_configuration_allow_http/metadata.json
+++ b/assets/queries/ansible/aws/cloudfront_configuration_allow_http/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "Cloudfront_configuration_allow_HTTP",
-  "queryName": "Cloudfront configuration allow HTTP",
+  "queryName": "Cloudfront Configuration Allows HTTP",
   "severity": "HIGH",
-  "category": null,
+  "category": "Network Security",
   "descriptionText": "Cloudfront distribution allows HTTP, it should be https-only or redirect-to-https",
   "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/cloudfront_distribution_module.html"
 }

--- a/assets/queries/ansible/aws/cloudfront_configuration_allow_http/metadata.json
+++ b/assets/queries/ansible/aws/cloudfront_configuration_allow_http/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Cloudfront_configuration_allow_HTTP",
+  "queryName": "Cloudfront configuration allow HTTP",
+  "severity": "HIGH",
+  "category": null,
+  "descriptionText": "Cloudfront distribution allows HTTP, it should be https-only or redirect-to-https",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/cloudfront_distribution_module.html"
+}

--- a/assets/queries/ansible/aws/cloudfront_configuration_allow_http/query.rego
+++ b/assets/queries/ansible/aws/cloudfront_configuration_allow_http/query.rego
@@ -1,0 +1,26 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cloudfrontDistribution := task["community.aws.cloudfront_distribution"]
+
+  cloudfrontDistribution.default_cache_behavior.viewer_protocol_policy = "allow-all"
+
+  result := {
+                "documentId":       document.id,
+                "searchKey":        sprintf("name={{%s}}.{{community.aws.cloudfront_distribution}}.default_cache_behavior.viewer_protocol_policy", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'default_cache_behavior.viewer_protocol_policy' is equal 'https-only'",
+                "keyActualValue": 	"'default_cache_behavior.viewer_protocol_policy' is equal 'allow-all'"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/cloudfront_configuration_allow_http/query.rego
+++ b/assets/queries/ansible/aws/cloudfront_configuration_allow_http/query.rego
@@ -12,7 +12,7 @@ CxPolicy [ result ] {
                 "documentId":       document.id,
                 "searchKey":        sprintf("name={{%s}}.{{community.aws.cloudfront_distribution}}.default_cache_behavior.viewer_protocol_policy", [task.name]),
                 "issueType":		"IncorrectValue",
-                "keyExpectedValue": "'default_cache_behavior.viewer_protocol_policy' is equal 'https-only'",
+                "keyExpectedValue": "'default_cache_behavior.viewer_protocol_policy' is equal to 'https-only' or 'redirect-to-https'",
                 "keyActualValue": 	"'default_cache_behavior.viewer_protocol_policy' is equal 'allow-all'"
               }
 }

--- a/assets/queries/ansible/aws/cloudfront_configuration_allow_http/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudfront_configuration_allow_http/test/negative.yaml
@@ -1,0 +1,36 @@
+- name: create a distribution with an origin, logging and default cache behavior
+  community.aws.cloudfront_distribution:
+    state: present
+    caller_reference: unique test distribution ID
+    origins:
+        - id: 'my test origin-000111'
+          domain_name: www.example.com
+          origin_path: /production
+          custom_headers:
+            - header_name: MyCustomHeaderName
+              header_value: MyCustomHeaderValue
+    default_cache_behavior:
+      target_origin_id: 'my test origin-000111'
+      forwarded_values:
+        query_string: true
+        cookies:
+          forward: all
+        headers:
+         - '*'
+      viewer_protocol_policy: https-only
+      smooth_streaming: true
+      compress: true
+      allowed_methods:
+        items:
+          - GET
+          - HEAD
+        cached_methods:
+          - GET
+          - HEAD
+    logging:
+      enabled: true
+      include_cookies: false
+      bucket: mylogbucket.s3.amazonaws.com
+      prefix: myprefix/
+    enabled: false
+    comment: this is a CloudFront distribution with logging

--- a/assets/queries/ansible/aws/cloudfront_configuration_allow_http/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudfront_configuration_allow_http/test/positive.yaml
@@ -1,0 +1,36 @@
+- name: create a distribution with an origin, logging and default cache behavior
+  community.aws.cloudfront_distribution:
+    state: present
+    caller_reference: unique test distribution ID
+    origins:
+        - id: 'my test origin-000111'
+          domain_name: www.example.com
+          origin_path: /production
+          custom_headers:
+            - header_name: MyCustomHeaderName
+              header_value: MyCustomHeaderValue
+    default_cache_behavior:
+      target_origin_id: 'my test origin-000111'
+      forwarded_values:
+        query_string: true
+        cookies:
+          forward: all
+        headers:
+         - '*'
+      viewer_protocol_policy: allow-all
+      smooth_streaming: true
+      compress: true
+      allowed_methods:
+        items:
+          - GET
+          - HEAD
+        cached_methods:
+          - GET
+          - HEAD
+    logging:
+      enabled: true
+      include_cookies: false
+      bucket: mylogbucket.s3.amazonaws.com
+      prefix: myprefix/
+    enabled: false
+    comment: this is a CloudFront distribution with logging

--- a/assets/queries/ansible/aws/cloudfront_configuration_allow_http/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudfront_configuration_allow_http/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Cloudfront configuration allow HTTP",
+		"queryName": "Cloudfront Configuration Allows HTTP",
 		"severity": "HIGH",
 		"line": 20
 	}

--- a/assets/queries/ansible/aws/cloudfront_configuration_allow_http/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudfront_configuration_allow_http/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Cloudfront configuration allow HTTP",
+		"severity": "HIGH",
+		"line": 20
+	}
+]


### PR DESCRIPTION
Added new query for Ansible.

Provide a aws.cloudfront_distribution resource and a resource to manage the viewer_protocol_policy

Closes #1506