### PR TITLE
Add ECS Service Admin Role Is Present query for Ansible

### DIFF
--- a/assets/queries/ansible/aws/ecs_service_admin_role_present/metadata.json
+++ b/assets/queries/ansible/aws/ecs_service_admin_role_present/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ECS_Service_Admin_Role_Present",
+  "queryName": "ECS Service Admin Role is Present",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "ECS Services must not have Admin roles, which means the attribute 'role' must not be an admin role",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/ecs_service_module.html"
+}

--- a/assets/queries/ansible/aws/ecs_service_admin_role_present/query.rego
+++ b/assets/queries/ansible/aws/ecs_service_admin_role_present/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  ecs := task["community.aws.ecs_service"]
+  ecsName := task.name
+  
+  is_string(ecs.role)
+  contains(lower(ecs.role), "admin")
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{community.aws.ecs_service}}.role", [ecsName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "community.aws.ecs_service.role is not an admin role",
+                "keyActualValue":   "community.aws.ecs_service.role is an admin role"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/ecs_service_admin_role_present/test/negative.yaml
+++ b/assets/queries/ansible/aws/ecs_service_admin_role_present/test/negative.yaml
@@ -1,0 +1,8 @@
+#this code is a correct code for which the query should not find any result
+- name: ECS Service
+  community.aws.ecs_service:
+    state: present
+    name: console-test-service
+    cluster: new_cluster
+    task_definition: 'new_cluster-task:1'
+    desired_count: 0

--- a/assets/queries/ansible/aws/ecs_service_admin_role_present/test/positive.yaml
+++ b/assets/queries/ansible/aws/ecs_service_admin_role_present/test/positive.yaml
@@ -1,0 +1,9 @@
+#this is a problematic code where the query should report a result(s)
+- name: ECS Service
+  community.aws.ecs_service:
+    state: present
+    name: console-test-service
+    cluster: new_cluster
+    task_definition: 'new_cluster-task:1'
+    desired_count: 0
+    role: admin

--- a/assets/queries/ansible/aws/ecs_service_admin_role_present/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/ecs_service_admin_role_present/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "ECS Service Admin Role is Present",
+		"severity": "HIGH",
+		"line": 9
+	}
+]


### PR DESCRIPTION
Adding ECS Service Admin Role Is Present query for Ansible, that checks if the attribute 'role' is an admin role.

Closes #1563