### PR TITLE
Add missing_user_instruction query for Docker

### DIFF
--- a/assets/queries/dockerfile/missing_user_instruction/metadata.json
+++ b/assets/queries/dockerfile/missing_user_instruction/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "missing_user_instruction",
+  "queryName": "Missing USER Instruction",
+  "severity": "HIGH",
+  "category": "Container",
+  "descriptionText": "A user should be specified in the dockerfile, otherwise the image will run as root",
+  "descriptionUrl": "https://docs.docker.com/engine/reference/builder/#user"
+}

--- a/assets/queries/dockerfile/missing_user_instruction/query.rego
+++ b/assets/queries/dockerfile/missing_user_instruction/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].command[name]
+
+  not hasUserInstruction(resource)
+
+	result := {
+    			    "documentId": 		  input.document[i].id,
+              "searchKey": 	      sprintf("FROM={{%s}}", [name]),
+              "issueType":		    "Missing Attribute",
+              "keyExpectedValue": "The 'Dockerfile' contains the 'USER' instruction",
+              "keyActualValue": 	 "The 'Dockerfile' does not contain any 'USER' instruction"
+            }
+}
+
+hasUserInstruction(resource) {
+	some j
+    	resource[j].Cmd == "user"
+}

--- a/assets/queries/dockerfile/missing_user_instruction/test/negative.dockerfile
+++ b/assets/queries/dockerfile/missing_user_instruction/test/negative.dockerfile
@@ -1,0 +1,7 @@
+FROM python:2.7
+RUN pip install Flask==0.11.1
+RUN useradd -ms /bin/bash patrick
+COPY --chown=patrick:patrick app /app
+WORKDIR /app
+USER patrick
+CMD ["python", "app.py"]

--- a/assets/queries/dockerfile/missing_user_instruction/test/positive.dockerfile
+++ b/assets/queries/dockerfile/missing_user_instruction/test/positive.dockerfile
@@ -1,0 +1,6 @@
+FROM python:2.7
+RUN pip install Flask==0.11.1
+RUN useradd -ms /bin/bash patrick
+COPY --chown=patrick:patrick app /app
+WORKDIR /app
+CMD ["python", "app.py"]

--- a/assets/queries/dockerfile/missing_user_instruction/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/missing_user_instruction/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Missing USER Instruction",
+		"severity": "HIGH",
+		"line": 1
+	}
+]


### PR DESCRIPTION
This query verifies if there's any `USER` instruction stated in a `dockerfile`.
Closes #1613
Closes #467