### PR TITLE
Add lambda_without_xray_tracing query Closes #1686

### DIFF
--- a/assets/queries/ansible/aws/lambda_without_xray_tracing/metadata.json
+++ b/assets/queries/ansible/aws/lambda_without_xray_tracing/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "lambda_without_xray_tracing",
+  "queryName": "Lambda Without X-Ray Tracing",
+  "severity": "LOW",
+  "category": "Logging",
+  "descriptionText": "Lambda should have X-Ray tracing enabled",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/lambda_module.html"
+}

--- a/assets/queries/ansible/aws/lambda_without_xray_tracing/query.rego
+++ b/assets/queries/ansible/aws/lambda_without_xray_tracing/query.rego
@@ -1,0 +1,41 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+    
+    object.get(task["community.aws.lambda"], "tracing_mode", "undefined") == "undefined"
+    
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s.{{community.aws.lambda}}", [task.name]),
+        "issueType":         "MissingAttribute",
+        "keyExpectedValue":  "community.aws.lambda.tracing_mode is set",
+        "keyActualValue": 	 "community.aws.lambda.tracing_mode is undefined"
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+    
+    task["community.aws.lambda"].tracing_mode != "Active"
+    
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s.{{community.aws.lambda}}.tracing_mode", [task.name]),
+        "issueType":         "IncorrectValue",
+        "keyExpectedValue":  "community.aws.lambda.tracing_mode is set to 'Active'",
+        "keyActualValue": 	 "community.aws.lambda.tracing_mode is not set to 'Active'"
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+}

--- a/assets/queries/ansible/aws/lambda_without_xray_tracing/test/negative.yaml
+++ b/assets/queries/ansible/aws/lambda_without_xray_tracing/test/negative.yaml
@@ -1,0 +1,29 @@
+- name: looped creation V3
+  community.aws.lambda:
+    name: '{{ item.name }}'
+    state: present
+    zip_file: '{{ item.zip_file }}'
+    runtime: 'python2.7'
+    role: 'arn:aws:iam::987654321012:role/lambda_basic_execution'
+    handler: 'hello_python.my_handler'
+    tracing_mode: "Active"
+    vpc_subnet_ids:
+    - subnet-123abcde
+    - subnet-edcba321
+    vpc_security_group_ids:
+    - sg-123abcde
+    - sg-edcba321
+    environment_variables: '{{ item.env_vars }}'
+    tags:
+      key1: 'value1'
+  loop:
+    - name: HelloWorld
+      zip_file: hello-code.zip
+      env_vars:
+        key1: "first"
+        key2: "second"
+    - name: ByeBye
+      zip_file: bye-code.zip
+      env_vars:
+        key1: "1"
+        key2: "2

--- a/assets/queries/ansible/aws/lambda_without_xray_tracing/test/positive.yaml
+++ b/assets/queries/ansible/aws/lambda_without_xray_tracing/test/positive.yaml
@@ -1,0 +1,57 @@
+- name: looped creation
+  community.aws.lambda:
+    name: '{{ item.name }}'
+    state: present
+    zip_file: '{{ item.zip_file }}'
+    runtime: 'python2.7'
+    role: 'arn:aws:iam::987654321012:role/lambda_basic_execution'
+    handler: 'hello_python.my_handler'
+    vpc_subnet_ids:
+    - subnet-123abcde
+    - subnet-edcba321
+    vpc_security_group_ids:
+    - sg-123abcde
+    - sg-edcba321
+    environment_variables: '{{ item.env_vars }}'
+    tags:
+      key1: 'value1'
+  loop:
+    - name: HelloWorld
+      zip_file: hello-code.zip
+      env_vars:
+        key1: "first"
+        key2: "second"
+    - name: ByeBye
+      zip_file: bye-code.zip
+      env_vars:
+        key1: "1"
+        key2: "2"
+- name: looped creation V2
+  community.aws.lambda:
+    name: '{{ item.name }}'
+    state: present
+    zip_file: '{{ item.zip_file }}'
+    runtime: 'python2.7'
+    role: 'arn:aws:iam::987654321012:role/lambda_basic_execution'
+    handler: 'hello_python.my_handler'
+    tracing_mode: "PassThrough"
+    vpc_subnet_ids:
+    - subnet-123abcde
+    - subnet-edcba321
+    vpc_security_group_ids:
+    - sg-123abcde
+    - sg-edcba321
+    environment_variables: '{{ item.env_vars }}'
+    tags:
+      key1: 'value1'
+  loop:
+    - name: HelloWorld
+      zip_file: hello-code.zip
+      env_vars:
+        key1: "first"
+        key2: "second"
+    - name: ByeBye
+      zip_file: bye-code.zip
+      env_vars:
+        key1: "1"
+        key2: "2"

--- a/assets/queries/ansible/aws/lambda_without_xray_tracing/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/lambda_without_xray_tracing/test/positive_expected_result.json
@@ -1,0 +1,13 @@
+[
+	{
+		"queryName": "Lambda Without X-Ray Tracing",
+		"severity": "LOW",
+		"line": 2
+	},
+
+	{
+		"queryName": "Lambda Without X-Ray Tracing",
+		"severity": "LOW",
+		"line": 37
+	}
+]


### PR DESCRIPTION
According to the documentation about attribute 'tracing_mode', "set mode to 'Active' to sample and trace incoming requests with AWS X-Ray. Turned off (set to 'PassThrough') by default".

So, for this query, it is necessary to check if attribute 'tracing_mode' exists. Furthermore, if when exits, is not set to 'Active' 

Closes #1686