### PR TITLE
Add Root Account Has Associated Active Access Keys query for Ansible

### DIFF
--- a/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/metadata.json
+++ b/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "Root_Account_Has_Associated_Active_Access_Keys",
+  "queryName": "Root Account Has Associated Active Access Keys",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "The AWS Root Account must not have active access keys associated, which means if there are access keys associated to the Root Account, they must be inactive.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/iam_module.html"
+}

--- a/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/query.rego
+++ b/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/query.rego
@@ -1,0 +1,31 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  iam := task["community.aws.iam"]
+  iamName := task.name
+  
+  is_string(iam.access_key_state)
+  lower(iam.access_key_state) == "active"
+  iam.iam_type == "user"
+  is_string(iam.name)
+  contains(lower(iam.name), "root")
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{community.aws.iam}}", [iamName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "community.aws.iam is not active for a root account",
+                "keyActualValue":   "community.aws.iam is active for a root account"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/test/negative.yaml
+++ b/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/test/negative.yaml
@@ -1,0 +1,11 @@
+#this code is a correct code for which the query should not find any result
+- name: Create two new IAM users with API keys
+  community.aws.iam:
+    iam_type: user
+    name: "{{ root }}"
+    state: present
+    password: "{{ temp_pass }}"
+    access_key_state: inactive
+  loop:
+    - jcleese
+    - mpython

--- a/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/test/positive.yaml
+++ b/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/test/positive.yaml
@@ -1,0 +1,11 @@
+#this is a problematic code where the query should report a result(s)
+- name: Create two new IAM users with API keys
+  community.aws.iam:
+    iam_type: user
+    name: "{{ root }}"
+    state: present
+    password: "{{ temp_pass }}"
+    access_key_state: active
+  loop:
+    - jcleese
+    - mpython

--- a/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Root Account Has Associated Active Access Keys",
+		"severity": "HIGH",
+		"line": 3
+	}
+]


### PR DESCRIPTION
Adding Root Account Has Associated Active Access Keys query for Ansible, because the AWS Root Account must not have active access keys associated.

Closes #1559