### PR TITLE
Add AWS Config Agg All Regions Not Enabled query

### DIFF
--- a/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/metadata.json
+++ b/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "AWS_Config_Configuration_Aggregator_All_Regions_Not_Enabled",
+  "queryName": "AWS Config Configuration Aggregator All Regions Not Enabled",
+  "severity": "HIGH",
+  "category": "Logging",
+  "descriptionText": "AWS Config Configuration Aggregator All Regions must be set to True",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/aws_config_aggregator_module.html#parameter-organization_source"
+}

--- a/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/query.rego
+++ b/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/query.rego
@@ -1,0 +1,52 @@
+package Cx
+
+CxPolicy [  result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cloudwatchlogs := task["community.aws.aws_config_aggregator"]
+
+  not isAnsibleTrue(cloudwatchlogs.account_sources.all_aws_regions)
+
+  result := {
+                "documentId":       document.id,
+                "searchKey":        sprintf("name=%s.{{community.aws.aws_config_aggregator}}.account_sources.all_aws_regions", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'aws_config_aggregator.account_sources' should have all_aws_regions set to true",
+                "keyActualValue": 	"'aws_config_aggregator.account_sources' has all_aws_regions set to false"
+              }
+}
+
+CxPolicy [  result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  cloudwatchlogs := task["community.aws.aws_config_aggregator"]
+
+  not isAnsibleTrue(cloudwatchlogs.organization_source.all_aws_regions)
+
+
+  result := {
+                "documentId":       document.id,
+                "searchKey":        sprintf("name=%s.{{community.aws.aws_config_aggregator}}.organization_source.all_aws_regions", [task.name]),
+				        "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'aws_config_aggregator.organization_source' should have all_aws_regions set to true",
+                "keyActualValue": 	"'aws_config_aggregator.organization_source' has all_aws_regions set to false"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}
+
+isAnsibleTrue(answer) {
+ 	lower(answer) == "yes"
+} else {
+	lower(answer) == "true"
+} else {
+	answer == true
+}

--- a/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/test/negative.yaml
@@ -1,0 +1,12 @@
+- name: Create cross-account aggregator
+  community.aws.aws_config_aggregator:
+    name: test_config_rule
+    state: present
+    account_sources:
+      account_ids:
+      - 1234567890
+      - 0123456789
+      - 9012345678
+      all_aws_regions: yes
+    organization_source:
+      all_aws_regions: yes

--- a/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/test/positive.yaml
@@ -1,0 +1,24 @@
+- name: Create cross-account aggregator
+  community.aws.aws_config_aggregator:
+    name: test_config_rule
+    state: present
+    account_sources:
+      account_ids:
+      - 1234567890
+      - 0123456789
+      - 9012345678
+      all_aws_regions: no
+    organization_source:
+      all_aws_regions: yes
+- name: Create cross-account aggregator2
+  community.aws.aws_config_aggregator:
+    name: test_config_rule
+    state: present
+    account_sources:
+      account_ids:
+      - 1234567890
+      - 0123456789
+      - 9012345678
+      all_aws_regions: yes
+    organization_source:
+      all_aws_regions: no

--- a/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "AWS Config Configuration Aggregator All Regions Not Enabled",
+		"severity": "HIGH",
+		"line": 10
+	},
+	{
+		"queryName": "AWS Config Configuration Aggregator All Regions Not Enabled",
+		"severity": "HIGH",
+		"line": 24
+	}
+]


### PR DESCRIPTION
Added new query for Ansible

Provide a aws_config_aggregator resource and a resource to manage all_aws_regions

Closes #1550