### PR TITLE
Fix detect line issues

### DIFF
--- a/assets/queries/ansible/aws/no_password_policy_enabled/query.rego
+++ b/assets/queries/ansible/aws/no_password_policy_enabled/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 
     result := {
         "documentId":        document.id,
-        "searchKey":         sprintf("name=%s", [task.name]),
+        "searchKey":         sprintf("name={{%s}}", [task.name]),
         "issueType":         "MissingAttribute",
         "keyExpectedValue":  "community.aws.iam_password_policy or iam_password_policy is set",
         "keyActualValue": 	 "community.aws.iam_password_policy or iam_password_policy is not set",
@@ -25,7 +25,7 @@ CxPolicy[result] {
     task := tasks[t]
 
     modules := {"community.aws.iam_password_policy", "iam_password_policy"}
-    
+
     attributes := {"require_lowercase", "require_numbers", "require_symbols", "require_uppercase"}
 
     object.get(task[modules[index]], attributes[j], "undefined") == "undefined"
@@ -46,12 +46,12 @@ CxPolicy[result] {
     task := tasks[t]
 
     modules := {"community.aws.iam_password_policy", "iam_password_policy"}
-    
+
     attributes := {"require_lowercase", "require_numbers", "require_symbols", "require_uppercase"}
 
     attribute := object.get(task[modules[index]], attributes[j], "undefined")
     attribute != "undefined"
-    
+
     not isTrueOrYes(attribute)
 
     result := {
@@ -74,6 +74,6 @@ getTasks(document) = result {
 isTrueOrYes(attribute) = allow {
     possibilities := {"yes", true}
     attribute == possibilities[j]
-    
+
 	allow = true
 }

--- a/assets/queries/ansible/azure/cosmosdb_account_without_tags/query.rego
+++ b/assets/queries/ansible/azure/cosmosdb_account_without_tags/query.rego
@@ -4,8 +4,9 @@ CxPolicy [ result ] {
   document := input.document[i]
   tasks := getTasks(document)
   task := tasks[t]
+  task.azure_rm_cosmosdbaccount
   not task.azure_rm_cosmosdbaccount.tags
-  
+
   result := {
           "documentId": document.id,
           "searchKey": sprintf("name=%s.{{azure_rm_cosmosdbaccount}}.tags", [task.name]),
@@ -20,6 +21,6 @@ getTasks(document) = result {
   result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
   count(result) != 0
 } else = result {
-  result := [body | playbook := document.playbooks[_]; body := playbook ]  
+  result := [body | playbook := document.playbooks[_]; body := playbook ]
   count(result) != 0
 }

--- a/assets/queries/cloudFormation/s3_buckets_are_publicly_accessible/query.rego
+++ b/assets/queries/cloudFormation/s3_buckets_are_publicly_accessible/query.rego
@@ -1,48 +1,48 @@
 package Cx
 
 CxPolicy [ result ] {
-   
+
     resourceBucket := input.document[indexBucket].Resources[nameBucket]
     resourceBucket.Type == "AWS::S3::Bucket"
 
-    policyStatements := [policyStatement | 	resourcePolicy := input.document[_].Resources[_]
-                                            resourcePolicy.Type == "AWS::S3::BucketPolicy"
-                                            checkRef(resourcePolicy.Properties.Bucket, nameBucket)
+    policyStatements := [policyStatement | 	resourcePolicy := input.document[indexBucket].Resources[_];
+                                            resourcePolicy.Type == "AWS::S3::BucketPolicy";
+                                            checkRef(resourcePolicy.Properties.Bucket, nameBucket);
                                             policyStatement := resourcePolicy.Properties.PolicyDocument.Statement[_]]
 
  	checkPolicyConfiguration(policyStatements)
-  
+
 	publicAccessBlockConfiguration := resourceBucket.Properties.PublicAccessBlockConfiguration
 	publicAccessBlockConfiguration.RestrictPublicBuckets == false
 
 	result := {
-                "documentId": 		input.document[i].id,
+                "documentId": 		input.document[indexBucket].id,
                 "searchKey": 	    sprintf("Resources.%s.Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets", [nameBucket]),
-                "issueType":		"IncorrectValue",  
+                "issueType":		"IncorrectValue",
                 "keyExpectedValue": "'Resources.Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets' is true",
                 "keyActualValue": 	"'Resources.Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets' is false"
                 }
 }
 
 CxPolicy [ result ] {
-   
+
   	resourceBucket := input.document[indexBucket].Resources[nameBucket]
   	resourceBucket.Type == "AWS::S3::Bucket"
 
-	policyStatements := [policyStatement | 	resourcePolicy := input.document[_].Resources[_]
-                                            resourcePolicy.Type == "AWS::S3::BucketPolicy"
-                                            checkRef(resourcePolicy.Properties.Bucket, nameBucket)
+	policyStatements := [policyStatement | 	resourcePolicy := input.document[indexBucket].Resources[_];
+                                            resourcePolicy.Type == "AWS::S3::BucketPolicy";
+                                            checkRef(resourcePolicy.Properties.Bucket, nameBucket);
                                             policyStatement := resourcePolicy.Properties.PolicyDocument.Statement[_]]
 
  	checkPolicyConfiguration(policyStatements)
-  
+
 	publicAccessBlockConfiguration := resourceBucket.Properties.PublicAccessBlockConfiguration
 	publicAccessBlockConfiguration.IgnorePublicAcls == false
 
 	result := {
-                "documentId": 		input.document[i].id,
+                "documentId": 		input.document[indexBucket].id,
                 "searchKey": 	    sprintf("Resources.%s.Properties.PublicAccessBlockConfiguration.IgnorePublicAcls", [nameBucket]),
-                "issueType":		"IncorrectValue",  
+                "issueType":		"IncorrectValue",
                 "keyExpectedValue": "'Resources.Properties.PublicAccessBlockConfiguration.IgnorePublicAcls' is true",
                 "keyActualValue": 	"'Resources.Properties.PublicAccessBlockConfiguration.IgnorePublicAcls' is false"
                 }
@@ -59,10 +59,10 @@ checkPolicy(policyProperty) {
 }
 checkPolicy(policyProperty) {
     policyProperty.Principal.AWS == "*"
-}  
+}
 checkPolicy(policyProperty) {
     policyProperty.Principal.AWS[_] == "*"
-}  
+}
 
 checkRef(obj, name) {
 	obj.Ref == name

--- a/assets/queries/terraform/aws/aws_config_rule_for_encrypted_vols_is_disabled/query.rego
+++ b/assets/queries/terraform/aws/aws_config_rule_for_encrypted_vols_is_disabled/query.rego
@@ -8,7 +8,7 @@ CxPolicy [ result ] {
 
 	result := {
                 "documentId": 		input.document[i].id,
-                "searchKey": 	    "aws_config_config_rule[0]", #refer to the first rule
+                "searchKey": 	    "aws_config_config_rule", #refer to the first rule
                 "issueType":		"MissingAttrbute",
                 "keyExpectedValue": "There is a 'aws_config_config_rule' resource has source id: 'ENCRYPTED_VOLUMES'",
                 "keyActualValue": 	"No 'aws_config_config_rule' resource has source id: 'ENCRYPTED_VOLUMES'"

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -250,7 +250,7 @@ func customConsoleWriter(fileLogger *zerolog.ConsoleWriter) zerolog.ConsoleWrite
 	}
 
 	fileLogger.FormatFieldValue = func(i interface{}) string {
-		return strings.ToUpper(fmt.Sprintf("%s", i))
+		return fmt.Sprintf("%s", i)
 	}
 
 	return *fileLogger

--- a/internal/tracker/ci.go
+++ b/internal/tracker/ci.go
@@ -22,3 +22,8 @@ func (c *CITracker) TrackFileFound() {
 func (c *CITracker) TrackFileParse() {
 	c.ParsedFiles++
 }
+
+// FailedDetectLine - queries that fail to detect line are counted as failed to execute queries
+func (c *CITracker) FailedDetectLine() {
+	c.ExecutedQueries--
+}

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Checkmarx/kics/pkg/model"
 	"github.com/agnivade/levenshtein"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -49,7 +50,7 @@ var DefaultVulnerabilityBuilder = func(ctx QueryContext, v interface{}) (model.V
 
 	logWithFields := log.With().
 		Str("scanID", ctx.scanID).
-		Str("fileID", file.ID).
+		Str("fileName", file.FileName).
 		Str("queryName", ctx.query.metadata.Query).
 		Logger()
 
@@ -58,12 +59,12 @@ var DefaultVulnerabilityBuilder = func(ctx QueryContext, v interface{}) (model.V
 	if s, ok := vOjb["searchKey"]; ok {
 		searchKey = s.(string)
 		if file.Kind == model.KindDOCKER {
-			line = detectDockerLine(ctx, &file, searchKey)
+			line = detectDockerLine(&file, searchKey, &logWithFields)
 		} else {
-			line = detectLine(ctx, &file, searchKey)
+			line = detectLine(&file, searchKey, &logWithFields)
 		}
 	} else {
-		logWithFields.Warn().Msg("saving result. failed to detect line")
+		logWithFields.Error().Msg("saving result. failed to detect line")
 	}
 
 	queryName := DefaultQueryName
@@ -134,7 +135,7 @@ func mergeWithMetadata(base, additional map[string]interface{}) map[string]inter
 	return base
 }
 
-func detectDockerLine(ctx QueryContext, file *model.FileMetadata, searchKey string) int {
+func detectDockerLine(file *model.FileMetadata, searchKey string, logWithFields *zerolog.Logger) int {
 	text := strings.ReplaceAll(file.OriginalData, "\r", "")
 	lines := prepareDockerFileLines(text)
 	isBreak := false
@@ -147,15 +148,7 @@ func detectDockerLine(ctx QueryContext, file *model.FileMetadata, searchKey stri
 	}
 
 	for _, key := range strings.Split(test, ".") {
-		var substr1, substr2 string
-		if parts := nameRegex.FindStringSubmatch(key); len(parts) == namePartsLength {
-			substr1, substr2 = getKeyWithCurlyBrackets(key, extractedString, parts)
-		} else if parts := strings.Split(key, "="); len(parts) == valuePartsLength {
-			substr1, substr2 = getKeyWithCurlyBrackets(key, extractedString, parts)
-		} else {
-			parts := []string{key, ""}
-			substr1, substr2 = getKeyWithCurlyBrackets(key, extractedString, parts)
-		}
+		substr1, substr2 := generateSubstrings(key, extractedString)
 
 		foundAtLeastOne, currentLine, isBreak = detectCurrentLine(lines, substr1, substr2, currentLine, foundAtLeastOne)
 
@@ -168,15 +161,12 @@ func detectDockerLine(ctx QueryContext, file *model.FileMetadata, searchKey stri
 		return currentLine + 1
 	}
 
-	log.Warn().
-		Str("scanID", ctx.scanID).
-		Str("fileID", file.ID).
-		Msgf("failed to detect line, query response %s", searchKey)
+	logWithFields.Warn().Msgf("failed to detect Docker line, query response %s", searchKey)
 
 	return UndetectedVulnerabilityLine
 }
 
-func detectLine(ctx QueryContext, file *model.FileMetadata, searchKey string) int {
+func detectLine(file *model.FileMetadata, searchKey string, logWithFields *zerolog.Logger) int {
 	text := strings.ReplaceAll(file.OriginalData, "\r", "")
 	lines := strings.Split(text, "\n")
 	foundAtLeastOne := false
@@ -190,15 +180,7 @@ func detectLine(ctx QueryContext, file *model.FileMetadata, searchKey string) in
 	}
 
 	for _, key := range strings.Split(sanitizedSubstring, ".") {
-		var substr1, substr2 string
-		if parts := nameRegex.FindStringSubmatch(key); len(parts) == namePartsLength {
-			substr1, substr2 = getKeyWithCurlyBrackets(key, extractedString, parts)
-		} else if parts := strings.Split(key, "="); len(parts) == valuePartsLength {
-			substr1, substr2 = getKeyWithCurlyBrackets(key, extractedString, parts)
-		} else {
-			parts := []string{key, ""}
-			substr1, substr2 = getKeyWithCurlyBrackets(key, extractedString, parts)
-		}
+		substr1, substr2 := generateSubstrings(key, extractedString)
 
 		foundAtLeastOne, currentLine, isBreak = detectCurrentLine(lines, substr1, substr2, currentLine, foundAtLeastOne)
 
@@ -211,12 +193,22 @@ func detectLine(ctx QueryContext, file *model.FileMetadata, searchKey string) in
 		return currentLine + 1
 	}
 
-	log.Warn().
-		Str("scanID", ctx.scanID).
-		Str("fileID", file.ID).
-		Msgf("failed to detect line, query response %s", searchKey)
+	logWithFields.Warn().Msgf("failed to detect line, query response %s", searchKey)
 
 	return UndetectedVulnerabilityLine
+}
+
+func generateSubstrings(key string, extractedString [][]string) (substr1Res, substr2Res string) {
+	var substr1, substr2 string
+	if parts := nameRegex.FindStringSubmatch(key); len(parts) == namePartsLength {
+		substr1, substr2 = getKeyWithCurlyBrackets(key, extractedString, parts)
+	} else if parts := strings.Split(key, "="); len(parts) == valuePartsLength {
+		substr1, substr2 = getKeyWithCurlyBrackets(key, extractedString, parts)
+	} else {
+		parts := []string{key, ""}
+		substr1, substr2 = getKeyWithCurlyBrackets(key, extractedString, parts)
+	}
+	return substr1, substr2
 }
 
 func selectLineWithMinimumDistance(distances map[int]int, startingFrom int) int {

--- a/pkg/engine/vulnerability_builder_test.go
+++ b/pkg/engine/vulnerability_builder_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Checkmarx/kics/pkg/model"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,7 +94,7 @@ ENTRYPOINT ["kubectl"]
 
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("detectDockerLine-%d", i), func(t *testing.T) {
-			v := detectDockerLine(testCase.ctx, testCase.file, testCase.searchKey)
+			v := detectDockerLine(testCase.file, testCase.searchKey, &zerolog.Logger{})
 			require.Equal(t, testCase.expected, v)
 		})
 	}


### PR DESCRIPTION
Closes #1791
Failed to detect line issues are now seen as a 'failed to execute query'.
The logger has been improved to print the name of the file and query name when there is a 'failed to detect line'.
