### PR TITLE
Add ec2_instance_has_public_ip query for Ansible

### DIFF
--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/metadata.json
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ec2_instance_has_public_ip",
+  "queryName": "EC2 Instance Has Public IP",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "EC2 Instance should not have a public IP address.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_module.html#parameter-assign_public_ip"
+}

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/query.rego
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/query.rego
@@ -1,0 +1,74 @@
+package Cx
+
+CxPolicy [result ]  {
+	document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+
+  ipValue := task["amazon.aws.ec2"].assign_public_ip
+  HasPublicIP(ipValue)
+
+	# There is no default value for assign_public_ip
+
+  result := {
+          "documentId": document.id,
+        	"searchKey": sprintf("name=%s.{{amazon.aws.ec2}}.assign_public_ip", [task.name]),
+        	"issueType": "IncorrectValue",
+       	 	"keyExpectedValue": sprintf("name=%s.{{amazon.aws.ec2}}.assign_public_ip is false, 'no' or undefined", [task.name]),
+        	"keyActualValue": sprintf("name=%s.{{amazon.aws.ec2}}.assign_public_ip is '%s'", [task.name, ipValue])
+            }
+}
+
+CxPolicy [result ]  {
+	document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+
+  ipValue := task["community.aws.ec2_launch_template"].network_interfaces.associate_public_ip_address
+  HasPublicIP(ipValue)
+
+  # There is no default value for associate_public_ip_address
+
+  result := {
+          "documentId": document.id,
+        	"searchKey": sprintf("name=%s.{{community.aws.ec2_launch_template}}.network_interfaces.associate_public_ip_address", [task.name]),
+        	"issueType": "IncorrectValue",
+       	 	"keyExpectedValue": sprintf("name=%s.{{community.aws.ec2_launch_template}}.network_interfaces.associate_public_ip_address is false, 'no' or undefined", [task.name]),
+        	"keyActualValue": sprintf("name=%s.{{community.aws.ec2_launch_template}}.network_interfaces.associate_public_ip_address is '%s'", [task.name, ipValue])
+            }
+}
+
+CxPolicy [result ]  {
+	document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+
+  ipValue := task["community.aws.ec2_instance"].network.assign_public_ip
+  HasPublicIP(ipValue)
+
+  # There is no default value for assign_public_ip
+
+  result := {
+          "documentId": document.id,
+        	"searchKey": sprintf("name=%s.{{community.aws.ec2_instance}}.network.assign_public_ip", [task.name]),
+        	"issueType": "IncorrectValue",
+       	 	"keyExpectedValue": sprintf("name=%s.{{community.aws.ec2_instance}}.network.assign_public_ip is false, 'no' or undefined", [task.name]),
+        	"keyActualValue": sprintf("name=%s.{{community.aws.ec2_instance}}.network.assign_public_ip is '%s'", [task.name, ipValue])
+            }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook]
+    count(result) != 0
+}
+
+HasPublicIP(value) {
+	lower(value) == "yes"
+} else {
+	lower(value) == "true"
+} else {
+	value == true
+}

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/negative.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/negative.yaml
@@ -1,0 +1,12 @@
+- amazon.aws.ec2:
+    key_name: mykey
+    instance_type: t2.micro
+    count: 3
+    vpc_subnet_id: subnet-29e63245
+    assign_public_ip: false
+- name: Create an ec2 launch template
+  community.aws.ec2_launch_template:
+    name: "my_template"
+    image_id: "ami-04b762b4289fba92b"
+    key_name: my_ssh_key
+    instance_type: t2.micro

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/positive.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/positive.yaml
@@ -1,0 +1,24 @@
+- name: example
+  amazon.aws.ec2:
+    key_name: mykey
+    instance_type: t2.micro
+    count: 3
+    vpc_subnet_id: subnet-29e63245
+    assign_public_ip: yes
+- name: Create an ec2 launch template
+  community.aws.ec2_launch_template:
+    name: "my_template"
+    image_id: "ami-04b762b4289fba92b"
+    key_name: my_ssh_key
+    instance_type: t2.micro
+    network_interfaces:
+      associate_public_ip_address: true
+- name: start an instance with a public IP address
+  community.aws.ec2_instance:
+    name: "public-compute-instance"
+    key_name: "prod-ssh-key"
+    vpc_subnet_id: subnet-5ca1ab1e
+    instance_type: c5.large
+    security_group: default
+    network:
+      assign_public_ip: true

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "EC2 Instance Has Public IP",
+		"severity": "HIGH",
+		"line": 7
+	},
+	{
+		"queryName": "EC2 Instance Has Public IP",
+		"severity": "HIGH",
+		"line": 15
+	},
+	{
+		"queryName": "EC2 Instance Has Public IP",
+		"severity": "HIGH",
+		"line": 24
+	}
+]


### PR DESCRIPTION
An EC2 Instance should not have a public IP address.
This query makes three verifications:

       1) if `assign_public_ip` from `amazon.aws.ec2` resource is set
       2) if `network_interfaces.associate_public_ip_address` from `community.aws.ec2_launch_template` resource is set 
       3) if `network.assign_public_ip` from `community.aws.ec2_instance` resource is set

Since there's no reference to default values in the documentation, I assumed that if the parameter was undefined there would be no public IP address associated to the instance.                   
Closes #1726