### PR TITLE
Add postgresql_log_connections_flag_not_set_to_on query for Ansible

### DIFF
--- a/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/metadata.json
+++ b/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/metadata.json
@@ -1,5 +1,5 @@
 {
-  "id": "postgresql_log_connections_flag_not_set_to_on",
+  "id": "d7a5616f-0a3f-4d43-bc2b-29d1a183e317",
   "queryName": "PostgreSQL log_connections Flag Not Set To ON",
   "severity": "HIGH",
   "category": "Network Security",

--- a/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/metadata.json
+++ b/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "postgresql_log_connections_flag_not_set_to_on",
+  "queryName": "PostgreSQL log_connections Flag Not Set To ON",
+  "severity": "HIGH",
+  "category": "Network Security",
+  "descriptionText": "PostgreSQL database instance should have a 'log_connections' flag with its value set to 'on'",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_instance_module.html#parameter-settings/database_flags"
+}

--- a/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/metadata.json
+++ b/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/metadata.json
@@ -2,7 +2,7 @@
   "id": "d7a5616f-0a3f-4d43-bc2b-29d1a183e317",
   "queryName": "PostgreSQL log_connections Flag Not Set To ON",
   "severity": "HIGH",
-  "category": "Network Security",
+  "category": "Logging",
   "descriptionText": "PostgreSQL database instance should have a 'log_connections' flag with its value set to 'on'",
   "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_instance_module.html#parameter-settings/database_flags"
 }

--- a/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/query.rego
+++ b/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/query.rego
@@ -1,0 +1,60 @@
+package Cx
+
+CxPolicy [result ]  {
+	document := input.document[i]
+	tasks := getTasks(document)
+	task := tasks[t]
+
+	gcp_task := task["google.cloud.gcp_sql_instance"]
+	contains(gcp_task.database_version, "POSTGRES")
+
+	IsMissingAttribute(gcp_task)
+
+	result := {
+			"documentId": document.id,
+			"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}", [task.name]),
+			"issueType": "MissingAttribute",
+			"keyExpectedValue": "{{google.cloud.gcp_sql_instance}}.settings.databaseFlags is defined",
+			"keyActualValue": "{{google.cloud.gcp_sql_instance}}.settings.databaseFlags is not defined"
+			}
+}
+
+CxPolicy [result ]  {
+	document := input.document[i]
+	tasks := getTasks(document)
+	task := tasks[t]
+
+	gcp_task := task["google.cloud.gcp_sql_instance"]
+	contains(gcp_task.database_version, "POSTGRES")
+
+	IsFlagOff(gcp_task.settings.databaseFlags)
+
+	result := {
+			"documentId": document.id,
+			"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.databaseFlags", [task.name]),
+			"issueType": "IncorrectValue",
+			"keyExpectedValue": "{{google.cloud.gcp_sql_instance}}.settings.databaseFlags has 'log_connections' flag set to 'on'",
+			"keyActualValue": "{{google.cloud.gcp_sql_instance}}.settings.databaseFlags has 'log_connections' flag set to 'off'"
+			}
+}
+
+getTasks(document) = result {
+	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
+	count(result) != 0
+} else = result {
+	result := [body | playbook := document.playbooks[_]; body := playbook]
+	count(result) != 0
+}
+
+IsMissingAttribute(gcp_task) {
+	object.get(gcp_task, "settings", "undefined") == "undefined"
+}
+
+IsMissingAttribute(gcp_task) {
+	object.get(gcp_task.settings, "databaseFlags", "undefined") == "undefined"
+}
+
+IsFlagOff(dbFlags) {
+	dbFlags[j].name == "log_connections"
+	lower(dbFlags[j].value) == "off"
+}

--- a/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/test/negative.yaml
+++ b/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/test/negative.yaml
@@ -1,0 +1,14 @@
+- name: create a instance
+  google.cloud.gcp_sql_instance:
+    name: GCP instance
+    settings:
+      databaseFlags:
+      - name: log_connections
+        value: on
+      tier: db-n1-standard-1
+    region: us-central1
+    project: test_project
+    database_version : POSTGRES_9_6
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/test/positive.yaml
+++ b/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/test/positive.yaml
@@ -1,0 +1,25 @@
+- name: create instance
+  google.cloud.gcp_sql_instance:
+    name: GCP instance
+    settings:
+      databaseFlags:
+      - name: log_connections
+        value: off
+      tier: db-n1-standard-1
+    region: us-central1
+    project: test_project
+    database_version : POSTGRES_9_6
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+- name: create another instance
+  google.cloud.gcp_sql_instance:
+    name: GCP instance 2
+    settings:
+      tier: db-n1-standard-1
+    region: us-central1
+    project: test_project
+    database_version : POSTGRES_9_6
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present

--- a/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+	{
+		"queryName": "PostgreSQL log_connections Flag Not Set To ON",
+		"severity": "HIGH",
+		"line": 5
+	},
+	{
+		"queryName": "PostgreSQL log_connections Flag Not Set To ON",
+		"severity": "HIGH",
+		"line": 16
+	}
+]


### PR DESCRIPTION
This query evaluates if there's a `log_connections` flag under `<module>.settings.databaseFlags` with its value set to `on`.
Closes #1752