### PR TITLE
Add deployment_without_poddisruptionbudget query for Kubernetes

### DIFF
--- a/assets/queries/k8s/deployment_without_poddisruptionbudget/metadata.json
+++ b/assets/queries/k8s/deployment_without_poddisruptionbudget/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "deployment_without_poddisruptionbudget",
+  "queryName": "Deployment Without PodDisruptionBudget",
+  "severity": "LOW",
+  "category": "High Availability",
+  "descriptionText": "Deployments should be assigned with a PodDisruptionBudget to ensure high availability",
+  "descriptionUrl": "https://kubernetes.io/docs/tasks/run-application/configure-pdb/"
+}

--- a/assets/queries/k8s/deployment_without_poddisruptionbudget/query.rego
+++ b/assets/queries/k8s/deployment_without_poddisruptionbudget/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy [result ] {
+
+  deployment := input.document[i]
+  deployment.kind == "Deployment"
+  metadata := deployment.metadata
+
+  not CheckIFPdbExists(deployment)
+
+  result := {
+              "documentId": 		input.document[i].id,
+              "searchKey": 	    sprintf("metadata.name=%s", [metadata.name]),
+              "issueType":		"MissingAttribute",
+              "keyExpectedValue": sprintf("metadata.name=%s are targeted by a PDB", [metadata.name]),
+              "keyActualValue": 	sprintf("metadata.name=%s are not targeted by a PDB", [metadata.name])
+            }
+}
+
+CheckIFPdbExists (deployments) = result{
+	documents := input.document
+	pdbs := [pdb | documents[index].kind == "PodDisruptionBudget"; pdb = documents[index]]
+
+  result := contains(pdbs, deployments.spec.selector.matchLabels.app)
+}
+
+contains (array, string) = true {
+	array[a].spec.selector.matchLabels.app == string
+}

--- a/assets/queries/k8s/deployment_without_poddisruptionbudget/test/negative.yaml
+++ b/assets/queries/k8s/deployment_without_poddisruptionbudget/test/negative.yaml
@@ -1,0 +1,31 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: nginx-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: nginx
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/assets/queries/k8s/deployment_without_poddisruptionbudget/test/positive.yaml
+++ b/assets/queries/k8s/deployment_without_poddisruptionbudget/test/positive.yaml
@@ -1,0 +1,31 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: nginx-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: xpto
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/assets/queries/k8s/deployment_without_poddisruptionbudget/test/positive_expected_result.json
+++ b/assets/queries/k8s/deployment_without_poddisruptionbudget/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Deployment Without PodDisruptionBudget",
+		"severity": "LOW",
+		"line": 14
+	}
+]


### PR DESCRIPTION
Deployments should be targeted by PodDisruptionBudgets, which limit the number of Pods of a replicated application that can be taken offline at any given time.
This query evaluates if the `matchLabels` applied to Pods in a `Deployment` are referenced in the `matchLabels` of any `PodDisruptionBudget`.

Closes #634
Closes #1606  