### PR TITLE
Add msk_cluster_encryption_enabled query for Terraform (#1761)

### DIFF
--- a/assets/queries/terraform/aws/msk_cluster_encryption_enabled/metadata.json
+++ b/assets/queries/terraform/aws/msk_cluster_encryption_enabled/metadata.json
@@ -1,5 +1,5 @@
 {
-  "id": "MSKClusterEncryptionNotEnabled",
+  "id": "6db52fa6-d4da-4608-908a-89f0c59e743e",
   "queryName": "MSK Cluster encryption is not enabled",
   "severity": "HIGH",
   "category": "Encryption and Key Management",

--- a/assets/queries/terraform/aws/msk_cluster_encryption_enabled/metadata.json
+++ b/assets/queries/terraform/aws/msk_cluster_encryption_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "MSKClusterEncryptionNotEnabled",
+  "queryName": "MSK Cluster encryption is not enabled",
+  "severity": "HIGH",
+  "category": "Encryption and Key Management",
+  "descriptionText": "Ensure MSK Cluster encryption in rest and transit is enabled",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#encryption_info"
+}

--- a/assets/queries/terraform/aws/msk_cluster_encryption_enabled/query.rego
+++ b/assets/queries/terraform/aws/msk_cluster_encryption_enabled/query.rego
@@ -1,0 +1,47 @@
+package Cx
+
+CxPolicy [ result ] {
+    msk_cluster := input.document[i].resource.aws_msk_cluster[name]
+    problems := checkEncryption(msk_cluster)
+    problems != "none"
+    
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    getSearchKey(problems, name),
+                "issueType":		getIssueType(problems),
+                "keyExpectedValue": "Should have 'rule.encryption_info' and, if 'rule.encryption_info.encryption_in_transit' is assigned, 'in_cluster' should be 'true' and 'client_broker' should be TLS",
+                "keyActualValue": 	"'rule.encryption_info' is unassigned or property 'in_cluster' is 'false' or property 'client_broker' is not 'TLS'"
+              }
+}
+
+checkEncryption(msk_cluster) = ".encryption_in_transit.in_cluster,encryption_in_transit.client_broker" {
+	encryptionInTransit = msk_cluster.encryption_info.encryption_in_transit
+    encryptionInTransit.client_broker != "TLS"
+    encryptionInTransit.in_cluster == false
+} else = ".encryption_info.encryption_in_transit.client_broker" {
+	encryptionInTransit = msk_cluster.encryption_info.encryption_in_transit
+    encryptionInTransit.client_broker != "TLS"
+} else = ".encryption_info.encryption_in_transit.in_cluster" {
+	encryptionInTransit = msk_cluster.encryption_info.encryption_in_transit
+    encryptionInTransit.in_cluster == false
+} else = "" {
+	not msk_cluster.encryption_info
+} else = "none" {
+	true
+}
+
+getSearchKey(problems, name) = str {
+	problemsSplited := split(problems, ",")
+    count(problemsSplited) == 2
+    defaultSearchValue := sprintf("msk_cluster[%s].encryption_info", [name])
+    str := concat(" and ", [concat("", [defaultSearchValue, problemsSplited[0]]), concat("", [defaultSearchValue, problemsSplited[1]])])
+} else = str {
+	defaultSearchValue := sprintf("msk_cluster[%s]", [name])
+    str := concat("", [defaultSearchValue, problems])
+}
+
+getIssueType(problems) = "MissingAttribute" {
+	problems == ""
+} else = "InvalidValue" {
+	true
+}

--- a/assets/queries/terraform/aws/msk_cluster_encryption_enabled/test/negative.tf
+++ b/assets/queries/terraform/aws/msk_cluster_encryption_enabled/test/negative.tf
@@ -1,0 +1,33 @@
+resource "aws_msk_cluster" "example1" {  
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.kms.arn
+  }
+}
+
+resource "aws_msk_cluster" "example2" {  
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.kms.arn
+    encryption_in_transit {
+      client_broker = "TLS"
+      in_cluster = true
+    }
+  }
+}
+
+resource "aws_msk_cluster" "example3" {  
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.kms.arn
+    encryption_in_transit {
+      client_broker = "TLS"
+    }
+  }
+}
+
+resource "aws_msk_cluster" "example4" {  
+  encryption_info {
+    encryption_at_rest_kms_key_arn = aws_kms_key.kms.arn
+    encryption_in_transit {
+      in_cluster = true
+    }
+  }
+}

--- a/assets/queries/terraform/aws/msk_cluster_encryption_enabled/test/positive.tf
+++ b/assets/queries/terraform/aws/msk_cluster_encryption_enabled/test/positive.tf
@@ -1,0 +1,42 @@
+resource "aws_msk_cluster" "example1" {
+  cluster_name           = "example"
+  kafka_version          = "2.4.1"
+  number_of_broker_nodes = 3
+}
+
+resource "aws_msk_cluster" "example2" {
+  cluster_name           = "example"
+  kafka_version          = "2.4.1"
+  number_of_broker_nodes = 3
+  
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "PLAINTEXT"
+    }
+  }
+}
+
+resource "aws_msk_cluster" "example3" {
+  cluster_name           = "example"
+  kafka_version          = "2.4.1"
+  number_of_broker_nodes = 3
+  
+  encryption_info {
+    encryption_in_transit {
+      in_cluster = false
+    }
+  }
+}
+
+resource "aws_msk_cluster" "example4" {
+  cluster_name           = "example"
+  kafka_version          = "2.4.1"
+  number_of_broker_nodes = 3
+  
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "PLAINTEXT"
+      in_cluster = false
+    }
+  }
+}

--- a/assets/queries/terraform/aws/msk_cluster_encryption_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/msk_cluster_encryption_enabled/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+	{
+		"queryName": "MSK Cluster encryption is not enabled",
+		"severity": "HIGH",
+		"line": 1
+	},
+	{
+		"queryName": "MSK Cluster encryption is not enabled",
+		"severity": "HIGH",
+		"line": 14
+	},
+	{
+		"queryName": "MSK Cluster encryption is not enabled",
+		"severity": "HIGH",
+		"line": 26
+	},
+	{
+		"queryName": "MSK Cluster encryption is not enabled",
+		"severity": "HIGH",
+		"line": 37
+	}
+]


### PR DESCRIPTION
MSK cluster should be encrypted i.e. should have attribute encryption_info defined and client_broker and in_cluster should be set with default value ("TLS" and true, respectively)
Closes #1761 