### PR TITLE
Add SQL Server Predictable Active Directory Account Name query for Ansible

### DIFF
--- a/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/metadata.json
+++ b/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "SQL_Server_Predictable_Active_Directory_Account_Name",
+  "queryName": "SQL Server Predictable Active Directory Account Name",
+  "severity": "MEDIUM",
+  "category": "Identity and Access Management",
+  "descriptionText": "Azure SQL Server must avoid using predictable Active Directory Administrator Account names, like 'Admin', which means the attribute 'ad_user' must be set to a name that is not easy to predict",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_adserviceprincipal_module.html"
+}

--- a/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/query.rego
+++ b/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/query.rego
@@ -1,0 +1,72 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  ad := task["azure_ad_serviceprincipal"]
+  adName := task.name
+  
+  ad.ad_user
+  is_string(ad.ad_user)
+  count(ad.ad_user) == 0
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_ad_serviceprincipal}}.ad_user", [adName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "azure_ad_serviceprincipal.ad_user is not empty",
+                "keyActualValue":   "azure_ad_serviceprincipal.ad_user is empty"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  ad := task["azure_ad_serviceprincipal"]
+  adName := task.name
+  
+  ad.ad_user == null
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_ad_serviceprincipal}}.ad_user", [adName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "azure_ad_serviceprincipal.ad_user is not null",
+                "keyActualValue":   "azure_ad_serviceprincipal.ad_user is null"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  ad := task["azure_ad_serviceprincipal"]
+  adName := task.name
+  
+  is_string(ad.ad_user)
+  check_predictable(ad.ad_user)
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{azure_ad_serviceprincipal}}.ad_user", [adName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": "azure_ad_serviceprincipal.ad_user is not predictable",
+                "keyActualValue":   "azure_ad_serviceprincipal.ad_user is predictable"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}
+
+check_predictable (name) {
+	predictable_names := {"admin", "administrator", "sqladmin", "root", "user", "azure_admin", "azure_administrator", "guest"}
+	some i
+    	predictable_names[i] == lower(name)
+}

--- a/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/test/negative.yaml
+++ b/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/test/negative.yaml
@@ -1,0 +1,7 @@
+#this code is a correct code for which the query should not find any result
+- name: create ad sp
+  azure_ad_serviceprincipal:
+    app_id: "{{ app_id }}"
+    state: present
+    tenant: "{{ tenant_id }}"
+    ad_user: unpredictableName

--- a/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/test/positive.yaml
+++ b/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/test/positive.yaml
@@ -1,0 +1,19 @@
+#this is a problematic code where the query should report a result(s)
+- name: create ad sp
+  azure_ad_serviceprincipal:
+    app_id: "{{ app_id }}"
+    state: present
+    tenant: "{{ tenant_id }}"
+    ad_user: admin
+- name: create ad sp2
+  azure_ad_serviceprincipal:
+    app_id: "{{ app_id2 }}"
+    state: present
+    tenant: "{{ tenant_id2 }}"
+    ad_user: ""
+- name: create ad sp3
+  azure_ad_serviceprincipal:
+    app_id: "{{ app_id3 }}"
+    state: present
+    tenant: "{{ tenant_id3 }}"
+    ad_user:

--- a/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "SQL Server Predictable Active Directory Account Name",
+		"severity": "MEDIUM",
+		"line": 7
+	},
+	{
+		"queryName": "SQL Server Predictable Active Directory Account Name",
+		"severity": "MEDIUM",
+		"line": 13
+	},
+	{
+		"queryName": "SQL Server Predictable Active Directory Account Name",
+		"severity": "MEDIUM",
+		"line": 19
+	}
+]


### PR DESCRIPTION
Adding SQL Server Predictable Active Directory Account Name query for Ansible, that checks if the attribute 'ad_user' is set to a name that is easy to predict.

Closes #1567