### PR TITLE
Add msk_cluster_logging_enabled query for terraform

### DIFF
--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/metadata.json
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ec2_instance_has_public_ip",
+  "queryName": "EC2 Instance Has Public IP",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "EC2 Instance should not have a public IP address.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_module.html#parameter-assign_public_ip"
+}

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/query.rego
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/query.rego
@@ -1,0 +1,74 @@
+package Cx
+
+CxPolicy [result ]  {
+	document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+
+  ipValue := task["amazon.aws.ec2"].assign_public_ip
+  HasPublicIP(ipValue)
+
+	# There is no default value for assign_public_ip
+
+  result := {
+          "documentId": document.id,
+        	"searchKey": sprintf("name=%s.{{amazon.aws.ec2}}.assign_public_ip", [task.name]),
+        	"issueType": "IncorrectValue",
+       	 	"keyExpectedValue": sprintf("name=%s.{{amazon.aws.ec2}}.assign_public_ip is false, 'no' or undefined", [task.name]),
+        	"keyActualValue": sprintf("name=%s.{{amazon.aws.ec2}}.assign_public_ip is '%s'", [task.name, ipValue])
+            }
+}
+
+CxPolicy [result ]  {
+	document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+
+  ipValue := task["community.aws.ec2_launch_template"].network_interfaces.associate_public_ip_address
+  HasPublicIP(ipValue)
+
+  # There is no default value for associate_public_ip_address
+
+  result := {
+          "documentId": document.id,
+        	"searchKey": sprintf("name=%s.{{community.aws.ec2_launch_template}}.network_interfaces.associate_public_ip_address", [task.name]),
+        	"issueType": "IncorrectValue",
+       	 	"keyExpectedValue": sprintf("name=%s.{{community.aws.ec2_launch_template}}.network_interfaces.associate_public_ip_address is false, 'no' or undefined", [task.name]),
+        	"keyActualValue": sprintf("name=%s.{{community.aws.ec2_launch_template}}.network_interfaces.associate_public_ip_address is '%s'", [task.name, ipValue])
+            }
+}
+
+CxPolicy [result ]  {
+	document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+
+  ipValue := task["community.aws.ec2_instance"].network.assign_public_ip
+  HasPublicIP(ipValue)
+
+  # There is no default value for assign_public_ip
+
+  result := {
+          "documentId": document.id,
+        	"searchKey": sprintf("name=%s.{{community.aws.ec2_instance}}.network.assign_public_ip", [task.name]),
+        	"issueType": "IncorrectValue",
+       	 	"keyExpectedValue": sprintf("name=%s.{{community.aws.ec2_instance}}.network.assign_public_ip is false, 'no' or undefined", [task.name]),
+        	"keyActualValue": sprintf("name=%s.{{community.aws.ec2_instance}}.network.assign_public_ip is '%s'", [task.name, ipValue])
+            }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook]
+    count(result) != 0
+}
+
+HasPublicIP(value) {
+	lower(value) == "yes"
+} else {
+	lower(value) == "true"
+} else {
+	value == true
+}

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/negative.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/negative.yaml
@@ -1,0 +1,12 @@
+- amazon.aws.ec2:
+    key_name: mykey
+    instance_type: t2.micro
+    count: 3
+    vpc_subnet_id: subnet-29e63245
+    assign_public_ip: false
+- name: Create an ec2 launch template
+  community.aws.ec2_launch_template:
+    name: "my_template"
+    image_id: "ami-04b762b4289fba92b"
+    key_name: my_ssh_key
+    instance_type: t2.micro

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/positive.yaml
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/positive.yaml
@@ -1,0 +1,24 @@
+- name: example
+  amazon.aws.ec2:
+    key_name: mykey
+    instance_type: t2.micro
+    count: 3
+    vpc_subnet_id: subnet-29e63245
+    assign_public_ip: yes
+- name: Create an ec2 launch template
+  community.aws.ec2_launch_template:
+    name: "my_template"
+    image_id: "ami-04b762b4289fba92b"
+    key_name: my_ssh_key
+    instance_type: t2.micro
+    network_interfaces:
+      associate_public_ip_address: true
+- name: start an instance with a public IP address
+  community.aws.ec2_instance:
+    name: "public-compute-instance"
+    key_name: "prod-ssh-key"
+    vpc_subnet_id: subnet-5ca1ab1e
+    instance_type: c5.large
+    security_group: default
+    network:
+      assign_public_ip: true

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "EC2 Instance Has Public IP",
+		"severity": "HIGH",
+		"line": 7
+	},
+	{
+		"queryName": "EC2 Instance Has Public IP",
+		"severity": "HIGH",
+		"line": 15
+	},
+	{
+		"queryName": "EC2 Instance Has Public IP",
+		"severity": "HIGH",
+		"line": 24
+	}
+]

--- a/assets/queries/ansible/azure/aks_without_rbac/metadata.json
+++ b/assets/queries/ansible/azure/aks_without_rbac/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "aks_without_rbac",
+  "queryName": "AKS Without RBAC",
+  "severity": "MEDIUM",
+  "category": "Network Security",
+  "descriptionText": "Azure Container Service (AKS) instance should have role-based access control (RBAC) enabled",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/azure/azcollection/azure_rm_aks_module.html"
+}

--- a/assets/queries/ansible/azure/aks_without_rbac/query.rego
+++ b/assets/queries/ansible/azure/aks_without_rbac/query.rego
@@ -1,0 +1,46 @@
+package Cx
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+    object.get(task["azure_rm_aks"], "enable_rbac", "undefined") == "undefined"
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s.{{azure_rm_aks}}", [task.name]),
+        "issueType":         "MissingAttribute",
+        "keyExpectedValue":  "azure_rm_aks.enable_rbac is defined",
+        "keyActualValue": 	 "azure_rm_aks.enable_rbac is undefined"
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    tasks := getTasks(document)
+    task := tasks[t]
+
+    not isYesOrTrue(task["azure_rm_aks"].enable_rbac)
+
+    result := {
+        "documentId":        document.id,
+        "searchKey":         sprintf("name=%s.{{azure_rm_aks}}.enable_rbac", [task.name]),
+        "issueType":         "IncorrectValue",
+        "keyExpectedValue":  "azure_rm_aks.enable_rbac is set to 'yes' or 'true'",
+        "keyActualValue": 	 "azure_rm_aks.enable_rbac is not set to 'yes' or 'true'"
+    }
+}
+
+getTasks(document) = result {
+    result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+    count(result) != 0
+} else = result {
+    result := [body | playbook := document.playbooks[_]; body := playbook ]
+    count(result) != 0
+}
+
+isYesOrTrue(attribute) {
+   options := {"yes", true, "true"}
+   lower(attribute) == lower(options[j])
+}

--- a/assets/queries/ansible/azure/aks_without_rbac/test/negative.yaml
+++ b/assets/queries/ansible/azure/aks_without_rbac/test/negative.yaml
@@ -1,0 +1,21 @@
+- name: Create an AKS instance v3
+  azure_rm_aks:
+    name: myAKS
+    resource_group: myResourceGroup
+    location: eastus
+    dns_prefix: akstest
+    kubernetes_version: 1.14.6
+    linux_profile:
+      admin_username: azureuser
+      ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAA...
+    service_principal:
+      client_id: "cf72ca99-f6b9-4004-b0e0-bee10c521948"
+      client_secret: "Password1234!"
+    agent_pool_profiles:
+      - name: default
+        count: 1
+        vm_size: Standard_DS1_v2
+        type: VirtualMachineScaleSets
+        max_count: 3
+        min_count: 1
+    enable_rbac: yes

--- a/assets/queries/ansible/azure/aks_without_rbac/test/positive.yaml
+++ b/assets/queries/ansible/azure/aks_without_rbac/test/positive.yaml
@@ -1,0 +1,41 @@
+- name: Create an AKS instance
+  azure_rm_aks:
+    name: myAKS
+    resource_group: myResourceGroup
+    location: eastus
+    dns_prefix: akstest
+    kubernetes_version: 1.14.6
+    linux_profile:
+      admin_username: azureuser
+      ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAA...
+    service_principal:
+      client_id: "cf72ca99-f6b9-4004-b0e0-bee10c521948"
+      client_secret: "Password1234!"
+    agent_pool_profiles:
+      - name: default
+        count: 1
+        vm_size: Standard_DS1_v2
+        type: VirtualMachineScaleSets
+        max_count: 3
+        min_count: 1
+    enable_rbac: no
+- name: Create an AKS instance v2
+  azure_rm_aks:
+    name: myAKS
+    resource_group: myResourceGroup
+    location: eastus
+    dns_prefix: akstest
+    kubernetes_version: 1.14.6
+    linux_profile:
+      admin_username: azureuser
+      ssh_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAA...
+    service_principal:
+      client_id: "cf72ca99-f6b9-4004-b0e0-bee10c521948"
+      client_secret: "Password1234!"
+    agent_pool_profiles:
+      - name: default
+        count: 1
+        vm_size: Standard_DS1_v2
+        type: VirtualMachineScaleSets
+        max_count: 3
+        min_count: 1

--- a/assets/queries/ansible/azure/aks_without_rbac/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/aks_without_rbac/test/positive_expected_result.json
@@ -1,0 +1,13 @@
+[
+	{
+		"queryName": "AKS Without RBAC",
+		"severity": "MEDIUM",
+		"line": 21
+	},
+
+	{
+		"queryName": "AKS Without RBAC",
+		"severity": "MEDIUM",
+		"line": 23
+	}
+]

--- a/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "cloud_sql_instance_ssl_disabled",
+  "queryName": "Cloud SQL Instance SSL Disabled",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "GCP SQL Instance should have reqire SSL defined",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_instance_module.html#parameter-settings/ip_configuration/require_ssl"
+}

--- a/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/query.rego
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/query.rego
@@ -1,0 +1,54 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_sql_instance"]
+  settings := instance.settings
+  ip_configuration := settings.ip_configuration
+
+  isAnsibleFalse(ip_configuration.require_ssl)
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration.require_ssl", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": "cloud_gcp_sql_instance.settings.ip_configuration.require_ssl is true",
+                "keyActualValue": 	"cloud_gcp_sql_instance.settings.ip_configuration.require_ssl is false"
+              }
+}
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_sql_instance"]
+  settings := instance.settings
+  ip_configuration := settings.ip_configuration
+
+  object.get(ip_configuration, "require_ssl", "undefined") == "undefined"
+
+	result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration", [task.name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "cloud_gcp_sql_instance.settings.ip_configuration.require_ssl is defined",
+                "keyActualValue": 	"cloud_gcp_sql_instance.settings.ip_configuration.require_ssl is undefined"
+              }
+}
+
+isAnsibleFalse(answer) {
+ 	lower(answer) == "no"
+} else {
+	lower(answer) == "false"
+} else {
+	answer == false
+}
+
+getTasks(document) = result {
+  result := document.playbooks[0].tasks
+} else = result {
+  object.get(document.playbooks[0],"tasks","undefined") == "undefined"
+  result := document.playbooks
+}

--- a/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/test/negative.yaml
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/test/negative.yaml
@@ -1,0 +1,14 @@
+- name: sample
+  tasks:
+  - name: sql_instance
+    google.cloud.gcp_sql_instance:
+      auth_kind: serviceaccount
+      name: "{{resource_name}}-2"
+      project: test_project
+      region: us-central1
+      service_account_file: /tmp/auth.pem
+      settings:
+        ip_configuration:
+          require_ssl : true
+        tier: db-n1-standard-1
+      state: present

--- a/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/test/positive.yaml
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/test/positive.yaml
@@ -1,0 +1,14 @@
+- name: sample
+  tasks:
+  - name: sql_instance
+    google.cloud.gcp_sql_instance:
+      auth_kind: serviceaccount
+      name: "{{resource_name}}-1"
+      project: test_project
+      region: us-central1
+      service_account_file: /tmp/auth.pem
+      settings:
+        ip_configuration:
+          require_ssl : false
+        tier: db-n1-standard-1
+      state: present

--- a/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Cloud SQL Instance SSL Disabled",
+		"severity": "HIGH",
+		"line": 12
+	}
+]

--- a/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/metadata.json
+++ b/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "log_min_duration_statement_wrong_value",
+  "queryName": "Log Min Duration Statement Wrong Value",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "PostgreSQL database 'log_min_duration_statement' flag isn't set to '-1'",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_instance_module.html#parameter-settings/database_flags"
+}

--- a/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/query.rego
+++ b/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/query.rego
@@ -1,0 +1,37 @@
+package Cx
+
+CxPolicy [ result ] {
+  document := input.document[i]
+  tasks := getTasks(document)
+  task := tasks[t]
+  instance := task["google.cloud.gcp_sql_instance"]
+  settings := instance.settings
+  database_flags := settings.database_flags
+
+  check_database_flags_content(database_flags)
+
+  result := {
+                "documentId": 		document.id,
+                "searchKey": 	    sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags", [task.name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags sets the log_min_duration_statement to -1", [task.name]),
+                "keyActualValue":   sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags doesn't set the log_min_duration_statement to -1", [task.name])
+              }
+}
+
+getTasks(document) = result {
+  result := document.playbooks[0].tasks
+} else = result {
+  object.get(document.playbooks[0],"tasks","undefined") == "undefined"
+  result := document.playbooks
+}
+
+check_database_flags_content(database_flags) {
+	database_flags[x].name == "log_min_duration_statement"
+	database_flags[x].value != -1
+}
+
+check_database_flags_content(database_flags) {
+	database_flags.name == "log_min_duration_statement"
+	database_flags.value != -1
+}

--- a/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/test/negative.yaml
+++ b/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/test/negative.yaml
@@ -1,0 +1,16 @@
+- name: sample
+  tasks:
+  - name: sql_instance
+    google.cloud.gcp_sql_instance:
+      auth_kind: serviceaccount
+      database_version: SQLSERVER_13_1
+      name: "{{resource_name}}-2"
+      project: test_project
+      region: us-central1
+      service_account_file: /tmp/auth.pem
+      settings:
+        database_flags:
+        - name: log_min_duration_statement
+          value: -1
+        tier: db-n1-standard-1
+      state: present

--- a/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/test/positive.yaml
+++ b/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/test/positive.yaml
@@ -1,0 +1,16 @@
+- name: sample
+  tasks:
+  - name: sql_instance
+    google.cloud.gcp_sql_instance:
+      auth_kind: serviceaccount
+      database_version: SQLSERVER_13_1
+      name: "{{resource_name}}-2"
+      project: test_project
+      region: us-central1
+      service_account_file: /tmp/auth.pem
+      settings:
+        database_flags:
+        - name: log_min_duration_statement
+          value: 0
+        tier: db-n1-standard-1
+      state: present

--- a/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Log Min Duration Statement Wrong Value",
+		"severity": "HIGH",
+		"line": 12
+	}
+]

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/metadata.json
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "ec2_network_acl_duplicate_rule",
+  "queryName": "EC2 Network ACL Duplicate Rule",
+  "severity": "LOW",
+  "category": "Network Security",
+  "descriptionText": "A Network ACL's rule numbers cannot be repeated unless one is egress and the other is ingress",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber"
+}

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
@@ -1,0 +1,36 @@
+package Cx
+
+CxPolicy [ result ] {
+  entry1 := input.document[i].Resources[name]
+  entry1.Type == "AWS::EC2::NetworkAclEntry"
+
+  entry2 := input.document[_].Resources[_]
+  entry2.Type == "AWS::EC2::NetworkAclEntry"
+
+  entry1 != entry2
+
+  # Refer the same Network ACL
+  getRef(entry1.Properties.NetworkAclId) == getRef(entry2.Properties.NetworkAclId)
+
+  # Both egress or both ingress
+  getTraffic(entry1) == getTraffic(entry2)
+
+  # Same rule number
+  entry1.Properties.RuleNumber == entry2.Properties.RuleNumber
+
+	result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("Resources.%s.Properties.RuleNumber", [name]),
+                "issueType":		"IncorrectValue",
+                "keyExpectedValue": sprintf("'Resources.%s' has not the same rule number as other entry for the same NetworkACL", [name]),
+                "keyActualValue": 	sprintf("'Resources.%s' has the same rule number as other entry for the same NetworkACL", [name])
+              }
+}
+
+getRef(obj) = obj.Ref {
+	object.get(obj, "Ref", "undefined") != "undefined"
+} else = obj
+
+getTraffic(entry) = "egress" {
+	object.get(entry.Properties, "Egress", "undefined") == true
+} else = "ingress"

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/negative.yaml
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/negative.yaml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyNACL:
+    Type: AWS::EC2::NetworkAcl
+    Properties:
+       VpcId: vpc-1122334455aabbccd
+  InboundRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: 6
+       RuleAction: allow
+       CidrBlock: 172.16.0.0/24
+       PortRange:
+         From: 22
+         To: 22
+  OutboundRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: -1
+       Egress: true
+       RuleAction: allow
+       CidrBlock: 0.0.0.0/0

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive.yaml
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive.yaml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyNACL:
+    Type: AWS::EC2::NetworkAcl
+    Properties:
+       VpcId: vpc-1122334455aabbccd
+  InboundRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: 6
+       Egress: true
+       RuleAction: allow
+       CidrBlock: 172.16.0.0/24
+       PortRange:
+         From: 22
+         To: 22
+  OutboundRule:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL
+       RuleNumber: 100
+       Protocol: -1
+       Egress: true
+       RuleAction: allow
+       CidrBlock: 0.0.0.0/0

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "EC2 Network ACL Duplicate Rule",
+		"severity": "LOW",
+		"line": 12
+	},
+	{
+		"queryName": "EC2 Network ACL Duplicate Rule",
+		"severity": "LOW",
+		"line": 25
+	}
+]

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/metadata.json
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "MSKClusterNotLogging",
   "queryName": "MSK Cluster logging is not enabled",
-  "severity": "LOW",
+  "severity": "MEDIUM",
   "category": "Logging",
   "descriptionText": "Ensure MSK Cluster Logging is enabled",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#broker_logs"

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/metadata.json
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "MSKClusterNotLogging",
+  "queryName": "MSK Cluster logging is not enabled",
+  "severity": "LOW",
+  "category": "Logging",
+  "descriptionText": "Ensure MSK Cluster Logging is enabled",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#broker_logs"
+}

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/query.rego
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/query.rego
@@ -1,0 +1,71 @@
+package Cx
+
+CxPolicy [ result ] {
+    msk_cluster := input.document[i].resource.aws_msk_cluster[name]
+    tech := msk_cluster.logging_info.broker_logs[techName]
+    not tech.enabled
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("msk_cluster[%s].logging_info.broker_logs[%s].enabled", [name, techName]),
+                "issueType":		getIssueType(msk_cluster, techName),
+                "keyExpectedValue": "'rule.logging_info.broker_logs.enabled' should be 'true' in every entry",
+                "keyActualValue": 	sprintf("msk_cluster[%s].logging_info.broker_logs[%s].enabled is %s", [name, techName, getActualValue(msk_cluster, techName)])
+              }
+}
+
+CxPolicy [ result ] {
+    msk_cluster := input.document[i].resource.aws_msk_cluster[name]
+
+    msk_cluster.logging_info
+    msk_cluster.logging_info.broker_logs
+    
+    not msk_cluster.logging_info.broker_logs["cloudwatch_logs"]
+    not msk_cluster.logging_info.broker_logs["firehose"]
+    not msk_cluster.logging_info.broker_logs["s3"]
+    
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("msk_cluster[%s].logging_info.broker_logs", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "Should have at least one of the following keys: 'cloudwatch_logs', 'firehose' or 's3'",
+                "keyActualValue": 	"'rule.logging_info.broker_logs.cloudwatch_logs', 'rule.logging_info.broker_logs.firehose' and 'rule.logging_info.broker_logs.s3' do not exists"
+              }
+}
+
+CxPolicy [ result ] {
+    msk_cluster := input.document[i].resource.aws_msk_cluster[name]
+    msk_cluster.logging_info
+    not msk_cluster.logging_info.broker_logs
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("msk_cluster[%s].logging_info", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "Should exists 'rule.logging_info.broker_logs'",
+                "keyActualValue": 	"'rule.logging_info.broker_logs' does not exists"
+              }
+}
+
+CxPolicy [ result ] {
+    msk_cluster := input.document[i].resource.aws_msk_cluster[name]
+    not msk_cluster.logging_info
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("msk_cluster[%s]", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "Should exists 'rule.logging_info'",
+                "keyActualValue": 	"'rule.logging_info' does not exists"
+              }
+}
+
+getIssueType(msk_cluster, techName) = "IncorretValue" {
+		_ = msk_cluster.logging_info.broker_logs[techName]["enabled"]
+} else = "MissingAttribute" {
+	true
+}
+
+getActualValue(msk_cluster, techName) = "false" {
+		_ = msk_cluster.logging_info.broker_logs[techName]["enabled"]
+} else = "missing" {
+	true
+}
+

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/query.rego
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/query.rego
@@ -17,7 +17,6 @@ CxPolicy [ result ] {
     msk_cluster := input.document[i].resource.aws_msk_cluster[name]
 
     msk_cluster.logging_info
-    msk_cluster.logging_info.broker_logs
     
     not msk_cluster.logging_info.broker_logs["cloudwatch_logs"]
     not msk_cluster.logging_info.broker_logs["firehose"]

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/query.rego
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/query.rego
@@ -34,19 +34,6 @@ CxPolicy [ result ] {
 
 CxPolicy [ result ] {
     msk_cluster := input.document[i].resource.aws_msk_cluster[name]
-    msk_cluster.logging_info
-    not msk_cluster.logging_info.broker_logs
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("msk_cluster[%s].logging_info", [name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "Should exists 'rule.logging_info.broker_logs'",
-                "keyActualValue": 	"'rule.logging_info.broker_logs' does not exists"
-              }
-}
-
-CxPolicy [ result ] {
-    msk_cluster := input.document[i].resource.aws_msk_cluster[name]
     not msk_cluster.logging_info
     result := {
                 "documentId": 		input.document[i].id,

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/negative.tf
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/negative.tf
@@ -1,0 +1,10 @@
+resource "aws_msk_cluster" "example" {  
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = aws_cloudwatch_log_group.test.name
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/positive.tf
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/positive.tf
@@ -1,0 +1,23 @@
+resource "aws_msk_cluster" "example1" {  
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = false
+        log_group = aws_cloudwatch_log_group.test.name
+      }
+      firehose {
+        delivery_stream = aws_kinesis_firehose_delivery_stream.test_stream.name
+      }
+      s3 {
+        enabled = true
+        bucket  = aws_s3_bucket.bucket.id
+        prefix  = "logs/msk-"
+      }
+    }
+  }
+}
+
+resource "aws_msk_cluster" "example2" {  
+  logging_info {
+  }
+}

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/positive_expected_result.json
@@ -1,17 +1,17 @@
 [
 	{
 		"queryName": "MSK Cluster logging is not enabled",
-		"severity": "LOW",
+		"severity": "MEDIUM",
 		"line": 2
 	},
 	{
 		"queryName": "MSK Cluster logging is not enabled",
-		"severity": "LOW",
+		"severity": "MEDIUM",
 		"line": 2
 	},
 	{
 		"queryName": "MSK Cluster logging is not enabled",
-		"severity": "LOW",
+		"severity": "MEDIUM",
 		"line": 21
 	}
 ]

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "MSK Cluster logging is not enabled",
+		"severity": "LOW",
+		"line": 2
+	},
+	{
+		"queryName": "MSK Cluster logging is not enabled",
+		"severity": "LOW",
+		"line": 2
+	},
+	{
+		"queryName": "MSK Cluster logging is not enabled",
+		"severity": "LOW",
+		"line": 21
+	}
+]


### PR DESCRIPTION
MSK cluster instances should have logging enabled. This query verifies if `logging_info` and `broker_logs` are defined and if the instances inside `broker_logs` have `enabled` defined and set true
Closes #1744 