### PR TITLE
Add gke_master_authorized_networks_disabled query for Ansible #1739

### DIFF
--- a/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "gke_master_authorized_networks_disabled",
+  "queryName": "GKE Master Authorized Networks Disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Master authorized networks must be enabled in GKE clusters",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_module.html#parameter-master_authorized_networks_config/enabled"
+}

--- a/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/query.rego
+++ b/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/query.rego
@@ -1,0 +1,65 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+  container_cluster := task["google.cloud.gcp_container_cluster"]
+
+  object.get(container_cluster, "master_authorized_networks_config", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_container_cluster}}", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'master_authorized_networks_config' is defined",
+                "keyActualValue": 	"'master_authorized_networks_config' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+  container_cluster := task["google.cloud.gcp_container_cluster"]
+
+  object.get(container_cluster.master_authorized_networks_config, "enabled", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_container_cluster}}.master_authorized_networks_config", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "'master_authorized_networks_config.enabled' is defined",
+                "keyActualValue": 	"'master_authorized_networks_config.enabled' is undefined"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  task := getTasks(document)[t]
+  container_cluster := task["google.cloud.gcp_container_cluster"]
+
+  not isAnsibleTrue(container_cluster.master_authorized_networks_config.enabled)
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_container_cluster}}.master_authorized_networks_config.enabled", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "'master_authorized_networks_config.enabled' is true",
+                "keyActualValue": 	"'master_authorized_networks_config.enabled' is false"
+              }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks ]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}
+
+isAnsibleTrue(answer) {
+ 	lower(answer) == "yes"
+} else {
+	lower(answer) == "true"
+} else {
+	answer == true
+}

--- a/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/test/negative.yaml
@@ -1,0 +1,12 @@
+---
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    initial_node_count: 2
+    location: us-central1-a
+    auth_kind: serviceaccount
+    master_authorized_networks_config:
+      cidr_blocks:
+        - cidr_block: 192.0.2.0/24
+      enabled: yes
+    state: present

--- a/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/test/positive.yaml
@@ -1,0 +1,26 @@
+---
+- name: create a cluster
+  google.cloud.gcp_container_cluster:
+    name: my-cluster
+    location: us-central1-a
+    auth_kind: serviceaccount
+    master_authorized_networks_config:
+      cidr_blocks:
+        - cidr_block: 192.0.2.0/24
+      enabled: no
+    state: present
+- name: create a second cluster
+  google.cloud.gcp_container_cluster:
+    name: my-second-cluster
+    location: us-central1-a
+    auth_kind: serviceaccount
+    master_authorized_networks_config:
+      cidr_blocks:
+        - cidr_block: 192.0.2.0/24
+    state: present
+- name: create a third cluster
+  google.cloud.gcp_container_cluster:
+    name: my-third-cluster
+    location: us-central1-a
+    auth_kind: serviceaccount
+    state: present

--- a/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "GKE Master Authorized Networks Disabled",
+		"severity": "HIGH",
+		"line": 10
+	},
+	{
+		"queryName": "GKE Master Authorized Networks Disabled",
+		"severity": "HIGH",
+		"line": 17
+	},
+	{
+		"queryName": "GKE Master Authorized Networks Disabled",
+		"severity": "HIGH",
+		"line": 22
+	}
+]


### PR DESCRIPTION
Closes #1739 

Master authorized networks must be enabled in GKE clusters