### PR TITLE
Add web_app_accepts_http_traffic query for Ansible

### DIFF
--- a/assets/queries/ansible/azure/web_app_accepts_http_traffic/metadata.json
+++ b/assets/queries/ansible/azure/web_app_accepts_http_traffic/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "web_app_accepts_http_traffic",
+  "queryName": "Web App Accepts HTTP Traffic",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Web app should only accept HTTPS traffic in Azure Web App Service.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_webapp_module.html#parameter-https_only"
+}

--- a/assets/queries/ansible/azure/web_app_accepts_http_traffic/query.rego
+++ b/assets/queries/ansible/azure/web_app_accepts_http_traffic/query.rego
@@ -1,0 +1,51 @@
+package Cx
+
+CxPolicy [result ]  {
+	document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  https_value := task["azure_rm_webapp"].https_only
+
+  not HasHttpsEnabled(https_value)
+
+  result := {
+        "documentId": document.id,
+        "searchKey": sprintf("name=%s.{{azure_rm_webapp}}.https_only", [task.name]),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": "{{azure_rm_webapp}}.https_only is set to true or 'yes'",
+        "keyActualValue": sprintf("{{azure_rm_webapp}}.https_only value is '%s'", [https_value])
+          }
+}
+
+CxPolicy [result ]  {
+	document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+	https := task["azure_rm_webapp"]
+
+  object.get(https, "https_only", "undefined") == "undefined"
+
+  result := {
+        "documentId": document.id,
+        "searchKey": sprintf("name=%s.{{azure_rm_webapp}}", [task.name]),
+        "issueType": "MissingAttribute",
+        "keyExpectedValue": sprintf("name=%s.{{azure_rm_webapp}}.https_only is defined", [task.name]),
+        "keyActualValue": sprintf("name=%s.{{azure_rm_webapp}}.https_only is undefined", [task.name])
+		  }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook]
+    count(result) != 0
+}
+
+HasHttpsEnabled(value) {
+	lower(value) == "yes"
+} else {
+	  lower(value) == "true"
+} else {
+	  value == true
+}

--- a/assets/queries/ansible/azure/web_app_accepts_http_traffic/test/negative.yaml
+++ b/assets/queries/ansible/azure/web_app_accepts_http_traffic/test/negative.yaml
@@ -1,0 +1,10 @@
+- name: Create a windows web app with non-exist app service plan
+  azure_rm_webapp:
+    resource_group: myResourceGroup
+    name: myWinWebapp
+    https_only: true
+    plan:
+      resource_group: myAppServicePlan_rg
+      name: myAppServicePlan
+      is_linux: false
+      sku: S1

--- a/assets/queries/ansible/azure/web_app_accepts_http_traffic/test/positive.yaml
+++ b/assets/queries/ansible/azure/web_app_accepts_http_traffic/test/positive.yaml
@@ -1,0 +1,19 @@
+- name: Create a windows web app with non-exist app service plan
+  azure_rm_webapp:
+    resource_group: myResourceGroup
+    name: myWinWebapp
+    https_only: false
+    plan:
+      resource_group: myAppServicePlan_rg
+      name: myAppServicePlan
+      is_linux: false
+      sku: S1
+- name: Create another windows web app
+  azure_rm_webapp:
+    resource_group: myResourceGroup
+    name: myWinWebapp
+    plan:
+      resource_group: myAppServicePlan_rg
+      name: myAppServicePlan
+      is_linux: false
+      sku: S1

--- a/assets/queries/ansible/azure/web_app_accepts_http_traffic/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/web_app_accepts_http_traffic/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "Web App Accepts HTTP Traffic",
+		"severity": "HIGH",
+		"line": 5
+	},
+	{
+		"queryName": "Web App Accepts HTTP Traffic",
+		"severity": "HIGH",
+		"line": 12
+	}
+]


### PR DESCRIPTION
Web app should only accept HTTPS traffic in Azure Web App Service.
This query verifies if attribute `https_only` from the `azure_rm_webapp` module is set. If so, it should be either `true` or `yes`.
Closes #1734 