### PR TITLE
Add redis_not_compliant query Closes #1569

### DIFF
--- a/assets/queries/ansible/aws/redis_not_compliant/metadata.json
+++ b/assets/queries/ansible/aws/redis_not_compliant/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "redis_not_compliant",
+  "queryName": "Redis Not Compliant",
+  "severity": "HIGH",
+  "category": "Data Security",
+  "descriptionText": "Check if the redis version is compliant with the necessary AWS PCI DSS requirements",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/elasticache_module.html"
+}

--- a/assets/queries/ansible/aws/redis_not_compliant/metadata.json
+++ b/assets/queries/ansible/aws/redis_not_compliant/metadata.json
@@ -4,5 +4,5 @@
   "severity": "HIGH",
   "category": "Data Security",
   "descriptionText": "Check if the redis version is compliant with the necessary AWS PCI DSS requirements",
-  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/elasticache_module.html"
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/elasticache_module.html#parameter-cache_engine_version"
 }

--- a/assets/queries/ansible/aws/redis_not_compliant/query.rego
+++ b/assets/queries/ansible/aws/redis_not_compliant/query.rego
@@ -1,0 +1,30 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  min_version_string = "4.0.10"
+  eval_version_number(task["community.aws.elasticache"].cache_engine_version) < eval_version_number(min_version_string)
+
+    result := {
+                "documentId": 		  input.document[i].id,
+                "searchKey":        sprintf("name=%s.{{community.aws.elasticache}}.cache_engine_version", [task.name]),
+                "issueType":		    "IncorrectValue",
+                "keyExpectedValue": sprintf("name=%s.{{community.aws.elasticache}}.cache_engine_version is compliant with the requirements", [task.name]),
+                "keyActualValue":   sprintf("name=%s.{{community.aws.elasticache}}.cache_engine_version isn't compliant with the requirements", [task.name])
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}
+
+eval_version_number(engine_version) = numeric_version {
+	version = split(engine_version, ".")
+	numeric_version = to_number(version[0]) * 100 + to_number(version[1]) * 10 + to_number(version[2])
+}

--- a/assets/queries/ansible/aws/redis_not_compliant/query.rego
+++ b/assets/queries/ansible/aws/redis_not_compliant/query.rego
@@ -11,8 +11,8 @@ CxPolicy [ result ] {
                 "documentId": 		  input.document[i].id,
                 "searchKey":        sprintf("name=%s.{{community.aws.elasticache}}.cache_engine_version", [task.name]),
                 "issueType":		    "IncorrectValue",
-                "keyExpectedValue": sprintf("name=%s.{{community.aws.elasticache}}.cache_engine_version is compliant with the requirements", [task.name]),
-                "keyActualValue":   sprintf("name=%s.{{community.aws.elasticache}}.cache_engine_version isn't compliant with the requirements", [task.name])
+                "keyExpectedValue": sprintf("name=%s.{{community.aws.elasticache}}.cache_engine_version is compliant with the AWS PCI DSS requirements", [task.name]),
+                "keyActualValue":   sprintf("name=%s.{{community.aws.elasticache}}.cache_engine_version isn't compliant with the AWS PCI DSS requirements", [task.name])
               }
 }
 

--- a/assets/queries/ansible/aws/redis_not_compliant/test/negative.yaml
+++ b/assets/queries/ansible/aws/redis_not_compliant/test/negative.yaml
@@ -1,0 +1,8 @@
+- name: Basic example
+  community.aws.elasticache:
+    name: "test-please-delete"
+    state: present
+    engine: memcached
+    cache_engine_version: 5.1.10
+    node_type: cache.m1.small
+    num_nodes: 1

--- a/assets/queries/ansible/aws/redis_not_compliant/test/positive.yaml
+++ b/assets/queries/ansible/aws/redis_not_compliant/test/positive.yaml
@@ -1,0 +1,8 @@
+- name: Basic example
+  community.aws.elasticache:
+    name: "test-please-delete"
+    state: present
+    engine: memcached
+    cache_engine_version: 1.4.14
+    node_type: cache.m1.small
+    num_nodes: 1

--- a/assets/queries/ansible/aws/redis_not_compliant/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/redis_not_compliant/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Redis Not Compliant",
+		"severity": "HIGH",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Closes #1569 
Checks if the Redis version is compliant with the necessary AWS PCI DSS requirements