### PR TITLE
Fix formatting for all k8s queries

### DIFF
--- a/assets/queries/k8s/HPA_targets_a_invalid_object/query.rego
+++ b/assets/queries/k8s/HPA_targets_a_invalid_object/query.rego
@@ -1,33 +1,32 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
+	resource := input.document[i].spec.metrics[index]
 
-  resource := input.document[i].spec.metrics[index]
-   
-  resourceKind := input.document[i].kind
+	resourceKind := input.document[i].kind
 
-  IsHPA(resourceKind) ;
-  not checkIsValidObject(resource) 
-            
-            result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    "spec.metrics",
-                "issueType":		  "IncorrectValue",
-                "keyExpectedValue": sprintf("spec.metrics[%d] is a valid object ", [index]),
-                "keyActualValue": 	sprintf("spec.metrics[%d] is an invalid object ", [index])
-            }
-            
+	IsHPA(resourceKind)
+	not checkIsValidObject(resource)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": "spec.metrics",
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.metrics[%d] is a valid object ", [index]),
+		"keyActualValue": sprintf("spec.metrics[%d] is an invalid object ", [index]),
+	}
 }
 
-IsHPA(resourceKind) = true {
+IsHPA(resourceKind) {
 	resourceKind == "HorizontalPodAutoscaler"
 }
 
-checkIsValidObject(resource){
-
-	resource.type == "Object"; resource.object != null; resource.object.metric != null; resource.object.target != null;
-    resource.object.describedObject.name != null;
-    resource.object.describedObject.apiVersion != null;
-    resource.object.describedObject.kind != null
-
+checkIsValidObject(resource) {
+	resource.type == "Object"
+	resource.object != null
+	resource.object.metric != null
+	resource.object.target != null
+	resource.object.describedObject.name != null
+	resource.object.describedObject.apiVersion != null
+	resource.object.describedObject.kind != null
 }

--- a/assets/queries/k8s/RBAC_wildcard/query.rego
+++ b/assets/queries/k8s/RBAC_wildcard/query.rego
@@ -1,63 +1,61 @@
 package Cx
 
-CxPolicy [result]  {
+CxPolicy[result] {
 	document := input.document[i]
-    metadata := document.metadata
-    checkKind(document.kind)
-    metadata.name
-    notExpectedKey := "*"
-    rules := document.rules[_]
-    rules.apiGroups[j] == notExpectedKey
-    
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.rules.apiGroups", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name[%s].rules.apiGroups shouldn't contain value: '%s'", [metadata.name, notExpectedKey]),
-                "keyActualValue": 	sprintf("metadata.name[%s].rules.apiGroups contains value: '%s'", [metadata.name, notExpectedKey])
-              }
+	metadata := document.metadata
+	checkKind(document.kind)
+	metadata.name
+	notExpectedKey := "*"
+	rules := document.rules[_]
+	rules.apiGroups[j] == notExpectedKey
 
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.rules.apiGroups", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name[%s].rules.apiGroups shouldn't contain value: '%s'", [metadata.name, notExpectedKey]),
+		"keyActualValue": sprintf("metadata.name[%s].rules.apiGroups contains value: '%s'", [metadata.name, notExpectedKey]),
+	}
 }
 
-CxPolicy [result]  {
+CxPolicy[result] {
 	document := input.document[i]
-    metadata := document.metadata
-    checkKind(document.kind)
-    metadata.name
-    notExpectedKey := "*"
-    document.rules[_].resources[j] == notExpectedKey
-    
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.rules.resources", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name[%s].rules.resources shouldn't contain value: '%s'", [metadata.name, notExpectedKey]),
-                "keyActualValue": 	sprintf("metadata.name[%s].rules.resources contains value: '%s'", [metadata.name, notExpectedKey])
-              }
+	metadata := document.metadata
+	checkKind(document.kind)
+	metadata.name
+	notExpectedKey := "*"
+	document.rules[_].resources[j] == notExpectedKey
 
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.rules.resources", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name[%s].rules.resources shouldn't contain value: '%s'", [metadata.name, notExpectedKey]),
+		"keyActualValue": sprintf("metadata.name[%s].rules.resources contains value: '%s'", [metadata.name, notExpectedKey]),
+	}
 }
 
-CxPolicy [result]  {
+CxPolicy[result] {
 	document := input.document[i]
-    metadata := document.metadata
-    checkKind(document.kind)
-    metadata.name
-    notExpectedKey := "*"
-    document.rules[_].verbs[j] == notExpectedKey
-    
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.rules.verbs", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name[%s].rules.verbs shouldn't contain value: '%s'", [metadata.name, notExpectedKey]),
-                "keyActualValue": 	sprintf("metadata.name[%s].rules.verbs contains value: '%s'", [metadata.name, notExpectedKey])
-              }
+	metadata := document.metadata
+	checkKind(document.kind)
+	metadata.name
+	notExpectedKey := "*"
+	document.rules[_].verbs[j] == notExpectedKey
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.rules.verbs", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name[%s].rules.verbs shouldn't contain value: '%s'", [metadata.name, notExpectedKey]),
+		"keyActualValue": sprintf("metadata.name[%s].rules.verbs contains value: '%s'", [metadata.name, notExpectedKey]),
+	}
 }
 
-checkKind(kind) = true{
-kind == "Role"
+checkKind(kind) {
+	kind == "Role"
 }
 
-checkKind(kind) = true{
-kind == "ClusterRole"
+checkKind(kind) {
+	kind == "ClusterRole"
 }

--- a/assets/queries/k8s/allowed_capabilities/query.rego
+++ b/assets/queries/k8s/allowed_capabilities/query.rego
@@ -1,51 +1,49 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    containers := document.spec.containers
-    
-    object.get(containers[index]["securityContext"]["capabilities"],"add", "undefined") != "undefined"
-    
+	containers := document.spec.containers
 
-	  result := {
-                "documentId": 		  input.document[i].id,
-                "issueType":		  "IncorrectValue",
-                "searchKey":          sprintf("metadata.name=%s.%s.containers.name=%s.securityContext.capabilities.add", [metadata.name, specInfo.path, containers[index].name]),
-                "keyExpectedValue":   sprintf("%s.containers.name=%s. does not have added capability",[specInfo.path, containers[index].name]),
-                "keyActualValue":     sprintf("%s.containers.name=%s. has added capability",[specInfo.path, containers[index].name])
-              }
+	object.get(containers[index].securityContext.capabilities, "add", "undefined") != "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "IncorrectValue",
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s.securityContext.capabilities.add", [metadata.name, specInfo.path, containers[index].name]),
+		"keyExpectedValue": sprintf("%s.containers.name=%s. does not have added capability", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers.name=%s. has added capability", [specInfo.path, containers[index].name]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    initContainers := document.spec.initContainers
-    
-    object.get(initContainers[index]["securityContext"]["capabilities"],"add", "undefined") != "undefined"
-    
+	initContainers := document.spec.initContainers
 
-	  result := {
-                "documentId": 		  input.document[i].id,
-                "issueType":		  "IncorrectValue",
-                "searchKey":          sprintf("metadata.name=%s.%s.initContainers.name=%s.securityContext.capabilities.add", [metadata.name, specInfo.path, initContainers[index].name]),
-                "keyExpectedValue":   sprintf("%s.initContainers.name=%s. does not have added capability",[specInfo.path, initContainers[index].name]),
-                "keyActualValue":     sprintf("%s.initContainers.name=%s. has added capability",[specInfo.path, initContainers[index].name])
-              }
+	object.get(initContainers[index].securityContext.capabilities, "add", "undefined") != "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "IncorrectValue",
+		"searchKey": sprintf("metadata.name=%s.%s.initContainers.name=%s.securityContext.capabilities.add", [metadata.name, specInfo.path, initContainers[index].name]),
+		"keyExpectedValue": sprintf("%s.initContainers.name=%s. does not have added capability", [specInfo.path, initContainers[index].name]),
+		"keyActualValue": sprintf("%s.initContainers.name=%s. has added capability", [specInfo.path, initContainers[index].name]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-} 
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/allowed_capabilities_sys_admin/query.rego
+++ b/assets/queries/k8s/allowed_capabilities_sys_admin/query.rego
@@ -1,34 +1,33 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    containers := document.spec.containers
-    
-    add:= object.get(containers[index]["securityContext"]["capabilities"],"add", "undefined")
-    add != "undefined"
-    add[_]== "SYS_ADMIN"
-    
+	containers := document.spec.containers
 
-	  result := {
-                "documentId": 		  input.document[i].id,
-                "issueType":		  "IncorrectValue",
-                "searchKey":          sprintf("metadata.name=%s.%s.containers.name=%s.securityContext.capabilities.add", [metadata.name, specInfo.path, containers[index].name]),
-                "keyExpectedValue":   sprintf("%s.containers.name=%s. does not use CAP_SYS_ADMIN Linux capability",[specInfo.path, containers[index].name]),
-                "keyActualValue":     sprintf("%s.containers.name=%s. uses CAP_SYS_ADMIN Linux capability",[specInfo.path, containers[index].name])
-              }
+	add := object.get(containers[index].securityContext.capabilities, "add", "undefined")
+	add != "undefined"
+	add[_] == "SYS_ADMIN"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "IncorrectValue",
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s.securityContext.capabilities.add", [metadata.name, specInfo.path, containers[index].name]),
+		"keyExpectedValue": sprintf("%s.containers.name=%s. does not use CAP_SYS_ADMIN Linux capability", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers.name=%s. uses CAP_SYS_ADMIN Linux capability", [specInfo.path, containers[index].name]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-} 
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/api_version_is_deprecated/query.rego
+++ b/assets/queries/k8s/api_version_is_deprecated/query.rego
@@ -1,32 +1,33 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
 
-    recommendedVersions := {
-                            "extensions/v1beta1" : {
-                                                      "Deployment" : "apps/v1",
-                                                      "DaemonSet" : "apps/v1",
-                                                      "Ingress" : "apps/v1"
-                                                   },
-                            "apps/v1beta1" : {
-                                                      "Deployment" : "apps/v1",
-                                                      "StatefulSet" : "apps/v1",
-                                                   },
-                            "apps/v1beta2" : {
-                                                      "Deployment" : "apps/v1",
-                                                      "DaemonSet" : "apps/v1",
-                                                      "StatefulSet" : "apps/v1"
-                                                   }
-                          }
-    object.get(recommendedVersions,document.apiVersion,"undefined") != "undefined"
-    object.get(recommendedVersions[document.apiVersion],document.kind,"undefined") != "undefined"
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("apiVersion=%s",[document.apiVersion]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'apiVersion' should be %s",[recommendedVersions[document.apiVersion][document.kind]]),
-                "keyActualValue": sprintf("'apiVersion' is deprecated and is %s",[document.apiVersion])
-              }
+	recommendedVersions := {
+		"extensions/v1beta1": {
+			"Deployment": "apps/v1",
+			"DaemonSet": "apps/v1",
+			"Ingress": "apps/v1",
+		},
+		"apps/v1beta1": {
+			"Deployment": "apps/v1",
+			"StatefulSet": "apps/v1",
+		},
+		"apps/v1beta2": {
+			"Deployment": "apps/v1",
+			"DaemonSet": "apps/v1",
+			"StatefulSet": "apps/v1",
+		},
+	}
+
+	object.get(recommendedVersions, document.apiVersion, "undefined") != "undefined"
+	object.get(recommendedVersions[document.apiVersion], document.kind, "undefined") != "undefined"
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("apiVersion=%s", [document.apiVersion]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'apiVersion' should be %s", [recommendedVersions[document.apiVersion][document.kind]]),
+		"keyActualValue": sprintf("'apiVersion' is deprecated and is %s", [document.apiVersion]),
+	}
 }

--- a/assets/queries/k8s/app_armor_config/query.rego
+++ b/assets/queries/k8s/app_armor_config/query.rego
@@ -1,51 +1,49 @@
 package Cx
 
-CxPolicy [result] {
+CxPolicy[result] {
 	document := input.document[i]
-    metadata := document.metadata
-    document.kind == "Pod"
-    metadata.annotations[key]
-    expectedKey := "container.apparmor.security.beta.kubernetes.io"
-    not startswith(key, expectedKey)
-    
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.annotations", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name[%s].annotations should contain key: '%s'", [metadata.name, expectedKey]),
-                "keyActualValue": 	sprintf("metadata.name[%s].annotations doesn't contain key: '%s'", [metadata.name, expectedKey])
-              }
+	metadata := document.metadata
+	document.kind == "Pod"
+	metadata.annotations[key]
+	expectedKey := "container.apparmor.security.beta.kubernetes.io"
+	not startswith(key, expectedKey)
 
-}
-CxPolicy [result] {
-	document := input.document[i]
-    metadata := document.metadata
-    document.kind == "Pod"
-    expectedKey := "container.apparmor.security.beta.kubernetes.io"
-    metadata.annotations == null
-    
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.annotations", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name[%s].annotations should contain AppArmor profile config: '%s'", [metadata.name, expectedKey]),
-                "keyActualValue": 	sprintf("metadata.name[%s].annotations doesn't contain AppArmor profile config: '%s'", [metadata.name, expectedKey])
-              }
-
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.annotations", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name[%s].annotations should contain key: '%s'", [metadata.name, expectedKey]),
+		"keyActualValue": sprintf("metadata.name[%s].annotations doesn't contain key: '%s'", [metadata.name, expectedKey]),
+	}
 }
 
-CxPolicy [result] {
+CxPolicy[result] {
 	document := input.document[i]
-    document.kind == "Pod"
-    metadata := document.metadata
-    not metadata.annotations
-   
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s", [metadata.name]),
-                "issueType":		"MissingValue",
-                "keyExpectedValue": sprintf("metadata.name[%s] should include annotations for AppArmor profile config",[metadata.name]),
-                "keyActualValue": 	sprintf("metadata.name[%s] doesn't contain AppArmor profile config in annotations", [metadata.name])
-              }
+	metadata := document.metadata
+	document.kind == "Pod"
+	expectedKey := "container.apparmor.security.beta.kubernetes.io"
+	metadata.annotations == null
 
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.annotations", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name[%s].annotations should contain AppArmor profile config: '%s'", [metadata.name, expectedKey]),
+		"keyActualValue": sprintf("metadata.name[%s].annotations doesn't contain AppArmor profile config: '%s'", [metadata.name, expectedKey]),
+	}
+}
+
+CxPolicy[result] {
+	document := input.document[i]
+	document.kind == "Pod"
+	metadata := document.metadata
+	not metadata.annotations
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"issueType": "MissingValue",
+		"keyExpectedValue": sprintf("metadata.name[%s] should include annotations for AppArmor profile config", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name[%s] doesn't contain AppArmor profile config in annotations", [metadata.name]),
+	}
 }

--- a/assets/queries/k8s/block_cluster_admin_role_binding/query.rego
+++ b/assets/queries/k8s/block_cluster_admin_role_binding/query.rego
@@ -1,16 +1,16 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i]
-  metadata := resource.metadata
-  resource.kind == "ClusterRoleBinding"
-  resource.roleRef.name == "cluster-admin"
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	resource.kind == "ClusterRoleBinding"
+	resource.roleRef.name == "cluster-admin"
 
 	result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.roleRef.name=cluster-admin", [metadata.name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("Resource name '%s' of kind '%s' isn't binding 'cluster-admin' role with superuser permissions", [metadata.name, resource.kind]),
-    "keyActualValue": sprintf("Resource name '%s' of kind '%s' is binding 'cluster-admin' role with superuser permissions", [metadata.name, resource.kind])
-  }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.roleRef.name=cluster-admin", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resource name '%s' of kind '%s' isn't binding 'cluster-admin' role with superuser permissions", [metadata.name, resource.kind]),
+		"keyActualValue": sprintf("Resource name '%s' of kind '%s' is binding 'cluster-admin' role with superuser permissions", [metadata.name, resource.kind]),
+	}
 }

--- a/assets/queries/k8s/block_privileged_container/query.rego
+++ b/assets/queries/k8s/block_privileged_container/query.rego
@@ -1,31 +1,31 @@
 package Cx
 
-CxPolicy [ result ] {
-  metadata:= input.document[i].metadata
-  spec := input.document[i].spec
-  containers := spec.containers
-  containers[c].securityContext.privileged == true
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	containers := spec.containers
+	containers[c].securityContext.privileged == true
 
-  result := {
-              "documentId": input.document[i].id,
-              "searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.privileged", [metadata.name, containers[c].name]),
-              "issueType": "IncorrectValue",
-              "keyExpectedValue": sprintf("spec.containers.name=%s.securityContext.privileged is false", [metadata.name, containers[c].name]),
-              "keyActualValue": sprintf("spec.containers.name=%s.securityContext.privileged is true", [metadata.name, containers[c].name])
-  }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.privileged", [metadata.name, containers[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.containers.name=%s.securityContext.privileged is false", [metadata.name, containers[c].name]),
+		"keyActualValue": sprintf("spec.containers.name=%s.securityContext.privileged is true", [metadata.name, containers[c].name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata:= input.document[i].metadata
-  spec := input.document[i].spec
-  initContainers := spec.initContainers
-  initContainers[c].securityContext.privileged == true
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	initContainers := spec.initContainers
+	initContainers[c].securityContext.privileged == true
 
-  result := {
-              "documentId": input.document[i].id,
-              "searchKey": sprintf("metadata.name=%s.spec.initContainers.name=%s.securityContext.privileged", [metadata.name, initContainers[c].name]),
-              "issueType": "IncorrectValue",
-              "keyExpectedValue": sprintf("spec.initContainers.name=%s.securityContext.privileged is false", [metadata.name, initContainers[c].name]),
-              "keyActualValue": sprintf("spec.initContainers.name=%s.securityContext.privileged is true", [metadata.name, initContainers[c].name])
-  }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.initContainers.name=%s.securityContext.privileged", [metadata.name, initContainers[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.initContainers.name=%s.securityContext.privileged is false", [metadata.name, initContainers[c].name]),
+		"keyActualValue": sprintf("spec.initContainers.name=%s.securityContext.privileged is true", [metadata.name, initContainers[c].name]),
+	}
 }

--- a/assets/queries/k8s/block_privileged_request_pod/query.rego
+++ b/assets/queries/k8s/block_privileged_request_pod/query.rego
@@ -1,15 +1,15 @@
 package Cx
 
-CxPolicy [ result ] {
-   metadata := input.document[i].metadata
-   spec := input.document[i].spec
-   spec.privileged 
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":      sprintf("metadata.name=%s.spec.privileged", [metadata.name]),
-                "issueType":		   "IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.privileged is false", [metadata.name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.privileged is true", [metadata.name])
-              }
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	spec.privileged
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.privileged", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.privileged is false", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.privileged is true", [metadata.name]),
+	}
 }

--- a/assets/queries/k8s/block_workload_mounting_os_dir/query.rego
+++ b/assets/queries/k8s/block_workload_mounting_os_dir/query.rego
@@ -1,87 +1,88 @@
 package Cx
 
-CxPolicy [result] {
-  resource := input.document[i]
-  metadata := resource.metadata
-  resource.kind == "Pod"
-  volumes := resource.spec.volumes
-  isOSDir(volumes[_].hostPath.path)
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("Workload name '%s' of kind '%s' should not mount a host sensitive OS directory '%s' with hostPath", [
-      resource.metadata.name,
-      resource.kind,
-      volumes[j].hostPath.path
-    ]),
-    "keyActualValue": sprintf("Workload name '%s' of kind '%s' is mounting a host sensitive OS directory '%s' with hostPath", [
-      resource.metadata.name,
-      resource.kind,
-      volumes[j].hostPath.path
-    ])
-  } 
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	resource.kind == "Pod"
+	volumes := resource.spec.volumes
+	isOSDir(volumes[_].hostPath.path)
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Workload name '%s' of kind '%s' should not mount a host sensitive OS directory '%s' with hostPath", [
+			resource.metadata.name,
+			resource.kind,
+			volumes[j].hostPath.path,
+		]),
+		"keyActualValue": sprintf("Workload name '%s' of kind '%s' is mounting a host sensitive OS directory '%s' with hostPath", [
+			resource.metadata.name,
+			resource.kind,
+			volumes[j].hostPath.path,
+		]),
+	}
 }
 
-CxPolicy [result] {
-  resource := input.document[i]
-  metadata := resource.metadata
-  resource.kind != "Pod"
-  spec := resource.spec.template.spec
-  volumes := spec.volumes
-  isOSDir(volumes[_].hostPath.path)
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("Workload name '%s' of kind '%s' should not mount a host sensitive OS directory '%s' with hostPath", [
-      resource.metadata.name,
-      resource.kind,
-      volumes[j].hostPath.path
-    ]),
-    "keyActualValue": sprintf("Workload name '%s' of kind '%s' is mounting a host sensitive OS directory '%s' with hostPath", [
-      resource.metadata.name,
-      resource.kind,
-      volumes[j].hostPath.path
-    ])
-  }
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	resource.kind != "Pod"
+	spec := resource.spec.template.spec
+	volumes := spec.volumes
+	isOSDir(volumes[_].hostPath.path)
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Workload name '%s' of kind '%s' should not mount a host sensitive OS directory '%s' with hostPath", [
+			resource.metadata.name,
+			resource.kind,
+			volumes[j].hostPath.path,
+		]),
+		"keyActualValue": sprintf("Workload name '%s' of kind '%s' is mounting a host sensitive OS directory '%s' with hostPath", [
+			resource.metadata.name,
+			resource.kind,
+			volumes[j].hostPath.path,
+		]),
+	}
 }
 
-CxPolicy [result] {
-  resource := input.document[i]
-  metadata := resource.metadata
-  resource.kind == "PersistentVolume"
-  hostPath := resource.spec.hostPath
-  isOSDir(hostPath.path)
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.spec.spec.hostPath.path", [metadata.name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("PersistentVolume name '%s' of kind '%s' should not mount a host sensitive OS directory '%s' with hostPath", [
-      resource.metadata.name,
-      resource.kind,
-      hostPath.path
-    ]),
-    "keyActualValue": sprintf("PersistentVolume name '%s' of kind '%s' is mounting a host sensitive OS directory '%s' with hostPath", [
-      resource.metadata.name,
-      resource.kind,
-      hostPath.path
-    ])
-  }
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	resource.kind == "PersistentVolume"
+	hostPath := resource.spec.hostPath
+	isOSDir(hostPath.path)
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.spec.hostPath.path", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("PersistentVolume name '%s' of kind '%s' should not mount a host sensitive OS directory '%s' with hostPath", [
+			resource.metadata.name,
+			resource.kind,
+			hostPath.path,
+		]),
+		"keyActualValue": sprintf("PersistentVolume name '%s' of kind '%s' is mounting a host sensitive OS directory '%s' with hostPath", [
+			resource.metadata.name,
+			resource.kind,
+			hostPath.path,
+		]),
+	}
 }
 
 isOSDir(mountPath) = result {
-  hostSensitiveDir = {
-  	"/bin", "/sbin", "/boot", "/cdrom", 
-    "/dev", "/etc", "/home", "/lib", 
-    "/media", "/proc","/root","/run",
-    "/seLinux","/srv","/usr", "/var"
-  }
-  result = listcontains(hostSensitiveDir, mountPath)
+	hostSensitiveDir = {
+		"/bin", "/sbin", "/boot", "/cdrom",
+		"/dev", "/etc", "/home", "/lib",
+		"/media", "/proc", "/root", "/run",
+		"/seLinux", "/srv", "/usr", "/var",
+	}
+
+	result = listcontains(hostSensitiveDir, mountPath)
 } else = result {
-  result = mountPath == "/"
+	result = mountPath == "/"
 }
 
 listcontains(dirs, elem) {
-  startswith(elem,dirs[_])
+	startswith(elem, dirs[_])
 }

--- a/assets/queries/k8s/cluster_allows_unsafe_sysctls/query.rego
+++ b/assets/queries/k8s/cluster_allows_unsafe_sysctls/query.rego
@@ -1,39 +1,39 @@
 package Cx
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  input.document[i].kind == "PodSecurityPolicy"
-  spec := input.document[i].spec
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	input.document[i].kind == "PodSecurityPolicy"
+	spec := input.document[i].spec
 
-  spec.allowedUnsafeSysctls
+	spec.allowedUnsafeSysctls
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.allowedUnsafeSysctls is undefined", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.allowedUnsafeSysctls is defined", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.allowedUnsafeSysctls is undefined", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.allowedUnsafeSysctls is defined", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  input.document[i].kind == "Pod"
-  spec := input.document[i].spec
-  
-  sysctl := spec.securityContext.sysctls[_].name
-  check_Unsafe(sysctl)
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	input.document[i].kind == "Pod"
+	spec := input.document[i].spec
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.securityContext.sysctls", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.securityContext.sysctls does not have an Unsafe Sysctl", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.securityContext.sysctls has an Unsafe Sysctl", [metadata.name])
-              }
+	sysctl := spec.securityContext.sysctls[_].name
+	check_Unsafe(sysctl)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.securityContext.sysctls", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.securityContext.sysctls does not have an Unsafe Sysctl", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.securityContext.sysctls has an Unsafe Sysctl", [metadata.name]),
+	}
 }
 
 check_Unsafe(sysctl) {
 	safeSysctls = {"kernel.shm_rmid_forced", "net.ipv4.ip_local_port_range", "net.ipv4.tcp_syncookies", "net.ipv4.ping_group_range"}
-    not safeSysctls[sysctl]
+	not safeSysctls[sysctl]
 }

--- a/assets/queries/k8s/container_cpu_requests_not_equal_limits/query.rego
+++ b/assets/queries/k8s/container_cpu_requests_not_equal_limits/query.rego
@@ -1,46 +1,46 @@
 package Cx
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  object.get(container.resources.requests, "cpu", "undefined") == "undefined"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	object.get(container.resources.requests, "cpu", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources.requests", [metadata.name, container.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.requests.cpu is defined", [container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.requests.cpu is not defined", [container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources.requests", [metadata.name, container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.requests.cpu is defined", [container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.requests.cpu is not defined", [container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  object.get(container.resources.limits, "cpu", "undefined") == "undefined"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	object.get(container.resources.limits, "cpu", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources.limits", [metadata.name, container.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.limits.cpu is defined", [container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.limits.cpu is not defined", [container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources.limits", [metadata.name, container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.limits.cpu is defined", [container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.limits.cpu is not defined", [container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  container.resources.requests.cpu != container.resources.limits.cpu
-  
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	container.resources.requests.cpu != container.resources.limits.cpu
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources", [metadata.name, container.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.requests.cpu is equal to spec.containers[%s].resources.limits.cpu", [container.name, container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.requests.cpu is not equal to spec.containers[%s].resources.limits.cpu", [container.name, container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources", [metadata.name, container.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.requests.cpu is equal to spec.containers[%s].resources.limits.cpu", [container.name, container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.requests.cpu is not equal to spec.containers[%s].resources.limits.cpu", [container.name, container.name]),
+	}
 }

--- a/assets/queries/k8s/container_memory_requests_not_equal_limits/query.rego
+++ b/assets/queries/k8s/container_memory_requests_not_equal_limits/query.rego
@@ -1,46 +1,46 @@
 package Cx
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  object.get(container.resources.requests, "memory", "undefined") == "undefined"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	object.get(container.resources.requests, "memory", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources.requests", [metadata.name, container.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.requests.memory is defined", [container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.requests.memory is not defined", [container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources.requests", [metadata.name, container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.requests.memory is defined", [container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.requests.memory is not defined", [container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  object.get(container.resources.limits, "memory", "undefined") == "undefined"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	object.get(container.resources.limits, "memory", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources.limits", [metadata.name, container.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.limits.memory is defined", [container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.limits.memory is not defined", [container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources.limits", [metadata.name, container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.limits.memory is defined", [container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.limits.memory is not defined", [container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  container.resources.requests.memory != container.resources.limits.memory
-  
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	container.resources.requests.memory != container.resources.limits.memory
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources", [metadata.name, container.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.requests.memory is equal to spec.containers[%s].resources.limits.memory", [container.name, container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.requests.memory is not equal to spec.containers[%s].resources.limits.memory", [container.name, container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources", [metadata.name, container.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.requests.memory is equal to spec.containers[%s].resources.limits.memory", [container.name, container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.requests.memory is not equal to spec.containers[%s].resources.limits.memory", [container.name, container.name]),
+	}
 }

--- a/assets/queries/k8s/container_requests_not_equal_limits/query.rego
+++ b/assets/queries/k8s/container_requests_not_equal_limits/query.rego
@@ -1,91 +1,91 @@
 package Cx
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  object.get(container.resources.requests, "memory", "undefined") == "undefined"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	object.get(container.resources.requests, "memory", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources.requests", [metadata.name, container.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.requests.memory is defined", [container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.requests.memory is not defined", [container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources.requests", [metadata.name, container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.requests.memory is defined", [container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.requests.memory is not defined", [container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  object.get(container.resources.requests, "cpu", "undefined") == "undefined"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	object.get(container.resources.requests, "cpu", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources.requests", [metadata.name, container.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.requests.cpu is defined", [container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.requests.cpu is not defined", [container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources.requests", [metadata.name, container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.requests.cpu is defined", [container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.requests.cpu is not defined", [container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  object.get(container.resources.limits, "memory", "undefined") == "undefined"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	object.get(container.resources.limits, "memory", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources.limits", [metadata.name, container.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.limits.memory is defined", [container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.limits.memory is not defined", [container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources.limits", [metadata.name, container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.limits.memory is defined", [container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.limits.memory is not defined", [container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  object.get(container.resources.limits, "cpu", "undefined") == "undefined"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	object.get(container.resources.limits, "cpu", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources.limits", [metadata.name, container.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.limits.cpu is defined", [container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.limits.cpu is not defined", [container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources.limits", [metadata.name, container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.limits.cpu is defined", [container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.limits.cpu is not defined", [container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  container.resources.requests.memory != container.resources.limits.memory
-  
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	container.resources.requests.memory != container.resources.limits.memory
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources", [metadata.name, container.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.requests.memory is equal to spec.containers[%s].resources.limits.memory", [container.name, container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.requests.memory is not equal to spec.containers[%s].resources.limits.memory", [container.name, container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources", [metadata.name, container.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.requests.memory is equal to spec.containers[%s].resources.limits.memory", [container.name, container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.requests.memory is not equal to spec.containers[%s].resources.limits.memory", [container.name, container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  container := input.document[i].spec.containers[c]
-  input.document[i].kind == "Pod"
-  container.resources.requests.cpu != container.resources.limits.cpu
-  
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	container := input.document[i].spec.containers[c]
+	input.document[i].kind == "Pod"
+	container.resources.requests.cpu != container.resources.limits.cpu
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.resources", [metadata.name, container.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("spec.containers[%s].resources.requests.cpu is equal to spec.containers[%s].resources.limits.cpu", [container.name, container.name]),
-                "keyActualValue": 	 sprintf("spec.containers[%s].resources.requests.cpu is not equal to spec.containers[%s].resources.limits.cpu", [container.name, container.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.resources", [metadata.name, container.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.containers[%s].resources.requests.cpu is equal to spec.containers[%s].resources.limits.cpu", [container.name, container.name]),
+		"keyActualValue": sprintf("spec.containers[%s].resources.requests.cpu is not equal to spec.containers[%s].resources.limits.cpu", [container.name, container.name]),
+	}
 }

--- a/assets/queries/k8s/container_runs_unmasked/query.rego
+++ b/assets/queries/k8s/container_runs_unmasked/query.rego
@@ -1,20 +1,19 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
 	metadata := input.document[i].metadata
-  spec := input.document[i].spec
+	spec := input.document[i].spec
 
-  document.kind == "PodSecurityPolicy"
+	document.kind == "PodSecurityPolicy"
 
-  spec.allowedProcMountTypes[_] == "Unmasked"
-    
+	spec.allowedProcMountTypes[_] == "Unmasked"
+
 	result := {
-    			    "documentId": 		input.document[i].id,
-              "searchKey": 	    sprintf("metadata.name=%s.spec.allowedProcMountTypes", [metadata.name]),
-              "issueType":		"IncorrectValue",
-              "keyExpectedValue": "AllowedProcMountTypes contains the value Default",
-              "keyActualValue": 	"AllowedProcMountTypes contains the value Unmasked",
-            }
-  
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.allowedProcMountTypes", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "AllowedProcMountTypes contains the value Default",
+		"keyActualValue": "AllowedProcMountTypes contains the value Unmasked",
+	}
 }

--- a/assets/queries/k8s/containers_run_as_root/query.rego
+++ b/assets/queries/k8s/containers_run_as_root/query.rego
@@ -1,120 +1,119 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "Pod"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "Pod"
 
-    spec := document.spec
+	spec := document.spec
 
-    metadata := document.metadata
-    result := checkRootParent(spec,"spec",metadata, input.document[i].id)
+	metadata := document.metadata
+	result := checkRootParent(spec, "spec", metadata, input.document[i].id)
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "CronJob"
 
-    spec := document.spec.jobTemplate.spec.template.spec
+	spec := document.spec.jobTemplate.spec.template.spec
 
-    metadata := document.metadata
-    result := checkRootParent(spec,"spec.jobTemplate.spec.template.spec",metadata, input.document[i].id)
+	metadata := document.metadata
+	result := checkRootParent(spec, "spec.jobTemplate.spec.template.spec", metadata, input.document[i].id)
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") != "Pod"
-    object.get(document,"kind","undefined") != "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") != "Pod"
+	object.get(document, "kind", "undefined") != "CronJob"
 
-    spec := document.spec.template.spec
+	spec := document.spec.template.spec
 
-    metadata := document.metadata
-    result := checkRootParent(spec,"spec.template.spec",metadata, input.document[i].id)
+	metadata := document.metadata
+	result := checkRootParent(spec, "spec.template.spec", metadata, input.document[i].id)
 }
 
-checkRootParent(spec,path,metadata, id) = result {
-  nonRootParent := object.get(spec.securityContext,"runAsNonRoot","undefined")
-  is_boolean(nonRootParent)
+checkRootParent(spec, path, metadata, id) = result {
+	nonRootParent := object.get(spec.securityContext, "runAsNonRoot", "undefined")
+	is_boolean(nonRootParent)
 
-  nonRootParent == true
+	nonRootParent == true
 
-  result := checkRootContainer(spec,path,metadata, id)
-
+	result := checkRootContainer(spec, path, metadata, id)
 }
 
-checkRootParent(spec,path,metadata, id) = result {
-  nonRootParent := object.get(spec.securityContext,"runAsNonRoot","undefined")
-  is_boolean(nonRootParent)
+checkRootParent(spec, path, metadata, id) = result {
+	nonRootParent := object.get(spec.securityContext, "runAsNonRoot", "undefined")
+	is_boolean(nonRootParent)
 
-  nonRootParent == false
+	nonRootParent == false
 
-  userParent := object.get(spec.securityContext,"runAsUser","undefined")
-  is_number(userParent)
+	userParent := object.get(spec.securityContext, "runAsUser", "undefined")
+	is_number(userParent)
 
-  userParent > 0
+	userParent > 0
 
-  result := checkUserContainer(spec,path,metadata, id)
+	result := checkUserContainer(spec, path, metadata, id)
 }
 
-checkRootParent(spec,path,metadata, id) = result {
-  object.get(spec.securityContext,"runAsNonRoot","undefined") == "undefined"
-  object.get(spec.securityContext,"runAsUser","undefined") == "undefined"
+checkRootParent(spec, path, metadata, id) = result {
+	object.get(spec.securityContext, "runAsNonRoot", "undefined") == "undefined"
+	object.get(spec.securityContext, "runAsUser", "undefined") == "undefined"
 
-  result := checkRootContainer(spec,path,metadata, id)
+	result := checkRootContainer(spec, path, metadata, id)
 }
 
-checkRootContainer(spec,path,metadata, id) = result {
-  some j
-    container := spec.containers[j]
-    not container.securityContext.runAsNonRoot
-    uid := container.securityContext.runAsUser
-    to_number(uid) <= 0
-    result := {
-                "documentId": 		id,
-                "searchKey": 	    sprintf("%s.containers",[path]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is higher than 0 and/or 'runAsNonRoot' is true",[path,j]),
-                "keyActualValue": 	sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true",[path,j]),
-              }
+checkRootContainer(spec, path, metadata, id) = result {
+	some j
+	container := spec.containers[j]
+	not container.securityContext.runAsNonRoot
+	uid := container.securityContext.runAsUser
+	to_number(uid) <= 0
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("%s.containers", [path]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is higher than 0 and/or 'runAsNonRoot' is true", [path, j]),
+		"keyActualValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true", [path, j]),
+	}
 }
 
-checkRootContainer(spec,path,metadata, id) = result {
-  some j
-    container := spec.containers[j]
-    not container.securityContext.runAsNonRoot
-    object.get(container.securityContext,"runAsUser","undefined") == "undefined"
-    result := {
-                "documentId": 		id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.containers",[metadata.name,path]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is set to higher than 0 and/or 'runAsNonRoot' is true",[path,j]),
-                "keyActualValue": 	sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true",[path,j]),
-              }
+checkRootContainer(spec, path, metadata, id) = result {
+	some j
+	container := spec.containers[j]
+	not container.securityContext.runAsNonRoot
+	object.get(container.securityContext, "runAsUser", "undefined") == "undefined"
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("metadata.name=%s.%s.containers", [metadata.name, path]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is set to higher than 0 and/or 'runAsNonRoot' is true", [path, j]),
+		"keyActualValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true", [path, j]),
+	}
 }
 
-checkUserContainer(spec,path,metadata, id) = result {
-  some j
-    container := spec.containers[j]
-    uid := container.securityContext.runAsUser
-    to_number(uid) <= 0
-    result := {
-                "documentId": 		id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.containers",[metadata.name,path]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is higher than 0 and/or 'runAsNonRoot' is true",[path,j]),
-                "keyActualValue": 	sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true",[path,j]),
-              }
+checkUserContainer(spec, path, metadata, id) = result {
+	some j
+	container := spec.containers[j]
+	uid := container.securityContext.runAsUser
+	to_number(uid) <= 0
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("metadata.name=%s.%s.containers", [metadata.name, path]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is higher than 0 and/or 'runAsNonRoot' is true", [path, j]),
+		"keyActualValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true", [path, j]),
+	}
 }
 
-checkUserContainer(spec,path,metadata, id) = result {
-  some j
-    container := spec.containers[j]
-    not container.securityContext.runAsNonRoot
-    object.get(container.securityContext,"runAsUser","undefined") == "undefined"
-    result := {
-                "documentId": 		id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.containers",[metadata.name,path]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is set to higher than 0 and/or 'runAsNonRoot' is true",[path,j]),
-                "keyActualValue": 	sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true",[path,j]),
-              }
+checkUserContainer(spec, path, metadata, id) = result {
+	some j
+	container := spec.containers[j]
+	not container.securityContext.runAsNonRoot
+	object.get(container.securityContext, "runAsUser", "undefined") == "undefined"
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("metadata.name=%s.%s.containers", [metadata.name, path]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is set to higher than 0 and/or 'runAsNonRoot' is true", [path, j]),
+		"keyActualValue": sprintf("'%s.containers[%d].securityContext.runAsUser' is 0 and 'runAsNonRoot' is not set to true", [path, j]),
+	}
 }

--- a/assets/queries/k8s/containers_run_with_low_uid/query.rego
+++ b/assets/queries/k8s/containers_run_with_low_uid/query.rego
@@ -1,155 +1,156 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "Pod"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "Pod"
 
-    spec := document.spec
+	spec := document.spec
 
-    isLowUID(spec)
+	isLowUID(spec)
 
-    metadata := document.metadata
-    result := checkContainersOverride(spec,"",metadata, input.document[i].id)
+	metadata := document.metadata
+	result := checkContainersOverride(spec, "", metadata, input.document[i].id)
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "Pod"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "Pod"
 
-    spec := document.spec
+	spec := document.spec
 
-    isSetUID(spec) != true
+	isSetUID(spec) != true
 
-    metadata := document.metadata
-    result := checkContainersSet(spec,"",metadata, input.document[i].id)
+	metadata := document.metadata
+	result := checkContainersSet(spec, "", metadata, input.document[i].id)
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "CronJob"
 
-    spec := document.spec.jobTemplate.spec.template.spec
+	spec := document.spec.jobTemplate.spec.template.spec
 
-    isLowUID(spec)
+	isLowUID(spec)
 
-    metadata := document.metadata
-    result := checkContainersOverride(spec,"spec.jobTemplate.spec.template.",metadata, input.document[i].id)
+	metadata := document.metadata
+	result := checkContainersOverride(spec, "spec.jobTemplate.spec.template.", metadata, input.document[i].id)
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "CronJob"
 
-    spec := document.spec.jobTemplate.spec.template.spec
+	spec := document.spec.jobTemplate.spec.template.spec
 
-    isSetUID(spec) != true
+	isSetUID(spec) != true
 
-    metadata := document.metadata
-    result := checkContainersSet(spec,"spec.jobTemplate.spec.template.",metadata, input.document[i].id)
-}
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") != "Pod"
-    object.get(document,"kind","undefined") != "CronJob"
-
-    spec := document.spec.template.spec
-
-    isSetUID(spec) != true
-
-    metadata := document.metadata
-    result := checkContainersSet(spec,"spec.template.",metadata, input.document[i].id)
+	metadata := document.metadata
+	result := checkContainersSet(spec, "spec.jobTemplate.spec.template.", metadata, input.document[i].id)
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") != "Pod"
-    object.get(document,"kind","undefined") != "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") != "Pod"
+	object.get(document, "kind", "undefined") != "CronJob"
 
-    spec := document.spec.template.spec
+	spec := document.spec.template.spec
 
-    isLowUID(spec)
+	isSetUID(spec) != true
 
-    metadata := document.metadata
-    result := checkContainersOverride(spec,"spec.template.",metadata, input.document[i].id)
+	metadata := document.metadata
+	result := checkContainersSet(spec, "spec.template.", metadata, input.document[i].id)
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") != "Pod"
-    object.get(document,"kind","undefined") != "CronJob" 
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") != "Pod"
+	object.get(document, "kind", "undefined") != "CronJob"
 
-    spec := document.spec.template.spec
+	spec := document.spec.template.spec
 
-    isSetUID(spec) != true
+	isLowUID(spec)
 
-    metadata := document.metadata
-    result := checkContainersSet(spec,"spec.template.",metadata, input.document[i].id)
+	metadata := document.metadata
+	result := checkContainersOverride(spec, "spec.template.", metadata, input.document[i].id)
+}
+
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") != "Pod"
+	object.get(document, "kind", "undefined") != "CronJob"
+
+	spec := document.spec.template.spec
+
+	isSetUID(spec) != true
+
+	metadata := document.metadata
+	result := checkContainersSet(spec, "spec.template.", metadata, input.document[i].id)
 }
 
 #if there are no containers to override low UID setting
-checkContainersOverride(spec,path,metadata, id) = result {
-    object.get(spec,"containers","undefined") == "undefined"
-    
-    result := {
-                "documentId": 		id,
-                "searchKey": 	    sprintf("metadata.name=%s.%sspec.securityContext.runAsUser",[metadata.name,path]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'%sspec.securityContext.runAsUser' is higher or equal to 10000",[path]),
-                "keyActualValue": 	sprintf("'%sspec.securityContext.runAsUser' is less than 10000",[path]),
-              }
+checkContainersOverride(spec, path, metadata, id) = result {
+	object.get(spec, "containers", "undefined") == "undefined"
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("metadata.name=%s.%sspec.securityContext.runAsUser", [metadata.name, path]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%sspec.securityContext.runAsUser' is higher or equal to 10000", [path]),
+		"keyActualValue": sprintf("'%sspec.securityContext.runAsUser' is less than 10000", [path]),
+	}
 }
 
 #if there are containers and one of them has also low UID setting
-checkContainersOverride(spec,path,metadata, id) = result {
-    containers := object.get(spec,"containers","undefined")
-    containers != "undefined"
+checkContainersOverride(spec, path, metadata, id) = result {
+	containers := object.get(spec, "containers", "undefined")
+	containers != "undefined"
 
-    some j
-      isLowUID(containers[j])
-      result := {
-                  "documentId": 		id,
-                  "searchKey": 	    sprintf("metadata.name=%s.%sspec.containers",[metadata.name,path]),
-                  "issueType":		"IncorrectValue",
-                  "keyExpectedValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is higher or equal to 10000",[path,j]),
-                  "keyActualValue": 	sprintf("'%sspec.containers[%d].securityContext.runAsUser' is less than 10000",[path,j]),
-                }
+	some j
+	isLowUID(containers[j])
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("metadata.name=%s.%sspec.containers", [metadata.name, path]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is higher or equal to 10000", [path, j]),
+		"keyActualValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is less than 10000", [path, j]),
+	}
 }
 
 #if there are containers and one of them doesn't override low UID setting
-checkContainersSet(spec,path,metadata, id) = result {
-    containers := object.get(spec,"containers","undefined")
-    containers != "undefined"
-    some j
-      isSetUID(containers[j]) != true
-      result := {
-                  "documentId": 		id,
-                  "searchKey": 	    sprintf("metadata.name=%s.%sspec.containers",[metadata.name,path]),
-                  "issueType":		"MissingAttribute",
-                  "keyExpectedValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is set and higher or equal to 10000",[path,j]),
-                  "keyActualValue": 	sprintf("'$sspec.containers[%d].securityContext.runAsUser' is undefined",[path,j]),
-                }
+checkContainersSet(spec, path, metadata, id) = result {
+	containers := object.get(spec, "containers", "undefined")
+	containers != "undefined"
+	some j
+	isSetUID(containers[j]) != true
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("metadata.name=%s.%sspec.containers", [metadata.name, path]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is set and higher or equal to 10000", [path, j]),
+		"keyActualValue": sprintf("'$sspec.containers[%d].securityContext.runAsUser' is undefined", [path, j]),
+	}
 }
 
 #if there are containers and one of them doesn't override low UID setting
-checkContainersSet(spec,path,metadata, id) = result {
-    containers := object.get(spec,"containers","undefined")
-    containers != "undefined"
+checkContainersSet(spec, path, metadata, id) = result {
+	containers := object.get(spec, "containers", "undefined")
+	containers != "undefined"
 
-    some j
-      isSetUID(containers[j]) != true
-      result := {
-                  "documentId": 		id,
-                  "searchKey": 	    sprintf("metadata.name=%s.%sspec.containers",[metadata.name,path]),
-                  "issueType":		"MissingAttribute",
-                  "keyExpectedValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is set and higher or equal to 10000",[path,j]),
-                  "keyActualValue": 	sprintf("'%sspec.containers[%d].securityContext.runAsUser' is undefined",[path,j]),
-                }
+	some j
+	isSetUID(containers[j]) != true
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("metadata.name=%s.%sspec.containers", [metadata.name, path]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is set and higher or equal to 10000", [path, j]),
+		"keyActualValue": sprintf("'%sspec.containers[%d].securityContext.runAsUser' is undefined", [path, j]),
+	}
 }
 
 isLowUID(spec) {
-  to_number(spec.securityContext.runAsUser) < 10000  
+	to_number(spec.securityContext.runAsUser) < 10000
 }
 
-isSetUID(spec) = true {
-  object.get(spec.securityContext,"runAsUser","undefined") != "undefined"
+isSetUID(spec) {
+	object.get(spec.securityContext, "runAsUser", "undefined") != "undefined"
 }

--- a/assets/queries/k8s/containers_security_context_capabilities_drop_all/query.rego
+++ b/assets/queries/k8s/containers_security_context_capabilities_drop_all/query.rego
@@ -1,23 +1,24 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    spec := document.spec.template.spec
-    containers := spec.containers
-    cap := containers[c].securityContext.capabilities
-    not contains(cap.drop,"ALL")
-	
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	spec := document.spec.template.spec
+	containers := spec.containers
+	cap := containers[c].securityContext.capabilities
+	not contains(cap.drop, "ALL")
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop", [metadata.name, containers[c].name]),
-                "issueType":		"IncorrectValue",
-				        "keyExpectedValue": sprintf("spec.containers[%s].securityContext.capabilities.drop is not 'ALL'", [metadata.name, containers[c].name]),
-                "keyActualValue": 	sprintf("spec.containers[%s].securityContext.capabilities.drop is 'ALL'", [metadata.name, containers[c].name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop", [metadata.name, containers[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.containers[%s].securityContext.capabilities.drop is not 'ALL'", [metadata.name, containers[c].name]),
+		"keyActualValue": sprintf("spec.containers[%s].securityContext.capabilities.drop is 'ALL'", [metadata.name, containers[c].name]),
+	}
 }
 
-contains(array, elem) = true {
-  upper(array[_]) == elem
-} else = false { true }
+contains(array, elem) {
+	upper(array[_]) == elem
+} else = false {
+	true
+}

--- a/assets/queries/k8s/containers_security_context_capabilities_drop_any/query.rego
+++ b/assets/queries/k8s/containers_security_context_capabilities_drop_any/query.rego
@@ -1,20 +1,18 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    spec := document.spec.template.spec
-    containers := spec.containers
-    cap := containers[c].securityContext.capabilities
-    object.get(cap, "drop", "undefined") == "undefined"
-	
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	spec := document.spec.template.spec
+	containers := spec.containers
+	cap := containers[c].securityContext.capabilities
+	object.get(cap, "drop", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities", [metadata.name, containers[c].name]),
-                "issueType":		"MissingAttribute",
-				        "keyExpectedValue": sprintf("spec.containers[%s].securityContext.capabilities.drop is Defined", [metadata.name, containers[c].name]),
-                "keyActualValue": 	sprintf("spec.containers[%s].securityContext.capabilities.drop is not Defined", [metadata.name, containers[c].name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities", [metadata.name, containers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("spec.containers[%s].securityContext.capabilities.drop is Defined", [metadata.name, containers[c].name]),
+		"keyActualValue": sprintf("spec.containers[%s].securityContext.capabilities.drop is not Defined", [metadata.name, containers[c].name]),
+	}
 }
-

--- a/assets/queries/k8s/cpu_limits/query.rego
+++ b/assets/queries/k8s/cpu_limits/query.rego
@@ -1,71 +1,67 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    containers := document.spec.containers
-    
-    
-    object.get(containers[index]["resources"]["limits"], "cpu", "undefined") == "undefined"
- 
-    result := {
-                "documentId":        input.document[i].id,
-                "issueType":         "MissingAttribute",
-                "searchKey":         sprintf("metadata.name=%s.%s.containers.name=%s.resources.limits", [metadata.name, specInfo.path, containers[index].name]),
-                "keyExpectedValue":  sprintf("%s.containers.name=%s does have CPU limits",[specInfo.path, containers[index].name]),
-                "keyActualValue":    sprintf("%s.containers.name=%s doesn't have CPU limits",[specInfo.path, containers[index].name])
-              }
+	containers := document.spec.containers
+
+	object.get(containers[index].resources.limits, "cpu", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s.resources.limits", [metadata.name, specInfo.path, containers[index].name]),
+		"keyExpectedValue": sprintf("%s.containers.name=%s does have CPU limits", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers.name=%s doesn't have CPU limits", [specInfo.path, containers[index].name]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    containers := document.spec.containers
-    
-    
-    object.get(containers[index]["resources"], "limits", "undefined") == "undefined"
- 
-    result := {
-                "documentId":        input.document[i].id,
-                "issueType":         "MissingAttribute",
-                "searchKey":         sprintf("metadata.name=%s.%s.containers.name=%s.resources", [metadata.name, specInfo.path, containers[index].name]),
-                "keyExpectedValue":  sprintf("%s.containers.name=%s does have limits defined",[specInfo.path, containers[index].name]),
-                "keyActualValue":    sprintf("%s.containers.name=%s doesn't have limits defined",[specInfo.path, containers[index].name])
-              }
+	containers := document.spec.containers
+
+	object.get(containers[index].resources, "limits", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s.resources", [metadata.name, specInfo.path, containers[index].name]),
+		"keyExpectedValue": sprintf("%s.containers.name=%s does have limits defined", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers.name=%s doesn't have limits defined", [specInfo.path, containers[index].name]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    containers := document.spec.containers
-    
-    
-    object.get(containers[index], "resources", "undefined") == "undefined"
- 
-    result := {
-                "documentId":        input.document[i].id,
-                "issueType":         "MissingAttribute",
-                "searchKey":         sprintf("metadata.name=%s.%s.containers.name=%s", [metadata.name, specInfo.path, containers[index].name]),
-                "keyExpectedValue":  sprintf("%s.containers.name=%s does have resources defined",[specInfo.path, containers[index].name]),
-                "keyActualValue":    sprintf("%s.containers.name=%s doesn't have resources defined",[specInfo.path, containers[index].name])
-              }
+	containers := document.spec.containers
+
+	object.get(containers[index], "resources", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s", [metadata.name, specInfo.path, containers[index].name]),
+		"keyExpectedValue": sprintf("%s.containers.name=%s does have resources defined", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers.name=%s doesn't have resources defined", [specInfo.path, containers[index].name]),
+	}
 }
-
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-} 
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/cpu_requests/query.rego
+++ b/assets/queries/k8s/cpu_requests/query.rego
@@ -1,71 +1,67 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
-    
-    containers := document.spec.containers
-    
-    object.get(containers[index]["resources"]["requests"], "cpu", "undefined") == "undefined"
-    
-    
-    result := {
-                "documentId":        input.document[i].id,
-                "issueType":         "MissingAttribute",
-                "searchKey":         sprintf("metadata.name=%s.%s.containers.name=%s.resources.requests", [metadata.name, specInfo.path, containers[index].name]),
-                "keyExpectedValue":  sprintf("%s.containers.name=%s.resources.requests does have CPU requests",[specInfo.path, containers[index].name]),
-                "keyActualValue":    sprintf("%s.containers.name=%s.resources.requests doesn't have CPU requests",[specInfo.path, containers[index].name])
-              }
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
+
+	containers := document.spec.containers
+
+	object.get(containers[index].resources.requests, "cpu", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s.resources.requests", [metadata.name, specInfo.path, containers[index].name]),
+		"keyExpectedValue": sprintf("%s.containers.name=%s.resources.requests does have CPU requests", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers.name=%s.resources.requests doesn't have CPU requests", [specInfo.path, containers[index].name]),
+	}
 }
 
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+	containers := document.spec.containers
 
-    containers := document.spec.containers
-    
-    
-    object.get(containers[index]["resources"], "requests", "undefined") == "undefined"
- 
-    result := {
-                "documentId":        input.document[i].id,
-                "issueType":         "MissingAttribute",
-                "searchKey":         sprintf("metadata.name=%s.%s.containers.name=%s.resources", [metadata.name, specInfo.path, containers[index].name]),
-                "keyExpectedValue":  sprintf("%s.containers.name=%s.resources does have requests defined",[specInfo.path, containers[index].name]),
-                "keyActualValue":    sprintf("%s.containers.name=%s.resources doesn't have requests defined",[specInfo.path, containers[index].name])
-              }
+	object.get(containers[index].resources, "requests", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s.resources", [metadata.name, specInfo.path, containers[index].name]),
+		"keyExpectedValue": sprintf("%s.containers.name=%s.resources does have requests defined", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers.name=%s.resources doesn't have requests defined", [specInfo.path, containers[index].name]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    containers := document.spec.containers
-    
-    
-    object.get(containers[index], "resources", "undefined") == "undefined"
- 
-    result := {
-                "documentId":        input.document[i].id,
-                "issueType":         "MissingAttribute",
-                "searchKey":         sprintf("metadata.name=%s.%s.containers.name=%s", [metadata.name, specInfo.path, containers[index].name]),
-                "keyExpectedValue":  sprintf("%s.containers.name=%s does have resources defined",[specInfo.path, containers[index].name]),
-                "keyActualValue":    sprintf("%s.containers.name=%s doesn't have resources defined",[specInfo.path, containers[index].name])
-              }
+	containers := document.spec.containers
+
+	object.get(containers[index], "resources", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s", [metadata.name, specInfo.path, containers[index].name]),
+		"keyExpectedValue": sprintf("%s.containers.name=%s does have resources defined", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers.name=%s doesn't have resources defined", [specInfo.path, containers[index].name]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-} 
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/cronjob_deadline_not_configured/query.rego
+++ b/assets/queries/k8s/cronjob_deadline_not_configured/query.rego
@@ -1,18 +1,18 @@
 package Cx
 
-CxPolicy [ result ] {
-  document := input.document[i]
-  spec := document.spec
-  metadata := document.metadata
-  kind := document.kind
-  kind == "CronJob"
-  object.get(spec, "startingDeadlineSeconds", "undefined") == "undefined"
+CxPolicy[result] {
+	document := input.document[i]
+	spec := document.spec
+	metadata := document.metadata
+	kind := document.kind
+	kind == "CronJob"
+	object.get(spec, "startingDeadlineSeconds", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec", [metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  "spec.startingDeadlineSeconds is defined",
-                "keyActualValue": 	 "spec.startingDeadlineSeconds is not defined"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "spec.startingDeadlineSeconds is defined",
+		"keyActualValue": "spec.startingDeadlineSeconds is not defined",
+	}
 }

--- a/assets/queries/k8s/default_namespace/query.rego
+++ b/assets/queries/k8s/default_namespace/query.rego
@@ -1,33 +1,32 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    metadata = document.metadata
+CxPolicy[result] {
+	document := input.document[i]
 
-    object.get(metadata, "namespace", "undefined") == "undefined"
+	metadata = document.metadata
 
-   	result := {
-                "documentId": 		   input.document[i].id,
-                "issueType":		     "MissingAttribute",
-                "searchKey": 	        sprintf("metadata.name=%s", [metadata.name]),
-                "keyExpectedValue":   sprintf("Namespace is set in document[%d]",[i]),
-                "keyActualValue": 	  sprintf("Namespace is not set in document[%d]",[i])
-              }
+	object.get(metadata, "namespace", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"keyExpectedValue": sprintf("Namespace is set in document[%d]", [i]),
+		"keyActualValue": sprintf("Namespace is not set in document[%d]", [i]),
+	}
 }
 
+CxPolicy[result] {
+	document := input.document[i]
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    metadata = document.metadata
-    metadata.namespace == "default"
+	metadata = document.metadata
+	metadata.namespace == "default"
 
-	  result := {
-                "documentId": 		   input.document[i].id,
-                "issueType":		     "IncorrectValue",
-                "searchKey": 	        sprintf("metadata.name=%s.namespace", [metadata.name]),
-                "keyExpectedValue":   sprintf("Default namespace is not used in document[%d]",[i]),
-                "keyActualValue": 	  sprintf("Default namespace is used in document[%d]",[i])
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "IncorrectValue",
+		"searchKey": sprintf("metadata.name=%s.namespace", [metadata.name]),
+		"keyExpectedValue": sprintf("Default namespace is not used in document[%d]", [i]),
+		"keyActualValue": sprintf("Default namespace is used in document[%d]", [i]),
+	}
 }

--- a/assets/queries/k8s/default_service_account_binding/query.rego
+++ b/assets/queries/k8s/default_service_account_binding/query.rego
@@ -1,18 +1,16 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-    subjects := document.subjects
-    subjects[c].kind == "ServiceAccount"
-    subjects[c].name == "default"
-
+	subjects := document.subjects
+	subjects[c].kind == "ServiceAccount"
+	subjects[c].name == "default"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("subjects.name=%s", [subjects[c].name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "subjects.kind=ServiceAccount.name is not default",
-                "keyActualValue": "subjects.kind=ServiceAccount.name is default"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("subjects.name=%s", [subjects[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "subjects.kind=ServiceAccount.name is not default",
+		"keyActualValue": "subjects.kind=ServiceAccount.name is default",
+	}
 }
-

--- a/assets/queries/k8s/default_service_account_in_use/query.rego
+++ b/assets/queries/k8s/default_service_account_in_use/query.rego
@@ -1,40 +1,39 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    document.kind == "ServiceAccount"
-    
-    metadata := document.metadata
-    metadata.name == "default"
-    
-    object.get(document, "automountServiceAccountToken", "undefined") == "undefined"
+CxPolicy[result] {
+	document := input.document[i]
 
-	  result := {
-                "documentId": 		    input.document[i].id,
-                "issueType":		      "MissingAttribute",
-                "searchKey": 	        sprintf("metadata.name=%s", [metadata.name]),
-                "keyExpectedValue":   sprintf("metadata.name=%s has automountServiceAccountToken set", [metadata.name]),
-                "keyActualValue": 	  sprintf("metadata.name=%s has automountServiceAccountToken undefined", [metadata.name])
-              }
+	document.kind == "ServiceAccount"
+
+	metadata := document.metadata
+	metadata.name == "default"
+
+	object.get(document, "automountServiceAccountToken", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"keyExpectedValue": sprintf("metadata.name=%s has automountServiceAccountToken set", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s has automountServiceAccountToken undefined", [metadata.name]),
+	}
 }
 
+CxPolicy[result] {
+	document := input.document[i]
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    document.kind == "ServiceAccount"
-    
-    metadata := document.metadata
-    metadata.name == "default" 
-    
-    document.automountServiceAccountToken == true
-	   
-    result := {
-                "documentId": 		    input.document[i].id,
-                "issueType":		      "IncorrectValue",
-                "searchKey": 	        sprintf("metadata.name=%s.automountServiceAccountToken", [metadata.name]),
-                "keyExpectedValue":   sprintf("metadata.name=%s has automountServiceAccountToken set to false", [metadata.name]),
-                "keyActualValue": 	  sprintf("metadata.name=%s has automountServiceAccountToken set to true", [metadata.name])
-              }
+	document.kind == "ServiceAccount"
+
+	metadata := document.metadata
+	metadata.name == "default"
+
+	document.automountServiceAccountToken == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "IncorrectValue",
+		"searchKey": sprintf("metadata.name=%s.automountServiceAccountToken", [metadata.name]),
+		"keyExpectedValue": sprintf("metadata.name=%s has automountServiceAccountToken set to false", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s has automountServiceAccountToken set to true", [metadata.name]),
+	}
 }

--- a/assets/queries/k8s/deployment_no_pod_anti_affinity/query.rego
+++ b/assets/queries/k8s/deployment_no_pod_anti_affinity/query.rego
@@ -1,208 +1,207 @@
 package Cx
 
-CxPolicy [ result ] {
-    deployment := input.document[i]
-    object.get(deployment,"kind","undefined") == "Deployment"
-    
-    metadata := deployment.metadata
-    
-    to_number(deployment.spec.replicas) > 2
+CxPolicy[result] {
+	deployment := input.document[i]
+	object.get(deployment, "kind", "undefined") == "Deployment"
 
-    object.get(deployment.spec.template.spec,"affinity","undefined") == "undefined"
+	metadata := deployment.metadata
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.template.spec.affinity' is set",
-                "keyActualValue": "'spec.template.spec.affinity' is undefined"
-              }
+	to_number(deployment.spec.replicas) > 2
+
+	object.get(deployment.spec.template.spec, "affinity", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.template.spec.affinity' is set",
+		"keyActualValue": "'spec.template.spec.affinity' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    deployment := input.document[i]
-    object.get(deployment,"kind","undefined") == "Deployment"
+CxPolicy[result] {
+	deployment := input.document[i]
+	object.get(deployment, "kind", "undefined") == "Deployment"
 
-    to_number(deployment.spec.replicas) > 2
+	to_number(deployment.spec.replicas) > 2
 
-    affinity := deployment.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") == "undefined"
-    
-    metadata := deployment.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity' is set",
-                "keyActualValue": "'spec.template.spec.affinity.podAntiAffinity' is undefined"
-              }
+	affinity := deployment.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") == "undefined"
+
+	metadata := deployment.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity' is set",
+		"keyActualValue": "'spec.template.spec.affinity.podAntiAffinity' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    deployment := input.document[i]
-    object.get(deployment,"kind","undefined") == "Deployment"
+CxPolicy[result] {
+	deployment := input.document[i]
+	object.get(deployment, "kind", "undefined") == "Deployment"
 
-    to_number(deployment.spec.replicas) > 2
+	to_number(deployment.spec.replicas) > 2
 
-    affinity := deployment.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") == "undefined"
-    
-    metadata := deployment.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity' is set",
-                "keyActualValue": "'spec.template.spec.affinity.podAntiAffinity' is undefined"
-              }
+	affinity := deployment.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") == "undefined"
+
+	metadata := deployment.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity' is set",
+		"keyActualValue": "'spec.template.spec.affinity.podAntiAffinity' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    deployment := input.document[i]
-    object.get(deployment,"kind","undefined") == "Deployment"
+CxPolicy[result] {
+	deployment := input.document[i]
+	object.get(deployment, "kind", "undefined") == "Deployment"
 
-    to_number(deployment.spec.replicas) > 2
+	to_number(deployment.spec.replicas) > 2
 
-    affinity := deployment.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") != "undefined"
-    
-    podAntiAffinity:= affinity.podAntiAffinity
+	affinity := deployment.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") != "undefined"
 
-    object.get(podAntiAffinity,"preferredDuringSchedulingIgnoredDuringExecution","undefined") == "undefined"
-    object.get(podAntiAffinity,"requiredDuringSchedulingIgnoredDuringExecution","undefined") == "undefined"
+	podAntiAffinity := affinity.podAntiAffinity
 
+	object.get(podAntiAffinity, "preferredDuringSchedulingIgnoredDuringExecution", "undefined") == "undefined"
+	object.get(podAntiAffinity, "requiredDuringSchedulingIgnoredDuringExecution", "undefined") == "undefined"
 
-    metadata := deployment.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution' and/or 'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution' is set",
-                "keyActualValue": "'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution' and 'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution' is undefined"
-              }
+	metadata := deployment.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution' and/or 'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution' is set",
+		"keyActualValue": "'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution' and 'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    deployment := input.document[i]
-    object.get(deployment,"kind","undefined") == "Deployment"
+CxPolicy[result] {
+	deployment := input.document[i]
+	object.get(deployment, "kind", "undefined") == "Deployment"
 
-    to_number(deployment.spec.replicas) > 2
+	to_number(deployment.spec.replicas) > 2
 
-    affinity := deployment.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") != "undefined"
-    
-    podAntiAffinity:= affinity.podAntiAffinity
+	affinity := deployment.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") != "undefined"
 
-    object.get(podAntiAffinity,"preferredDuringSchedulingIgnoredDuringExecution","undefined") != "undefined"
+	podAntiAffinity := affinity.podAntiAffinity
 
-    pref := podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[j]
+	object.get(podAntiAffinity, "preferredDuringSchedulingIgnoredDuringExecution", "undefined") != "undefined"
 
-    object.get(pref.podAffinityTerm,"topologyKey","undefined") != "kubernetes.io/hostname"
+	pref := podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[j]
 
-    metadata := deployment.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%s].podAffinityTerm.topologyKey' is set and is 'kubernetes.io/hostname'",[j]),
-                "keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%s].podAffinityTerm.topologyKey' is invalid or undefined",[j])
-              }
+	object.get(pref.podAffinityTerm, "topologyKey", "undefined") != "kubernetes.io/hostname"
+
+	metadata := deployment.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%s].podAffinityTerm.topologyKey' is set and is 'kubernetes.io/hostname'", [j]),
+		"keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%s].podAffinityTerm.topologyKey' is invalid or undefined", [j]),
+	}
 }
 
-CxPolicy [ result ] {
-    deployment := input.document[i]
-    object.get(deployment,"kind","undefined") == "Deployment"
+CxPolicy[result] {
+	deployment := input.document[i]
+	object.get(deployment, "kind", "undefined") == "Deployment"
 
-    to_number(deployment.spec.replicas) > 2
+	to_number(deployment.spec.replicas) > 2
 
-    affinity := deployment.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") != "undefined"
-    
-    podAntiAffinity:= affinity.podAntiAffinity
+	affinity := deployment.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") != "undefined"
 
-    object.get(podAntiAffinity,"preferredDuringSchedulingIgnoredDuringExecution","undefined") != "undefined"
+	podAntiAffinity := affinity.podAntiAffinity
 
-    pref := podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[j]
+	object.get(podAntiAffinity, "preferredDuringSchedulingIgnoredDuringExecution", "undefined") != "undefined"
 
-    object.get(pref.podAffinityTerm,"topologyKey","undefined") == "kubernetes.io/hostname"
+	pref := podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[j]
 
-    templateLabels := deployment.spec.template.metadata.labels 
-    selectorLabels := pref.podAffinityTerm.labelSelector.matchLabels
+	object.get(pref.podAffinityTerm, "topologyKey", "undefined") == "kubernetes.io/hostname"
 
-    matchLabels(templateLabels,selectorLabels) == false
+	templateLabels := deployment.spec.template.metadata.labels
+	selectorLabels := pref.podAffinityTerm.labelSelector.matchLabels
 
-    metadata := deployment.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.labelSelector.matchLabels",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%d].podAffinityTerm.labelSelector.matchLabels' match any label on template metadata",[j]),
-                "keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%d].podAffinityTerm.labelSelector.matchLabels' don't match any label on template metadata",[j])
-              }
+	matchLabels(templateLabels, selectorLabels) == false
+
+	metadata := deployment.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.labelSelector.matchLabels", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%d].podAffinityTerm.labelSelector.matchLabels' match any label on template metadata", [j]),
+		"keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%d].podAffinityTerm.labelSelector.matchLabels' don't match any label on template metadata", [j]),
+	}
 }
 
-CxPolicy [ result ] {
-    deployment := input.document[i]
-    object.get(deployment,"kind","undefined") == "Deployment"
+CxPolicy[result] {
+	deployment := input.document[i]
+	object.get(deployment, "kind", "undefined") == "Deployment"
 
-    to_number(deployment.spec.replicas) > 2
+	to_number(deployment.spec.replicas) > 2
 
-    affinity := deployment.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") != "undefined"
-    
-    podAntiAffinity:= affinity.podAntiAffinity
+	affinity := deployment.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") != "undefined"
 
-    object.get(podAntiAffinity,"requiredDuringSchedulingIgnoredDuringExecution","undefined") != "undefined"
+	podAntiAffinity := affinity.podAntiAffinity
 
-    pref := podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[j]
+	object.get(podAntiAffinity, "requiredDuringSchedulingIgnoredDuringExecution", "undefined") != "undefined"
 
-    object.get(pref,"topologyKey","undefined") != "kubernetes.io/hostname"
+	pref := podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[j]
 
-    metadata := deployment.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].topologyKey' is set and is 'kubernetes.io/hostname'",[j]),
-                "keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].topologyKey' is invalid or undefined",[j])
-              }
+	object.get(pref, "topologyKey", "undefined") != "kubernetes.io/hostname"
+
+	metadata := deployment.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].topologyKey' is set and is 'kubernetes.io/hostname'", [j]),
+		"keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].topologyKey' is invalid or undefined", [j]),
+	}
 }
 
-CxPolicy [ result ] {
-    deployment := input.document[i]
-    object.get(deployment,"kind","undefined") == "Deployment"
+CxPolicy[result] {
+	deployment := input.document[i]
+	object.get(deployment, "kind", "undefined") == "Deployment"
 
-    to_number(deployment.spec.replicas) > 2
+	to_number(deployment.spec.replicas) > 2
 
-    affinity := deployment.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") != "undefined"
-    
-    podAntiAffinity:= affinity.podAntiAffinity
+	affinity := deployment.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") != "undefined"
 
-    object.get(podAntiAffinity,"requiredDuringSchedulingIgnoredDuringExecution","undefined") != "undefined"
+	podAntiAffinity := affinity.podAntiAffinity
 
-    pref := podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[j]
+	object.get(podAntiAffinity, "requiredDuringSchedulingIgnoredDuringExecution", "undefined") != "undefined"
 
-    object.get(pref,"topologyKey","undefined") == "kubernetes.io/hostname"
+	pref := podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[j]
 
-    templateLabels := deployment.spec.template.metadata.labels 
-    selectorLabels := pref.labelSelector.matchLabels
+	object.get(pref, "topologyKey", "undefined") == "kubernetes.io/hostname"
 
-    matchLabels(templateLabels,selectorLabels) == false
+	templateLabels := deployment.spec.template.metadata.labels
+	selectorLabels := pref.labelSelector.matchLabels
 
-    metadata := deployment.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution.labelSelector.matchLabels",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].labelSelector.matchLabels' match any label on template metadata",[j]),
-                "keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].labelSelector.matchLabels' don't match any label on template metadata",[j])
-              }
+	matchLabels(templateLabels, selectorLabels) == false
+
+	metadata := deployment.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution.labelSelector.matchLabels", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].labelSelector.matchLabels' match any label on template metadata", [j]),
+		"keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].labelSelector.matchLabels' don't match any label on template metadata", [j]),
+	}
 }
 
-matchLabels(templateLabels,selectorLabels) = true {
-  some Key
-    templateLabels[Key] == selectorLabels[Key]
+matchLabels(templateLabels, selectorLabels) {
+	some Key
+	templateLabels[Key] == selectorLabels[Key]
 } else = false {
-  true
+	true
 }

--- a/assets/queries/k8s/deployment_without_pod_disruption_budget/query.rego
+++ b/assets/queries/k8s/deployment_without_pod_disruption_budget/query.rego
@@ -1,29 +1,28 @@
 package Cx
 
-CxPolicy [result ] {
+CxPolicy[result] {
+	deployment := input.document[i]
+	deployment.kind == "Deployment"
+	metadata := deployment.metadata
 
-  deployment := input.document[i]
-  deployment.kind == "Deployment"
-  metadata := deployment.metadata
+	not CheckIFPdbExists(deployment)
 
-  not CheckIFPdbExists(deployment)
-
-  result := {
-              "documentId": 		input.document[i].id,
-              "searchKey": 	    sprintf("metadata.name=%s", [metadata.name]),
-              "issueType":		"MissingAttribute",
-              "keyExpectedValue": sprintf("metadata.name=%s are targeted by a PDB", [metadata.name]),
-              "keyActualValue": 	sprintf("metadata.name=%s are not targeted by a PDB", [metadata.name])
-            }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s are targeted by a PDB", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s are not targeted by a PDB", [metadata.name]),
+	}
 }
 
-CheckIFPdbExists (deployments) = result{
+CheckIFPdbExists(deployments) = result {
 	documents := input.document
 	pdbs := [pdb | documents[index].kind == "PodDisruptionBudget"; pdb = documents[index]]
 
-  result := contains(pdbs, deployments.spec.selector.matchLabels.app)
+	result := contains(pdbs, deployments.spec.selector.matchLabels.app)
 }
 
-contains (array, string) = true {
+contains(array, string) {
 	array[a].spec.selector.matchLabels.app == string
 }

--- a/assets/queries/k8s/host_aliases_undefined_or_empty/query.rego
+++ b/assets/queries/k8s/host_aliases_undefined_or_empty/query.rego
@@ -1,48 +1,48 @@
 package Cx
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  object.get(spec, "hostAliases", "undefined") == "undefined"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	object.get(spec, "hostAliases", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec", [metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.hostAliases is defined", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.hostAliases is undefined", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.hostAliases is defined", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.hostAliases is undefined", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  spec.hostAliases == null
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	spec.hostAliases == null
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.hostAliases", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.hostAliases is not null", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.hostAliases is null", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.hostAliases", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.hostAliases is not null", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.hostAliases is null", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  checkAction(spec.hostAliases)
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	checkAction(spec.hostAliases)
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.hostAliases", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.hostAliases is not empty", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.hostAliases is empty", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.hostAliases", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.hostAliases is not empty", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.hostAliases is empty", [metadata.name]),
+	}
 }
 
-checkAction(action) = true {
+checkAction(action) {
 	is_array(action)
 	count(action) == 0
 }

--- a/assets/queries/k8s/hpa_targeted_deployments_with_configured_replica_count/query.rego
+++ b/assets/queries/k8s/hpa_targeted_deployments_with_configured_replica_count/query.rego
@@ -1,20 +1,20 @@
 package Cx
 
-CxPolicy [ result ] {  
-  metadata := input.document[i].metadata
-  replicasCheck := input.document[i].spec.replicas
-  kindCheck := input.document[i].kind
-  scaleKindCheck := input.document[j].spec.scaleTargetRef.kind
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	replicasCheck := input.document[i].spec.replicas
+	kindCheck := input.document[i].kind
+	scaleKindCheck := input.document[j].spec.scaleTargetRef.kind
 
-  metadata.name == input.document[j].spec.scaleTargetRef.name  
-  kindCheck == "Deployment"
-  scaleKindCheck == "Deployment"
-   
+	metadata.name == input.document[j].spec.scaleTargetRef.name
+	kindCheck == "Deployment"
+	scaleKindCheck == "Deployment"
+
 	result := {
-                "documentId": 		    input.document[i].id,
-                "searchKey": 	        sprintf("metadata.name=%s.spec.replicas", [metadata.name]),
-                "issueType":		      "IncorrectValue",
-                "keyExpectedValue":   sprintf("metadata.name=%s.spec.replicas is undefined", [metadata.name]),
-				        "keyActualValue":     sprintf("metadata.name=%s.spec.replicas is defined", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.replicas", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.replicas is undefined", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.replicas is defined", [metadata.name]),
+	}
 }

--- a/assets/queries/k8s/image_defined/query.rego
+++ b/assets/queries/k8s/image_defined/query.rego
@@ -1,37 +1,37 @@
 package Cx
 
-CxPolicy [ result ] {
-   document := input.document
-   metadata := document[i].metadata
-   spec := document[i].spec
-   containers := spec.containers
-   images = object.get(containers[c], "image", "undefined") != "undefined"
-   not images
+CxPolicy[result] {
+	document := input.document
+	metadata := document[i].metadata
+	spec := document[i].spec
+	containers := spec.containers
+	images = object.get(containers[c], "image", "undefined") != "undefined"
+	not images
 
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s", [metadata.name, containers[c].name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.image is defined", [metadata.name, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers.name=%s.image is undefined", [metadata.name, containers[c].name])
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s", [metadata.name, containers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.image is defined", [metadata.name, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers.name=%s.image is undefined", [metadata.name, containers[c].name]),
+	}
 }
 
-CxPolicy [ result ] {
-   document := input.document
-   metadata := document[i].metadata
-   spec := document[i].spec
-   containers := spec.containers
-   images = containers[c].image
-   check_content(images)
+CxPolicy[result] {
+	document := input.document
+	metadata := document[i].metadata
+	spec := document[i].spec
+	containers := spec.containers
+	images = containers[c].image
+	check_content(images)
 
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.image", [metadata.name, containers[c].name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.image is not null, empty or latest", [metadata.name, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers.name=%s.image is null, empty or latest", [metadata.name, containers[c].name])
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.image", [metadata.name, containers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.image is not null, empty or latest", [metadata.name, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers.name=%s.image is null, empty or latest", [metadata.name, containers[c].name]),
+	}
 }
 
 check_content(images) {

--- a/assets/queries/k8s/image_pull_policy_of_container_is_not_always/query.rego
+++ b/assets/queries/k8s/image_pull_policy_of_container_is_not_always/query.rego
@@ -1,19 +1,19 @@
 package Cx
 
-CxPolicy [ result ] {
-   document := input.document
-   metadata := document[i].metadata
-   spec := document[i].spec
-   containers := spec.containers
-   containers[c].imagePullPolicy != "Always"
+CxPolicy[result] {
+	document := input.document
+	metadata := document[i].metadata
+	spec := document[i].spec
+	containers := spec.containers
+	containers[c].imagePullPolicy != "Always"
 
-   not contains(containers[c].image, ":latest")
+	not contains(containers[c].image, ":latest")
 
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.imagePullPolicy", [metadata.name, containers[c].name]),
-                "issueType":		   "IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.imagePullPolicy should be Always", [metadata.name, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers.name=%s.imagePullPolicy is incorrect", [metadata.name, containers[c].name])
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.imagePullPolicy", [metadata.name, containers[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.imagePullPolicy should be Always", [metadata.name, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers.name=%s.imagePullPolicy is incorrect", [metadata.name, containers[c].name]),
+	}
 }

--- a/assets/queries/k8s/incorrect_volume_claim_access_mode_read_write_once/query.rego
+++ b/assets/queries/k8s/incorrect_volume_claim_access_mode_read_write_once/query.rego
@@ -1,37 +1,37 @@
 package Cx
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  volumeClaims := input.document[i].spec.volumeClaimTemplates
-     
-  vClaimsWitReadWriteOnce := [ vClaims | contains(volumeClaims[v].spec.accessModes, "ReadWriteOnce") == true; vClaims := volumeClaims[v].metadata.name]
-  count(vClaimsWitReadWriteOnce) == 0
-    
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	volumeClaims := input.document[i].spec.volumeClaimTemplates
+
+	vClaimsWitReadWriteOnce := [vClaims | contains(volumeClaims[v].spec.accessModes, "ReadWriteOnce") == true; vClaims := volumeClaims[v].metadata.name]
+	count(vClaimsWitReadWriteOnce) == 0
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.volumeClaimTemplates", [metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.volumeClaimTemplates has one template with a 'ReadWriteOnce'", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.volumeClaimTemplates does not have a template with a 'ReadWriteOnce'", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.volumeClaimTemplates", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.volumeClaimTemplates has one template with a 'ReadWriteOnce'", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.volumeClaimTemplates does not have a template with a 'ReadWriteOnce'", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  volumeClaims := input.document[i].spec.volumeClaimTemplates
-     
-  vClaimsWitReadWriteOnce := [ vClaims | contains(volumeClaims[v].spec.accessModes, "ReadWriteOnce") == true; vClaims := volumeClaims[v].metadata.name]
-  count(vClaimsWitReadWriteOnce) > 1
-       
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	volumeClaims := input.document[i].spec.volumeClaimTemplates
+
+	vClaimsWitReadWriteOnce := [vClaims | contains(volumeClaims[v].spec.accessModes, "ReadWriteOnce") == true; vClaims := volumeClaims[v].metadata.name]
+	count(vClaimsWitReadWriteOnce) > 1
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.volumeClaimTemplates", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.volumeClaimTemplates has only one template with a 'ReadWriteOnce'", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.volumeClaimTemplates has multiple templates with 'ReadWriteOnce'", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.volumeClaimTemplates", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.volumeClaimTemplates has only one template with a 'ReadWriteOnce'", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.volumeClaimTemplates has multiple templates with 'ReadWriteOnce'", [metadata.name]),
+	}
 }
 
-contains(array, string) = true{
-    array[_] == string
+contains(array, string) {
+	array[_] == string
 }

--- a/assets/queries/k8s/ingress_controller_exposes_workload/query.rego
+++ b/assets/queries/k8s/ingress_controller_exposes_workload/query.rego
@@ -1,53 +1,52 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    document.kind == "Ingress"
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
-    annotations := metadata.annotations
+CxPolicy[result] {
+	document := input.document[i]
+	document.kind == "Ingress"
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
+	annotations := metadata.annotations
 
-    object.get(annotations,"kubernetes.io/ingress.class", "undefined") != "undefined"
-    
-    spec := document.spec
-    
-    backend := spec["rules"][x]["http"]["paths"][j]["backend"]
-    
-    serviceName := backend["serviceName"]
-    servicePort := backend["servicePort"]
-    
-    ingressControllerExposesWorload(serviceName, servicePort)
-    
+	object.get(annotations, "kubernetes.io/ingress.class", "undefined") != "undefined"
+
+	spec := document.spec
+
+	backend := spec.rules[x].http.paths[j].backend
+
+	serviceName := backend.serviceName
+	servicePort := backend.servicePort
+
+	ingressControllerExposesWorload(serviceName, servicePort)
+
 	result := {
-                "documentId": 		  input.document[i].id,
-                "issueType":		  "IncorrectValue",
-                "searchKey":          sprintf("metadata.name=%s.%s.rules.http.paths.backend", [metadata.name, specInfo.path]),
-                "keyExpectedValue":   sprintf("metadata.name=%s is not exposing the workload", [metadata.name]),
-                "keyActualValue":     sprintf("metadata.name=%s is exposing the workload", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"issueType": "IncorrectValue",
+		"searchKey": sprintf("metadata.name=%s.%s.rules.http.paths.backend", [metadata.name, specInfo.path]),
+		"keyExpectedValue": sprintf("metadata.name=%s is not exposing the workload", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s is exposing the workload", [metadata.name]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-} 
-
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}
 
 ingressControllerExposesWorload(serviceName, servicePort) = allow {
-  documents := input.document
+	documents := input.document
 
-  services := [service | documents[index].kind == "Service"; service = documents[index]]
-  
-  services[x]["spec"]["ports"][j]["targetPort"] == servicePort
+	services := [service | documents[index].kind == "Service"; service = documents[index]]
 
-  services[x]["metadata"]["name"] == serviceName
+	services[x].spec.ports[j].targetPort == servicePort
 
-  allow = true
+	services[x].metadata.name == serviceName
+
+	allow = true
 }

--- a/assets/queries/k8s/kubernetes_dashboard_integration/query.rego
+++ b/assets/queries/k8s/kubernetes_dashboard_integration/query.rego
@@ -1,55 +1,55 @@
 package Cx
 
-CxPolicy [ result ] {
-   document := input.document
-   metadata := document[i].metadata
-   
-   specInfo := get_spec_info(document[i]) 
-   containers := specInfo.spec.containers
-   check_image_content(containers[j])
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":      sprintf("metadata.name=%s.%s.containers.name=%s.image", [metadata.name, specInfo.path, containers[j].name]),
-                "issueType":		   "IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.%s.containers.name=%s.image has not kubernetes-dashboard deployed", [metadata.name, specInfo.path, containers[j].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.%s.containers.name=%s.image has kubernetes-dashboard deployed", [metadata.name, specInfo.path, containers[j].name])
-             }
+CxPolicy[result] {
+	document := input.document
+	metadata := document[i].metadata
+
+	specInfo := get_spec_info(document[i])
+	containers := specInfo.spec.containers
+	check_image_content(containers[j])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s.image", [metadata.name, specInfo.path, containers[j].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.%s.containers.name=%s.image has not kubernetes-dashboard deployed", [metadata.name, specInfo.path, containers[j].name]),
+		"keyActualValue": sprintf("metadata.name=%s.%s.containers.name=%s.image has kubernetes-dashboard deployed", [metadata.name, specInfo.path, containers[j].name]),
+	}
 }
 
-CxPolicy [ result ] {
-   document := input.document
-   metadata := document[i].metadata
-   
-   specInfo := get_spec_info(document[i])
-   init_containers := specInfo.spec.initContainers
-   check_image_content(init_containers[j])
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":      sprintf("metadata.name=%s.%s.initContainers.name=%s.image", [metadata.name, specInfo.path, init_containers[j].name]),
-                "issueType":		   "IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.%s.initContainers.name=%s.image has not kubernetes-dashboard deployed", [metadata.name, specInfo.path, init_containers[j].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.%s.initContainers.name=%s.image has kubernetes-dashboard deployed", [metadata.name, specInfo.path, init_containers[j].name])
-             }
-}
+CxPolicy[result] {
+	document := input.document
+	metadata := document[i].metadata
 
-check_image_content(containers) {
-  contains(containers.image, "kubernetes-dashboard")
+	specInfo := get_spec_info(document[i])
+	init_containers := specInfo.spec.initContainers
+	check_image_content(init_containers[j])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.initContainers.name=%s.image", [metadata.name, specInfo.path, init_containers[j].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.%s.initContainers.name=%s.image has not kubernetes-dashboard deployed", [metadata.name, specInfo.path, init_containers[j].name]),
+		"keyActualValue": sprintf("metadata.name=%s.%s.initContainers.name=%s.image has kubernetes-dashboard deployed", [metadata.name, specInfo.path, init_containers[j].name]),
+	}
 }
 
 check_image_content(containers) {
-  contains(containers.image, "kubernetesui")
+	contains(containers.image, "kubernetes-dashboard")
+}
+
+check_image_content(containers) {
+	contains(containers.image, "kubernetesui")
 }
 
 get_spec_info(document) = specInfo {
-  templates := {"job_template", "jobTemplate"}
-  spec := document.spec[templates[t]].spec.template.spec
-  specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-  spec := document.spec.template.spec
-  specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-  spec := document.spec
-  specInfo := {"spec": spec, "path": "spec"}
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
 }

--- a/assets/queries/k8s/kubernetes_docker_socket_volume/query.rego
+++ b/assets/queries/k8s/kubernetes_docker_socket_volume/query.rego
@@ -1,59 +1,53 @@
 package Cx
 
-CxPolicy [ result ] {
-	  document := input.document[i]
-    document.kind == "Pod"
-    metadata:= document.metadata
-    spec := document.spec
-    volumes := spec.volumes
-    volumes[c].hostPath.path == "/var/run/docker.sock"
-
-	
+CxPolicy[result] {
+	document := input.document[i]
+	document.kind == "Pod"
+	metadata := document.metadata
+	spec := document.spec
+	volumes := spec.volumes
+	volumes[c].hostPath.path == "/var/run/docker.sock"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[c].name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("spec.volumes[%s].hostPath.path is not '/var/run/docker.sock'", [volumes[c].name]),
-                "keyActualValue": 	sprintf("spec.volumes[%s].hostPath.path is '/var/run/docker.sock'", [volumes[c].name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.volumes[%s].hostPath.path is not '/var/run/docker.sock'", [volumes[c].name]),
+		"keyActualValue": sprintf("spec.volumes[%s].hostPath.path is '/var/run/docker.sock'", [volumes[c].name]),
+	}
 }
 
-CxPolicy [ result ] {
-	  document := input.document[i]
-    document.kind != "Pod"
-    document.kind != "CronJob"
-    metadata:= document.metadata
-    spec:= document.spec.template.spec
-    volumes := spec.volumes
-    volumes[c].hostPath.path == "/var/run/docker.sock"
-
-	
+CxPolicy[result] {
+	document := input.document[i]
+	document.kind != "Pod"
+	document.kind != "CronJob"
+	metadata := document.metadata
+	spec := document.spec.template.spec
+	volumes := spec.volumes
+	volumes[c].hostPath.path == "/var/run/docker.sock"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[c].name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("spec.volumes[%s].hostPath.path is not '/var/run/docker.sock'", [volumes[c].name]),
-                "keyActualValue": 	sprintf("spec.volumes[%s].hostPath.path is '/var/run/docker.sock'", [ volumes[c].name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.volumes[%s].hostPath.path is not '/var/run/docker.sock'", [volumes[c].name]),
+		"keyActualValue": sprintf("spec.volumes[%s].hostPath.path is '/var/run/docker.sock'", [volumes[c].name]),
+	}
 }
 
-CxPolicy [ result ] {
-	  document := input.document[i]
-    document.kind == "CronJob"
-    metadata:= document.metadata
-    spec := document.spec.jobTemplate.spec.template.spec
-    volumes := spec.volumes
-    volumes[c].hostPath.path == "/var/run/docker.sock"
-
-	
+CxPolicy[result] {
+	document := input.document[i]
+	document.kind == "CronJob"
+	metadata := document.metadata
+	spec := document.spec.jobTemplate.spec.template.spec
+	volumes := spec.volumes
+	volumes[c].hostPath.path == "/var/run/docker.sock"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[c].name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("spec.volumes[%s].hostPath.path is not '/var/run/docker.sock'", [volumes[c].name]),
-                "keyActualValue": 	sprintf("spec.volumes[%s].hostPath.path is '/var/run/docker.sock'", [volumes[c].name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.volumes[%s].hostPath.path is not '/var/run/docker.sock'", [volumes[c].name]),
+		"keyActualValue": sprintf("spec.volumes[%s].hostPath.path is '/var/run/docker.sock'", [volumes[c].name]),
+	}
 }

--- a/assets/queries/k8s/kubernetes_host_ports/query.rego
+++ b/assets/queries/k8s/kubernetes_host_ports/query.rego
@@ -1,38 +1,36 @@
 package Cx
 
-CxPolicy [ result ] {
-	  document := input.document[i]
-    metadata:= document.metadata
-    spec := document.spec
-    containers := spec.containers
-	  ports := containers[c].ports
-    object.get(ports[k],"hostPort","undefined") != "undefined"
-	
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	spec := document.spec
+	containers := spec.containers
+	ports := containers[c].ports
+	object.get(ports[k], "hostPort", "undefined") != "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("metadata.name=%s.spec.containers.name=%s.ports", [metadata.name, containers[c].name]), 
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("spec[%s].containers[%s].ports[%s].hostPort is not Defined", [metadata.name, containers[c].name, ports[k].hostIP]),
-                "keyActualValue": 	sprintf("spec[%s].containers[%s].ports[%s].hostPort is Defined", [metadata.name, containers[c].name, ports[k].hostIP])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.ports", [metadata.name, containers[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec[%s].containers[%s].ports[%s].hostPort is not Defined", [metadata.name, containers[c].name, ports[k].hostIP]),
+		"keyActualValue": sprintf("spec[%s].containers[%s].ports[%s].hostPort is Defined", [metadata.name, containers[c].name, ports[k].hostIP]),
+	}
 }
 
-CxPolicy [ result ] {
-	  document := input.document[i]
-    document.kind = "Pod"
-    metadata:= document.metadata
-    spec := document.spec.template.spec
-    containers := spec.containers
-	  ports := containers[c].ports
-    object.get(ports[k],"hostPort","undefined") != "undefined"
-	
+CxPolicy[result] {
+	document := input.document[i]
+	document.kind = "Pod"
+	metadata := document.metadata
+	spec := document.spec.template.spec
+	containers := spec.containers
+	ports := containers[c].ports
+	object.get(ports[k], "hostPort", "undefined") != "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("metadata.name=%s.spec.template.spec.containers.name=%s.ports", [metadata.name, containers[c].name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("spec[%s].template.spec.containers[%s].ports[%s].hostPort is not Defined", [metadata.name, containers[c].name, ports[k].hostIP]),
-                "keyActualValue": 	sprintf("spec[%s].template.spec.containers[%s].ports[%s].hostPort is Defined", [metadata.name, containers[c].name, ports[k].hostIP])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.containers.name=%s.ports", [metadata.name, containers[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec[%s].template.spec.containers[%s].ports[%s].hostPort is not Defined", [metadata.name, containers[c].name, ports[k].hostIP]),
+		"keyActualValue": sprintf("spec[%s].template.spec.containers[%s].ports[%s].hostPort is Defined", [metadata.name, containers[c].name, ports[k].hostIP]),
+	}
 }

--- a/assets/queries/k8s/kubernetes_image_digest/query.rego
+++ b/assets/queries/k8s/kubernetes_image_digest/query.rego
@@ -1,38 +1,34 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-  metadata:= document.metadata
-  spec := document.spec
-  containers := spec.containers
-  image := containers[c].image
-  not contains(image, "@")
-    
-	
+	metadata := document.metadata
+	spec := document.spec
+	containers := spec.containers
+	image := containers[c].image
+	not contains(image, "@")
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("metadata.name=%s.spec.containers.name=%s.image", [metadata.name, containers[c].name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.image has '@'", [metadata.name, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers.name=%s.image '@'", [metadata.name, containers[c].name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.image", [metadata.name, containers[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.image has '@'", [metadata.name, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers.name=%s.image '@'", [metadata.name, containers[c].name]),
+	}
 }
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-  metadata:= document.metadata
-  spec := document.spec
-  containers := spec.containers
-  object.get(containers[k],"image","undefined") == "undefined"
-    
-	
+	metadata := document.metadata
+	spec := document.spec
+	containers := spec.containers
+	object.get(containers[k], "image", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("metadata.name=%s.spec.containers", [metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.image is Defined", [metadata.name, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers.name=%s.image is Undefined", [metadata.name, containers[c].name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.image is Defined", [metadata.name, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers.name=%s.image is Undefined", [metadata.name, containers[c].name]),
+	}
 }

--- a/assets/queries/k8s/limit_capabilities_from_the_container/query.rego
+++ b/assets/queries/k8s/limit_capabilities_from_the_container/query.rego
@@ -1,20 +1,20 @@
 package Cx
 
-CxPolicy [ result ] {
-   metadata := input.document[i].metadata
-   spec := input.document[i].spec
-   containers := spec.containers
-   drop := containers[c].securityContext.capabilities.drop
-   
-   not contains(drop, "ALL")
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":        sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop", [metadata.name, containers[c].name]),
-                "issueType":		   "IncorrectValue",
-                "keyExpectedValue": sprintf("All metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop must be dropped", [metadata.name, containers[c].name]),
-                "keyActualValue": 	sprintf("Are not being metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop dropped", [metadata.name, containers[c].name])
-              }
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	containers := spec.containers
+	drop := containers[c].securityContext.capabilities.drop
+
+	not contains(drop, "ALL")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop", [metadata.name, containers[c].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("All metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop must be dropped", [metadata.name, containers[c].name]),
+		"keyActualValue": sprintf("Are not being metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop dropped", [metadata.name, containers[c].name]),
+	}
 }
 
 contains(drop, elem) {

--- a/assets/queries/k8s/limit_capabilities_of_the_psp/query.rego
+++ b/assets/queries/k8s/limit_capabilities_of_the_psp/query.rego
@@ -1,18 +1,18 @@
 package Cx
 
-CxPolicy [ result ] {
-   document := input.document
-   metadata := document[i].metadata
-   spec := document[i].spec
-   document[i].kind == "PodSecurityPolicy"
-   requiredDropCapabilities := object.get(spec, "requiredDropCapabilities", "undefined") != "undefined"
-   not requiredDropCapabilities 
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":      sprintf("metadata.name=%s.spec", [metadata.name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.requiredDropCapabilities is defined", [metadata.name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.requiredDropCapabilities is undefined", [metadata.name])
-              }
+CxPolicy[result] {
+	document := input.document
+	metadata := document[i].metadata
+	spec := document[i].spec
+	document[i].kind == "PodSecurityPolicy"
+	requiredDropCapabilities := object.get(spec, "requiredDropCapabilities", "undefined") != "undefined"
+	not requiredDropCapabilities
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.requiredDropCapabilities is defined", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.requiredDropCapabilities is undefined", [metadata.name]),
+	}
 }

--- a/assets/queries/k8s/liveness_probe_not_defined/query.rego
+++ b/assets/queries/k8s/liveness_probe_not_defined/query.rego
@@ -1,23 +1,23 @@
 package Cx
 
-CxPolicy [ result ] {
-   document := input.document[i]
-   spec := document.spec
-   metadata := document.metadata
-   kind := document.kind
-   not check_kind(document.kind)
-   
-   containers := spec.containers
-   exists_liveness_probe = object.get(containers[index], "livenessProbe", "undefined") == "undefined"
-   exists_liveness_probe
-	
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":        sprintf("metadata.name=%s.spec.containers[%d].name=%s", [metadata.name, index, containers[index].name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s is defined", [metadata.name, index, containers[index].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers[%d].name=%s is undefined", [metadata.name, index, containers[index].name])
-             } 
+CxPolicy[result] {
+	document := input.document[i]
+	spec := document.spec
+	metadata := document.metadata
+	kind := document.kind
+	not check_kind(document.kind)
+
+	containers := spec.containers
+	exists_liveness_probe = object.get(containers[index], "livenessProbe", "undefined") == "undefined"
+	exists_liveness_probe
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s", [metadata.name, index, containers[index].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s is defined", [metadata.name, index, containers[index].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s is undefined", [metadata.name, index, containers[index].name]),
+	}
 }
 
 # Ignore 'Job' and 'CronJob'

--- a/assets/queries/k8s/memory_limits_not_defined/query.rego
+++ b/assets/queries/k8s/memory_limits_not_defined/query.rego
@@ -1,76 +1,75 @@
 package Cx
 
-CxPolicy [ result ] {
-   metadata := input.document[i].metadata
-   spec := input.document[i].spec 
-   containers := spec.containers
-   limits := containers[c].resources.limits
-   exists_memory := object.get(limits, "memory", "undefined") != "undefined"
-   not exists_memory
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":        sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits.memory", [metadata.name, c, containers[c].name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits.memory is defined", [metadata.name, c, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits.memory is undefined", [metadata.name, c, containers[c].name])
-              }
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	containers := spec.containers
+	limits := containers[c].resources.limits
+	exists_memory := object.get(limits, "memory", "undefined") != "undefined"
+	not exists_memory
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits.memory", [metadata.name, c, containers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits.memory is defined", [metadata.name, c, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits.memory is undefined", [metadata.name, c, containers[c].name]),
+	}
 }
 
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	exists_containers := object.get(spec, "containers", "undefined") != "undefined"
+	not exists_containers
 
-CxPolicy [ result ] {
-   metadata := input.document[i].metadata
-   spec := input.document[i].spec
-   exists_containers := object.get(spec, "containers", "undefined") != "undefined"
-   not exists_containers
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":        sprintf("metadata.name=%s.spec.containers", [metadata.name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers is defined", [metadata.name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers is undefined", [metadata.name])
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers is defined", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers is undefined", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-   metadata := input.document[i].metadata
-   spec := input.document[i].spec
-   exists_containers := object.get(spec, "containers", "undefined") != "undefined"
-   exists_containers
-   
-   containers := spec.containers
-   exists_resources := object.get(containers[c], "resources", "undefined") != "undefined"
-   not exists_resources
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources", [metadata.name, c, containers[c].name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are defined", [metadata.name, c, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are undefined", [metadata.name, c, containers[c].name])
-              }
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	exists_containers := object.get(spec, "containers", "undefined") != "undefined"
+	exists_containers
+
+	containers := spec.containers
+	exists_resources := object.get(containers[c], "resources", "undefined") != "undefined"
+	not exists_resources
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources", [metadata.name, c, containers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are defined", [metadata.name, c, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are undefined", [metadata.name, c, containers[c].name]),
+	}
 }
 
-CxPolicy [ result ] {
-   metadata := input.document[i].metadata
-   spec := input.document[i].spec
-   exists_containers := object.get(spec, "containers", "undefined") != "undefined"
-   exists_containers
-   
-   containers := spec.containers
-   exists_resources := object.get(containers[c], "resources", "undefined") != "undefined"
-   exists_resources
-   
-   resources := spec.containers[c].resources
-   exists_limits := object.get(resources, "limits", "undefined") != "undefined"
-   not exists_limits
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits", [metadata.name, c, containers[c].name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits are defined", [metadata.name, c, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits are undefined", [metadata.name, c, containers[c].name])
-              }
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	exists_containers := object.get(spec, "containers", "undefined") != "undefined"
+	exists_containers
+
+	containers := spec.containers
+	exists_resources := object.get(containers[c], "resources", "undefined") != "undefined"
+	exists_resources
+
+	resources := spec.containers[c].resources
+	exists_limits := object.get(resources, "limits", "undefined") != "undefined"
+	not exists_limits
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits", [metadata.name, c, containers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits are defined", [metadata.name, c, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits are undefined", [metadata.name, c, containers[c].name]),
+	}
 }

--- a/assets/queries/k8s/memory_requests_not_defined/query.rego
+++ b/assets/queries/k8s/memory_requests_not_defined/query.rego
@@ -1,76 +1,75 @@
 package Cx
 
-CxPolicy [ result ] {
-   metadata := input.document[i].metadata
-   spec := input.document[i].spec 
-   containers := spec.containers
-   requests := containers[c].resources.requests
-   exists_memory := object.get(requests, "memory", "undefined") != "undefined"
-   not exists_memory
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":        sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests.memory", [metadata.name, c, containers[c].name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests.memory is defined", [metadata.name, c, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests.memory is undefined", [metadata.name, c, containers[c].name])
-              }
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	containers := spec.containers
+	requests := containers[c].resources.requests
+	exists_memory := object.get(requests, "memory", "undefined") != "undefined"
+	not exists_memory
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests.memory", [metadata.name, c, containers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests.memory is defined", [metadata.name, c, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests.memory is undefined", [metadata.name, c, containers[c].name]),
+	}
 }
 
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	exists_containers := object.get(spec, "containers", "undefined") != "undefined"
+	not exists_containers
 
-CxPolicy [ result ] {
-   metadata := input.document[i].metadata
-   spec := input.document[i].spec
-   exists_containers := object.get(spec, "containers", "undefined") != "undefined"
-   not exists_containers
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":        sprintf("metadata.name=%s.spec", [metadata.name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec is defined", [metadata.name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec is undefined", [metadata.name])
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec is defined", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec is undefined", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-   metadata := input.document[i].metadata
-   spec := input.document[i].spec
-   exists_containers := object.get(spec, "containers", "undefined") != "undefined"
-   exists_containers
-   
-   containers := spec.containers
-   exists_resources := object.get(containers[c], "resources", "undefined") != "undefined"
-   not exists_resources
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources", [metadata.name, c, containers[c].name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are defined", [metadata.name, c, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are undefined", [metadata.name, c, containers[c].name])
-              }
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	exists_containers := object.get(spec, "containers", "undefined") != "undefined"
+	exists_containers
+
+	containers := spec.containers
+	exists_resources := object.get(containers[c], "resources", "undefined") != "undefined"
+	not exists_resources
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources", [metadata.name, c, containers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are defined", [metadata.name, c, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are undefined", [metadata.name, c, containers[c].name]),
+	}
 }
 
-CxPolicy [ result ] {
-   metadata := input.document[i].metadata
-   spec := input.document[i].spec
-   exists_containers := object.get(spec, "containers", "undefined") != "undefined"
-   exists_containers
-   
-   containers := spec.containers
-   exists_resources := object.get(containers[c], "resources", "undefined") != "undefined"
-   exists_resources
-   
-   resources := spec.containers[c].resources
-   exists_requests := object.get(resources, "requests", "undefined") != "undefined"
-   not exists_requests
-   
-   result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests", [metadata.name, c, containers[c].name]),
-                "issueType":		   "MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests are defined", [metadata.name, c, containers[c].name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests are undefined", [metadata.name, c, containers[c].name])
-              }
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	exists_containers := object.get(spec, "containers", "undefined") != "undefined"
+	exists_containers
+
+	containers := spec.containers
+	exists_resources := object.get(containers[c], "resources", "undefined") != "undefined"
+	exists_resources
+
+	resources := spec.containers[c].resources
+	exists_requests := object.get(resources, "requests", "undefined") != "undefined"
+	not exists_requests
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests", [metadata.name, c, containers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests are defined", [metadata.name, c, containers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests are undefined", [metadata.name, c, containers[c].name]),
+	}
 }

--- a/assets/queries/k8s/metadata_label_is_invalid/query.rego
+++ b/assets/queries/k8s/metadata_label_is_invalid/query.rego
@@ -1,18 +1,18 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    labels := metadata.labels
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	labels := metadata.labels
 
-    some key
-      value := labels[key]
-      regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", value) == false
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.labels.%s",[metadata.name,key]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": sprintf("'metadata.labels.%s' has valid label %s",[key,value]),
-                "keyActualValue": sprintf("'metadata.labels.%s' has invalid label %s",[key,value])
-              }
+	some key
+	value := labels[key]
+	regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", value) == false
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.labels.%s", [metadata.name, key]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'metadata.labels.%s' has valid label %s", [key, value]),
+		"keyActualValue": sprintf("'metadata.labels.%s' has invalid label %s", [key, value]),
+	}
 }

--- a/assets/queries/k8s/net_raw_capabilities_disabled/query.rego
+++ b/assets/queries/k8s/net_raw_capabilities_disabled/query.rego
@@ -1,23 +1,23 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    document.kind == "PodSecurityPolicy"
-    metadata := document.metadata
-    spec := document.spec
-    not contains(spec.requiredDropCapabilities, ["ALL","NET_RAW"])
-	
+CxPolicy[result] {
+	document := input.document[i]
+	document.kind == "PodSecurityPolicy"
+	metadata := document.metadata
+	spec := document.spec
+	not contains(spec.requiredDropCapabilities, ["ALL", "NET_RAW"])
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("metadata.name=%s.spec.requiredDropCapabilities",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "spec.requiredDropCapabilities 'is ALL or NET_RAW'",
-                "keyActualValue": 	"spec.requiredDropCapabilities 'is not ALL or NET_RAW'",
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.requiredDropCapabilities", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "spec.requiredDropCapabilities 'is ALL or NET_RAW'",
+		"keyActualValue": "spec.requiredDropCapabilities 'is not ALL or NET_RAW'",
+	}
 }
 
-contains(array, elem) = true {
-  upper(array[_]) == elem[_]
-} else = false { true }
-
+contains(array, elem) {
+	upper(array[_]) == elem[_]
+} else = false {
+	true
+}

--- a/assets/queries/k8s/net_raw_capabilities_disabled_minimized/query.rego
+++ b/assets/queries/k8s/net_raw_capabilities_disabled_minimized/query.rego
@@ -1,25 +1,25 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    document.kind == "PodSecurityPolicy"
-    metadata := document.metadata
-    spec := document.spec
-    containers := spec.containers
-    capabilities := spec.containers[k].securityContext.capabilities
-    not contains(capabilities.drop, ["ALL","NET_RAW"])
-	
+CxPolicy[result] {
+	document := input.document[i]
+	document.kind == "PodSecurityPolicy"
+	metadata := document.metadata
+	spec := document.spec
+	containers := spec.containers
+	capabilities := spec.containers[k].securityContext.capabilities
+	not contains(capabilities.drop, ["ALL", "NET_RAW"])
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop",[metadata.name, containers[k].name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop is ALL or NET_RAW",[metadata.name, containers[k].name]),
-                "keyActualValue": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop is not ALL or NET_RAW",[metadata.name, containers[k].name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop", [metadata.name, containers[k].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop is ALL or NET_RAW", [metadata.name, containers[k].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.capabilities.drop is not ALL or NET_RAW", [metadata.name, containers[k].name]),
+	}
 }
 
-contains(array, elem) = true {
-  upper(array[_]) == elem[_]
-} else = false { true }
-
+contains(array, elem) {
+	upper(array[_]) == elem[_]
+} else = false {
+	true
+}

--- a/assets/queries/k8s/network_policy_not_targeting_pods/query.rego
+++ b/assets/queries/k8s/network_policy_not_targeting_pods/query.rego
@@ -1,32 +1,32 @@
 package Cx
 
-CxPolicy [ result ] {
-      document := input.document[i]
-      metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
 
-      object.get(document,"kind","undefined") == "NetworkPolicy"
+	object.get(document, "kind", "undefined") == "NetworkPolicy"
 
-      object.get(document.spec,"podSelector","undefined") != null
+	object.get(document.spec, "podSelector", "undefined") != null
 
-      targetLabels := document.spec.podSelector.matchLabels
-      findTargettedPod(targetLabels[key],key) == false
-   
-      result := {
-                  "documentId": 		input.document[i].id,
-                  "searchKey": 	    sprintf("metadata.name=%s.spec.podSelector.matchLabels.%s",[metadata.name,key]),
-                  "issueType":		"IncorrectValue",
-                  "keyExpectedValue": sprintf("'spec.podSelector.matchLabels.%s' is targeting at least a pod",[key]),
-                  "keyActualValue": sprintf("'spec.podSelector.matchLabels.%s' is not targeting any pod",[key])
-               }
+	targetLabels := document.spec.podSelector.matchLabels
+	findTargettedPod(targetLabels[key], key) == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.podSelector.matchLabels.%s", [metadata.name, key]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.podSelector.matchLabels.%s' is targeting at least a pod", [key]),
+		"keyActualValue": sprintf("'spec.podSelector.matchLabels.%s' is not targeting any pod", [key]),
+	}
 }
 
-findTargettedPod(lValue,lKey) = true {
-   pod := input.document[_]
-   object.get(pod,"kind","undefined") != "NetworkPolicy"
-   labels := pod.metadata.labels
-   some key
-      key == lKey
-      labels[key] == lValue
+findTargettedPod(lValue, lKey) {
+	pod := input.document[_]
+	object.get(pod, "kind", "undefined") != "NetworkPolicy"
+	labels := pod.metadata.labels
+	some key
+	key == lKey
+	labels[key] == lValue
 } else = false {
 	true
 }

--- a/assets/queries/k8s/non_kube_system_pod_with_host_mount/query.rego
+++ b/assets/queries/k8s/non_kube_system_pod_with_host_mount/query.rego
@@ -1,158 +1,157 @@
 package Cx
 
-CxPolicy [result] {
-  resource := input.document[i]
-  metadata := resource.metadata
-  not metadata.namespace
-  resource.kind == "Pod"
-  volumes := resource.spec.volumes
-  volumes[_].hostPath.path
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' should not have hostPath '%s' mounted", [
-      metadata.name,
-      resource.kind,
-      "default",
-      volumes[j].hostPath.path
-    ]),
-    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' has a hostPath '%s' mounted", [
-      metadata.name,
-      resource.kind,
-      "default",
-      volumes[j].hostPath.path
-    ])
-  } 
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	not metadata.namespace
+	resource.kind == "Pod"
+	volumes := resource.spec.volumes
+	volumes[_].hostPath.path
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' should not have hostPath '%s' mounted", [
+			metadata.name,
+			resource.kind,
+			"default",
+			volumes[j].hostPath.path,
+		]),
+		"keyActualValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' has a hostPath '%s' mounted", [
+			metadata.name,
+			resource.kind,
+			"default",
+			volumes[j].hostPath.path,
+		]),
+	}
 }
 
-CxPolicy [result] {
-  resource := input.document[i]
-  metadata := resource.metadata
-  namespace := metadata.namespace
-  namespace != "kube-system"
-  resource.kind == "Pod"
-  volumes := resource.spec.volumes
-  volumes[_].hostPath.path
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' should not have hostPath '%s' mounted", [
-      metadata.name,
-      resource.kind,
-      metadata.namespace,
-      volumes[j].hostPath.path
-    ]),
-    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' has a hostPath '%s' mounted", [
-      metadata.name,
-      resource.kind,
-      metadata.namespace,
-      volumes[j].hostPath.path
-    ])
-  } 
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	namespace := metadata.namespace
+	namespace != "kube-system"
+	resource.kind == "Pod"
+	volumes := resource.spec.volumes
+	volumes[_].hostPath.path
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' should not have hostPath '%s' mounted", [
+			metadata.name,
+			resource.kind,
+			metadata.namespace,
+			volumes[j].hostPath.path,
+		]),
+		"keyActualValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' has a hostPath '%s' mounted", [
+			metadata.name,
+			resource.kind,
+			metadata.namespace,
+			volumes[j].hostPath.path,
+		]),
+	}
 }
 
-
-CxPolicy [result] {
-  resource := input.document[i]
-  metadata := resource.metadata
-  namespace := metadata.namespace
-  namespace != "kube-system"
-  resource.kind != "Pod"
-  volumes := resource.spec.template.spec.volumes
-  volumes[_].hostPath.path
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' should not have hostPath '%s' mounted", [
-      metadata.name,
-      resource.kind,
-      "default",
-      volumes[j].hostPath.path
-    ]),
-    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' has a hostPath '%s' mounted", [
-      metadata.name,
-      resource.kind,
-      "default",
-      volumes[j].hostPath.path
-    ])
-  }
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	namespace := metadata.namespace
+	namespace != "kube-system"
+	resource.kind != "Pod"
+	volumes := resource.spec.template.spec.volumes
+	volumes[_].hostPath.path
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' should not have hostPath '%s' mounted", [
+			metadata.name,
+			resource.kind,
+			"default",
+			volumes[j].hostPath.path,
+		]),
+		"keyActualValue": sprintf("Resource name '%s' of kind '%s' in non kube-system namespace '%s' has a hostPath '%s' mounted", [
+			metadata.name,
+			resource.kind,
+			"default",
+			volumes[j].hostPath.path,
+		]),
+	}
 }
 
-CxPolicy [result] {
-  resource := input.document[i]
-  metadata := resource.metadata
-  not metadata.namespace
-  resource.kind != "Pod"
-  volumes := resource.spec.template.spec.volumes
-  volumes[_].hostPath.path
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' should not have hostPath '%s' mounted", [
-      metadata.name,
-      resource.kind,
-      "default",
-      volumes[j].hostPath.path
-    ]),
-    "keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' has a hostPath '%s' mounted", [
-      metadata.name,
-      resource.kind,
-      "default",
-      volumes[j].hostPath.path
-    ])
-  }
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	not metadata.namespace
+	resource.kind != "Pod"
+	volumes := resource.spec.template.spec.volumes
+	volumes[_].hostPath.path
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' should not have hostPath '%s' mounted", [
+			metadata.name,
+			resource.kind,
+			"default",
+			volumes[j].hostPath.path,
+		]),
+		"keyActualValue": sprintf("Resource name '%s' of kind '%s' in a non kube-system namespace '%s' has a hostPath '%s' mounted", [
+			metadata.name,
+			resource.kind,
+			"default",
+			volumes[j].hostPath.path,
+		]),
+	}
 }
 
-CxPolicy [result] {
-  resource := input.document[i]
-  metadata := resource.metadata
-  resource.kind == "PersistentVolume"
-  metadata.namespace != "kube-system"
-  path := resource.spec.hostPath.path
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.spec.hostPath.path", [metadata.name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("PersistentVolume name '%s' of kind '%s' in non kube-system namespace '%s' should not mount a host sensitive OS directory '%s' with hostPath", [
-      metadata.name,
-      resource.kind,
-      metadata.namespace,
-      path
-    ]),
-    "keyActualValue": sprintf("PersistentVolume name '%s' of kind '%s' in non kube-system namespace '%s' is mounting a host sensitive OS directory '%s' with hostPath", [
-      metadata.name,
-      resource.kind,
-      metadata.namespace,
-      path
-    ])
-  }
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	resource.kind == "PersistentVolume"
+	metadata.namespace != "kube-system"
+	path := resource.spec.hostPath.path
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.hostPath.path", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("PersistentVolume name '%s' of kind '%s' in non kube-system namespace '%s' should not mount a host sensitive OS directory '%s' with hostPath", [
+			metadata.name,
+			resource.kind,
+			metadata.namespace,
+			path,
+		]),
+		"keyActualValue": sprintf("PersistentVolume name '%s' of kind '%s' in non kube-system namespace '%s' is mounting a host sensitive OS directory '%s' with hostPath", [
+			metadata.name,
+			resource.kind,
+			metadata.namespace,
+			path,
+		]),
+	}
 }
 
-CxPolicy [result] {
-  resource := input.document[i]
-  metadata := resource.metadata
-  resource.kind == "PersistentVolume"
-  not metadata.namespace
-  path := resource.spec.hostPath.path
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.hostPath.path", [metadata.name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("PersistentVolume name '%s' of kind '%s' in non kube-system namespace '%s' should not mount a host sensitive OS directory '%s' with hostPath", [
-      metadata.name,
-      resource.kind,
-      "default",
-      path
-    ]),
-    "keyActualValue": sprintf("PersistentVolume name '%s' of kind '%s' in non kube-system namespace '%s' is mounting a host sensitive OS directory '%s' with hostPath", [
-      metadata.name,
-      resource.kind,
-      "default",
-      path
-    ])
-  }
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	resource.kind == "PersistentVolume"
+	not metadata.namespace
+	path := resource.spec.hostPath.path
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.hostPath.path", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("PersistentVolume name '%s' of kind '%s' in non kube-system namespace '%s' should not mount a host sensitive OS directory '%s' with hostPath", [
+			metadata.name,
+			resource.kind,
+			"default",
+			path,
+		]),
+		"keyActualValue": sprintf("PersistentVolume name '%s' of kind '%s' in non kube-system namespace '%s' is mounting a host sensitive OS directory '%s' with hostPath", [
+			metadata.name,
+			resource.kind,
+			"default",
+			path,
+		]),
+	}
 }

--- a/assets/queries/k8s/permissive_access_to_create_pods/query.rego
+++ b/assets/queries/k8s/permissive_access_to_create_pods/query.rego
@@ -1,83 +1,85 @@
 package Cx
+
 create := "create"
+
 pods := "pods"
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-    rules := document.rules
-    metadata := document.metadata
-    
-    isRoleKind(document.kind)
-    rules[j].verbs[l] == create
-    rules[j].resources[k] == pods
-    
+	rules := document.rules
+	metadata := document.metadata
+
+	isRoleKind(document.kind)
+	rules[j].verbs[l] == create
+	rules[j].resources[k] == pods
+
 	result := {
-                "documentId": 	  	input.document[i].id,
-                "searchKey": 	      sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, create] ),
-                "issueType":	    	"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain the value 'create' when metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name] ),
-                "keyActualValue": 	sprintf("metadata.name=%s.rules.verbs contains the value 'create' and metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name] )
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, create]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain the value 'create' when metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.rules.verbs contains the value 'create' and metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-    rules := document.rules
-    metadata := document.metadata
-    
-    isRoleKind(document.kind)
-    rules[j].verbs[l] == create
-    isWildCardValue(rules[j].resources[k])
-    
+	rules := document.rules
+	metadata := document.metadata
+
+	isRoleKind(document.kind)
+	rules[j].verbs[l] == create
+	isWildCardValue(rules[j].resources[k])
+
 	result := {
-                "documentId": 	  	input.document[i].id,
-                "searchKey": 	      sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, create] ),
-                "issueType":	    	"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain the value 'create' when metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name] ),
-                "keyActualValue": 	sprintf("metadata.name=%s.rules.verbs contains the value 'create' and metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name] )
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, create]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain the value 'create' when metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.rules.verbs contains the value 'create' and metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-    rules := document.rules
-    metadata := document.metadata
-    
-    isRoleKind(document.kind)
-    isWildCardValue(rules[j].verbs[l])
-    rules[j].resources[k] == pods
-    
+	rules := document.rules
+	metadata := document.metadata
+
+	isRoleKind(document.kind)
+	isWildCardValue(rules[j].verbs[l])
+	rules[j].resources[k] == pods
+
 	result := {
-                "documentId": 	  	input.document[i].id,
-                "searchKey": 	      sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, rules[j].verbs[l]] ),
-                "issueType":		    "IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name] ),
-                "keyActualValue": 	sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name] )
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, rules[j].verbs[l]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains the value 'pods'", [metadata.name, metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-    rules := document.rules
-    metadata := document.metadata
-    
-    isRoleKind(document.kind)
-    isWildCardValue(rules[j].verbs[l])
-    isWildCardValue(rules[j].resources[k])
-    
-	result := {
-                "documentId": 	  	input.document[i].id,
-                "searchKey": 	      sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, rules[j].verbs[l]] ),
-                "issueType":		    "IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name] ),
-                "keyActualValue": 	sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name] )
-              }
-}
+	rules := document.rules
+	metadata := document.metadata
 
+	isRoleKind(document.kind)
+	isWildCardValue(rules[j].verbs[l])
+	isWildCardValue(rules[j].resources[k])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.rules.verbs.%s", [metadata.name, rules[j].verbs[l]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains a wildcard value", [metadata.name, metadata.name]),
+	}
+}
 
 isWildCardValue(val) {
-	 regex.match(".*\\*.*", val)
+	regex.match(".*\\*.*", val)
 }
 
-isRoleKind("ClusterRole")
-isRoleKind("Role")
+isRoleKind("ClusterRole") = true
+
+isRoleKind("Role") = true

--- a/assets/queries/k8s/pod_network_policy_not_configured/query.rego
+++ b/assets/queries/k8s/pod_network_policy_not_configured/query.rego
@@ -1,71 +1,71 @@
 package Cx
 
-CxPolicy [ result ] {
-      document := input.document[i]
-      metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
 
-      object.get(document,"kind","undefined") != "NetworkPolicy"
+	object.get(document, "kind", "undefined") != "NetworkPolicy"
 
-      findNetworkPolicy(document.metadata.labels[key],key) == false
-   
-      result := {
-                  "documentId": 		input.document[i].id,
-                  "searchKey": 	    sprintf("metadata.name=%s.labels.%s",[metadata.name,key]),
-                  "issueType":		"MissingAttribute",
-                  "keyExpectedValue": sprintf("'metadata.labels.%s' is targeted by a network policy",[key]),
-                  "keyActualValue": sprintf("'metadata.labels.%s' is not targeted by a network policy",[key])
-               }
+	findNetworkPolicy(document.metadata.labels[key], key) == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.labels.%s", [metadata.name, key]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'metadata.labels.%s' is targeted by a network policy", [key]),
+		"keyActualValue": sprintf("'metadata.labels.%s' is not targeted by a network policy", [key]),
+	}
 }
 
-CxPolicy [ result ] {
-      document := input.document[i]
-      metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
 
-      object.get(document,"kind","undefined") != "NetworkPolicy"
-		
-      findNetworkPolicy(document.metadata.labels[key],key) == true
-      properNetworkPolicy(document.metadata.labels[key],key) == false
-   
-      result := {
-                  "documentId": 		input.document[i].id,
-                  "searchKey": 	    sprintf("metadata.name=%s.labels.%s",[metadata.name,key]),
-                  "issueType":		"IncorrectValue",
-                  "keyExpectedValue": sprintf("'metadata.labels.%s' is targeted by a proper network policy (covers both ingress and egress)",[key]),
-                  "keyActualValue": sprintf("'metadata.labels.%s' is not targeted by a proper network policy (does not cover ingress and egress)",[key])
-               }
+	object.get(document, "kind", "undefined") != "NetworkPolicy"
+
+	findNetworkPolicy(document.metadata.labels[key], key) == true
+	properNetworkPolicy(document.metadata.labels[key], key) == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.labels.%s", [metadata.name, key]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'metadata.labels.%s' is targeted by a proper network policy (covers both ingress and egress)", [key]),
+		"keyActualValue": sprintf("'metadata.labels.%s' is not targeted by a proper network policy (does not cover ingress and egress)", [key]),
+	}
 }
 
-findNetworkPolicy(lValue,lKey) = true {
-   networkPolicy := input.document[_]
-   object.get(networkPolicy,"kind","undefined") == "NetworkPolicy"
-   spec := networkPolicy.spec
-   some key
-      key == lKey
-      spec.podSelector.matchLabels[key] == lValue
+findNetworkPolicy(lValue, lKey) {
+	networkPolicy := input.document[_]
+	object.get(networkPolicy, "kind", "undefined") == "NetworkPolicy"
+	spec := networkPolicy.spec
+	some key
+	key == lKey
+	spec.podSelector.matchLabels[key] == lValue
 } else = false {
 	true
 }
 
-properNetworkPolicy(lValue,lKey) = true {
-   networkPolicy := input.document[_]
-   object.get(networkPolicy,"kind","undefined") == "NetworkPolicy"
-   spec := networkPolicy.spec
-   some key
-      key == lKey
-      spec.podSelector.matchLabels[key] == lValue
-      properSpec(spec) == true
+properNetworkPolicy(lValue, lKey) {
+	networkPolicy := input.document[_]
+	object.get(networkPolicy, "kind", "undefined") == "NetworkPolicy"
+	spec := networkPolicy.spec
+	some key
+	key == lKey
+	spec.podSelector.matchLabels[key] == lValue
+	properSpec(spec) == true
 } else = false {
 	true
 }
 
-properSpec(spec) = true {
-   object.get(spec,"policyTypes","undefined") != "undefined"
-   spec.policyTypes[_] == "Ingress"
-   spec.policyTypes[_] == "Egress"
-} else = true {
-   object.get(spec,"policyTypes","undefined") == "undefined"
-   object.get(spec,"egress","undefined") != "undefined"
-   count(spec.egress) > 0
+properSpec(spec) {
+	object.get(spec, "policyTypes", "undefined") != "undefined"
+	spec.policyTypes[_] == "Ingress"
+	spec.policyTypes[_] == "Egress"
+} else {
+	object.get(spec, "policyTypes", "undefined") == "undefined"
+	object.get(spec, "egress", "undefined") != "undefined"
+	count(spec.egress) > 0
 } else = false {
-   true
+	true
 }

--- a/assets/queries/k8s/pod_or_container_without_security_context/query.rego
+++ b/assets/queries/k8s/pod_or_container_without_security_context/query.rego
@@ -1,54 +1,53 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
 
-    metadata := document.metadata
-    
-    spec := document.spec
-    
-    document.kind == "Pod"
-    
-    object.get(spec, "securityContext", "undefined") == "undefined"
+	metadata := document.metadata
+
+	spec := document.spec
+
+	document.kind == "Pod"
+
+	object.get(spec, "securityContext", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		  input.document[i].id,
-                "issueType":		  "MissingAttribute",
-                "searchKey": 	      sprintf("metadata.name=%s.%s", [metadata.name, specInfo.path]),
-                "keyExpectedValue":   sprintf("metadata.name=%s.%s has a security context",[metadata.name,specInfo.path]),
-                "keyActualValue": 	  sprintf("metadata.name=%s.%s does not have a security context",[metadata.name,specInfo.path])
-              }
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s.%s", [metadata.name, specInfo.path]),
+		"keyExpectedValue": sprintf("metadata.name=%s.%s has a security context", [metadata.name, specInfo.path]),
+		"keyActualValue": sprintf("metadata.name=%s.%s does not have a security context", [metadata.name, specInfo.path]),
+	}
 }
 
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    metadata := document.metadata
+	containers := document.spec.containers
 
-    containers := document.spec.containers
-    
-    object.get(containers[index], "securityContext", "undefined") == "undefined"
+	object.get(containers[index], "securityContext", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		  input.document[i].id,
-                "issueType":		  "MissingAttribute",
-                "searchKey": 	      sprintf("metadata.name=%s.%s.containers.name=%s", [metadata.name, specInfo.path,containers[index].name]),
-                "keyExpectedValue":   sprintf("%s.containers.name=%s has a security context",[specInfo.path, containers[index].name]),
-                "keyActualValue": 	  sprintf("%s.containers.name=%s does not have a security context",[specInfo.path, containers[index].name])
-              }
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s", [metadata.name, specInfo.path, containers[index].name]),
+		"keyExpectedValue": sprintf("%s.containers.name=%s has a security context", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers.name=%s does not have a security context", [specInfo.path, containers[index].name]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-} 
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/privilege_escalation_allowed/query.rego
+++ b/assets/queries/k8s/privilege_escalation_allowed/query.rego
@@ -1,50 +1,48 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    containers := document.spec.containers
-    
-    object.get(containers[index]["securityContext"],"allowPrivilegeEscalation", "undefined") == "undefined"
-    
+	containers := document.spec.containers
+
+	object.get(containers[index].securityContext, "allowPrivilegeEscalation", "undefined") == "undefined"
 
 	result := {
-                "documentId":        input.document[i].id,
-                "searchKey":         sprintf("metadata.name=%s.%s.containers.name=%s.securityContext", [metadata.name, specInfo.path, containers[index].name]),
-                "issueType":         "MissingAttribute",
-                "keyExpectedValue":  sprintf("%s.containers[%s].securityContext is set", [specInfo.path, containers[index].name]),
-                "keyActualValue":    sprintf("%s.containers[%s].securityContext is undefined", [specInfo.path, containers[index].name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s.securityContext", [metadata.name, specInfo.path, containers[index].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s.containers[%s].securityContext is set", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers[%s].securityContext is undefined", [specInfo.path, containers[index].name]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    containers := document.spec.containers
-    containers[index].securityContext.allowPrivilegeEscalation == true
-    
+	containers := document.spec.containers
+	containers[index].securityContext.allowPrivilegeEscalation == true
 
 	result := {
-                "documentId":        input.document[i].id,
-                "searchKey":         sprintf("metadata.name=%s.%s.containers.name=%s.securityContext.allowPrivilegeEscalation", [metadata.name, specInfo.path, containers[index].name]),
-                "issueType":         "IncorrectValue",
-                "keyExpectedValue":  sprintf("%s.containers[%s].securityContext.allowPrivilegeEscalation is false", [specInfo.path, containers[index].name]),
-                "keyActualValue":    sprintf("%s.containers[%s].securityContext.allowPrivilegeEscalation is true", [specInfo.path, containers[index].name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.containers.name=%s.securityContext.allowPrivilegeEscalation", [metadata.name, specInfo.path, containers[index].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s.containers[%s].securityContext.allowPrivilegeEscalation is false", [specInfo.path, containers[index].name]),
+		"keyActualValue": sprintf("%s.containers[%s].securityContext.allowPrivilegeEscalation is true", [specInfo.path, containers[index].name]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-} 
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/psp_allows_privilege_escalation/query.rego
+++ b/assets/queries/k8s/psp_allows_privilege_escalation/query.rego
@@ -1,52 +1,49 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    document.kind == "PodSecurityPolicy"
-    
-    object.get(document.spec,"allowPrivilegeEscalation", "undefined") == "undefined"
+	document.kind == "PodSecurityPolicy"
 
-	result := {
-                "documentId": 		  input.document[i].id,
-                "issueType":		  "MissingAttribute",
-                "searchKey": 	      sprintf("metadata.name=%s.%s", [metadata.name,specInfo.path]),
-                "keyExpectedValue":   "Attribute 'allowPrivilegeEscalation' is set",
-                "keyActualValue": 	  "Attribute 'allowPrivilegeEscalation' is undefined",
-              }
-}
-
-
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
-
-    document.kind == "PodSecurityPolicy"
-    
-    document.spec.allowPrivilegeEscalation == true
+	object.get(document.spec, "allowPrivilegeEscalation", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		  input.document[i].id,
-                "issueType":		  "IncorrectValue",
-                "searchKey": 	      sprintf("metadata.name=%s.%s.allowPrivilegeEscalation", [metadata.name, specInfo.path]),
-                "keyExpectedValue":   "Attribute 'allowPrivilegeEscalation' is false",
-                "keyActualValue": 	  "Attribute 'allowPrivilegeEscalation' is true"
-              }
+		"documentId": input.document[i].id,
+		"issueType": "MissingAttribute",
+		"searchKey": sprintf("metadata.name=%s.%s", [metadata.name, specInfo.path]),
+		"keyExpectedValue": "Attribute 'allowPrivilegeEscalation' is set",
+		"keyActualValue": "Attribute 'allowPrivilegeEscalation' is undefined",
+	}
 }
 
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
+	document.kind == "PodSecurityPolicy"
+
+	document.spec.allowPrivilegeEscalation == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"issueType": "IncorrectValue",
+		"searchKey": sprintf("metadata.name=%s.%s.allowPrivilegeEscalation", [metadata.name, specInfo.path]),
+		"keyExpectedValue": "Attribute 'allowPrivilegeEscalation' is false",
+		"keyActualValue": "Attribute 'allowPrivilegeEscalation' is true",
+	}
+}
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-} 
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/psp_allows_sharing_host_ipc/query.rego
+++ b/assets/queries/k8s/psp_allows_sharing_host_ipc/query.rego
@@ -1,17 +1,17 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    document.kind == "PodSecurityPolicy"
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	document.kind == "PodSecurityPolicy"
 
-    document.spec.hostIPC == true
+	document.spec.hostIPC == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.hostIPC", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "'spec.hostIPC' is false or undefined",
-                "keyActualValue": 	"'spec.hostIPC' is true"
-              }
-} 
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.hostIPC", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'spec.hostIPC' is false or undefined",
+		"keyActualValue": "'spec.hostIPC' is true",
+	}
+}

--- a/assets/queries/k8s/psp_allows_sharing_host_pid/query.rego
+++ b/assets/queries/k8s/psp_allows_sharing_host_pid/query.rego
@@ -1,17 +1,17 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    document.kind == "PodSecurityPolicy"
-    
-    document.spec.hostPID == true
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	document.kind == "PodSecurityPolicy"
+
+	document.spec.hostPID == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.hostPID", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "'spec.hostPID' is false or undefined",
-                "keyActualValue": 	"'spec.hostPID' is true"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.hostPID", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'spec.hostPID' is false or undefined",
+		"keyActualValue": "'spec.hostPID' is true",
+	}
 }

--- a/assets/queries/k8s/psp_containers_share_host_network_namespace/query.rego
+++ b/assets/queries/k8s/psp_containers_share_host_network_namespace/query.rego
@@ -1,17 +1,17 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    object.get(document,"kind","undefined") == "PodSecurityPolicy"
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	object.get(document, "kind", "undefined") == "PodSecurityPolicy"
 
-    object.get(document.spec,"hostNetwork","undefined") == true
+	object.get(document.spec, "hostNetwork", "undefined") == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.hostNetwork",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "'spec.hostNetwork' is false or undefined",
-                "keyActualValue": 	"'spec.hostNetwork' is true"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.hostNetwork", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'spec.hostNetwork' is false or undefined",
+		"keyActualValue": "'spec.hostNetwork' is true",
+	}
 }

--- a/assets/queries/k8s/psp_has_allowed_capabilities/query.rego
+++ b/assets/queries/k8s/psp_has_allowed_capabilities/query.rego
@@ -1,31 +1,31 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    specInfo := getSpecInfo(document)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
+	specInfo := getSpecInfo(document)
+	metadata := document.metadata
 
-    document.kind == "PodSecurityPolicy"
-    
-    object.get(document.spec,"allowedCapabilities", "undefined") != "undefined"
+	document.kind == "PodSecurityPolicy"
+
+	object.get(document.spec, "allowedCapabilities", "undefined") != "undefined"
 
 	result := {
-                "documentId": 		  input.document[i].id,
-                "issueType":		  "IncorrectValue",
-                "searchKey":          sprintf("metadata.name=%s.%s.allowedCapabilities", [metadata.name, specInfo.path]),
-                "keyExpectedValue":   "PodSecurityPolicy does not have allowed capabilities",
-                "keyActualValue": 	  "PodSecurityPolicy has allowed capabilities"
-              }
+		"documentId": input.document[i].id,
+		"issueType": "IncorrectValue",
+		"searchKey": sprintf("metadata.name=%s.%s.allowedCapabilities", [metadata.name, specInfo.path]),
+		"keyExpectedValue": "PodSecurityPolicy does not have allowed capabilities",
+		"keyActualValue": "PodSecurityPolicy has allowed capabilities",
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-} 
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/rbac_roles_with_read_secrets_permissions/query.rego
+++ b/assets/queries/k8s/rbac_roles_with_read_secrets_permissions/query.rego
@@ -1,39 +1,39 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i]
-  readVerbs := [ "get", "watch", "list" ]
+CxPolicy[result] {
+	resource := input.document[i]
+	readVerbs := ["get", "watch", "list"]
 
-  resource.kind == "Role"
-  resource.rules[_].resources[_] == "secrets"
+	resource.kind == "Role"
+	resource.rules[_].resources[_] == "secrets"
 
-  some j,k
-  resource.rules[_].verbs[j] == readVerbs[k]
+	some j, k
+	resource.rules[_].verbs[j] == readVerbs[k]
 
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.rules.verbs", [resource.metadata.name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": "Roles should not be allowed to send read verbs to 'secrets' resources",
-    "keyActualValue": sprintf("Roles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rules[_].verbs)])
-  }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.rules.verbs", [resource.metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Roles should not be allowed to send read verbs to 'secrets' resources",
+		"keyActualValue": sprintf("Roles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rules[_].verbs)]),
+	}
 }
 
-CxPolicy [ result ] {
-  resource := input.document[i]
-  readVerbs := [ "get", "watch", "list" ]
+CxPolicy[result] {
+	resource := input.document[i]
+	readVerbs := ["get", "watch", "list"]
 
-  resource.kind == "ClusterRole"
-  resource.rules[_].resources[_] == "secrets"
+	resource.kind == "ClusterRole"
+	resource.rules[_].resources[_] == "secrets"
 
-  some j,k
-  resource.rules[_].verbs[j] == readVerbs[k]
+	some j, k
+	resource.rules[_].verbs[j] == readVerbs[k]
 
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("metadata.name=%s.rules.verbs", [resource.metadata.name]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": "ClusterRoles should not be allowed to send read verbs to 'secrets' resources",
-    "keyActualValue": sprintf("ClusterRoles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rules[_].verbs)])
-  }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.rules.verbs", [resource.metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "ClusterRoles should not be allowed to send read verbs to 'secrets' resources",
+		"keyActualValue": sprintf("ClusterRoles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rules[_].verbs)]),
+	}
 }

--- a/assets/queries/k8s/readiness_probe_not_configured/query.rego
+++ b/assets/queries/k8s/readiness_probe_not_configured/query.rego
@@ -1,21 +1,20 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") != "Job"
-    object.get(document,"kind","undefined") != "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") != "Job"
+	object.get(document, "kind", "undefined") != "CronJob"
 
+	some j
+	container := document.spec.containers[j]
+	object.get(container, "readinessProbe", "undefined") == "undefined"
 
-    some j
-      container := document.spec.containers[j]
-      object.get(container,"readinessProbe","undefined") == "undefined"
-    
-    metadata := document.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": sprintf("'spec.containers[%d].readinessProbe' is set",[j]),
-                "keyActualValue": sprintf("'spec.containers[%d].readinessProbe' is undefined",[j])
-              }
+	metadata := document.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'spec.containers[%d].readinessProbe' is set", [j]),
+		"keyActualValue": sprintf("'spec.containers[%d].readinessProbe' is undefined", [j]),
+	}
 }

--- a/assets/queries/k8s/resource_with_allow_privilege_escalation/query.rego
+++ b/assets/queries/k8s/resource_with_allow_privilege_escalation/query.rego
@@ -1,49 +1,49 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := input.document[i].metadata
-    specInfo := getSpecInfo(document)
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := input.document[i].metadata
+	specInfo := getSpecInfo(document)
 
-    contexts := {"securityContext", "security_context"}
-    properties := {"allowPrivilegeEscalation", "allow_privilege_escalation"}
-    specInfo.spec.containers[_][contexts[c]][properties[p]] == true
+	contexts := {"securityContext", "security_context"}
+	properties := {"allowPrivilegeEscalation", "allow_privilege_escalation"}
+	specInfo.spec.containers[_][contexts[c]][properties[p]] == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.containers.%s.%s", [metadata.name, specInfo.path, contexts[c], properties[p]]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("%s.containers.%s.%s = false", [specInfo.path, contexts[c], properties[p]]),
-                "keyActualValue": 	sprintf("%s.containers.%s.%s = true", [specInfo.path, contexts[c], properties[p]])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.containers.%s.%s", [metadata.name, specInfo.path, contexts[c], properties[p]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s.containers.%s.%s = false", [specInfo.path, contexts[c], properties[p]]),
+		"keyActualValue": sprintf("%s.containers.%s.%s = true", [specInfo.path, contexts[c], properties[p]]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := input.document[i].metadata
-    specInfo := getSpecInfo(document)
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := input.document[i].metadata
+	specInfo := getSpecInfo(document)
 
-    contexts := {"securityContext", "security_context"}
-    properties := {"allowPrivilegeEscalation", "allow_privilege_escalation"}
-    specInfo.spec.initContainers[_][contexts[c]][properties[p]] == true
+	contexts := {"securityContext", "security_context"}
+	properties := {"allowPrivilegeEscalation", "allow_privilege_escalation"}
+	specInfo.spec.initContainers[_][contexts[c]][properties[p]] == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.initContainers.%s.%s", [metadata.name, specInfo.path, contexts[c], properties[p]]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("%s.initContainers.%s.%s = false", [specInfo.path, contexts[c], properties[p]]),
-                "keyActualValue": 	sprintf("%s.initContainers.%s.%s = true", [specInfo.path, contexts[c], properties[p]])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.initContainers.%s.%s", [metadata.name, specInfo.path, contexts[c], properties[p]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s.initContainers.%s.%s = false", [specInfo.path, contexts[c], properties[p]]),
+		"keyActualValue": sprintf("%s.initContainers.%s.%s = true", [specInfo.path, contexts[c], properties[p]]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
 }

--- a/assets/queries/k8s/root_container_file_system_not_readonly/query.rego
+++ b/assets/queries/k8s/root_container_file_system_not_readonly/query.rego
@@ -1,53 +1,53 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
+CxPolicy[result] {
+	document := input.document[i]
 
-    some j
-      container := document.spec.containers[j]
-      object.get(container,"securityContext","undefined") == "undefined"
-    
-    metadata := document.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s",[metadata.name,container.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": sprintf("'spec.containers[%d].securityContext' is set",[j]),
-                "keyActualValue": sprintf("'spec.containers[%d].securityContext' is undefined",[j])
-              }
+	some j
+	container := document.spec.containers[j]
+	object.get(container, "securityContext", "undefined") == "undefined"
+
+	metadata := document.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s", [metadata.name, container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'spec.containers[%d].securityContext' is set", [j]),
+		"keyActualValue": sprintf("'spec.containers[%d].securityContext' is undefined", [j]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
+CxPolicy[result] {
+	document := input.document[i]
 
-    some j
-      container := document.spec.containers[j]
-      securityContext := container.securityContext
-      object.get(securityContext,"readOnlyRootFilesystem","undefined") == "undefined"
-    
-    metadata := document.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.securityContext",[metadata.name,container.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is set and is true",[j]),
-                "keyActualValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is undefined",[j])
-              }
+	some j
+	container := document.spec.containers[j]
+	securityContext := container.securityContext
+	object.get(securityContext, "readOnlyRootFilesystem", "undefined") == "undefined"
+
+	metadata := document.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext", [metadata.name, container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is set and is true", [j]),
+		"keyActualValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is undefined", [j]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
+CxPolicy[result] {
+	document := input.document[i]
 
-    some j
-      container := document.spec.containers[j]
-      container.securityContext.readOnlyRootFilesystem == false
-    
-    metadata := document.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.readOnlyRootFilesystem",[metadata.name,container.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is true",[j]),
-                "keyActualValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is false",[j])
-              }
+	some j
+	container := document.spec.containers[j]
+	container.securityContext.readOnlyRootFilesystem == false
+
+	metadata := document.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.name=%s.securityContext.readOnlyRootFilesystem", [metadata.name, container.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is true", [j]),
+		"keyActualValue": sprintf("'spec.containers[%d].securityContext.readOnlyRootFilesystem' is false", [j]),
+	}
 }

--- a/assets/queries/k8s/root_containers_admitted/query.rego
+++ b/assets/queries/k8s/root_containers_admitted/query.rego
@@ -1,123 +1,123 @@
 package Cx
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  input.document[i].kind == "PodSecurityPolicy"
-  spec.privileged == true
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	input.document[i].kind == "PodSecurityPolicy"
+	spec.privileged == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.privileged", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.privileged is set to 'false'", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.privileged is set to 'true'", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.privileged", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.privileged is set to 'false'", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.privileged is set to 'true'", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  input.document[i].kind == "PodSecurityPolicy"
-  spec.allowPrivilegeEscalation == true
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	input.document[i].kind == "PodSecurityPolicy"
+	spec.allowPrivilegeEscalation == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.allowPrivilegeEscalation", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.allowPrivilegeEscalation is set to 'false'", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.allowPrivilegeEscalation is set to 'true'", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.allowPrivilegeEscalation", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.allowPrivilegeEscalation is set to 'false'", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.allowPrivilegeEscalation is set to 'true'", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  input.document[i].kind == "PodSecurityPolicy"
-  spec.readOnlyRootFilesystem == true
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	input.document[i].kind == "PodSecurityPolicy"
+	spec.readOnlyRootFilesystem == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.readOnlyRootFilesystem", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.readOnlyRootFilesystem is set to 'false'", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.readOnlyRootFilesystem is set to 'true'", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.readOnlyRootFilesystem", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.readOnlyRootFilesystem is set to 'false'", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.readOnlyRootFilesystem is set to 'true'", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  input.document[i].kind == "PodSecurityPolicy"
-  spec.runAsUser.rule != "MustRunAsNonRoot"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	input.document[i].kind == "PodSecurityPolicy"
+	spec.runAsUser.rule != "MustRunAsNonRoot"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.runAsUser.rule", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.runAsUser.rule is equal to 'MustRunAsNonRoot'", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.runAsUser.rule is not equal to 'MustRunAsNonRoot'", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.runAsUser.rule", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.runAsUser.rule is equal to 'MustRunAsNonRoot'", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.runAsUser.rule is not equal to 'MustRunAsNonRoot'", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  input.document[i].kind == "PodSecurityPolicy"
-  spec.supplementalGroups.rule != "MustRunAs"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	input.document[i].kind == "PodSecurityPolicy"
+	spec.supplementalGroups.rule != "MustRunAs"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.supplementalGroups.rule", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.supplementalGroups limits its ranges", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.supplementalGroups does not limit its ranges", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.supplementalGroups.rule", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.supplementalGroups limits its ranges", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.supplementalGroups does not limit its ranges", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  input.document[i].kind == "PodSecurityPolicy"
-  spec.supplementalGroups.rule == "MustRunAs"
-  spec.supplementalGroups.ranges[_].min == 0
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	input.document[i].kind == "PodSecurityPolicy"
+	spec.supplementalGroups.rule == "MustRunAs"
+	spec.supplementalGroups.ranges[_].min == 0
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.supplementalGroups", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.supplementalGroups does not allow range '0' (root)", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.supplementalGroups allows range '0' (root)", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.supplementalGroups", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.supplementalGroups does not allow range '0' (root)", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.supplementalGroups allows range '0' (root)", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  input.document[i].kind == "PodSecurityPolicy"
-  spec.fsGroup.rule != "MustRunAs"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	input.document[i].kind == "PodSecurityPolicy"
+	spec.fsGroup.rule != "MustRunAs"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.fsGroup.rule", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.fsGroup limits its ranges", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.fsGroup does not limit its ranges", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.fsGroup.rule", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.fsGroup limits its ranges", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.fsGroup does not limit its ranges", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  input.document[i].kind == "PodSecurityPolicy"
-  spec.fsGroup.rule == "MustRunAs"
-  spec.fsGroup.ranges[_].min == 0
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	input.document[i].kind == "PodSecurityPolicy"
+	spec.fsGroup.rule == "MustRunAs"
+	spec.fsGroup.ranges[_].min == 0
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.fsGroup", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.fsGroup does not allow range '0'", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.fsGroup allows range '0'", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.fsGroup", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.fsGroup does not allow range '0'", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.fsGroup allows range '0'", [metadata.name]),
+	}
 }

--- a/assets/queries/k8s/sa_allows_access_secrets/query.rego
+++ b/assets/queries/k8s/sa_allows_access_secrets/query.rego
@@ -1,56 +1,54 @@
 package Cx
 
-CxPolicy [result] {
-    document := input.document[i]
-    metadata := document.metadata
-    
-    validKind := ["Role","ClusterRole"]
-    ruleTaint := ["get","watch","list","*"]
-    resourcesTaint := ["secrets"]
-    
-    kind := document.kind
-    contains(validKind,kind)
-    name := metadata.name
-    
-    bindingExists(name,kind)
-    
-   	resources := document.rules[_].resources; 
-    some resource
-    	contains(resourcesTaint,resources[resource])
-    
-    rules := document.rules[_].verbs;    
-    some rule
-    	contains(ruleTaint,rules[rule])
-    
-    result := {
-                "documentId":        input.document[i].id,
-                "searchKey":         sprintf("metadata.name=%s.rules.verbs", [metadata.name]),
-                "issueType":        "IncorrectValue",
-                "keyExpectedValue":  sprintf("The metadata.name=%s.rules.verbs should not contain the following verbs: [%s]", [metadata.name,rules]),
-                "keyActualValue":    sprintf("The metadata.name=%s.rules.verbs contain the following verbs: [%s]", [metadata.name,rules])
-              }
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+
+	validKind := ["Role", "ClusterRole"]
+	ruleTaint := ["get", "watch", "list", "*"]
+	resourcesTaint := ["secrets"]
+
+	kind := document.kind
+	contains(validKind, kind)
+	name := metadata.name
+
+	bindingExists(name, kind)
+
+	resources := document.rules[_].resources
+	some resource
+	contains(resourcesTaint, resources[resource])
+
+	rules := document.rules[_].verbs
+	some rule
+	contains(ruleTaint, rules[rule])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.rules.verbs", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("The metadata.name=%s.rules.verbs should not contain the following verbs: [%s]", [metadata.name, rules]),
+		"keyActualValue": sprintf("The metadata.name=%s.rules.verbs contain the following verbs: [%s]", [metadata.name, rules]),
+	}
 }
 
-contains(arr1,string) = true{
+contains(arr1, string) {
 	arr1[_] == string
 }
 
-bindingExists(name,kind) = true{
-	
-    kind == "Role"
-    
+bindingExists(name, kind) {
+	kind == "Role"
+
 	some roleBinding
-    	input.document[roleBinding].kind == "RoleBinding"
-        input.document[roleBinding].subjects[_].kind == "ServiceAccount"
-        input.document[roleBinding].roleRef.kind == "Role"
-        input.document[roleBinding].roleRef.name == name              
-} else = true{
-	
-    kind == "ClusterRole"
-    
+	input.document[roleBinding].kind == "RoleBinding"
+	input.document[roleBinding].subjects[_].kind == "ServiceAccount"
+	input.document[roleBinding].roleRef.kind == "Role"
+	input.document[roleBinding].roleRef.name == name
+} else {
+	kind == "ClusterRole"
+
 	some roleBinding
-    	input.document[roleBinding].kind == "ClusterRoleBinding"
-        input.document[roleBinding].subjects[_].kind == "ServiceAccount"
-        input.document[roleBinding].roleRef.kind == "ClusterRole"
-        input.document[roleBinding].roleRef.name == name
+	input.document[roleBinding].kind == "ClusterRoleBinding"
+	input.document[roleBinding].subjects[_].kind == "ServiceAccount"
+	input.document[roleBinding].roleRef.kind == "ClusterRole"
+	input.document[roleBinding].roleRef.name == name
 }

--- a/assets/queries/k8s/seccomp_is_not_configured/query.rego
+++ b/assets/queries/k8s/seccomp_is_not_configured/query.rego
@@ -1,197 +1,197 @@
 package Cx
 
 #pods
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "Pod"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "Pod"
 
-    metadata := document.metadata
-    object.get(metadata,"annotations","undefined") != "undefined"
+	metadata := document.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
 
-    annotations := metadata.annotations
-    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") == "undefined"
+	annotations := metadata.annotations
+	object.get(annotations, "seccomp.security.alpha.kubernetes.io/defaultProfileName", "undefined") == "undefined"
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is set",
-                "keyActualValue": 	"'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is undefined"
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is set",
+		"keyActualValue": "'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "Pod"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "Pod"
 
-    metadata := document.metadata
-    object.get(metadata,"annotations","undefined") != "undefined"
-    annotations := metadata.annotations
+	metadata := document.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
+	annotations := metadata.annotations
 
-    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") != "undefined"
+	object.get(annotations, "seccomp.security.alpha.kubernetes.io/defaultProfileName", "undefined") != "undefined"
 
-    seccomp := annotations["seccomp.security.alpha.kubernetes.io/defaultProfileName"]
+	seccomp := annotations["seccomp.security.alpha.kubernetes.io/defaultProfileName"]
 
-    seccomp != "runtime/default"
+	seccomp != "runtime/default"
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is 'runtime/default'",
-                "keyActualValue": 	sprintf("'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is '%s'",[seccomp])
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is 'runtime/default'",
+		"keyActualValue": sprintf("'metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is '%s'", [seccomp]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "Pod"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "Pod"
 
-    metadata := document.metadata
-    object.get(metadata,"annotations","undefined") == "undefined"
+	metadata := document.metadata
+	object.get(metadata, "annotations", "undefined") == "undefined"
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'metadata.annotations' is set",
-                "keyActualValue": 	"'metadata.annotations' is undefined"
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'metadata.annotations' is set",
+		"keyActualValue": "'metadata.annotations' is undefined",
+	}
 }
 
 ###################################################################
 
 #cronjob
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "CronJob"
 
-    metadata := document.spec.jobTemplate.spec.template.metadata
+	metadata := document.spec.jobTemplate.spec.template.metadata
 
-    parentMetadata := document.metadata
-    object.get(metadata,"annotations","undefined") == "undefined"
+	parentMetadata := document.metadata
+	object.get(metadata, "annotations", "undefined") == "undefined"
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.jobTemplate.spec.template.metadata",[parentMetadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.jobTemplate.spec.template.metadata.annotations' is set",
-                "keyActualValue": 	"'spec.jobTemplate.spec.template.metadata.annotations' is undefined"
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.jobTemplate.spec.template.metadata", [parentMetadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.jobTemplate.spec.template.metadata.annotations' is set",
+		"keyActualValue": "'spec.jobTemplate.spec.template.metadata.annotations' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "CronJob"
 
-    metadata := document.spec.jobTemplate.spec.template.metadata
+	metadata := document.spec.jobTemplate.spec.template.metadata
 
-    parentMetadata := document.metadata
-    object.get(metadata,"annotations","undefined") != "undefined"
+	parentMetadata := document.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
 
-    annotations := metadata.annotations
-    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") == "undefined"
+	annotations := metadata.annotations
+	object.get(annotations, "seccomp.security.alpha.kubernetes.io/defaultProfileName", "undefined") == "undefined"
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.jobTemplate.spec.template.metadata.annotations",[parentMetadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is set",
-                "keyActualValue": 	"'spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is undefined"
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.jobTemplate.spec.template.metadata.annotations", [parentMetadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is set",
+		"keyActualValue": "'spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") == "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") == "CronJob"
 
-    metadata := document.spec.jobTemplate.spec.template.metadata
+	metadata := document.spec.jobTemplate.spec.template.metadata
 
-    parentMetadata := document.metadata
-    object.get(metadata,"annotations","undefined") != "undefined"
-    annotations := metadata.annotations
+	parentMetadata := document.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
+	annotations := metadata.annotations
 
-    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") != "undefined"
+	object.get(annotations, "seccomp.security.alpha.kubernetes.io/defaultProfileName", "undefined") != "undefined"
 
-    seccomp := annotations["seccomp.security.alpha.kubernetes.io/defaultProfileName"]
+	seccomp := annotations["seccomp.security.alpha.kubernetes.io/defaultProfileName"]
 
-    seccomp != "runtime/default"
+	seccomp != "runtime/default"
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName",[parentMetadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "'spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is 'runtime/default'",
-                "keyActualValue": 	sprintf("'spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is '%s'",[seccomp])
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName", [parentMetadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is 'runtime/default'",
+		"keyActualValue": sprintf("'spec.jobTemplate.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is '%s'", [seccomp]),
+	}
 }
 
 ###################################################################
 
 #general
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") != "Pod"
-    object.get(document,"kind","undefined") != "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") != "Pod"
+	object.get(document, "kind", "undefined") != "CronJob"
 
-    metadata := document.spec.template.metadata
+	metadata := document.spec.template.metadata
 
-    parentMetadata := document.metadata
-    object.get(metadata,"annotations","undefined") == "undefined"
+	parentMetadata := document.metadata
+	object.get(metadata, "annotations", "undefined") == "undefined"
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.metadata",[parentMetadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.template.metadata.annotations' is set",
-                "keyActualValue": 	"'spec.template.metadata.annotations' is undefined"
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.metadata", [parentMetadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.template.metadata.annotations' is set",
+		"keyActualValue": "'spec.template.metadata.annotations' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") != "Pod"
-    object.get(document,"kind","undefined") != "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") != "Pod"
+	object.get(document, "kind", "undefined") != "CronJob"
 
-    metadata := document.spec.template.metadata
+	metadata := document.spec.template.metadata
 
-    parentMetadata := document.metadata
-    object.get(metadata,"annotations","undefined") != "undefined"
+	parentMetadata := document.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
 
-    annotations := metadata.annotations
-    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") == "undefined"
+	annotations := metadata.annotations
+	object.get(annotations, "seccomp.security.alpha.kubernetes.io/defaultProfileName", "undefined") == "undefined"
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.metadata.annotations",[parentMetadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is set",
-                "keyActualValue": 	"'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is undefined"
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.metadata.annotations", [parentMetadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is set",
+		"keyActualValue": "'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    object.get(document,"kind","undefined") != "Pod"
-    object.get(document,"kind","undefined") != "CronJob"
+CxPolicy[result] {
+	document := input.document[i]
+	object.get(document, "kind", "undefined") != "Pod"
+	object.get(document, "kind", "undefined") != "CronJob"
 
-    metadata := document.spec.template.metadata
+	metadata := document.spec.template.metadata
 
-    parentMetadata := document.metadata
-    object.get(metadata,"annotations","undefined") != "undefined"
-    annotations := metadata.annotations
+	parentMetadata := document.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
+	annotations := metadata.annotations
 
-    object.get(annotations,"seccomp.security.alpha.kubernetes.io/defaultProfileName","undefined") != "undefined"
+	object.get(annotations, "seccomp.security.alpha.kubernetes.io/defaultProfileName", "undefined") != "undefined"
 
-    seccomp := annotations["seccomp.security.alpha.kubernetes.io/defaultProfileName"]
+	seccomp := annotations["seccomp.security.alpha.kubernetes.io/defaultProfileName"]
 
-    seccomp != "runtime/default"
+	seccomp != "runtime/default"
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName",[parentMetadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is 'runtime/default'",
-                "keyActualValue": 	sprintf("'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is '%s'",[seccomp]),
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName", [parentMetadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is 'runtime/default'",
+		"keyActualValue": sprintf("'spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName' is '%s'", [seccomp]),
+	}
 }

--- a/assets/queries/k8s/secrets_as_environment_variables/query.rego
+++ b/assets/queries/k8s/secrets_as_environment_variables/query.rego
@@ -1,54 +1,54 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    specInfo := getSpecInfo(document)
-    
-    containers := ["containers", "initContainers"]
-    
-    specInfo.spec[containers[c]][j].env[k].valueFrom.secretKeyRef
-    
-    container_name := specInfo.spec[containers[c]][j].name
-    env_name := specInfo.spec[containers[c]][j].env[k].name
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	specInfo := getSpecInfo(document)
+
+	containers := ["containers", "initContainers"]
+
+	specInfo.spec[containers[c]][j].env[k].valueFrom.secretKeyRef
+
+	container_name := specInfo.spec[containers[c]][j].name
+	env_name := specInfo.spec[containers[c]][j].env[k].name
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.%s.name=%s.env.name=%s.valueFrom.secretKeyRef", [metadata.name, specInfo.path, containers[c], container_name, env_name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'%s.%s.name=%s.env.name=%s.valueFrom.secretKeyRef' is undefined", [specInfo.path, containers[c], container_name, env_name]),
-                "keyActualValue": 	sprintf("'%s.%s.name=%s.env.name=%s.valueFrom.secretKeyRef' is defined", [specInfo.path, containers[c], container_name, env_name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.%s.name=%s.env.name=%s.valueFrom.secretKeyRef", [metadata.name, specInfo.path, containers[c], container_name, env_name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s.%s.name=%s.env.name=%s.valueFrom.secretKeyRef' is undefined", [specInfo.path, containers[c], container_name, env_name]),
+		"keyActualValue": sprintf("'%s.%s.name=%s.env.name=%s.valueFrom.secretKeyRef' is defined", [specInfo.path, containers[c], container_name, env_name]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    specInfo := getSpecInfo(document)
-    
-    containers := ["containers", "initContainers"]
-    
-    specInfo.spec[containers[c]][j].envFrom[k].secretRef
-    
-    container_name := specInfo.spec[containers[c]][j].name
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	specInfo := getSpecInfo(document)
+
+	containers := ["containers", "initContainers"]
+
+	specInfo.spec[containers[c]][j].envFrom[k].secretRef
+
+	container_name := specInfo.spec[containers[c]][j].name
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.%s.name=%s.envFrom", [metadata.name, specInfo.path, containers[c], container_name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'%s.%s.name=%s.envFrom.secretRef' is undefined", [specInfo.path, containers[c], container_name]),
-                "keyActualValue": 	sprintf("'%s.%s.name=%s.envFrom.secretRef' is defined", [specInfo.path, containers[c], container_name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.%s.name=%s.envFrom", [metadata.name, specInfo.path, containers[c], container_name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s.%s.name=%s.envFrom.secretRef' is undefined", [specInfo.path, containers[c], container_name]),
+		"keyActualValue": sprintf("'%s.%s.name=%s.envFrom.secretRef' is defined", [specInfo.path, containers[c], container_name]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
 }

--- a/assets/queries/k8s/service_account_name_undefined_or_empty/query.rego
+++ b/assets/queries/k8s/service_account_name_undefined_or_empty/query.rego
@@ -1,48 +1,48 @@
 package Cx
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  object.get(spec, "serviceAccountName", "undefined") == "undefined"
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	object.get(spec, "serviceAccountName", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec", [metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.serviceAccountName is defined", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.serviceAccountName is undefined", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.serviceAccountName is defined", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.serviceAccountName is undefined", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  spec.serviceAccountName == null
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	spec.serviceAccountName == null
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.serviceAccountName", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.serviceAccountName is not null", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.serviceAccountName is null", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.serviceAccountName", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.serviceAccountName is not null", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.serviceAccountName is null", [metadata.name]),
+	}
 }
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  spec := input.document[i].spec
-  checkAction(spec.serviceAccountName)
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	checkAction(spec.serviceAccountName)
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.serviceAccountName", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("metadata.name=%s.spec.serviceAccountName is not empty", [metadata.name]),
-                "keyActualValue": 	 sprintf("metadata.name=%s.spec.serviceAccountName is empty", [metadata.name])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.serviceAccountName", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.serviceAccountName is not empty", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.serviceAccountName is empty", [metadata.name]),
+	}
 }
 
-checkAction(action) = true {
+checkAction(action) {
 	is_string(action)
 	count(action) == 0
 }

--- a/assets/queries/k8s/service_account_token_automount_not_disabled/query.rego
+++ b/assets/queries/k8s/service_account_token_automount_not_disabled/query.rego
@@ -1,45 +1,45 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    specInfo := getSpecInfo(document)
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	specInfo := getSpecInfo(document)
 
-    object.get(specInfo.spec, "automountServiceAccountToken", "undefined") == "undefined"
+	object.get(specInfo.spec, "automountServiceAccountToken", "undefined") == "undefined"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s", [metadata.name, specInfo.path]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": sprintf("'%s.automountServiceAccountToken' is false", [specInfo.path]),
-                "keyActualValue": 	sprintf("'%s.automountServiceAccountToken' is undefined", [specInfo.path])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s", [metadata.name, specInfo.path]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'%s.automountServiceAccountToken' is false", [specInfo.path]),
+		"keyActualValue": sprintf("'%s.automountServiceAccountToken' is undefined", [specInfo.path]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    specInfo := getSpecInfo(document)
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	specInfo := getSpecInfo(document)
 
-    specInfo.spec.automountServiceAccountToken == true
+	specInfo.spec.automountServiceAccountToken == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.automountServiceAccountToken", [metadata.name, specInfo.path]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'%s.automountServiceAccountToken' is false", [specInfo.path]),
-                "keyActualValue": 	sprintf("'%s.automountServiceAccountToken' is true", [specInfo.path])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.automountServiceAccountToken", [metadata.name, specInfo.path]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s.automountServiceAccountToken' is false", [specInfo.path]),
+		"keyActualValue": sprintf("'%s.automountServiceAccountToken' is true", [specInfo.path]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-}  
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/service_does_not_target_pod/query.rego
+++ b/assets/queries/k8s/service_does_not_target_pod/query.rego
@@ -1,54 +1,53 @@
 package Cx
 
-CxPolicy [ result ] {
-   
-  service := input.document[i]
-  service.kind == "Service"
-  metadata := service.metadata
-  ports := service.spec.ports
-  servicePorts := ports[j]
-  contains(service.spec.selector.app)
-  not confirmPorts(servicePorts)
-  
-  result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.ports.name=%s.targetPort", [metadata.name,ports[k].name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.ports=%s.targetPort has a Pod Port", [metadata.name,servicePorts.name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.ports=%s.targetPort does not have a Pod Port", [metadata.name,servicePorts.name])
-            }
+CxPolicy[result] {
+	service := input.document[i]
+	service.kind == "Service"
+	metadata := service.metadata
+	ports := service.spec.ports
+	servicePorts := ports[j]
+	contains(service.spec.selector.app)
+	not confirmPorts(servicePorts)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.ports.name=%s.targetPort", [metadata.name, ports[k].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.ports=%s.targetPort has a Pod Port", [metadata.name, servicePorts.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.ports=%s.targetPort does not have a Pod Port", [metadata.name, servicePorts.name]),
+	}
 }
 
-CxPolicy [ result ] {
-   
-  service := input.document[i]
-  service.kind == "Service"
-  metadata := service.metadata
-  ports := service.spec.ports
-  servicePorts := ports[j]
-  not contains(service.spec.selector.app)
-  
+CxPolicy[result] {
+	service := input.document[i]
+	service.kind == "Service"
+	metadata := service.metadata
+	ports := service.spec.ports
+	servicePorts := ports[j]
+	not contains(service.spec.selector.app)
 
-  
-  result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.selector.app", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.selector.app Pod label match with Service", [metadata.name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.selector.app Pod label does not match with Service", [metadata.name])
-            }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.selector.app", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.selector.app Pod label match with Service", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.selector.app Pod label does not match with Service", [metadata.name]),
+	}
 }
 
-confirmPorts(servicePorts) = true {
+confirmPorts(servicePorts) {
 	pod := input.document[i]
-    pod.kind == "Pod"
-    containers := pod.spec.containers[j]
-    containers.ports[k].containerPort == servicePorts.targetPort
-} else = false {true}
+	pod.kind == "Pod"
+	containers := pod.spec.containers[j]
+	containers.ports[k].containerPort == servicePorts.targetPort
+} else = false {
+	true
+}
 
-contains(string) = true {
+contains(string) {
 	pod := input.document[i]
-    pod.kind == "Pod"
+	pod.kind == "Pod"
 	pod.metadata.labels.app == string
-} else = false {true}
-
+} else = false {
+	true
+}

--- a/assets/queries/k8s/service_type_is_nodeport/query.rego
+++ b/assets/queries/k8s/service_type_is_nodeport/query.rego
@@ -1,18 +1,17 @@
 package Cx
 
-CxPolicy [ result ] {
-	  document := input.document[i]
-    metadata:= document.metadata
-    lower(document.kind) == "service"
-    spec := document.spec
-    lower(spec.type) == "nodeport"
-	
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	lower(document.kind) == "service"
+	spec := document.spec
+	lower(spec.type) == "nodeport"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	   sprintf("metadata.name=%s.spec.type", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "spec.type is not 'NodePort'",
-                "keyActualValue": 	"spec.type is 'NodePort'"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.type", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "spec.type is not 'NodePort'",
+		"keyActualValue": "spec.type is 'NodePort'",
+	}
 }

--- a/assets/queries/k8s/service_with_external_load_balance/query.rego
+++ b/assets/queries/k8s/service_with_external_load_balance/query.rego
@@ -1,38 +1,34 @@
 package Cx
 
-CxPolicy [ result ] {
-   
-  service := input.document[i]
-  service.kind == "Service"
-  metadata := service.metadata  
-  
-  not CheckIfDestinationPortExists(service)
-  
-  
-  result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec", [metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s is not exposing a workload", [metadata.name]),
-                "keyActualValue": 	sprintf("metadata.name=%s is exposing a workload", [metadata.name])
-            }
+CxPolicy[result] {
+	service := input.document[i]
+	service.kind == "Service"
+	metadata := service.metadata
+
+	not CheckIfDestinationPortExists(service)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s is not exposing a workload", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s is exposing a workload", [metadata.name]),
+	}
 }
 
-
-
-CheckIfDestinationPortExists (service) = result {
-
+CheckIfDestinationPortExists(service) = result {
 	documents := input.document
 	pod := [pod | documents[index].spec.template.metadata.labels.app == service.spec.selector.app; pod = documents[index]]
-    service.spec.type == "LoadBalancer"
-    
-    result := contains(pod, service.spec.selector.app);contains(pod, service.spec.ports[k].targetPort)
+	service.spec.type == "LoadBalancer"
+
+	result := contains(pod, service.spec.selector.app)
+	contains(pod, service.spec.ports[k].targetPort)
 }
 
-contains (array, string) = true {
+contains(array, string) {
 	array[a].spec.template.metadata.labels.app == string
 }
 
-contains (array, string) = true {
+contains(array, string) {
 	array[a].spec.template.spec.containers[c].ports[p].containerPort == string
 }

--- a/assets/queries/k8s/shared_host_ipc_namespace/query.rego
+++ b/assets/queries/k8s/shared_host_ipc_namespace/query.rego
@@ -1,29 +1,29 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    specInfo := getSpecInfo(document)
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	specInfo := getSpecInfo(document)
 
-    specInfo.spec.hostIPC == true
+	specInfo.spec.hostIPC == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.hostIPC", [metadata.name, specInfo.path]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'%s.hostIPC' is false or undefined", [specInfo.path]),
-                "keyActualValue": 	sprintf("'%s.hostIPC' is true", [specInfo.path])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.hostIPC", [metadata.name, specInfo.path]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s.hostIPC' is false or undefined", [specInfo.path]),
+		"keyActualValue": sprintf("'%s.hostIPC' is true", [specInfo.path]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-}  
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/shared_host_network_namespace/query.rego
+++ b/assets/queries/k8s/shared_host_network_namespace/query.rego
@@ -1,29 +1,29 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    specInfo := getSpecInfo(document)
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	specInfo := getSpecInfo(document)
 
-    specInfo.spec.hostNetwork == true
+	specInfo.spec.hostNetwork == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.hostNetwork", [metadata.name, specInfo.path]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'%s.hostNetwork' is false or undefined", [specInfo.path]),
-                "keyActualValue": 	sprintf("'%s.hostNetwork' is true", [specInfo.path])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.hostNetwork", [metadata.name, specInfo.path]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s.hostNetwork' is false or undefined", [specInfo.path]),
+		"keyActualValue": sprintf("'%s.hostNetwork' is true", [specInfo.path]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
 }

--- a/assets/queries/k8s/shared_host_pid_namespace/query.rego
+++ b/assets/queries/k8s/shared_host_pid_namespace/query.rego
@@ -1,29 +1,29 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    metadata := document.metadata
-    specInfo := getSpecInfo(document)
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	specInfo := getSpecInfo(document)
 
-    specInfo.spec.hostPID == true
+	specInfo.spec.hostPID == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.%s.hostPID", [metadata.name, specInfo.path]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'%s.hostPID' is false or undefined", [specInfo.path]),
-                "keyActualValue": 	sprintf("'%s.hostPID' is true", [specInfo.path])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.hostPID", [metadata.name, specInfo.path]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s.hostPID' is false or undefined", [specInfo.path]),
+		"keyActualValue": sprintf("'%s.hostPID' is true", [specInfo.path]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
-} 
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
+}

--- a/assets/queries/k8s/shared_service_account/query.rego
+++ b/assets/queries/k8s/shared_service_account/query.rego
@@ -1,35 +1,35 @@
 package Cx
 
-CxPolicy [ result ] {
-  document := input.document[i]
-  metadata := document.metadata
-  specInfo := getSpecInfo(document)
-  serviceAccount := specInfo.spec.serviceAccountName
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+	specInfo := getSpecInfo(document)
+	serviceAccount := specInfo.spec.serviceAccountName
 
-  document_other := input.document[j]
-  i != j
-  specInfo_other := getSpecInfo(document_other)
-  serviceAccount_other := specInfo_other.spec.serviceAccountName
+	document_other := input.document[j]
+	i != j
+	specInfo_other := getSpecInfo(document_other)
+	serviceAccount_other := specInfo_other.spec.serviceAccountName
 
-  serviceAccount == serviceAccount_other
+	serviceAccount == serviceAccount_other
 
-  result := {
-              "documentId":       input.document[i].id,
-              "searchKey": 	      sprintf("metadata.name=%s.%s.serviceAccountName", [metadata.name, specInfo.path]),
-              "issueType":		    "IncorrectValue",
-              "keyExpectedValue": sprintf("'%s.serviceAccountName' is not shared with other workloads", [specInfo.path]),
-              "keyActualValue": 	sprintf("'%s.serviceAccountName' is shared with other workloads", [specInfo.path])
-            }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.%s.serviceAccountName", [metadata.name, specInfo.path]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s.serviceAccountName' is not shared with other workloads", [specInfo.path]),
+		"keyActualValue": sprintf("'%s.serviceAccountName' is shared with other workloads", [specInfo.path]),
+	}
 }
 
 getSpecInfo(document) = specInfo {
-    templates := {"job_template", "jobTemplate"}
-    spec := document.spec[templates[t]].spec.template.spec
-    specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
+	templates := {"job_template", "jobTemplate"}
+	spec := document.spec[templates[t]].spec.template.spec
+	specInfo := {"spec": spec, "path": sprintf("spec.%s.spec.template.spec", [templates[t]])}
 } else = specInfo {
-    spec := document.spec.template.spec
-    specInfo := {"spec": spec, "path": "spec.template.spec"}
+	spec := document.spec.template.spec
+	specInfo := {"spec": spec, "path": "spec.template.spec"}
 } else = specInfo {
-    spec := document.spec
-    specInfo := {"spec": spec, "path": "spec"}
+	spec := document.spec
+	specInfo := {"spec": spec, "path": "spec"}
 }

--- a/assets/queries/k8s/statefulset_no_pod_anti_affinity/query.rego
+++ b/assets/queries/k8s/statefulset_no_pod_anti_affinity/query.rego
@@ -1,208 +1,207 @@
 package Cx
 
-CxPolicy [ result ] {
-    statefulset := input.document[i]
-    object.get(statefulset,"kind","undefined") == "StatefulSet"
-    
-    metadata := statefulset.metadata
-    
-    to_number(statefulset.spec.replicas) > 2
+CxPolicy[result] {
+	statefulset := input.document[i]
+	object.get(statefulset, "kind", "undefined") == "StatefulSet"
 
-    object.get(statefulset.spec.template.spec,"affinity","undefined") == "undefined"
+	metadata := statefulset.metadata
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.template.spec.affinity' is set",
-                "keyActualValue": "'spec.template.spec.affinity' is undefined"
-              }
+	to_number(statefulset.spec.replicas) > 2
+
+	object.get(statefulset.spec.template.spec, "affinity", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.template.spec.affinity' is set",
+		"keyActualValue": "'spec.template.spec.affinity' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    statefulset := input.document[i]
-    object.get(statefulset,"kind","undefined") == "StatefulSet"
+CxPolicy[result] {
+	statefulset := input.document[i]
+	object.get(statefulset, "kind", "undefined") == "StatefulSet"
 
-    to_number(statefulset.spec.replicas) > 2
+	to_number(statefulset.spec.replicas) > 2
 
-    affinity := statefulset.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") == "undefined"
-    
-    metadata := statefulset.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity' is set",
-                "keyActualValue": "'spec.template.spec.affinity.podAntiAffinity' is undefined"
-              }
+	affinity := statefulset.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") == "undefined"
+
+	metadata := statefulset.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity' is set",
+		"keyActualValue": "'spec.template.spec.affinity.podAntiAffinity' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    statefulset := input.document[i]
-    object.get(statefulset,"kind","undefined") == "StatefulSet"
+CxPolicy[result] {
+	statefulset := input.document[i]
+	object.get(statefulset, "kind", "undefined") == "StatefulSet"
 
-    to_number(statefulset.spec.replicas) > 2
+	to_number(statefulset.spec.replicas) > 2
 
-    affinity := statefulset.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") == "undefined"
-    
-    metadata := statefulset.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity' is set",
-                "keyActualValue": "'spec.template.spec.affinity.podAntiAffinity' is undefined"
-              }
+	affinity := statefulset.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") == "undefined"
+
+	metadata := statefulset.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity' is set",
+		"keyActualValue": "'spec.template.spec.affinity.podAntiAffinity' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    statefulset := input.document[i]
-    object.get(statefulset,"kind","undefined") == "StatefulSet"
+CxPolicy[result] {
+	statefulset := input.document[i]
+	object.get(statefulset, "kind", "undefined") == "StatefulSet"
 
-    to_number(statefulset.spec.replicas) > 2
+	to_number(statefulset.spec.replicas) > 2
 
-    affinity := statefulset.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") != "undefined"
-    
-    podAntiAffinity:= affinity.podAntiAffinity
+	affinity := statefulset.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") != "undefined"
 
-    object.get(podAntiAffinity,"preferredDuringSchedulingIgnoredDuringExecution","undefined") == "undefined"
-    object.get(podAntiAffinity,"requiredDuringSchedulingIgnoredDuringExecution","undefined") == "undefined"
+	podAntiAffinity := affinity.podAntiAffinity
 
+	object.get(podAntiAffinity, "preferredDuringSchedulingIgnoredDuringExecution", "undefined") == "undefined"
+	object.get(podAntiAffinity, "requiredDuringSchedulingIgnoredDuringExecution", "undefined") == "undefined"
 
-    metadata := statefulset.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution' and/or 'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution' is set",
-                "keyActualValue": "'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution' and 'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution' is undefined"
-              }
+	metadata := statefulset.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution' and/or 'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution' is set",
+		"keyActualValue": "'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution' and 'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution' is undefined",
+	}
 }
 
-CxPolicy [ result ] {
-    statefulset := input.document[i]
-    object.get(statefulset,"kind","undefined") == "StatefulSet"
+CxPolicy[result] {
+	statefulset := input.document[i]
+	object.get(statefulset, "kind", "undefined") == "StatefulSet"
 
-    to_number(statefulset.spec.replicas) > 2
+	to_number(statefulset.spec.replicas) > 2
 
-    affinity := statefulset.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") != "undefined"
-    
-    podAntiAffinity:= affinity.podAntiAffinity
+	affinity := statefulset.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") != "undefined"
 
-    object.get(podAntiAffinity,"preferredDuringSchedulingIgnoredDuringExecution","undefined") != "undefined"
+	podAntiAffinity := affinity.podAntiAffinity
 
-    pref := podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[j]
+	object.get(podAntiAffinity, "preferredDuringSchedulingIgnoredDuringExecution", "undefined") != "undefined"
 
-    object.get(pref.podAffinityTerm,"topologyKey","undefined") != "kubernetes.io/hostname"
+	pref := podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[j]
 
-    metadata := statefulset.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%s].podAffinityTerm.topologyKey' is set and is 'kubernetes.io/hostname'",[j]),
-                "keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%s].podAffinityTerm.topologyKey' is invalid or undefined",[j])
-              }
+	object.get(pref.podAffinityTerm, "topologyKey", "undefined") != "kubernetes.io/hostname"
+
+	metadata := statefulset.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%s].podAffinityTerm.topologyKey' is set and is 'kubernetes.io/hostname'", [j]),
+		"keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%s].podAffinityTerm.topologyKey' is invalid or undefined", [j]),
+	}
 }
 
-CxPolicy [ result ] {
-    statefulset := input.document[i]
-    object.get(statefulset,"kind","undefined") == "StatefulSet"
+CxPolicy[result] {
+	statefulset := input.document[i]
+	object.get(statefulset, "kind", "undefined") == "StatefulSet"
 
-    to_number(statefulset.spec.replicas) > 2
+	to_number(statefulset.spec.replicas) > 2
 
-    affinity := statefulset.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") != "undefined"
-    
-    podAntiAffinity:= affinity.podAntiAffinity
+	affinity := statefulset.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") != "undefined"
 
-    object.get(podAntiAffinity,"preferredDuringSchedulingIgnoredDuringExecution","undefined") != "undefined"
+	podAntiAffinity := affinity.podAntiAffinity
 
-    pref := podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[j]
+	object.get(podAntiAffinity, "preferredDuringSchedulingIgnoredDuringExecution", "undefined") != "undefined"
 
-    object.get(pref.podAffinityTerm,"topologyKey","undefined") == "kubernetes.io/hostname"
+	pref := podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[j]
 
-    templateLabels := statefulset.spec.template.metadata.labels 
-    selectorLabels := pref.podAffinityTerm.labelSelector.matchLabels
+	object.get(pref.podAffinityTerm, "topologyKey", "undefined") == "kubernetes.io/hostname"
 
-    matchLabels(templateLabels,selectorLabels) == false
+	templateLabels := statefulset.spec.template.metadata.labels
+	selectorLabels := pref.podAffinityTerm.labelSelector.matchLabels
 
-    metadata := statefulset.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.labelSelector.matchLabels",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%d].podAffinityTerm.labelSelector.matchLabels' match any label on template metadata",[j]),
-                "keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%d].podAffinityTerm.labelSelector.matchLabels' don't match any label on template metadata",[j])
-              }
+	matchLabels(templateLabels, selectorLabels) == false
+
+	metadata := statefulset.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.labelSelector.matchLabels", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%d].podAffinityTerm.labelSelector.matchLabels' match any label on template metadata", [j]),
+		"keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[%d].podAffinityTerm.labelSelector.matchLabels' don't match any label on template metadata", [j]),
+	}
 }
 
-CxPolicy [ result ] {
-    statefulset := input.document[i]
-    object.get(statefulset,"kind","undefined") == "StatefulSet"
+CxPolicy[result] {
+	statefulset := input.document[i]
+	object.get(statefulset, "kind", "undefined") == "StatefulSet"
 
-    to_number(statefulset.spec.replicas) > 2
+	to_number(statefulset.spec.replicas) > 2
 
-    affinity := statefulset.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") != "undefined"
-    
-    podAntiAffinity:= affinity.podAntiAffinity
+	affinity := statefulset.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") != "undefined"
 
-    object.get(podAntiAffinity,"requiredDuringSchedulingIgnoredDuringExecution","undefined") != "undefined"
+	podAntiAffinity := affinity.podAntiAffinity
 
-    pref := podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[j]
+	object.get(podAntiAffinity, "requiredDuringSchedulingIgnoredDuringExecution", "undefined") != "undefined"
 
-    object.get(pref,"topologyKey","undefined") != "kubernetes.io/hostname"
+	pref := podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[j]
 
-    metadata := statefulset.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].topologyKey' is set and is 'kubernetes.io/hostname'",[j]),
-                "keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].topologyKey' is invalid or undefined",[j])
-              }
+	object.get(pref, "topologyKey", "undefined") != "kubernetes.io/hostname"
+
+	metadata := statefulset.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].topologyKey' is set and is 'kubernetes.io/hostname'", [j]),
+		"keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].topologyKey' is invalid or undefined", [j]),
+	}
 }
 
-CxPolicy [ result ] {
-    statefulset := input.document[i]
-    object.get(statefulset,"kind","undefined") == "StatefulSet"
+CxPolicy[result] {
+	statefulset := input.document[i]
+	object.get(statefulset, "kind", "undefined") == "StatefulSet"
 
-    to_number(statefulset.spec.replicas) > 2
+	to_number(statefulset.spec.replicas) > 2
 
-    affinity := statefulset.spec.template.spec.affinity
-    object.get(affinity,"podAntiAffinity","undefined") != "undefined"
-    
-    podAntiAffinity:= affinity.podAntiAffinity
+	affinity := statefulset.spec.template.spec.affinity
+	object.get(affinity, "podAntiAffinity", "undefined") != "undefined"
 
-    object.get(podAntiAffinity,"requiredDuringSchedulingIgnoredDuringExecution","undefined") != "undefined"
+	podAntiAffinity := affinity.podAntiAffinity
 
-    pref := podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[j]
+	object.get(podAntiAffinity, "requiredDuringSchedulingIgnoredDuringExecution", "undefined") != "undefined"
 
-    object.get(pref,"topologyKey","undefined") == "kubernetes.io/hostname"
+	pref := podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[j]
 
-    templateLabels := statefulset.spec.template.metadata.labels 
-    selectorLabels := pref.labelSelector.matchLabels
+	object.get(pref, "topologyKey", "undefined") == "kubernetes.io/hostname"
 
-    matchLabels(templateLabels,selectorLabels) == false
+	templateLabels := statefulset.spec.template.metadata.labels
+	selectorLabels := pref.labelSelector.matchLabels
 
-    metadata := statefulset.metadata
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution.labelSelector.matchLabels",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].labelSelector.matchLabels' match any label on template metadata",[j]),
-                "keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].labelSelector.matchLabels' don't match any label on template metadata",[j])
-              }
+	matchLabels(templateLabels, selectorLabels) == false
+
+	metadata := statefulset.metadata
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution.labelSelector.matchLabels", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].labelSelector.matchLabels' match any label on template metadata", [j]),
+		"keyActualValue": sprintf("'spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[%d].labelSelector.matchLabels' don't match any label on template metadata", [j]),
+	}
 }
 
-matchLabels(templateLabels,selectorLabels) = true {
-  some Key
-    templateLabels[Key] == selectorLabels[Key]
+matchLabels(templateLabels, selectorLabels) {
+	some Key
+	templateLabels[Key] == selectorLabels[Key]
 } else = false {
-  true
+	true
 }

--- a/assets/queries/k8s/statefulset_requests_storage/query.rego
+++ b/assets/queries/k8s/statefulset_requests_storage/query.rego
@@ -1,18 +1,17 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-  metadata := document.metadata
-  volumeClaimTemplates := document.spec.volumeClaimTemplates
+	metadata := document.metadata
+	volumeClaimTemplates := document.spec.volumeClaimTemplates
 
-  object.get(volumeClaimTemplates[j].spec.resources.requests, "storage", "undefined") != "undefined"
+	object.get(volumeClaimTemplates[j].spec.resources.requests, "storage", "undefined") != "undefined"
 
 	result := {
-                "documentId": 		document.id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.volumeClaimTemplates.spec.resources.requests.storage=%s", [metadata.name, volumeClaimTemplates[j].spec.resources.requests.storage] ),
-                "issueType":		  "IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.volumeClaimTemplates.spec.resources.requests.storage should not be set", [metadata.name] ),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.volumeClaimTemplates.spec.resources.requests.storage should is set to %s", [metadata.name, volumeClaimTemplates[j].spec.resources.requests.storage] )
-              }
+		"documentId": document.id,
+		"searchKey": sprintf("metadata.name=%s.spec.volumeClaimTemplates.spec.resources.requests.storage=%s", [metadata.name, volumeClaimTemplates[j].spec.resources.requests.storage]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.volumeClaimTemplates.spec.resources.requests.storage should not be set", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.volumeClaimTemplates.spec.resources.requests.storage should is set to %s", [metadata.name, volumeClaimTemplates[j].spec.resources.requests.storage]),
+	}
 }
-

--- a/assets/queries/k8s/statefulset_without_pod_disruption_budget/query.rego
+++ b/assets/queries/k8s/statefulset_without_pod_disruption_budget/query.rego
@@ -1,31 +1,28 @@
 package Cx
 
-CxPolicy [result ] {
+CxPolicy[result] {
+	statefulset := input.document[i]
+	statefulset.kind == "StatefulSet"
+	metadata := statefulset.metadata
 
-  statefulset := input.document[i]
-  statefulset.kind == "StatefulSet"
-  metadata := statefulset.metadata
+	not CheckIFPdbExists(statefulset)
 
-  not CheckIFPdbExists(statefulset)
-
-  result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s", [metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": sprintf("metadata.name=%s is not targeted by a PDB", [metadata.name]),
-                "keyActualValue": 	sprintf("metadata.name=%s is not targeted by a PDB", [metadata.name])
-            }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s is not targeted by a PDB", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s is not targeted by a PDB", [metadata.name]),
+	}
 }
 
-CheckIFPdbExists (statefulsets) = result{
-
+CheckIFPdbExists(statefulsets) = result {
 	documents := input.document
 	pdbs := [pdb | documents[index].kind == "PodDisruptionBudget"; pdb = documents[index]]
 
-  result := contains(pdbs, statefulsets.spec.selector.matchLabels.app)
-
+	result := contains(pdbs, statefulsets.spec.selector.matchLabels.app)
 }
 
-contains (array, string) = true {
+contains(array, string) {
 	array[a].spec.selector.matchLabels.app == string
 }

--- a/assets/queries/k8s/statefulsets_without_service_name/query.rego
+++ b/assets/queries/k8s/statefulsets_without_service_name/query.rego
@@ -1,21 +1,20 @@
 package Cx
 
-CxPolicy [ result ] {
-  metadata := input.document[i].metadata
-  input.document[i].kind == "Service"
-  specs := input.document[i].spec
-  specs.clusterIP != "None"
-  some j
-  input.document[j].kind == "StatefulSet"
-  input.document[j].spec.selector.matchLabels == input.document[j].spec.template.metadata.labels
-  metadata.name == input.document[j].spec.serviceName
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	input.document[i].kind == "Service"
+	specs := input.document[i].spec
+	specs.clusterIP != "None"
+	some j
+	input.document[j].kind == "StatefulSet"
+	input.document[j].spec.selector.matchLabels == input.document[j].spec.template.metadata.labels
+	metadata.name == input.document[j].spec.serviceName
 
-  
 	result := {
-                "documentId": 		  input.document[i].id,
-                "searchKey": 	      sprintf("metadata.name=%s.spec.serviceName", [metadata.name]),
-                "issueType":		    "IncorrectValue",
-                "keyExpectedValue": sprintf("metadata.name=%s.spec.serviceName refers to a Headless Service", [metadata.name]),
-                "keyActualValue": 	sprintf("metadata.name=%s.spec.serviceName doesn't refers to a Headless Service", [metadata.name]),
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.serviceName", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.serviceName refers to a Headless Service", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.serviceName doesn't refers to a Headless Service", [metadata.name]),
+	}
 }

--- a/assets/queries/k8s/tiller_deployment_is_accessible_within_cluster/query.rego
+++ b/assets/queries/k8s/tiller_deployment_is_accessible_within_cluster/query.rego
@@ -1,130 +1,127 @@
 package Cx
 
 # container
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    isTiller(document)
-    
-    container := document.spec.containers[j]
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
 
-    contains(container.image,"tiller")
+	isTiller(document)
 
-    object.get(container,"args","undefined") == "undefined"
-    
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":        sprintf("metadata.name=%s.spec.containers",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("'spec.containers[%s].args' is set", [container.name]),
-                "keyActualValue": 	sprintf("'spec.containers[%s].args' is undefined", [container.name])
-              }
+	container := document.spec.containers[j]
+	metadata := document.metadata
+
+	contains(container.image, "tiller")
+
+	object.get(container, "args", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'spec.containers[%s].args' is set", [container.name]),
+		"keyActualValue": sprintf("'spec.containers[%s].args' is undefined", [container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    isTiller(document)
-    
-    container := document.spec.containers[j]
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
 
-    contains(container.image,"tiller")
+	isTiller(document)
 
-    object.get(container,"args","undefined") != "undefined"
+	container := document.spec.containers[j]
+	metadata := document.metadata
 
-    not listenLocal(container.args)
-    
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": sprintf("metadata.name=%s.spec.containers.args",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  sprintf("'spec.containers[%s].args' set the container to listen to localhost",[container.name]),
-                "keyActualValue": 	sprintf("'spec.containers[%s].args' is not setting the container to lister to localhost", [container.name])
-              }
+	contains(container.image, "tiller")
+
+	object.get(container, "args", "undefined") != "undefined"
+
+	not listenLocal(container.args)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.args", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.containers[%s].args' set the container to listen to localhost", [container.name]),
+		"keyActualValue": sprintf("'spec.containers[%s].args' is not setting the container to lister to localhost", [container.name]),
+	}
 }
 
 #template container
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    isTillerTemplate(document)
+CxPolicy[result] {
+	document := input.document[i]
+
+	isTillerTemplate(document)
 
 	container := document.spec.template.spec.containers[j]
-    metadata := document.metadata
-    
-    object.get(container,"args","undefined") == "undefined"
-    
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":        sprintf("metadata.name=%s.spec.template.spec.containers",[metadata.name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":  sprintf("'spec.template.spec.containers[%s].args' is set", [container.name]),
-                "keyActualValue": 	sprintf("'spec.template.spec.containers[%s].args' is undefined", [container.name])
-              }
-    
+	metadata := document.metadata
+
+	object.get(container, "args", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.containers", [metadata.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'spec.template.spec.containers[%s].args' is set", [container.name]),
+		"keyActualValue": sprintf("'spec.template.spec.containers[%s].args' is undefined", [container.name]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    isTillerTemplate(document)
+CxPolicy[result] {
+	document := input.document[i]
+
+	isTillerTemplate(document)
 
 	container := document.spec.template.spec.containers[j]
-    metadata := document.metadata
-    
-    object.get(container,"args","undefined") != "undefined"
-    not listenLocal(container.args)
-    
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":        sprintf("metadata.name=%s.spec.template.spec.containers.args",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                 "keyExpectedValue":  sprintf("'spec.template.spec.containers[%s].args' set the container to listen to localhost", [container.name]),
-                "keyActualValue": 	sprintf("'spec.template.spec.containers[%s].args' is not setting the container to lister to localhost", [container.name])
-              }
-    
+	metadata := document.metadata
+
+	object.get(container, "args", "undefined") != "undefined"
+	not listenLocal(container.args)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.containers.args", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'spec.template.spec.containers[%s].args' set the container to listen to localhost", [container.name]),
+		"keyActualValue": sprintf("'spec.template.spec.containers[%s].args' is not setting the container to lister to localhost", [container.name]),
+	}
 }
+
 ############################################################
 isTiller(document) {
-    document.spec.containers
-    checkMetadata(document.metadata)
+	document.spec.containers
+	checkMetadata(document.metadata)
 }
 
 isTillerTemplate(document) {
-    document.spec.template.spec.containers
-    checkMetadata(document.spec.template.metadata)
+	document.spec.template.spec.containers
+	checkMetadata(document.spec.template.metadata)
 }
 
 checkMetadata(metadata) {
-    contains(metadata.name,"tiller")
+	contains(metadata.name, "tiller")
 }
 
 checkMetadata(metadata) {
-    object.get(metadata.labels,"app","undefined") == "helm"
+	object.get(metadata.labels, "app", "undefined") == "helm"
 }
 
 checkMetadata(metadata) {
-    contains(object.get(metadata.labels,"name","undefined"),"tiller")
+	contains(object.get(metadata.labels, "name", "undefined"), "tiller")
 }
+
 ##############################################################
 
-
-
 listenLocal(args) {
-    some j
-        arg := args[j]
-        is_string(arg)
-        contains(arg,"--listen")
-        localAddress(arg)
+	some j
+	arg := args[j]
+	is_string(arg)
+	contains(arg, "--listen")
+	localAddress(arg)
 }
 
 localAddress(arg) {
-    contains(arg,"localhost")
+	contains(arg, "localhost")
 }
 
 localAddress(arg) {
-    contains(arg,"127.0.0.1")
+	contains(arg, "127.0.0.1")
 }
-

--- a/assets/queries/k8s/tiller_is_deployed/query.rego
+++ b/assets/queries/k8s/tiller_is_deployed/query.rego
@@ -1,78 +1,78 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    checkMetadata(document.metadata)
-    metadata := document.metadata
+CxPolicy[result] {
+	document := input.document[i]
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  "'metadata' does not refer any Tiller resource",
-                "keyActualValue": 	"'metadata' refer to a Tiller resource"
-              }
+	checkMetadata(document.metadata)
+	metadata := document.metadata
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'metadata' does not refer any Tiller resource",
+		"keyActualValue": "'metadata' refer to a Tiller resource",
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    some j
-        contains(object.get(document.spec.containers[j],"image","undefined"), "tiller")
-    
-    metadata := document.metadata
-    
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  "'spec.containers' don't have any Tiller containers",
-                "keyActualValue": 	"'spec.containers' contains a Tiller container"
-              }
+CxPolicy[result] {
+	document := input.document[i]
+
+	some j
+	contains(object.get(document.spec.containers[j], "image", "undefined"), "tiller")
+
+	metadata := document.metadata
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'spec.containers' don't have any Tiller containers",
+		"keyActualValue": "'spec.containers' contains a Tiller container",
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    checkMetadata(document.spec.template.metadata)
+CxPolicy[result] {
+	document := input.document[i]
 
-    metadata := document.metadata
+	checkMetadata(document.spec.template.metadata)
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.metadata",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  "'spec.template.metadata' does not refer any Tiller resource",
-                "keyActualValue": 	"'spec.template.metadata' refer to a Tiller resource"
-              }
+	metadata := document.metadata
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.metadata", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'spec.template.metadata' does not refer any Tiller resource",
+		"keyActualValue": "'spec.template.metadata' refer to a Tiller resource",
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    
-    some j
-        contains(object.get(document.spec.template.spec.containers[j],"image","undefined"), "tiller")
+CxPolicy[result] {
+	document := input.document[i]
 
-    metadata := document.metadata
+	some j
+	contains(object.get(document.spec.template.spec.containers[j], "image", "undefined"), "tiller")
 
-    result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.template.spec.containers",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue":  "'spec.template.spec.containers' don't have any Tiller containers",
-                "keyActualValue": 	"'spec.template.spec.containers' contains a Tiller container"
-              }
-}
+	metadata := document.metadata
 
-checkMetadata(metadata) {
-    contains(metadata.name,"tiller")
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.template.spec.containers", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'spec.template.spec.containers' don't have any Tiller containers",
+		"keyActualValue": "'spec.template.spec.containers' contains a Tiller container",
+	}
 }
 
 checkMetadata(metadata) {
-    object.get(metadata.labels,"app","undefined") == "helm"
+	contains(metadata.name, "tiller")
 }
 
 checkMetadata(metadata) {
-    contains(object.get(metadata.labels,"name","undefined"),"tiller")
+	object.get(metadata.labels, "app", "undefined") == "helm"
+}
+
+checkMetadata(metadata) {
+	contains(object.get(metadata.labels, "name", "undefined"), "tiller")
 }

--- a/assets/queries/k8s/tiller_service_not_deleted/query.rego
+++ b/assets/queries/k8s/tiller_service_not_deleted/query.rego
@@ -1,55 +1,54 @@
 package Cx
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    keyword := "tiller"
+CxPolicy[result] {
+	document := input.document[i]
+	keyword := "tiller"
 
-    metadata := document.metadata
-    contains(metadata.name,keyword)
+	metadata := document.metadata
+	contains(metadata.name, keyword)
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s",[metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "metadata.name does not contain 'tiller'",
-                "keyActualValue":  "document[%d].metadata.name contains 'tiller'"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "metadata.name does not contain 'tiller'",
+		"keyActualValue": "document[%d].metadata.name contains 'tiller'",
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    keyword := "tiller"
+CxPolicy[result] {
+	document := input.document[i]
+	keyword := "tiller"
 
-    metadata := document.metadata
-    labels:= metadata.labels
-    some j
-        contains(labels[j],keyword)
-    
+	metadata := document.metadata
+	labels := metadata.labels
+	some j
+	contains(labels[j], keyword)
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s", [metadata.name]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "metadata.labels does not have values that contain 'tiller'",
-                "keyActualValue": 	sprintf("metadata.labels.%s contains 'tiller'", [j])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "metadata.labels does not have values that contain 'tiller'",
+		"keyActualValue": sprintf("metadata.labels.%s contains 'tiller'", [j]),
+	}
 }
 
-CxPolicy [ result ] {
-    document := input.document[i]
-    keyword := "tiller"
-    metadata := document.metadata
-    selector := document.spec.selector
+CxPolicy[result] {
+	document := input.document[i]
+	keyword := "tiller"
+	metadata := document.metadata
+	selector := document.spec.selector
 
-    some j
-        is_string(selector[j])
-        contains(selector[j],keyword)
-
+	some j
+	is_string(selector[j])
+	contains(selector[j], keyword)
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.selector.%s", [metadata.name,j]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "spec.selector does not have values that contain 'tiller'",
-                "keyActualValue": 	sprintf("spec.selector.%s contains 'tiller'", [j])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.selector.%s", [metadata.name, j]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "spec.selector does not have values that contain 'tiller'",
+		"keyActualValue": sprintf("spec.selector.%s contains 'tiller'", [j]),
+	}
 }

--- a/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/query.rego
+++ b/assets/queries/k8s/volume_mount_with_OS_directory_write_permissions/query.rego
@@ -1,49 +1,43 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
+	resource := input.document[i]
+	containers := resource.spec.containers
+	volumeMounts := containers[_].volumeMounts
+	is_OS_Dir(volumeMounts[v].mountPath)
+	volumeMounts[v].readOnly == false
 
-  resource := input.document[i]
-  containers := resource.spec.containers
-  volumeMounts := containers[_].volumeMounts
-  is_OS_Dir(volumeMounts[v].mountPath) 
-  volumeMounts[v].readOnly == false
-   
-  result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("metadata.name=%s.spec.containers.volumeMounts.name=%s.readyOnly", [resource.metadata.name, volumeMounts[v].name]),
-                "issueType":		"IncorrectValue", 
-                "keyExpectedValue": sprintf("spec.containers.volumeMounts[%s].readOnly is true",[volumeMounts[v].name]),
-                "keyActualValue": 	sprintf("spec.containers.volumeMounts[%s].readOnly is false",[volumeMounts[v].name])
-              }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.volumeMounts.name=%s.readyOnly", [resource.metadata.name, volumeMounts[v].name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.containers.volumeMounts[%s].readOnly is true", [volumeMounts[v].name]),
+		"keyActualValue": sprintf("spec.containers.volumeMounts[%s].readOnly is false", [volumeMounts[v].name]),
+	}
 }
 
-CxPolicy [ result ] {
-
-  resource := input.document[i]
-  containers := resource.spec.containers
-  volumeMounts := containers[_]["volumeMounts"]
-  is_OS_Dir(volumeMounts[v]["mountPath"]) 
-  object.get(volumeMounts[v] ,"readOnly", "undefined") == "undefined"
-  result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	     sprintf("metadata.name=%s.spec.containers.volumeMounts.name=%s", [resource.metadata.name, volumeMounts[v].name]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue":	sprintf("spec.containers.volumeMounts[%s].readOnly is set",[volumeMounts[v].name]),
-                "keyActualValue": 	sprintf("spec.containers.volumeMounts[%s].readOnly is undefined",[volumeMounts[v].name])
-              }
+CxPolicy[result] {
+	resource := input.document[i]
+	containers := resource.spec.containers
+	volumeMounts := containers[_].volumeMounts
+	is_OS_Dir(volumeMounts[v].mountPath)
+	object.get(volumeMounts[v], "readOnly", "undefined") == "undefined"
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name=%s.spec.containers.volumeMounts.name=%s", [resource.metadata.name, volumeMounts[v].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("spec.containers.volumeMounts[%s].readOnly is set", [volumeMounts[v].name]),
+		"keyActualValue": sprintf("spec.containers.volumeMounts[%s].readOnly is undefined", [volumeMounts[v].name]),
+	}
 }
-
-
 
 is_OS_Dir(mountPath) = result {
-      hostSensitiveDir = {"/bin", "/sbin","/boot","/cdrom","/dev","/etc","/home","/lib","/media","/proc","/root","/run","/seLinux","/srv","/usr","/var"}
-   	  result  = startswith( mountPath,hostSensitiveDir[_])
+	hostSensitiveDir = {"/bin", "/sbin", "/boot", "/cdrom", "/dev", "/etc", "/home", "/lib", "/media", "/proc", "/root", "/run", "/seLinux", "/srv", "/usr", "/var"}
+	result = startswith(mountPath, hostSensitiveDir[_])
 } else = result {
-      result  =  mountPath == "/"
-
+	result = mountPath == "/"
 }
 
 listcontains(dirs, elem) {
-  startswith(elem,dirs[_])
+	startswith(elem, dirs[_])
 }
-


### PR DESCRIPTION
Signed-off-by: Rogério Peixoto <rogerio.peixoto@checkmarx.com>

Closes #1814

### Platform
*Kubernetes*

### Description
*Run `opa fmt --write` for all k8s rego files*

```
#!/usr/bin/env bash
shopt -s extglob
COUNT=0
for rego in echo ./assets/queries/k8s/**/*.rego; do
  echo $rego
  opa fmt -w $rego
  COUNT=$(( COUNT + 1 ))
done
echo "Formatted $COUNT queries"
```