### PR TITLE
Add S3 Bucket With Any Principal query for Ansible

### DIFF
--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/metadata.json
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "S3_Bucket_With_Any_Principal",
+  "queryName": "S3 Bucket With Any Principal",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "S3 Buckets must not allow Actions From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_s3_module.html"
+}

--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/metadata.json
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/metadata.json
@@ -4,5 +4,5 @@
   "severity": "HIGH",
   "category": "Identity and Access Management",
   "descriptionText": "S3 Buckets must not allow Actions From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion.",
-  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_s3_module.html"
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html"
 }

--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  bucket := task["amazon.aws.aws_s3"]
+  bucketName := task.name
+  
+  contains(bucket.permission, "public")
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.aws_s3}}", [bucketName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "amazon.aws.aws_s3 does not allow Action From All Principals",
+                "keyActualValue":   "amazon.aws.aws_s3 allows Action From All Principals"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/query.rego
@@ -4,17 +4,18 @@ CxPolicy [ result ] {
   document := input.document[i]
   tasks := getTasks(document)
   task := tasks[t]
-  bucket := task["amazon.aws.aws_s3"]
+  bucket := task["amazon.aws.s3_bucket"]
   bucketName := task.name
   
-  contains(bucket.permission, "public")
+  bucket.policy.Statement[_].Effect == "Allow"
+  bucket.policy.Statement[_].Principal == "*"
 
     result := {
                 "documentId":       input.document[i].id,
-                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.aws_s3}}", [bucketName]),
+                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
                 "issueType":        "IncorrectValue",
-                "keyExpectedValue": "amazon.aws.aws_s3 does not allow Action From All Principals",
-                "keyActualValue":   "amazon.aws.aws_s3 allows Action From All Principals"
+                "keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow Action From All Principals", [bucketName]),
+                "keyActualValue":   sprintf("amazon.aws.s3_bucket[%s] allows Action From All Principals", [bucketName])
               }
 }
 

--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/negative.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/negative.yaml
@@ -1,0 +1,8 @@
+#this code is a correct code for which the query should not find any result
+- name: Simple GET operation
+  amazon.aws.aws_s3:
+    bucket: mybucket
+    object: /my/desired/key.txt
+    dest: /usr/local/myfile.txt
+    mode: get
+    permission: private

--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/negative.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/negative.yaml
@@ -1,8 +1,11 @@
 #this code is a correct code for which the query should not find any result
-- name: Simple GET operation
-  amazon.aws.aws_s3:
-    bucket: mybucket
-    object: /my/desired/key.txt
-    dest: /usr/local/myfile.txt
-    mode: get
-    permission: private
+- name: Bucket
+  amazon.aws.s3_bucket:
+    name: mys3bucket
+    state: present
+    policy:
+      Version: "2020-10-07"
+      Statement:
+      - Effect: Deny
+        Action: GetObject
+        Principal: "*"

--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/positive.yaml
@@ -1,15 +1,11 @@
 #this is a problematic code where the query should report a result(s)
-- name: Simple GET operation1
-  amazon.aws.aws_s3:
-    bucket: mybucket1
-    object: /my/desired/key.txt
-    dest: /usr/local/myfile.txt
-    mode: get
-    permission: public-read-write
-- name: Simple GET operation2
-  amazon.aws.aws_s3:
-    bucket: mybucket2
-    object: /my/desired/key.txt
-    dest: /usr/local/myfile.txt
-    mode: get
-    permission: public-read
+- name: Bucket
+  amazon.aws.s3_bucket:
+    name: mys3bucket
+    state: present
+    policy:
+      Version: "2020-10-07"
+      Statement:
+      - Effect: Allow
+        Action: GetObject
+        Principal: "*"

--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/positive.yaml
@@ -1,0 +1,15 @@
+#this is a problematic code where the query should report a result(s)
+- name: Simple GET operation1
+  amazon.aws.aws_s3:
+    bucket: mybucket1
+    object: /my/desired/key.txt
+    dest: /usr/local/myfile.txt
+    mode: get
+    permission: public-read-write
+- name: Simple GET operation2
+  amazon.aws.aws_s3:
+    bucket: mybucket2
+    object: /my/desired/key.txt
+    dest: /usr/local/myfile.txt
+    mode: get
+    permission: public-read

--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/positive_expected_result.json
@@ -2,11 +2,6 @@
 	{
 		"queryName": "S3 Bucket With Any Principal",
 		"severity": "HIGH",
-		"line": 3
-	},
-	{
-		"queryName": "S3 Bucket With Any Principal",
-		"severity": "HIGH",
-		"line": 10
+		"line": 8
 	}
 ]

--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "S3 Bucket With Any Principal",
+		"severity": "HIGH",
+		"line": 3
+	},
+	{
+		"queryName": "S3 Bucket With Any Principal",
+		"severity": "HIGH",
+		"line": 10
+	}
+]


### PR DESCRIPTION
Adding S3 Bucket With Any Principal query for Ansible, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion.

Closes #1555