### PR TITLE
Add msk_cluster_logging_enabled query for terraform (#1744)

### DIFF
--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/metadata.json
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "MSKClusterNotLogging",
+  "queryName": "MSK Cluster logging is not enabled",
+  "severity": "MEDIUM",
+  "category": "Logging",
+  "descriptionText": "Ensure MSK Cluster Logging is enabled",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#broker_logs"
+}

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/metadata.json
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/metadata.json
@@ -1,5 +1,5 @@
 {
-  "id": "MSKClusterNotLogging",
+  "id": "2f56b7ab-7fba-4e93-82f0-247e5ddeb239",
   "queryName": "MSK Cluster logging is not enabled",
   "severity": "MEDIUM",
   "category": "Logging",

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/query.rego
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/query.rego
@@ -1,0 +1,63 @@
+package Cx
+
+CxPolicy [ result ] {
+    msk_cluster := input.document[i].resource.aws_msk_cluster[name]
+    tech := msk_cluster.logging_info.broker_logs[instanceType]
+    not tech.enabled
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf(getSearchKey(msk_cluster, instanceType), [name, instanceType]),
+                "issueType":		  getIssueType(msk_cluster, instanceType),
+                "keyExpectedValue": "'rule.logging_info.broker_logs.enabled' should be 'true' in every entry",
+                "keyActualValue": 	sprintf("msk_cluster[%s].logging_info.broker_logs.%s.enabled is %s", [name, instanceType, getActualValue(msk_cluster, instanceType)])
+              }
+}
+
+CxPolicy [ result ] {
+    msk_cluster := input.document[i].resource.aws_msk_cluster[name]
+
+    msk_cluster.logging_info
+    
+    not msk_cluster.logging_info.broker_logs["cloudwatch_logs"]
+    not msk_cluster.logging_info.broker_logs["firehose"]
+    not msk_cluster.logging_info.broker_logs["s3"]
+    
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("msk_cluster[%s].logging_info.broker_logs", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "Should have at least one of the following keys: 'cloudwatch_logs', 'firehose' or 's3'",
+                "keyActualValue": 	"'rule.logging_info.broker_logs.cloudwatch_logs', 'rule.logging_info.broker_logs.firehose' and 'rule.logging_info.broker_logs.s3' do not exists"
+              }
+}
+
+CxPolicy [ result ] {
+    msk_cluster := input.document[i].resource.aws_msk_cluster[name]
+    not msk_cluster.logging_info
+    result := {
+                "documentId": 		input.document[i].id,
+                "searchKey": 	    sprintf("msk_cluster[%s]", [name]),
+                "issueType":		"MissingAttribute",
+                "keyExpectedValue": "Should exists 'rule.logging_info'",
+                "keyActualValue": 	"'rule.logging_info' does not exists"
+              }
+}
+
+getSearchKey(msk_cluster, instanceType) = "msk_cluster[%s].logging_info.broker_logs.%s.enabled" {
+  _ = msk_cluster.logging_info.broker_logs[instanceType]["enabled"]
+} else = "msk_cluster[%s].logging_info.broker_logs.%s" {
+  true
+}
+
+getIssueType(msk_cluster, instanceType) = "IncorretValue" {
+	_ = msk_cluster.logging_info.broker_logs[instanceType]["enabled"]
+} else = "MissingAttribute" {
+	true
+}
+
+getActualValue(msk_cluster, instanceType) = "false" {
+	_ = msk_cluster.logging_info.broker_logs[instanceType]["enabled"]
+} else = "missing" {
+	true
+}
+

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/negative.tf
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/negative.tf
@@ -1,0 +1,10 @@
+resource "aws_msk_cluster" "example" {  
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = aws_cloudwatch_log_group.test.name
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/positive.tf
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/positive.tf
@@ -1,0 +1,22 @@
+resource "aws_msk_cluster" "example1" {  
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = false
+        log_group = aws_cloudwatch_log_group.test.name
+      }
+      firehose {
+        delivery_stream = aws_kinesis_firehose_delivery_stream.test_stream.name
+      }
+      s3 {
+        enabled = true
+        bucket  = aws_s3_bucket.bucket.id
+        prefix  = "logs/msk-"
+      }
+    }
+  }
+}
+
+resource "aws_msk_cluster" "example2" {  
+  
+}

--- a/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/msk_cluster_logging_enabled/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+	{
+		"queryName": "MSK Cluster logging is not enabled",
+		"severity": "MEDIUM",
+		"line": 5
+	},
+	{
+		"queryName": "MSK Cluster logging is not enabled",
+		"severity": "MEDIUM",
+		"line": 8
+	},
+	{
+		"queryName": "MSK Cluster logging is not enabled",
+		"severity": "MEDIUM",
+		"line": 20
+	}
+]


### PR DESCRIPTION
MSK cluster instances should have logging enabled. This query verifies if logging_info and broker_logs are defined and if the instances inside broker_logs have enabled defined and set true
Closes #1744