### PR TITLE
Add S3 Bucket Allows WriteACP Action From All Principals query for Ansible

### DIFF
--- a/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/metadata.json
+++ b/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "S3_Bucket_Allows_Write_ACP_Action_From_All_Principals",
+  "queryName": "S3 Bucket Allows Write_ACP Action From All Principals",
+  "severity": "HIGH",
+  "category": "Identity and Access Management",
+  "descriptionText": "S3 Buckets must not allow Write_ACP Action From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion. This means the 'Effect' must not be 'Allow' when the 'Action' is Write_ACP, for all Principals.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_bucket_module.html"
+}

--- a/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/query.rego
@@ -1,0 +1,30 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  bucket := task["amazon.aws.s3_bucket"]
+  bucketName := task.name
+
+  bucket.policy.Statement[_].Effect == "Allow"
+  contains(lower(bucket.policy.Statement[_].Action), "write")
+  contains(lower(bucket.policy.Statement[_].Action), "acp")
+  bucket.policy.Statement[_].Principal == "*"
+
+    result := {
+                "documentId":       input.document[i].id,
+                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
+                "issueType":        "IncorrectValue",
+                "keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow WriteACP Action From All Principals", [bucketName]),
+                "keyActualValue":   sprintf("amazon.aws.s3_bucket[%s] allows WriteACP Action From All Principals", [bucketName])
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]  
+    count(result) != 0
+} 

--- a/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/query.rego
@@ -5,7 +5,8 @@ CxPolicy [ result ] {
   tasks := getTasks(document)
   task := tasks[t]
   bucket := task["amazon.aws.s3_bucket"]
-  bucketName := task.name
+  taskName := task.name
+  bucketName := bucket.name
 
   bucket.policy.Statement[_].Effect == "Allow"
   contains(lower(bucket.policy.Statement[_].Action), "write")
@@ -14,7 +15,7 @@ CxPolicy [ result ] {
 
     result := {
                 "documentId":       input.document[i].id,
-                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
+                "searchKey":        sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [taskName]),
                 "issueType":        "IncorrectValue",
                 "keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow WriteACP Action From All Principals", [bucketName]),
                 "keyActualValue":   sprintf("amazon.aws.s3_bucket[%s] allows WriteACP Action From All Principals", [bucketName])

--- a/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/test/negative.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/test/negative.yaml
@@ -1,0 +1,11 @@
+#this code is a correct code for which the query should not find any result
+- name: Bucket
+  amazon.aws.s3_bucket:
+    name: mys3bucket
+    state: present
+    policy:
+      Version: "2020-10-07"
+      Statement:
+      - Effect: Deny
+        Action: WriteACP
+        Principal: "*"

--- a/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/test/positive.yaml
@@ -8,4 +8,4 @@
       Statement:
       - Effect: Allow
         Action: WriteACP
-        Principal: "*" 
+        Principal: "*"

--- a/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/test/positive.yaml
@@ -1,0 +1,11 @@
+#this is a problematic code where the query should report a result(s)
+- name: Bucket
+  amazon.aws.s3_bucket:
+    name: mys3bucket
+    state: present
+    policy:
+      Version: "2020-10-07"
+      Statement:
+      - Effect: Allow
+        Action: WriteACP
+        Principal: "*" 

--- a/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/s3_bucket_allows_writeACP_action_from_all_principals/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "S3 Bucket Allows Write_ACP Action From All Principals",
+		"severity": "HIGH",
+		"line": 8
+	}
+]


### PR DESCRIPTION
Adding S3 Bucket Allows WriteACP Action From All Principals query for Ansible, that checks if the 'Effect' is'Allow' when the 'Action' is Write_ACP, for all Principals.

Closes #1691