### PR TITLE
Configure Sonar to include go unit tests

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,14 +1,19 @@
 sonar.projectKey=Checkmarx_kics
 sonar.organization=checkmarx
 
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=.
+sonar.exclusions=**/*_test.go, **/vendor/**
+
+sonar.tests=.
 sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/vendor/**
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=kics
 #sonar.projectVersion=1.0
 
-# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-#sonar.sources=.
-
 # Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
+sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,8 @@
 sonar.projectKey=Checkmarx_kics
 sonar.organization=checkmarx
 
+sonar.test.inclusions=**/*_test.go
+
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=kics
 #sonar.projectVersion=1.0


### PR DESCRIPTION
Configure Sonar using sonar-project.properties file to find the test files and properly calculate coverage.

Currently Sonar is flagging tests as "Lines to cover":

![image](https://user-images.githubusercontent.com/75368139/103804355-e46b3d00-5049-11eb-8b0c-75bb8552e385.png)

Closes #1746