### PR TITLE
Add Cloudfront without WAF query

### DIFF
--- a/assets/queries/ansible/aws/cloudfront_without_waf/metadata.json
+++ b/assets/queries/ansible/aws/cloudfront_without_waf/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "Cloudfront_without_WAF",
-  "queryName": "Cloudfront without WAF",
+  "queryName": "Cloudfront Without WAF",
   "severity": "LOW",
-  "category": null,
+  "category": "Network Security",
   "descriptionText": "CloudFront Distribution without WAF enabled",
   "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/cloudfront_distribution_module.html"
 }

--- a/assets/queries/ansible/aws/cloudfront_without_waf/metadata.json
+++ b/assets/queries/ansible/aws/cloudfront_without_waf/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Cloudfront_without_WAF",
+  "queryName": "Cloudfront without WAF",
+  "severity": "LOW",
+  "category": null,
+  "descriptionText": "CloudFront Distribution without WAF enabled",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/cloudfront_distribution_module.html"
+}

--- a/assets/queries/ansible/aws/cloudfront_without_waf/query.rego
+++ b/assets/queries/ansible/aws/cloudfront_without_waf/query.rego
@@ -1,0 +1,26 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  redshiftCluster := task["community.aws.cloudfront_distribution"]
+
+  not redshiftCluster.web_acl_id
+
+  result := {
+                "documentId":       document.id,
+                "searchKey":        sprintf("name={{%s}}.{{community.aws.cloudfront_distribution}}", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'web_acl_id' exists",
+                "keyActualValue": 	"'web_acl_id' is missing"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/cloudfront_without_waf/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudfront_without_waf/test/negative.yaml
@@ -1,0 +1,9 @@
+- name: create a basic distribution with defaults and tags
+  community.aws.cloudfront_distribution:
+    state: present
+    default_origin_domain_name: www.my-cloudfront-origin.com
+    tags:
+      Name: example distribution
+      Project: example project
+      Priority: '1'
+    web_acl_id: "teste"

--- a/assets/queries/ansible/aws/cloudfront_without_waf/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudfront_without_waf/test/negative.yaml
@@ -6,4 +6,4 @@
       Name: example distribution
       Project: example project
       Priority: '1'
-    web_acl_id: "teste"
+    web_acl_id: my-web-acl-id

--- a/assets/queries/ansible/aws/cloudfront_without_waf/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudfront_without_waf/test/positive.yaml
@@ -1,0 +1,8 @@
+- name: create a basic distribution with defaults and tags
+  community.aws.cloudfront_distribution:
+    state: present
+    default_origin_domain_name: www.my-cloudfront-origin.com
+    tags:
+      Name: example distribution
+      Project: example project
+      Priority: '1'

--- a/assets/queries/ansible/aws/cloudfront_without_waf/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudfront_without_waf/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Cloudfront without WAF",
+		"queryName": "Cloudfront Without WAF",
 		"severity": "LOW",
 		"line": 2
 	}

--- a/assets/queries/ansible/aws/cloudfront_without_waf/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudfront_without_waf/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Cloudfront without WAF",
+		"severity": "LOW",
+		"line": 2
+	}
+]


### PR DESCRIPTION
Added new query for Ansible.

Provide a aws.cloudfront_distribution resource and a resource to manage the web_acl_id

Closes #1514