### PR TITLE
Add S3 Bucket Allows Delete Action From All Principals query for Ansible

### DIFF
--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/metadata.json
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/metadata.json
@@ -4,5 +4,5 @@
   "severity": "HIGH",
   "category": "Identity and Access Management",
   "descriptionText": "S3 Buckets must not allow Delete Action From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion.",
-  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_s3_module.html"
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html"
 }

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/metadata.json
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "S3_Bucket_Allows_Delete_Action_From_All_Principals",
+  "queryName": "S3 Bucket Allows Delete Action From All Principals",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "S3 Buckets must not allow Delete Action From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_s3_module.html"
+}

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
@@ -1,0 +1,36 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  bucket := task["amazon.aws.aws_s3"]
+  bucketName := task.name
+  
+  checkDelete(bucket.mode)
+  contains(bucket.permission, "public")
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.aws_s3}}", [bucketName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "amazon.aws.aws_s3 does not allow Delete Action From All Principals",
+                "keyActualValue":   "amazon.aws.aws_s3 allows Delete Action From All Principals"
+              }
+}
+
+checkDelete(mode) {
+  contains(mode, "delete")
+}
+
+checkDelete(mode) {
+  contains(mode, "delobj")
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
@@ -4,27 +4,20 @@ CxPolicy [ result ] {
   document := input.document[i]
   tasks := getTasks(document)
   task := tasks[t]
-  bucket := task["amazon.aws.aws_s3"]
+  bucket := task["amazon.aws.s3_bucket"]
   bucketName := task.name
   
-  checkDelete(bucket.mode)
-  contains(bucket.permission, "public")
+  bucket.policy.Statement[_].Effect == "Allow"
+  contains(lower(bucket.policy.Statement[_].Action), "delete")
+  bucket.policy.Statement[_].Principal == "*"
 
     result := {
                 "documentId":       input.document[i].id,
-                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.aws_s3}}", [bucketName]),
+                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
                 "issueType":        "IncorrectValue",
-                "keyExpectedValue": "amazon.aws.aws_s3 does not allow Delete Action From All Principals",
-                "keyActualValue":   "amazon.aws.aws_s3 allows Delete Action From All Principals"
+                "keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow Delete Action From All Principals", [bucketName]),
+                "keyActualValue":   sprintf("amazon.aws.s3_bucket[%s] allows Delete Action From All Principals", [bucketName])
               }
-}
-
-checkDelete(mode) {
-  contains(mode, "delete")
-}
-
-checkDelete(mode) {
-  contains(mode, "delobj")
 }
 
 getTasks(document) = result {

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/negative.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/negative.yaml
@@ -1,0 +1,8 @@
+#this code is a correct code for which the query should not find any result
+- name: Simple GET operation
+  amazon.aws.aws_s3:
+    bucket: mybucket
+    object: /my/desired/key.txt
+    dest: /usr/local/myfile.txt
+    mode: delete
+    permission: private

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/negative.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/negative.yaml
@@ -1,8 +1,11 @@
 #this code is a correct code for which the query should not find any result
-- name: Simple GET operation
-  amazon.aws.aws_s3:
-    bucket: mybucket
-    object: /my/desired/key.txt
-    dest: /usr/local/myfile.txt
-    mode: delete
-    permission: private
+- name: Bucket
+  amazon.aws.s3_bucket:
+    name: mys3bucket
+    state: present
+    policy:
+      Version: "2020-10-07"
+      Statement:
+      - Effect: Deny
+        Action: DeleteObject
+        Principal: "*"

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/positive.yaml
@@ -1,15 +1,11 @@
 #this is a problematic code where the query should report a result(s)
-- name: Simple GET operation1
-  amazon.aws.aws_s3:
-    bucket: mybucket1
-    object: /my/desired/key.txt
-    dest: /usr/local/myfile.txt
-    mode: delete
-    permission: public-read-write
-- name: Simple GET operation2
-  amazon.aws.aws_s3:
-    bucket: mybucket2
-    object: /my/desired/key.txt
-    dest: /usr/local/myfile.txt
-    mode: delobj
-    permission: public-read-write
+- name: Bucket
+  amazon.aws.s3_bucket:
+    name: mys3bucket
+    state: present
+    policy:
+      Version: "2020-10-07"
+      Statement:
+      - Effect: Allow
+        Action: DeleteObject
+        Principal: "*"

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/positive.yaml
@@ -1,0 +1,15 @@
+#this is a problematic code where the query should report a result(s)
+- name: Simple GET operation1
+  amazon.aws.aws_s3:
+    bucket: mybucket1
+    object: /my/desired/key.txt
+    dest: /usr/local/myfile.txt
+    mode: delete
+    permission: public-read-write
+- name: Simple GET operation2
+  amazon.aws.aws_s3:
+    bucket: mybucket2
+    object: /my/desired/key.txt
+    dest: /usr/local/myfile.txt
+    mode: delobj
+    permission: public-read-write

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "S3 Bucket Allows Delete Action From All Principals",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "S3 Bucket Allows Delete Action From All Principals",
+		"severity": "HIGH",
+		"line": 10
+	}
+]

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/test/positive_expected_result.json
@@ -2,11 +2,6 @@
 	{
 		"queryName": "S3 Bucket Allows Delete Action From All Principals",
 		"severity": "HIGH",
-		"line": 3
-	},
-	{
-		"queryName": "S3 Bucket Allows Delete Action From All Principals",
-		"severity": "HIGH",
-		"line": 10
+		"line": 8
 	}
 ]


### PR DESCRIPTION
Adding S3 Bucket Allows Delete Action From All Principals query for Ansible, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion.

Closes #1545