### PR TITLE
Add sqs_with_sse_disabled query for Ansible #1504

### DIFF
--- a/assets/queries/ansible/aws/sqs_with_sse_disabled/metadata.json
+++ b/assets/queries/ansible/aws/sqs_with_sse_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "sqs_with_sse_disabled",
+  "queryName": "SQS With SSE Disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Amazon Simple Queue Service (SQS) queue is not protecting the contents of their messages using Server-Side Encryption (SSE)",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/sqs_queue_module.html#parameter-kms_master_key_id"
+}

--- a/assets/queries/ansible/aws/sqs_with_sse_disabled/query.rego
+++ b/assets/queries/ansible/aws/sqs_with_sse_disabled/query.rego
@@ -1,0 +1,25 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+  sqs_queue := task["community.aws.sqs_queue"]
+
+  object.get(sqs_queue, "kms_master_key_id", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{community.aws.sqs_queue}}", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'kms_master_key_id' is defined",
+                "keyActualValue": 	"'kms_master_key_id' is undefined"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/sqs_with_sse_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/sqs_with_sse_disabled/test/negative.yaml
@@ -1,0 +1,15 @@
+---
+- name: Create SQS queue with redrive policy
+  community.aws.sqs_queue:
+    name: my-queue
+    region: ap-southeast-2
+    default_visibility_timeout: 120
+    message_retention_period: 86400
+    maximum_message_size: 1024
+    delivery_delay: 30
+    receive_message_wait_time: 20
+    kms_master_key_id: key-id
+    policy: "{{ json_dict }}"
+    redrive_policy:
+      maxReceiveCount: 5
+      deadLetterTargetArn: arn:aws:sqs:eu-west-1:123456789012:my-dead-queue

--- a/assets/queries/ansible/aws/sqs_with_sse_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/sqs_with_sse_disabled/test/positive.yaml
@@ -1,0 +1,14 @@
+---
+- name: Create SQS queue with redrive policy
+  community.aws.sqs_queue:
+    name: my-queue
+    region: ap-southeast-2
+    default_visibility_timeout: 120
+    message_retention_period: 86400
+    maximum_message_size: 1024
+    delivery_delay: 30
+    receive_message_wait_time: 20
+    policy: "{{ json_dict }}"
+    redrive_policy:
+      maxReceiveCount: 5
+      deadLetterTargetArn: arn:aws:sqs:eu-west-1:123456789012:my-dead-queue

--- a/assets/queries/ansible/aws/sqs_with_sse_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/sqs_with_sse_disabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "SQS With SSE Disabled",
+		"severity": "HIGH",
+		"line": 3
+	}
+]


### PR DESCRIPTION
Closes #1504 

Amazon Simple Queue Service (SQS) queue is not protecting the contents of their messages using Server-Side Encryption (SSE)

Checks if 'kms_master_key_id' is undefined in a 'community.aws.sqs_queue' resource