### PR TITLE
Add update_instruction_alone query for Docker

### DIFF
--- a/assets/queries/dockerfile/update_instruction_alone/metadata.json
+++ b/assets/queries/dockerfile/update_instruction_alone/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "update_instruction_alone",
+  "queryName": "Update Instruction Alone",
+  "severity": "MEDIUM",
+  "category": "Image",
+  "descriptionText": "Instruction 'RUN <package-manager> update' should always be followed by '<package-manager> install' in the same RUN statement",
+  "descriptionUrl": "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run"
+}

--- a/assets/queries/dockerfile/update_instruction_alone/query.rego
+++ b/assets/queries/dockerfile/update_instruction_alone/query.rego
@@ -1,0 +1,37 @@
+package Cx
+
+CxPolicy [ result ] {
+	resource := input.document[i].command[name][_]
+ 	resource.Cmd == "run"
+ 	command := resource.Value[0]
+
+  contains(command, "update")
+  not updateFollowedByInstall(command)
+
+	result := {
+    			      "documentId": 		input.document[i].id,
+              	"searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+              	"issueType":		 "IncorrectValue",
+              	"keyExpectedValue": "Instruction 'RUN <package-manager> update' is followed by 'RUN <package-manager> install' ",
+              	"keyActualValue": 	 "Instruction 'RUN <package-manager> update' isn't followed by 'RUN <package-manager> install in the same 'RUN' statement",
+            }
+}
+
+updateFollowedByInstall(command) {
+
+  commandList = [
+    			    "install",
+				      "source-install",
+				      "reinstall",
+				      "groupinstall",
+				      "localinstall",
+              ]
+
+  update := indexof(command, "update")
+  update != -1
+
+  install := indexof(command, commandList[_])
+  install != -1
+
+  update<install
+}

--- a/assets/queries/dockerfile/update_instruction_alone/test/negative.dockerfile
+++ b/assets/queries/dockerfile/update_instruction_alone/test/negative.dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:18.04
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends mysql-client \
+    && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["mysql"]

--- a/assets/queries/dockerfile/update_instruction_alone/test/positive.dockerfile
+++ b/assets/queries/dockerfile/update_instruction_alone/test/positive.dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:18.04
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends mysql-client \
+    && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT ["mysql"]

--- a/assets/queries/dockerfile/update_instruction_alone/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/update_instruction_alone/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Update Instruction Alone",
+		"severity": "MEDIUM",
+		"line": 2
+	}
+]


### PR DESCRIPTION
`RUN <package-manager> update`  should always be combined with `<package-manager> install` in the same `RUN` statement. Using `<package-manager> update` alone in a `RUN` statement causes caching issues and subsequent `<package-manager> install` instructions fails.
Closes #518