### PR TITLE
Add Cloudwatch without retention days query

### DIFF
--- a/assets/queries/ansible/aws/cloudwatch_without_retention_days/metadata.json
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_days/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Cloudwatch_without_retention_days",
+  "queryName": "Cloudwatch without retention days",
+  "severity": "LOW",
+  "category": null,
+  "descriptionText": "Cloudwatch log groups without retention days specified",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/cloudwatchlogs_log_group_module.html"
+}

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_days/metadata.json
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_days/metadata.json
@@ -1,8 +1,8 @@
 {
   "id": "Cloudwatch_without_retention_days",
-  "queryName": "Cloudwatch without retention days",
+  "queryName": "Cloudwatch Without Retention Days",
   "severity": "LOW",
-  "category": null,
+  "category": "Logging",
   "descriptionText": "Cloudwatch log groups without retention days specified",
   "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/cloudwatchlogs_log_group_module.html"
 }

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_days/query.rego
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_days/query.rego
@@ -1,0 +1,26 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cloudwatchlogs := task["community.aws.cloudwatchlogs_log_group"]
+
+  not cloudwatchlogs.retention
+
+  result := {
+                "documentId":       document.id,
+                "searchKey":        sprintf("{{community.aws.cloudwatchlogs_log_group}}.name=%s", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'retention_in_days' equal 30",
+                "keyActualValue": 	"'retention_in_days' is missing"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_days/query.rego
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_days/query.rego
@@ -12,8 +12,8 @@ CxPolicy [ result ] {
                 "documentId":       document.id,
                 "searchKey":        sprintf("{{community.aws.cloudwatchlogs_log_group}}.name=%s", [task.name]),
                 "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'retention_in_days' equal 30",
-                "keyActualValue": 	"'retention_in_days' is missing"
+                "keyExpectedValue": "'retention_in_days' is set",
+                "keyActualValue": 	"'retention_in_days' is not set"
               }
 }
 

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_days/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_days/test/negative.yaml
@@ -1,0 +1,6 @@
+- name: create cloudwatchlogs log group
+  community.aws.cloudwatchlogs_log_group:
+    state: present
+    log_group_name: test-log-group
+    tags: { "Name": "test-log-group", "Env" : "QA" }
+    retention: 7

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_days/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_days/test/positive.yaml
@@ -1,0 +1,5 @@
+- name: create cloudwatchlogs log group
+  community.aws.cloudwatchlogs_log_group:
+    state: present
+    log_group_name: test-log-group
+    tags: { "Name": "test-log-group", "Env" : "QA" }

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_days/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_days/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Cloudwatch without retention days",
+		"queryName": "Cloudwatch Without Retention Days",
 		"severity": "LOW",
 		"line": 2
 	}

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_days/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_days/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Cloudwatch without retention days",
+		"severity": "LOW",
+		"line": 2
+	}
+]


### PR DESCRIPTION
Added new query for Ansible.

Provide a aws.cloudfront_distribution resource and a resource to manage the web_acl_id

Closes #1517