### PR TITLE
Add blob_container_with_public_access query for Ansible

### DIFF
--- a/assets/queries/ansible/azure/blob_container_with_public_access/metadata.json
+++ b/assets/queries/ansible/azure/blob_container_with_public_access/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "blob_container_with_public_access",
+  "queryName": "Blob Container With Public Access",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "Anonymous, public read access to a container and its blobs are enabled in Azure Blob Storage",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_storageblob_module.html#parameter-public_access"
+}

--- a/assets/queries/ansible/azure/blob_container_with_public_access/query.rego
+++ b/assets/queries/ansible/azure/blob_container_with_public_access/query.rego
@@ -1,0 +1,32 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+    hasPublicAccess(task["azure_rm_storageblob"].public_access)
+
+    result := {
+        "documentId": document.id,
+        "searchKey": sprintf("name=%s.{{azure_rm_storageblob}}.public_access", [task.name]),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": "azure_rm_storageblob.public_access is not set",
+        "keyActualValue": "azure_rm_storageblob.public_access is equal to 'blob' or 'container'"
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}
+
+hasPublicAccess(access) {
+ 	lower(access) == "blob"
+}
+
+hasPublicAccess(access) {
+ 	lower(access) == "container"
+}

--- a/assets/queries/ansible/azure/blob_container_with_public_access/test/negative.yaml
+++ b/assets/queries/ansible/azure/blob_container_with_public_access/test/negative.yaml
@@ -1,0 +1,9 @@
+- name: Create container foo and upload a file
+  azure_rm_storageblob:
+    resource_group: myResourceGroup
+    storage_account_name: clh0002
+    container: foo
+    blob: graylog.png
+    src: ./files/graylog.png
+    content_type: 'application/image'
+# access mode defaults to private

--- a/assets/queries/ansible/azure/blob_container_with_public_access/test/positive.yaml
+++ b/assets/queries/ansible/azure/blob_container_with_public_access/test/positive.yaml
@@ -1,0 +1,18 @@
+- name: Create container foo and upload a file
+  azure_rm_storageblob:
+    resource_group: myResourceGroup
+    storage_account_name: clh0002
+    container: foo
+    blob: graylog.png
+    src: ./files/graylog.png
+    content_type: 'application/image'
+    public_access: blob
+- name: Create container foo2 and upload a file
+  azure_rm_storageblob:
+    resource_group: myResourceGroup
+    storage_account_name: clh0002
+    container: foo2
+    blob: graylog.png
+    src: ./files/graylog.png
+    public_access: container
+    content_type: 'application/image'

--- a/assets/queries/ansible/azure/blob_container_with_public_access/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/blob_container_with_public_access/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Blob Container With Public Access",
+		"severity": "HIGH",
+		"line": 9
+	},
+	{
+		"queryName": "Blob Container With Public Access",
+		"severity": "HIGH",
+		"line": 17
+	}
+]


### PR DESCRIPTION
By default, containers are private, so this query evaluates if parameter `public_access` from the `azure_rm_storageblob` module is set to `blob` or `container` . Closes #1557