### PR TITLE
Add public_port_wide query Closes #1586

### DIFF
--- a/assets/queries/ansible/aws/public_port_wide/metadata.json
+++ b/assets/queries/ansible/aws/public_port_wide/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "public_port_wide",
+  "queryName": "Public Port Wide",
+  "severity": "HIGH",
+  "category": "Network Ports Security",
+  "descriptionText": "AWS Security Group should not have public port wide",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_group_module.html"
+}

--- a/assets/queries/ansible/aws/public_port_wide/query.rego
+++ b/assets/queries/ansible/aws/public_port_wide/query.rego
@@ -1,0 +1,76 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+    
+    fromPort := task["amazon.aws.ec2_group"].rules[index].from_port
+    toPort := task["amazon.aws.ec2_group"].rules[index].to_port
+    
+    (toPort - fromPort) > 0
+    
+    cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+    isEntireNetwork(cidr)
+  
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
+        "issueType":         "IncorrectValue",
+        "keyExpectedValue":  sprintf("amazon.aws.ec2_group.rules[%d] has not public port wide", [index]),
+        "keyActualValue": 	 sprintf("amazon.aws.ec2_group.rules[%d] has public port wide", [index])
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+    
+    fromPort := task["amazon.aws.ec2_group"].rules[index].from_port
+    toPort := task["amazon.aws.ec2_group"].rules[index].to_port
+    
+    (toPort - fromPort) > 0
+    
+    cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ipv6
+    isEntireNetwork(cidr)
+  
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
+        "issueType":         "IncorrectValue",
+        "keyExpectedValue":  sprintf("amazon.aws.ec2_group.rules[%d] has not public port wide", [index]),
+        "keyActualValue": 	 sprintf("amazon.aws.ec2_group.rules[%d] has public port wide", [index])
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}
+
+isEntireNetwork(cidr) = allow {
+   
+    isArray := is_array(cidr)
+    
+    cidrs = {"0.0.0.0/0", "::/0"}
+    
+    count({x | cidr[x]; cidr[x] == cidrs[j]}) != 0
+
+    allow = true
+}
+
+isEntireNetwork(cidr) = allow {
+   
+    isString := is_string(cidr)
+
+    cidrs = {"0.0.0.0/0", "::/0"}
+    cidr == cidrs[j]
+
+    allow = true
+}

--- a/assets/queries/ansible/aws/public_port_wide/test/negative.yaml
+++ b/assets/queries/ansible/aws/public_port_wide/test/negative.yaml
@@ -1,0 +1,15 @@
+- name: example ec2 group v2
+  amazon.aws.ec2_group:
+    name: example
+    description: an example EC2 group
+    vpc_id: 12345
+    region: eu-west-1
+    rules:
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: 10.0.0.0/8

--- a/assets/queries/ansible/aws/public_port_wide/test/positive.yaml
+++ b/assets/queries/ansible/aws/public_port_wide/test/positive.yaml
@@ -1,0 +1,15 @@
+- name: example ec2 group
+  amazon.aws.ec2_group:
+    name: example
+    description: an example EC2 group
+    vpc_id: 12345
+    region: eu-west-1
+    rules:
+      - proto: tcp
+        from_port: 80
+        to_port: 82
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 2
+        to_port: 22
+        cidr_ipv6: ::/0

--- a/assets/queries/ansible/aws/public_port_wide/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/public_port_wide/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Public Port Wide",
+		"severity": "HIGH",
+		"line": 7
+	},
+	{
+		"queryName": "Public Port Wide",
+		"severity": "HIGH",
+		"line": 7
+	}
+]


### PR DESCRIPTION
To check if port wide is public, it is necessary to check if:

- attribute 'from_port' less attribute 'to_port' is greater than 0
- attribute 'cidr' is set to "0.0.0.0/0" or "::/0"

Closes #1586