### PR TITLE
Add compute_instance_is_publicly_accessible query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/metadata.json
+++ b/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "compute_instance_is_publicly_accessible",
+  "queryName": "Compute Instance Is Publicly Accessible",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "Compute instances shouldn't be accessible from the Internet.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_module.html#parameter-network_interfaces/access_configs"
+}

--- a/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/metadata.json
+++ b/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/metadata.json
@@ -1,5 +1,5 @@
 {
-  "id": "compute_instance_is_publicly_accessible",
+  "id": "829f1c60-2bab-44c6-8a21-5cd9d39a2c82",
   "queryName": "Compute Instance Is Publicly Accessible",
   "severity": "HIGH",
   "category": "Network Security",

--- a/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/query.rego
@@ -1,0 +1,25 @@
+package Cx
+
+CxPolicy [result ]  {
+	document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+
+  task["google.cloud.gcp_compute_instance"].network_interfaces[_].access_configs
+
+  result := {
+            "documentId": document.id,
+        	  "searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_instance}}.network_interfaces", [task.name]),
+        	  "issueType": "IncorrectValue",
+       	 	  "keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.network_interfaces.access_configs is not defined",
+        	  "keyActualValue": "{{google.cloud.gcp_compute_instance}}.network_interfaces.access_configs is defined"
+            }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook]
+    count(result) != 0
+}

--- a/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/query.rego
@@ -9,7 +9,7 @@ CxPolicy [result ]  {
 
   result := {
             "documentId": document.id,
-        	  "searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_instance}}.network_interfaces", [task.name]),
+        	  "searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_instance}}.network_interfaces.access_configs", [task.name]),
         	  "issueType": "IncorrectValue",
        	 	  "keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.network_interfaces.access_configs is not defined",
         	  "keyActualValue": "{{google.cloud.gcp_compute_instance}}.network_interfaces.access_configs is defined"

--- a/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/test/negative.yaml
+++ b/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/test/negative.yaml
@@ -1,0 +1,9 @@
+- name: create a instance
+  google.cloud.gcp_compute_instance:
+    name: test_object
+    network_interfaces:
+    - network: "{{ network }}"
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    state: present

--- a/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/test/positive.yaml
+++ b/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/test/positive.yaml
@@ -1,0 +1,13 @@
+- name: create a instance
+  google.cloud.gcp_compute_instance:
+    name: test_object
+    network_interfaces:
+    - network: "{{ network }}"
+      access_configs:
+      - name: External NAT
+        nat_ip: "{{ address }}"
+        type: ONE_TO_ONE_NAT
+    zone: us-central1-a
+    project: test_project
+    auth_kind: serviceaccount
+    state: present

--- a/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/test/positive_expected_result.json
@@ -2,6 +2,6 @@
 	{
 		"queryName": "Compute Instance Is Publicly Accessible",
 		"severity": "HIGH",
-		"line": 4
+		"line": 6
 	}
 ]

--- a/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Compute Instance Is Publicly Accessible",
+		"severity": "HIGH",
+		"line": 4
+	}
+]


### PR DESCRIPTION
Compute instances shouldn't have access configurations set, i.e. IPs via which the instances can be accessed via the Internet.
This query verifies if the attribute `access_configs` is defined.
Closes #1742