### PR TITLE
Add trusted_microsoft_services_not_enabled query for Ansible

### DIFF
--- a/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/metadata.json
+++ b/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "trusted_microsoft_services_not_enabled",
+  "queryName": "Trusted Microsoft Services Not Enabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Ensure 'Trusted Microsoft Services' is enabled for Storage Account access.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_storageaccount_module.html#parameter-network_acls/bypass"
+}

--- a/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/metadata.json
+++ b/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/metadata.json
@@ -3,6 +3,6 @@
   "queryName": "Trusted Microsoft Services Not Enabled",
   "severity": "HIGH",
   "category": "Network Security",
-  "descriptionText": "Ensure 'Trusted Microsoft Services' is enabled for Storage Account access.",
+  "descriptionText": "Ensure Trusted Microsoft Services have Storage Account access.",
   "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_storageaccount_module.html#parameter-network_acls/bypass"
 }

--- a/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/query.rego
+++ b/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/query.rego
@@ -1,0 +1,37 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+   	task["azure_rm_storageaccount"].network_acls.default_action == "Deny"
+    not containsAzureService(task["azure_rm_storageaccount"].network_acls.bypass)
+
+    result := {
+
+        "documentId": document.id,
+        "searchKey": sprintf("name=%s.{{azure_rm_storageaccount}}.network_acls.bypass", [task.name]),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": "azure_rm_storageaccount.network_acls.bypass is not set or contains 'AzureServices'",
+        "keyActualValue": "azure_rm_storageaccount.network_acls.bypass does not contain 'AzureServices' "
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}
+
+containsAzureService(bypass) {
+	bypass == "\"\""
+}
+
+containsAzureService(bypass) {
+	values := split(bypass,",")
+    some j
+    	values[j] == "AzureServices"
+}

--- a/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/test/negative.yaml
+++ b/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/test/negative.yaml
@@ -1,0 +1,47 @@
+- name: configure firewall and virtual networks
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0002
+    type: Standard_RAGRS
+    network_acls:
+      bypass: AzureServices,Metrics
+      default_action: Deny
+      virtual_network_rules:
+        - id: /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet
+          action: Allow
+      ip_rules:
+        - value: 1.2.3.4
+          action: Allow
+        - value: 123.234.123.0/24
+          action: Allow
+- name: configure firewall and virtual networks2
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0003
+    type: Standard_RAGRS
+    network_acls:
+      default_action: Deny
+      virtual_network_rules:
+        - id: /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet
+          action: Allow
+      ip_rules:
+        - value: 1.2.3.4
+          action: Allow
+        - value: 123.234.123.0/24
+          action: Allow
+- name: configure firewall and virtual networks3
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0004
+    type: Standard_RAGRS
+    network_acls:
+      default_action: Deny
+      bypass: AzureServices
+      virtual_network_rules:
+        - id: /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet
+          action: Allow
+      ip_rules:
+        - value: 1.2.3.4
+          action: Allow
+        - value: 123.234.123.0/24
+          action: Allow

--- a/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/test/positive.yaml
+++ b/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/test/positive.yaml
@@ -1,0 +1,48 @@
+- name: configure firewall and virtual networks
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0002
+    type: Standard_RAGRS
+    network_acls:
+      bypass: Metrics
+      default_action: Deny
+      virtual_network_rules:
+        - id: /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet
+          action: Allow
+      ip_rules:
+        - value: 1.2.3.4
+          action: Allow
+        - value: 123.234.123.0/24
+          action: Allow
+- name: configure firewall and virtual networks2
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0003
+    type: Standard_RAGRS
+    network_acls:
+      default_action: Deny
+      bypass: Metrics,Logging
+      virtual_network_rules:
+        - id: /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet
+          action: Allow
+      ip_rules:
+        - value: 1.2.3.4
+          action: Allow
+        - value: 123.234.123.0/24
+          action: Allow
+- name: configure firewall and virtual networks3
+  azure_rm_storageaccount:
+    resource_group: myResourceGroup
+    name: clh0004
+    type: Standard_RAGRS
+    network_acls:
+      default_action: Deny
+      bypass: ""
+      virtual_network_rules:
+        - id: /subscriptions/mySubscriptionId/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet
+          action: Allow
+      ip_rules:
+        - value: 1.2.3.4
+          action: Allow
+        - value: 123.234.123.0/24
+          action: Allow

--- a/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "Trusted Microsoft Services Not Enabled",
+		"severity": "HIGH",
+		"line": 7
+	},
+	{
+		"queryName": "Trusted Microsoft Services Not Enabled",
+		"severity": "HIGH",
+		"line": 24
+	},
+	{
+		"queryName": "Trusted Microsoft Services Not Enabled",
+		"severity": "HIGH",
+		"line": 40
+	}
+]


### PR DESCRIPTION
This query evaluates if 'Trusted Microsoft Services' is disabled for Storage Account access, by checking if the field `bypass` doesn't contain the value `AzureServices`, or it is set to `""`.
Closes #1570 