### PR TITLE
Add public_storage_account query for Ansible

### DIFF
--- a/assets/queries/ansible/azure/public_storage_account/metadata.json
+++ b/assets/queries/ansible/azure/public_storage_account/metadata.json
@@ -3,6 +3,6 @@
   "queryName": "Public Storage Account",
   "severity": "HIGH",
   "category": "Network Security",
-  "descriptionText": "Check if 'network_rules' is open to public.",
+  "descriptionText": "Check if 'network_acls' is open to public.",
   "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_storageaccount_module.html#parameter-network_acls"
 }

--- a/assets/queries/ansible/azure/public_storage_account/metadata.json
+++ b/assets/queries/ansible/azure/public_storage_account/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "public_storage_account",
+  "queryName": "Public Storage Account",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Check if 'network_rules' is open to public.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_storageaccount_module.html#parameter-network_acls"
+}

--- a/assets/queries/ansible/azure/public_storage_account/query.rego
+++ b/assets/queries/ansible/azure/public_storage_account/query.rego
@@ -1,0 +1,46 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+   	task["azure_rm_storageaccount"].network_acls.default_action == "Allow"
+
+    result := {
+        "documentId": document.id,
+        "searchKey": sprintf("name=%s.{{azure_rm_storageaccount}}.network_acls.default_action", [task.name]),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": "azure_rm_storageaccount.network_acls.default_action is not set",
+        "keyActualValue": "azure_rm_storageaccount.network_acls.default_action is 'Allow'"
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+   	task["azure_rm_storageaccount"].network_acls.default_action == "Deny"
+
+    ip_rules := task["azure_rm_storageaccount"].network_acls.ip_rules
+
+    some j
+    	ip_rules[j].value == "0.0.0.0/0"
+
+    result := {
+        "documentId": document.id,
+        "searchKey": sprintf("name=%s.{{azure_rm_storageaccount}}.network_acls.ip_rules", [task.name]),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": "azure_rm_storageaccount.network_acls.default_action is 'Deny' and azure_rm_storageaccount.network_acls.ip_rules does not contain value '0.0.0.0/0' ",
+        "keyActualValue": "azure_rm_storageaccount.network_acls.default_action is 'Deny' and azure_rm_storageaccount.network_acls.ip_rules contains value '0.0.0.0/0'"
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook]
+    count(result) != 0
+}

--- a/assets/queries/ansible/azure/public_storage_account/test/negative.yaml
+++ b/assets/queries/ansible/azure/public_storage_account/test/negative.yaml
@@ -1,0 +1,11 @@
+- name: configure firewall and virtual networks
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0002
+    type: Standard_RAGRS
+    network_acls:
+      bypass: AzureServices,Metrics
+      default_action: Deny
+      ip_rules:
+        - value: 1.2.3.4
+          action: Allow

--- a/assets/queries/ansible/azure/public_storage_account/test/positive.yaml
+++ b/assets/queries/ansible/azure/public_storage_account/test/positive.yaml
@@ -1,0 +1,19 @@
+- name: configure firewall and virtual networks
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0002
+    type: Standard_RAGRS
+    network_acls:
+      bypass: AzureServices,Metrics
+      default_action: Deny
+      ip_rules:
+        - value: 0.0.0.0/0
+          action: Allow
+- name: configure firewall and more virtual networks
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0003
+    type: Standard_RAGRS
+    network_acls:
+      bypass: AzureServices,Metrics
+      default_action: Allow

--- a/assets/queries/ansible/azure/public_storage_account/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/public_storage_account/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Public Storage Account",
+		"severity": "HIGH",
+		"line": 9
+	},
+	{
+		"queryName": "Public Storage Account",
+		"severity": "HIGH",
+		"line": 19
+	}
+]


### PR DESCRIPTION
The default network access rule for Storage Accounts should not be open to public.
This query evaluates if parameter `default_action`  from `azure_rm_storageaccount`  module is set to `Allow`, or if it's set to `Deny` and `ip_rules` contains the value `0.0.0.0/0`.
Closes #1561 