### PR TITLE
Add statefulset_without_poddisruptionbudget query for Kubernetes

### DIFF
--- a/assets/queries/k8s/statefulset_without_poddisruptionbudget/metadata.json
+++ b/assets/queries/k8s/statefulset_without_poddisruptionbudget/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "statefulset_without_poddisruptionbudget",
+  "queryName": "StatefulSet Without PodDisruptionBudget",
+  "severity": "LOW",
+  "category": "High Availability",
+  "descriptionText": "StatefulSets should be assigned with a PodDisruptionBudget to ensure high availability",
+  "descriptionUrl": "https://kubernetes.io/docs/tasks/run-application/configure-pdb/"
+}

--- a/assets/queries/k8s/statefulset_without_poddisruptionbudget/query.rego
+++ b/assets/queries/k8s/statefulset_without_poddisruptionbudget/query.rego
@@ -1,0 +1,31 @@
+package Cx
+
+CxPolicy [result ] {
+
+  statefulset := input.document[i]
+  statefulset.kind == "StatefulSet"
+  metadata := statefulset.metadata
+
+  not CheckIFPdbExists(statefulset)
+
+  result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("metadata.name=%s", [metadata.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": sprintf("metadata.name=%s is not targeted by a PDB", [metadata.name]),
+                "keyActualValue": 	sprintf("metadata.name=%s is not targeted by a PDB", [metadata.name])
+            }
+}
+
+CheckIFPdbExists (statefulsets) = result{
+
+	documents := input.document
+	pdbs := [pdb | documents[index].kind == "PodDisruptionBudget"; pdb = documents[index]]
+
+  result := contains(pdbs, statefulsets.spec.selector.matchLabels.app)
+
+}
+
+contains (array, string) = true {
+	array[a].spec.selector.matchLabels.app == string
+}

--- a/assets/queries/k8s/statefulset_without_poddisruptionbudget/test/negative.yaml
+++ b/assets/queries/k8s/statefulset_without_poddisruptionbudget/test/negative.yaml
@@ -1,0 +1,35 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: nginx-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  serviceName: "nginx"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: k8s.gcr.io/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html

--- a/assets/queries/k8s/statefulset_without_poddisruptionbudget/test/positive.yaml
+++ b/assets/queries/k8s/statefulset_without_poddisruptionbudget/test/positive.yaml
@@ -1,0 +1,37 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: nginx-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: xpto
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  requiredDropCapabilities:
+    - ALL
+  selector:
+    matchLabels:
+      app: nginx
+  serviceName: "nginx"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: k8s.gcr.io/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html

--- a/assets/queries/k8s/statefulset_without_poddisruptionbudget/test/positive_expected_result.json
+++ b/assets/queries/k8s/statefulset_without_poddisruptionbudget/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "StatefulSet Without PodDisruptionBudget",
+		"severity": "LOW",
+		"line": 14
+	}
+]


### PR DESCRIPTION
StatefulSets should be targeted by PodDisruptionBudgets, which limit the number of Pods of a replicated application that can be taken offline at any given time.
This query evaluates if the `matchLabels` applied to pods in a `Statefulset` are referenced in the `matchLabels` of any `PodDisruptionBudget` .

Closes #633
Closes #1602 