### PR TITLE
Add ec2_network_acl_duplicate_rule query for AWS CloudFormation #1693

### DIFF
--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/metadata.json
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/metadata.json
@@ -2,7 +2,7 @@
   "id": "ec2_network_acl_duplicate_rule",
   "queryName": "EC2 Network ACL Duplicate Rule",
   "severity": "LOW",
-  "category": null,
+  "category": "Network Security",
   "descriptionText": "A Network ACL's rule numbers cannot be repeated unless one is egress and the other is ingress",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber"
 }

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/metadata.json
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ec2_network_acl_duplicate_rule",
+  "queryName": "EC2 Network ACL Duplicate Rule",
+  "severity": "LOW",
+  "category": null,
+  "descriptionText": "A Network ACL's rule numbers cannot be repeated unless one is egress and the other is ingress",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber"
+}

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
@@ -1,0 +1,36 @@
+package Cx
+
+CxPolicy [ result ] {
+  entry1 := input.document[i].Resources[name]
+  entry1.Type == "AWS::EC2::NetworkAclEntry"
+
+  entry2 := input.document[_].Resources[_]
+  entry2.Type == "AWS::EC2::NetworkAclEntry"
+
+  entry1 != entry2
+
+  # Refer the same Network ACL
+  getRef(entry1.Properties.NetworkAclId) == getRef(entry2.Properties.NetworkAclId)
+
+  # Both egress or both ingress
+  getTraffic(entry1) == getTraffic(entry2)
+
+  # Same rule number
+  entry1.Properties.RuleNumber == entry2.Properties.RuleNumber
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.RuleNumber", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'Resources.%s' has not the same rule number as other entry for the same NetworkACL", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s' has the same rule number as other entry for the same NetworkACL", [name])
+              }
+}
+
+getRef(obj) = obj.Ref {
+	object.get(obj, "Ref", "undefined") != "undefined"
+} else = obj
+
+getTraffic(entry) = "egress" {
+	object.get(entry.Properties, "Egress", "undefined") == true
+} else = "ingress"

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/negative.yaml
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/negative.yaml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyNACL:
+    Type: AWS::EC2::NetworkAcl
+    Properties:
+       VpcId: vpc-1122334455aabbccd
+  InboundRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: 6
+       RuleAction: allow
+       CidrBlock: 172.16.0.0/24
+       PortRange:
+         From: 22
+         To: 22
+  OutboundRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: -1
+       Egress: true
+       RuleAction: allow
+       CidrBlock: 0.0.0.0/0

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive.yaml
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive.yaml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyNACL:
+    Type: AWS::EC2::NetworkAcl
+    Properties:
+       VpcId: vpc-1122334455aabbccd
+  InboundRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: 6
+       Egress: true
+       RuleAction: allow
+       CidrBlock: 172.16.0.0/24
+       PortRange:
+         From: 22
+         To: 22
+  OutboundRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: -1
+       Egress: true
+       RuleAction: allow
+       CidrBlock: 0.0.0.0/0

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "EC2 Network ACL Duplicate Rule",
+		"severity": "LOW",
+		"line": 12
+	},
+	{
+		"queryName": "EC2 Network ACL Duplicate Rule",
+		"severity": "LOW",
+		"line": 25
+	}
+]


### PR DESCRIPTION
Closes #1693 

A Network ACL's rule numbers cannot be repeated unless one is egress and the other is ingress