### PR TITLE
Add ec2_public_instance_exposed_through_subnet query for AWS CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/metadata.json
+++ b/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ec2_public_instance_exposed_through_subnet",
+  "queryName": "EC2 Public Instance Exposed Through Subnet",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "EC2 instances with public IP addresses shouldn't allow for unrestricted traffic to their subnets",
+  "descriptionUrl": "https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html"
+}

--- a/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/query.rego
+++ b/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/query.rego
@@ -1,0 +1,41 @@
+package Cx
+
+CxPolicy [result ]  {
+
+  resources := input.document[i].Resources
+  resource := resources[j]
+  resource.Type == "AWS::EC2::Instance"
+
+  networkInterface := resource.Properties.NetworkInterfaces[n]
+  networkInterface.AssociatePublicIpAddress
+  subnetName := networkInterface.SubnetId
+
+  resources[subnetName]
+
+  some k
+  	resources[k].Type == "AWS::EC2::SubnetRouteTableAssociation"
+    resources[k].Properties.SubnetId == subnetName
+    routeTable := resources[k].Properties.RouteTableId
+
+  some l
+  	resources[l].Type = "AWS::EC2::Route"
+    resources[l].Properties.RouteTableId == routeTable
+
+  HasPublicDestinationCidr(resources[l])
+
+  result := {
+              "documentId": 		input.document[i].id,
+              "searchKey": 	    sprintf("Resources.%s", [subnetName]),
+              "issueType":		"IncorrectValue",
+              "keyExpectedValue": sprintf("Resources.%s is a private subnet",[subnetName]),
+              "keyActualValue": 	sprintf("Resources.%s has a route for unrestricted internet traffic",[subnetName])
+            }
+}
+
+HasPublicDestinationCidr(resource) {
+	resource.Properties.DestinationIpv6CidrBlock == "::/0"
+}
+
+HasPublicDestinationCidr(resource) {
+	resource.Properties.DestinationCidrBlock == "0.0.0.0/0"
+}

--- a/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/test/negative.yaml
+++ b/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/test/negative.yaml
@@ -1,0 +1,87 @@
+Resources:
+  myVPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsSupport: false
+      EnableDnsHostnames: false
+      InstanceTenancy: dedicated
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref myVPC
+  myRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref myVPC
+  myRoute:
+      Type: AWS::EC2::Route
+      DependsOn: VPCGatewayAttachment
+      Properties:
+        RouteTableId: !Ref myRouteTable
+        DestinationCidrBlock: 0.0.0.0/0
+        DestinationIpv6CidrBlock: ::/0
+        GatewayId: !Ref InternetGateway
+  mySubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref myVPC
+      CidrBlock: 10.0.0.0/24
+      AvailabilityZone: "us-east-1a"
+  mySubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref mySubnet
+      RouteTableId: !Ref myRouteTable
+  Ec2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-0ff8a91507f77f867
+      KeyName: !Ref Keyname
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: false
+          DeviceIndex: "0"
+          SubnetId: !Ref mySubnet
+---
+Resources:
+  myVPC_2:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsSupport: false
+      EnableDnsHostnames: false
+      InstanceTenancy: dedicated
+  InternetGateway_2:
+    Type: AWS::EC2::InternetGateway
+  VPCGatewayAttachment_2:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway_2
+      VpcId: !Ref myVPC_2
+  myRouteTable_2:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref myVPC_2
+  mySubnet_2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref myVPC_2
+      CidrBlock: 10.0.0.0/24
+      AvailabilityZone: "us-east-1a"
+  mySubnetRouteTableAssociation_2:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref mySubnet_2
+      RouteTableId: !Ref myRouteTable_2
+  Ec2Instance_2:
+    Type: AWS::EC2::Instance
+      Properties:
+        ImageId: ami-0ff8a91507f77f867
+        KeyName: !Ref Keyname
+        NetworkInterfaces:
+          - AssociatePublicIpAddress: true
+            DeviceIndex: "0"
+            SubnetId: !Ref mySubnet_2

--- a/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/test/positive.yaml
+++ b/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/test/positive.yaml
@@ -1,0 +1,47 @@
+Resources:
+  myVPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsSupport: false
+      EnableDnsHostnames: false
+      InstanceTenancy: dedicated
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId: !Ref InternetGateway
+      VpcId: !Ref myVPC
+  myRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref myVPC
+  myRoute:
+      Type: AWS::EC2::Route
+      DependsOn: VPCGatewayAttachment
+      Properties:
+        RouteTableId: !Ref myRouteTable
+        DestinationCidrBlock: 0.0.0.0/0
+        DestinationIpv6CidrBlock: ::/0
+        GatewayId: !Ref InternetGateway
+  mySubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref myVPC
+      CidrBlock: 10.0.0.0/24
+      AvailabilityZone: "us-east-1a"
+  mySubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref mySubnet
+      RouteTableId: !Ref myRouteTable
+  Ec2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: ami-0ff8a91507f77f867
+      KeyName: !Ref Keyname
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: true
+          DeviceIndex: "0"
+          SubnetId: !Ref mySubnet

--- a/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "EC2 Public Instance Exposed Through Subnet",
+		"severity": "HIGH",
+		"line": 28
+	}
+]


### PR DESCRIPTION
EC2 instances with public IP that permit unrestricted internet traffic to their subnets are vulnerable to breaches and various attacks.
 
This query begins by verifying if there's a public IP Address associated to the instance, by checking in the list of `NetworkInterfaces`  the value of `AssociatePublicIpAddress` attribute. 

If `true`, it evaluates if the subnet referenced under the `SubnetId` attribute has a route table associated, with a route with `DestinationCidrBlock`  == 0.0.0.0/0,  or `DestinationIpv6CidrBlock` == ::/0. 

Closes #1699