### PR TITLE
Add cloudtrail_log_files_not_encrypted_with_kms query Closes #1661

### DIFF
--- a/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/metadata.json
+++ b/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "cloudtrail_log_files_not_encrypted_with_kms",
+  "queryName": "CloudTrail Log Files Not Encrypted With KMS",
+  "severity": "MEDIUM",
+  "category": "Logging",
+  "descriptionText": "CloudTrail Log Files should be encrypted with Key Management Service (KMS)",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/cloudtrail_module.html"
+}

--- a/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+    
+    modules := {"community.aws.cloudtrail", "cloudtrail"}
+    
+    object.get(task[modules[index]], "kms_key_id", "undefined") == "undefined"
+
+    
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
+        "issueType":         "MissingAttribute",
+        "keyExpectedValue":  sprintf("%s.kms_key_id is set", [modules[index]]),
+        "keyActualValue": 	 sprintf("%s.kms_key_id is undefined", [modules[index]])
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/test/negative.yaml
@@ -1,0 +1,14 @@
+- name: create multi-region trail with validation and tags v2
+  community.aws.cloudtrail:
+    state: present
+    name: default
+    s3_bucket_name: mylogbucket
+    region: us-east-1
+    is_multi_region_trail: true
+    enable_log_file_validation: true
+    cloudwatch_logs_role_arn: "arn:aws:iam::123456789012:role/CloudTrail_CloudWatchLogs_Role"
+    cloudwatch_logs_log_group_arn: "arn:aws:logs:us-east-1:123456789012:log-group:CloudTrail/DefaultLogGroup:*"
+    kms_key_id: "alias/MyAliasName"
+    tags:
+      environment: dev
+      Name: default

--- a/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/test/positive.yaml
@@ -1,0 +1,7 @@
+- name: no sns topic name
+  community.aws.cloudtrail:
+    state: present
+    name: default
+    s3_bucket_name: mylogbucket
+    s3_key_prefix: cloudtrail
+    region: us-east-1

--- a/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+	{
+		"queryName": "CloudTrail Log Files Not Encrypted With KMS",
+		"severity": "MEDIUM",
+		"line": 2
+	}
+
+]


### PR DESCRIPTION
According to the documentation, "By default, the log files delivered by CloudTrail to your bucket are encrypted by Amazon server-side encryption with Amazon S3-managed encryption keys (SSE-S3). To provide a security layer that is directly manageable, you can instead use server-side encryption with AWS KMS–managed keys (SSE-KMS) for your CloudTrail log files."

So, for this query, it is necessary to check if attribute 'kms_key_id' exists.

Closes #1661 