### PR TITLE
Add S3 Bucket Allows List Action From All Principals query for Ansible

### DIFF
--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/metadata.json
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "S3_Bucket_Allows_List_Action_From_All_Principals",
+  "queryName": "S3 Bucket Allows List Action From All Principals",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "S3 Buckets must not allow List Action From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_s3_module.html"
+}

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/metadata.json
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/metadata.json
@@ -4,5 +4,5 @@
   "severity": "HIGH",
   "category": "Identity and Access Management",
   "descriptionText": "S3 Buckets must not allow List Action From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion.",
-  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_s3_module.html"
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html"
 }

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
@@ -7,6 +7,7 @@ CxPolicy [ result ] {
   bucket := task["amazon.aws.s3_bucket"]
   bucketName := task.name
   
+  bucket.policy.Statement[_].Effect == "Allow"
   contains(lower(bucket.policy.Statement[_].Action), "list")
   bucket.policy.Statement[_].Principal == "*"
 
@@ -14,8 +15,8 @@ CxPolicy [ result ] {
                 "documentId":       input.document[i].id,
                 "searchKey":        sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
                 "issueType":        "IncorrectValue",
-                "keyExpectedValue": "amazon.aws.s3_bucket does not allow List Action From All Principals",
-                "keyActualValue":   "amazon.aws.s3_bucket allows List Action From All Principals"
+                "keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow List Action From All Principals", [bucketName]),
+                "keyActualValue":   sprintf("amazon.aws.s3_bucket[%s] allows List Action From All Principals", [bucketName])
               }
 }
 

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  bucket := task["amazon.aws.aws_s3"]
+  bucketName := task.name
+  
+  contains(bucket.mode, "list")
+  contains(bucket.permission, "public")
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.aws_s3}}", [bucketName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "amazon.aws.aws_s3 does not allow List Action From All Principals",
+                "keyActualValue":   "amazon.aws.aws_s3 allows List Action From All Principals"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
@@ -4,18 +4,18 @@ CxPolicy [ result ] {
   document := input.document[i]
   tasks := getTasks(document)
   task := tasks[t]
-  bucket := task["amazon.aws.aws_s3"]
+  bucket := task["amazon.aws.s3_bucket"]
   bucketName := task.name
   
-  contains(bucket.mode, "list")
-  contains(bucket.permission, "public")
+  contains(lower(bucket.policy.Statement[_].Action), "list")
+  bucket.policy.Statement[_].Principal == "*"
 
     result := {
                 "documentId":       input.document[i].id,
-                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.aws_s3}}", [bucketName]),
+                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
                 "issueType":        "IncorrectValue",
-                "keyExpectedValue": "amazon.aws.aws_s3 does not allow List Action From All Principals",
-                "keyActualValue":   "amazon.aws.aws_s3 allows List Action From All Principals"
+                "keyExpectedValue": "amazon.aws.s3_bucket does not allow List Action From All Principals",
+                "keyActualValue":   "amazon.aws.s3_bucket allows List Action From All Principals"
               }
 }
 

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/negative.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/negative.yaml
@@ -1,0 +1,8 @@
+#this code is a correct code for which the query should not find any result
+- name: Simple GET operation
+  amazon.aws.aws_s3:
+    bucket: mybucket
+    object: /my/desired/key.txt
+    dest: /usr/local/myfile.txt
+    mode: list
+    permission: private

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/negative.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/negative.yaml
@@ -1,8 +1,11 @@
 #this code is a correct code for which the query should not find any result
-- name: Simple GET operation
-  amazon.aws.aws_s3:
-    bucket: mybucket
-    object: /my/desired/key.txt
-    dest: /usr/local/myfile.txt
-    mode: list
-    permission: private
+- name: Bucket
+  amazon.aws.s3_bucket:
+    name: mys3bucket
+    state: present
+    policy:
+      Version: "2020-10-07"
+      Statement:
+      - Effect: Allow
+        Action: ListObject
+        Principal: "NotAll"

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/positive.yaml
@@ -1,0 +1,8 @@
+#this is a problematic code where the query should report a result(s)
+- name: Simple GET operation
+  amazon.aws.aws_s3:
+    bucket: mybucket
+    object: /my/desired/key.txt
+    dest: /usr/local/myfile.txt
+    mode: list
+    permission: public-read-write

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/positive.yaml
@@ -1,8 +1,11 @@
 #this is a problematic code where the query should report a result(s)
-- name: Simple GET operation
-  amazon.aws.aws_s3:
-    bucket: mybucket
-    object: /my/desired/key.txt
-    dest: /usr/local/myfile.txt
-    mode: list
-    permission: public-read-write
+- name: Bucket
+  amazon.aws.s3_bucket:
+    name: mys3bucket
+    state: present
+    policy:
+      Version: "2020-10-07"
+      Statement:
+      - Effect: Allow
+        Action: ListObject
+        Principal: "*"

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/positive_expected_result.json
@@ -2,6 +2,6 @@
 	{
 		"queryName": "S3 Bucket Allows List Action From All Principals",
 		"severity": "HIGH",
-		"line": 3
+		"line": 8
 	}
 ]

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "S3 Bucket Allows List Action From All Principals",
+		"severity": "HIGH",
+		"line": 3
+	}
+]


### PR DESCRIPTION
Adding S3 Bucket Allows List Action From All Principals query for Ansible, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion.

Closes #1540