### PR TITLE
Fix formatting for all dockerfile queries

### DIFF
--- a/assets/queries/dockerfile/add_instead_of_copy/query.rego
+++ b/assets/queries/dockerfile/add_instead_of_copy/query.rego
@@ -1,20 +1,20 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "add"
-  not tarfileChecker(resource.Value, ".tar")
-  not tarfileChecker(resource.Value, ".tar.")
-  
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "add"
+	not tarfileChecker(resource.Value, ".tar")
+	not tarfileChecker(resource.Value, ".tar.")
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		"IncorrectValue", 
-                "keyExpectedValue": sprintf("'COPY' %s", [resource.Value[0]]),
-                "keyActualValue": 	sprintf("'ADD' %s", [resource.Value[0]])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'COPY' %s", [resource.Value[0]]),
+		"keyActualValue": sprintf("'ADD' %s", [resource.Value[0]]),
+	}
 }
 
 tarfileChecker(cmdValue, elem) {
-  contains(cmdValue[_], elem)
+	contains(cmdValue[_], elem)
 }

--- a/assets/queries/dockerfile/aliase_names_must_be_unique/query.rego
+++ b/assets/queries/dockerfile/aliase_names_must_be_unique/query.rego
@@ -1,33 +1,29 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
+	resource := input.document[i].command[name][com]
+	resource.Cmd == "from"
 
-    resource := input.document[i].command[name][com]
-    resource.Cmd == "from"
+	idx := getIndex(resource.Value)
 
-    idx := getIndex(resource.Value)
+	nameAlias := resource.Value[idx]
 
-    nameAlias := resource.Value[idx]
-
-    aliasResource := input.document[i].command[name2][alias]
-    aliasResource != resource
-    aliasResource.Cmd == "from"
-    idx_2 := getIndex(aliasResource.Value)
-    aliasResource.Value[idx_2] == nameAlias
-
-
-
+	aliasResource := input.document[i].command[name2][alias]
+	aliasResource != resource
+	aliasResource.Cmd == "from"
+	idx_2 := getIndex(aliasResource.Value)
+	aliasResource.Value[idx_2] == nameAlias
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}", [aliasResource.Value[idx_2]]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "Different FROM commands don't have the same alias defined",
-                "keyActualValue": 	sprintf("Different FROM commands with with the same alias '%s' defined", [aliasResource.Value[idx_2]])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}", [aliasResource.Value[idx_2]]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "Different FROM commands don't have the same alias defined",
+		"keyActualValue": sprintf("Different FROM commands with with the same alias '%s' defined", [aliasResource.Value[idx_2]]),
+	}
 }
 
 getIndex(val) = idx {
 	val[i] == "as"
-    idx = i+1
+	idx = i + 1
 }

--- a/assets/queries/dockerfile/apk_add_using_local_cache_path/query.rego
+++ b/assets/queries/dockerfile/apk_add_using_local_cache_path/query.rego
@@ -1,26 +1,26 @@
 package Cx
 
-CxPolicy [ result ] {
-  command := input.document[i].command[name][_]
-  command.Cmd == "run"
-  
-  # Split the commands (e.g., RUN command1 && command2 && command3)
-  runCommands := split(command.Value[0], "&&")
-  containsApkAddWithoutNoCache(runCommands)
-	
+CxPolicy[result] {
+	command := input.document[i].command[name][_]
+	command.Cmd == "run"
+
+	# Split the commands (e.g., RUN command1 && command2 && command3)
+	runCommands := split(command.Value[0], "&&")
+	containsApkAddWithoutNoCache(runCommands)
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name, command.Original]),
-                "issueType":		"IncorrectValue", 
-                "keyExpectedValue": "'RUN' does not contain 'apk add' command without '--no-cache' switch",
-                "keyActualValue": 	"'RUN' contains 'apk add' command without '--no-cache' switch"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, command.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'RUN' does not contain 'apk add' command without '--no-cache' switch",
+		"keyActualValue": "'RUN' contains 'apk add' command without '--no-cache' switch",
+	}
 }
 
 containsApkAddWithoutNoCache(commands) {
-  some i
-    command := trim_space(commands[i])
-    startswith(command, "apk ")
-    contains(command, " add ")
-    not contains(command, "--no-cache")
+	some i
+	command := trim_space(commands[i])
+	startswith(command, "apk ")
+	contains(command, " add ")
+	not contains(command, "--no-cache")
 }

--- a/assets/queries/dockerfile/apt_get_without_no_recommends_flag/query.rego
+++ b/assets/queries/dockerfile/apt_get_without_no_recommends_flag/query.rego
@@ -1,91 +1,103 @@
 package Cx
 
-CxPolicy [ result ] {
-  runCmd := input.document[i].command[name][_]
-  isRunCmd(runCmd) 
-  
-  value := runCmd.Value
-  count(value) == 1 #command is in a single string
+CxPolicy[result] {
+	runCmd := input.document[i].command[name][_]
+	isRunCmd(runCmd)
 
-  cmd := value[0]
+	value := runCmd.Value
+	count(value) == 1 #command is in a single string
 
-  searchIndex := indexof(cmd,"apt-get")
+	cmd := value[0]
 
-  searchIndex != -1
+	searchIndex := indexof(cmd, "apt-get")
 
-  aptGetCmd := trimCmdEnd(substring(cmd,searchIndex+8,count(cmd)-searchIndex-8))
+	searchIndex != -1
 
-  not hasNoRecommendsFlag(aptGetCmd)
+	aptGetCmd := trimCmdEnd(substring(cmd, searchIndex + 8, (count(cmd) - searchIndex) - 8))
 
-	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name,runCmd.Original]),
-                "issueType":		"IncorrectValue", 
-                "keyExpectedValue": sprintf("'%s' uses '--no-install-recommends' flag to avoid installing additional packages", [runCmd.Original]),
-                "keyActualValue": 	sprintf("'%s' does not use '--no-install-recommends' flag to avoid installing additional packages", [runCmd.Original])
-              }
-}
-
-CxPolicy [ result ] {
-  runCmd := input.document[i].command[name][_]
-  isRunCmd(runCmd) 
-  
-  value := runCmd.Value
-  count(value) > 1 #command is in several tokens
-  
-  aptGetIdx := getAptGetIdx(value)
-  aptGetIdx != -1
-  aptGetCmdLastIdx := getCmdLastIdx(value,aptGetIdx)
-
-  not checkRecommendsFlag(value,aptGetIdx,aptGetCmdLastIdx)
-
-  cmdFormatted := replace(runCmd.Original,"\"","'")
+	not hasNoRecommendsFlag(aptGetCmd)
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name,runCmd.Original]),
-                "issueType":		"IncorrectValue", 
-                "keyExpectedValue": sprintf("'%s' uses '--no-install-recommends' flag to avoid installing additional packages", [cmdFormatted]),
-                "keyActualValue": 	sprintf("'%s' does not use '--no-install-recommends' flag to avoid installing additional packages", [cmdFormatted])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s' uses '--no-install-recommends' flag to avoid installing additional packages", [runCmd.Original]),
+		"keyActualValue": sprintf("'%s' does not use '--no-install-recommends' flag to avoid installing additional packages", [runCmd.Original]),
+	}
 }
 
-isRunCmd(com) = true{
-  com.Cmd == "run"
-} else = false
+CxPolicy[result] {
+	runCmd := input.document[i].command[name][_]
+	isRunCmd(runCmd)
+
+	value := runCmd.Value
+	count(value) > 1 #command is in several tokens
+
+	aptGetIdx := getAptGetIdx(value)
+	aptGetIdx != -1
+	aptGetCmdLastIdx := getCmdLastIdx(value, aptGetIdx)
+
+	not checkRecommendsFlag(value, aptGetIdx, aptGetCmdLastIdx)
+
+	cmdFormatted := replace(runCmd.Original, "\"", "'")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s' uses '--no-install-recommends' flag to avoid installing additional packages", [cmdFormatted]),
+		"keyActualValue": sprintf("'%s' does not use '--no-install-recommends' flag to avoid installing additional packages", [cmdFormatted]),
+	}
+}
+
+isRunCmd(com) {
+	com.Cmd == "run"
+} else = false {
+	true
+}
 
 trimCmdEnd(cmd) = trimmed {
-  termOps := ["&&","||","|","&",";"]
+	termOps := ["&&", "||", "|", "&", ";"]
 
-  splitStr := split(cmd," ")
-  some i, j
-      splitStr[i] == termOps[j] 
-      indexTerm := indexof(cmd,termOps[j])
-      trimmed := substring(cmd,0,count(cmd) - indexTerm)
-} else = cmd
+	splitStr := split(cmd, " ")
+	some i, j
+	splitStr[i] == termOps[j]
+	indexTerm := indexof(cmd, termOps[j])
+	trimmed := substring(cmd, 0, count(cmd) - indexTerm)
+} else = cmd {
+	true
+}
 
 hasNoRecommendsFlag(arg) {
-  flags := ["--no-install-recommends","apt::install-recommends=false"]
-  contains(arg,flags[_])
-} else = false
+	flags := ["--no-install-recommends", "apt::install-recommends=false"]
+	contains(arg, flags[_])
+} else = false {
+	true
+}
 
 getAptGetIdx(value) = idx {
-  some i
-    value[i] == "apt-get"
-    idx := i+1
-} else = -1
+	some i
+	value[i] == "apt-get"
+	idx := i + 1
+} else = -1 {
+	true
+}
 
-getCmdLastIdx(arr,initCmdIdx) = idx {
-  termOps := ["&&","||","|","&",";"]
-  some i
-    i > initCmdIdx
-    arr[i] == termOps[i]
-    idx := i-1
-} else = count(arr)-1
+getCmdLastIdx(arr, initCmdIdx) = idx {
+	termOps := ["&&", "||", "|", "&", ";"]
+	some i
+	i > initCmdIdx
+	arr[i] == termOps[i]
+	idx := i - 1
+} else = count(arr) - 1 {
+	true
+}
 
-checkRecommendsFlag(cmd,start,end) {
-  some i
-    i >= start 
-    i <= end
-    hasNoRecommendsFlag(cmd[i])
-} else = false
+checkRecommendsFlag(cmd, start, end) {
+	some i
+	i >= start
+	i <= end
+	hasNoRecommendsFlag(cmd[i])
+} else = false {
+	true
+}

--- a/assets/queries/dockerfile/apt_get_without_yes_flag/query.rego
+++ b/assets/queries/dockerfile/apt_get_without_yes_flag/query.rego
@@ -1,91 +1,103 @@
 package Cx
 
-CxPolicy [ result ] {
-  runCmd := input.document[i].command[name][_]
-  isRunCmd(runCmd) 
-  
-  value := runCmd.Value
-  count(value) == 1 #command is in a single string
+CxPolicy[result] {
+	runCmd := input.document[i].command[name][_]
+	isRunCmd(runCmd)
 
-  cmd := value[0]
+	value := runCmd.Value
+	count(value) == 1 #command is in a single string
 
-  searchIndex := indexof(cmd,"apt-get")
+	cmd := value[0]
 
-  searchIndex != -1
+	searchIndex := indexof(cmd, "apt-get")
 
-  aptGetCmd := trimCmdEnd(substring(cmd,searchIndex+8,count(cmd)-searchIndex-8))
+	searchIndex != -1
 
-  not hasYesFlag(aptGetCmd)
+	aptGetCmd := trimCmdEnd(substring(cmd, searchIndex + 8, (count(cmd) - searchIndex) - 8))
 
-	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
-                "issueType":		"IncorrectValue", 
-                "keyExpectedValue": sprintf("'%s' uses '-y' flag to avoid user manual input", [runCmd.Original]),
-                "keyActualValue": 	sprintf("'%s' does not use '-y' flag to avoid user manual input", [runCmd.Original])
-              }
-}
-
-CxPolicy [ result ] {
-  runCmd := input.document[i].command[name][_]
-  isRunCmd(runCmd) 
-  
-  value := runCmd.Value
-  count(value) > 1 #command is in several tokens
-  
-  aptGetIdx := getAptGetIdx(value)
-  aptGetIdx != -1
-  aptGetCmdLastIdx := getCmdLastIdx(value,aptGetIdx)
-
-  not checkYesFlag(value,aptGetIdx,aptGetCmdLastIdx)
-
-  cmdFormatted := replace(runCmd.Original,"\"","'")
+	not hasYesFlag(aptGetCmd)
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
-                "issueType":		"IncorrectValue", 
-                "keyExpectedValue": sprintf("'%s' uses '-y' flag to avoid user manual input", [cmdFormatted]),
-                "keyActualValue": 	sprintf("'%s' does not use '-y' flag to avoid user manual input", [cmdFormatted])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s' uses '-y' flag to avoid user manual input", [runCmd.Original]),
+		"keyActualValue": sprintf("'%s' does not use '-y' flag to avoid user manual input", [runCmd.Original]),
+	}
 }
 
-isRunCmd(com) = true{
-  com.Cmd == "run"
-} else = false
+CxPolicy[result] {
+	runCmd := input.document[i].command[name][_]
+	isRunCmd(runCmd)
+
+	value := runCmd.Value
+	count(value) > 1 #command is in several tokens
+
+	aptGetIdx := getAptGetIdx(value)
+	aptGetIdx != -1
+	aptGetCmdLastIdx := getCmdLastIdx(value, aptGetIdx)
+
+	not checkYesFlag(value, aptGetIdx, aptGetCmdLastIdx)
+
+	cmdFormatted := replace(runCmd.Original, "\"", "'")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s' uses '-y' flag to avoid user manual input", [cmdFormatted]),
+		"keyActualValue": sprintf("'%s' does not use '-y' flag to avoid user manual input", [cmdFormatted]),
+	}
+}
+
+isRunCmd(com) {
+	com.Cmd == "run"
+} else = false {
+	true
+}
 
 trimCmdEnd(cmd) = trimmed {
-  termOps := ["&&","||","|","&",";"]
+	termOps := ["&&", "||", "|", "&", ";"]
 
-  splitStr := split(cmd," ")
-  some i, j
-      splitStr[i] == termOps[j] 
-      indexTerm := indexof(cmd,termOps[j])
-      trimmed := substring(cmd,0,count(cmd) - indexTerm)
-} else = cmd
+	splitStr := split(cmd, " ")
+	some i, j
+	splitStr[i] == termOps[j]
+	indexTerm := indexof(cmd, termOps[j])
+	trimmed := substring(cmd, 0, count(cmd) - indexTerm)
+} else = cmd {
+	true
+}
 
 hasYesFlag(arg) {
-  flags := ["-y","-yes","--assume-yes"]
-  contains(arg,flags[_])
-} else = false
+	flags := ["-y", "-yes", "--assume-yes"]
+	contains(arg, flags[_])
+} else = false {
+	true
+}
 
 getAptGetIdx(value) = idx {
-  some i
-    value[i] == "apt-get"
-    idx := i+1
-} else = -1
+	some i
+	value[i] == "apt-get"
+	idx := i + 1
+} else = -1 {
+	true
+}
 
-getCmdLastIdx(arr,initCmdIdx) = idx {
-  termOps := ["&&","||","|","&",";"]
-  some i
-    i > initCmdIdx
-    arr[i] == termOps[i]
-    idx := i-1
-} else = count(arr)-1
+getCmdLastIdx(arr, initCmdIdx) = idx {
+	termOps := ["&&", "||", "|", "&", ";"]
+	some i
+	i > initCmdIdx
+	arr[i] == termOps[i]
+	idx := i - 1
+} else = count(arr) - 1 {
+	true
+}
 
-checkYesFlag(cmd,start,end) {
-  some i
-    i >= start 
-    i <= end
-    hasYesFlag(cmd[i])
-} else = false
+checkYesFlag(cmd, start, end) {
+	some i
+	i >= start
+	i <= end
+	hasYesFlag(cmd[i])
+} else = false {
+	true
+}

--- a/assets/queries/dockerfile/changing_default_shell_using_shell_command/query.rego
+++ b/assets/queries/dockerfile/changing_default_shell_using_shell_command/query.rego
@@ -1,14 +1,14 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "shell"
-  
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "shell"
+
 	result := {
-                "documentId": 		  input.document[i].id,
-                "searchKey": 	      sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		    "IncorrectValue", 
-                "keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} uses the RUN command to change the default shell", [name, resource.Original]),
-                "keyActualValue": 	sprintf("FROM={{%s}}.{{%s}} uses the SHELL command to change the default shell", [name, resource.Original]),
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} uses the RUN command to change the default shell", [name, resource.Original]),
+		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} uses the SHELL command to change the default shell", [name, resource.Original]),
+	}
 }

--- a/assets/queries/dockerfile/copy_2_Args/query.rego
+++ b/assets/queries/dockerfile/copy_2_Args/query.rego
@@ -1,23 +1,22 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
 
-    resource := input.document[i].command[name][_]
-    
-    resource.Cmd == "copy"
-    
-    command := resource.Value
-    
-    numElems := count(command)
-    numElems > 2
-    
-  	not endswith(command[numElems - 1],"/")
+	resource.Cmd == "copy"
+
+	command := resource.Value
+
+	numElems := count(command)
+	numElems > 2
+
+	not endswith(command[minus(numElems, 1)], "/")
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.COPY={{%s}}", [name, resource.Value[0]]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "When COPY command has more than two arguments, the last one should end with a slash",
-                "keyActualValue": 	"COPY command has more than two arguments and the last one does not end with a slash"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.COPY={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "When COPY command has more than two arguments, the last one should end with a slash",
+		"keyActualValue": "COPY command has more than two arguments and the last one does not end with a slash",
+	}
 }

--- a/assets/queries/dockerfile/copy_from_references_current_from_alias/query.rego
+++ b/assets/queries/dockerfile/copy_from_references_current_from_alias/query.rego
@@ -1,32 +1,31 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "copy"
 
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "copy"
-  
-  contains(resource.Flags[x],"--from=")
-  aux_split := split(resource.Flags[x], "=")
-  
-  isAliasCurrentFromAlias(name, aux_split[1])
+	contains(resource.Flags[x], "--from=")
+	aux_split := split(resource.Flags[x], "=")
 
-  result := {
-                "documentId": 		  input.document[i].id,
-                "searchKey":        sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		    "IncorrectValue",
-                "keyExpectedValue": "COPY --from does not reference the current FROM alias",
-                "keyActualValue": 	"COPY --from references the current FROM alias"
-              }
+	isAliasCurrentFromAlias(name, aux_split[1])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "COPY --from does not reference the current FROM alias",
+		"keyActualValue": "COPY --from references the current FROM alias",
+	}
 }
 
 isAliasCurrentFromAlias(currentName, currentAlias) = allow {
-  resource := input.document[i].command[name][_]
-  currentName == name
-  
-  resource.Cmd == "from"
-  previousAlias := resource.Value[2]
-  
-  previousAlias == currentAlias
-  
-  allow = true
+	resource := input.document[i].command[name][_]
+	currentName == name
+
+	resource.Cmd == "from"
+	previousAlias := resource.Value[2]
+
+	previousAlias == currentAlias
+
+	allow = true
 }

--- a/assets/queries/dockerfile/copy_from_without_from_alias_defined_previously/query.rego
+++ b/assets/queries/dockerfile/copy_from_without_from_alias_defined_previously/query.rego
@@ -1,32 +1,31 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "copy"
 
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "copy"
-  
-  contains(resource.Flags[x],"--from=")
-  resource.Flags[x] != "--from=0"
-  aux_split := split(resource.Flags[x], "=")
-  
-  not isPreviousAlias(resource.StartLine, aux_split[1])
+	contains(resource.Flags[x], "--from=")
+	resource.Flags[x] != "--from=0"
+	aux_split := split(resource.Flags[x], "=")
 
-  result := {
-                "documentId": 		  input.document[i].id,
-                "searchKey":        sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		    "IncorrectValue",
-                "keyExpectedValue": "COPY '--from' references a previous defined FROM alias",
-                "keyActualValue": 	"COPY '--from' does not reference a previous defined FROM alias"
-              }
+	not isPreviousAlias(resource.StartLine, aux_split[1])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "COPY '--from' references a previous defined FROM alias",
+		"keyActualValue": "COPY '--from' does not reference a previous defined FROM alias",
+	}
 }
 
 isPreviousAlias(startLine, currentAlias) = allow {
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "from"
-  previousAlias := resource.Value[2]
-  
-  previousAlias == currentAlias
-  resource.EndLine < startLine
-  
-  allow = true
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "from"
+	previousAlias := resource.Value[2]
+
+	previousAlias == currentAlias
+	resource.EndLine < startLine
+
+	allow = true
 }

--- a/assets/queries/dockerfile/gem_install_without_version/query.rego
+++ b/assets/queries/dockerfile/gem_install_without_version/query.rego
@@ -1,16 +1,16 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "run"
-  contains(resource.Original, "gem install ") 
-  not contains(resource.Original, ":") 
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "run"
+	contains(resource.Original, "gem install ")
+	not contains(resource.Original, ":")
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("%s is 'gem install <gem>:<version>'", [resource.Original]),
-                "keyActualValue": 	sprintf("%s is 'gem install <gem>', you should use 'gem install <gem>:<version>", [resource.Original])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s is 'gem install <gem>:<version>'", [resource.Original]),
+		"keyActualValue": sprintf("%s is 'gem install <gem>', you should use 'gem install <gem>:<version>", [resource.Original]),
+	}
 }

--- a/assets/queries/dockerfile/healthcheck_instruction_missing/query.rego
+++ b/assets/queries/dockerfile/healthcheck_instruction_missing/query.rego
@@ -1,18 +1,18 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name]
-  not contains(resource, "healthcheck")
+CxPolicy[result] {
+	resource := input.document[i].command[name]
+	not contains(resource, "healthcheck")
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}", [name]),
-                "issueType":		"MissingAttribute",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "Dockerfile contains instruction 'HEALTHCHECK'",
-                "keyActualValue": 	"Dockerfile doesn't contain instruction 'HEALTHCHECK'"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}", [name]),
+		"issueType": "MissingAttribute", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "Dockerfile contains instruction 'HEALTHCHECK'",
+		"keyActualValue": "Dockerfile doesn't contain instruction 'HEALTHCHECK'",
+	}
 }
 
 contains(cmd, elem) {
-  cmd[_].Cmd = elem
+	cmd[_].Cmd = elem
 }

--- a/assets/queries/dockerfile/image_version_not_explicit/query.rego
+++ b/assets/queries/dockerfile/image_version_not_explicit/query.rego
@@ -1,19 +1,16 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
-    resource.Cmd == "from"
-    not resource.Value[0] == "scratch"
-    not contains(resource.Value[0], ":") 
+	resource.Cmd == "from"
+	not resource.Value[0] == "scratch"
+	not contains(resource.Value[0], ":")
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}", [name]),
-                "issueType":		"MissingAttribute",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": sprintf("FROM %s:'version'", [resource.Value[0]]),
-                "keyActualValue": 	sprintf("FROM %s'", [resource.Value[0]])
-              } 
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}", [name]),
+		"issueType": "MissingAttribute", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": sprintf("FROM %s:'version'", [resource.Value[0]]),
+		"keyActualValue": sprintf("FROM %s'", [resource.Value[0]]),
+	}
 }
-
-
-

--- a/assets/queries/dockerfile/image_version_using_latest/query.rego
+++ b/assets/queries/dockerfile/image_version_using_latest/query.rego
@@ -1,19 +1,16 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
-    resource.Cmd == "from"
-    not resource.Value[0] == "scratch"
-    contains(resource.Value[0], ":latest")
+	resource.Cmd == "from"
+	not resource.Value[0] == "scratch"
+	contains(resource.Value[0], ":latest")
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}", [name]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": sprintf("FROM %s:'version' where version is not 'latest'", [resource.Value[0]]),
-                "keyActualValue": 	sprintf("FROM %s'", [resource.Value[0]])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}", [name]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": sprintf("FROM %s:'version' where version is not 'latest'", [resource.Value[0]]),
+		"keyActualValue": sprintf("FROM %s'", [resource.Value[0]]),
+	}
 }
-
-
-

--- a/assets/queries/dockerfile/last_user_is_root/query.rego
+++ b/assets/queries/dockerfile/last_user_is_root/query.rego
@@ -1,15 +1,15 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name]
-  userCmd := [ x | resource[j].Cmd == "user"; x:= resource[j]]
-  userCmd[count(userCmd)-1].Value[0] == "root"
+CxPolicy[result] {
+	resource := input.document[i].command[name]
+	userCmd := [x | resource[j].Cmd == "user"; x := resource[j]]
+	userCmd[minus(count(userCmd), 1)].Value[0] == "root"
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name, userCmd[count(userCmd)-1].Original]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "Last User isn't root",
-                "keyActualValue": 	"Last User is root"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, userCmd[minus(count(userCmd), 1)].Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Last User isn't root",
+		"keyActualValue": "Last User is root",
+	}
 }

--- a/assets/queries/dockerfile/maintainer_instruction_being_used/query.rego
+++ b/assets/queries/dockerfile/maintainer_instruction_being_used/query.rego
@@ -1,14 +1,14 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "maintainer"
-  
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "maintainer"
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.MAINTAINER={{%s}}", [name, resource.Value[0]]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": sprintf("Maintainer instruction being used in Label 'LABEL maintainer=%s'", [resource.Value[0]]),
-                "keyActualValue": 	sprintf("Maintainer instruction not being used in Label 'MAINTAINER %s'", [resource.Value[0]])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.MAINTAINER={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": sprintf("Maintainer instruction being used in Label 'LABEL maintainer=%s'", [resource.Value[0]]),
+		"keyActualValue": sprintf("Maintainer instruction not being used in Label 'MAINTAINER %s'", [resource.Value[0]]),
+	}
 }

--- a/assets/queries/dockerfile/missing_dnf_clean_all/query.rego
+++ b/assets/queries/dockerfile/missing_dnf_clean_all/query.rego
@@ -1,57 +1,57 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
- 	resource.Cmd == "run"
- 	command := resource.Value[0]
+	resource.Cmd == "run"
+	command := resource.Value[0]
 
-  containsInstallCommand(command)
+	containsInstallCommand(command)
 
-  not containsCleanAfterInstall(command)
-    
+	not containsCleanAfterInstall(command)
+
 	result := {
-    			      "documentId": 		input.document[i].id,
-              	"searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
-              	"issueType":		 "IncorrectValue",
-              	"keyExpectedValue": "After installing a package with dnf, command 'dnf clean all' is run.",
-              	"keyActualValue": 	 "Command `dnf clean all` should be run after installing packages.",
-            }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "After installing a package with dnf, command 'dnf clean all' is run.",
+		"keyActualValue": "Command `dnf clean all` should be run after installing packages.",
+	}
 }
 
-containsInstallCommand(command){
-  installCommands = [
-        "dnf install",
-        "dnf in",
-        "dnf reinstall",
-        "dnf rei",
-        "dnf install-n",
-        "dnf install-na",
-        "dnf install-nevra"      
-        ]
-  contains(command, installCommands[_])    
+containsInstallCommand(command) {
+	installCommands = [
+		"dnf install",
+		"dnf in",
+		"dnf reinstall",
+		"dnf rei",
+		"dnf install-n",
+		"dnf install-na",
+		"dnf install-nevra",
+	]
+
+	contains(command, installCommands[_])
 }
 
 # `dnf clean all` should come after `dnf install`
 containsCleanAfterInstall(command) {
-
 	contains(command, "dnf clean all")
-    
-  installCommands = [
-        	"dnf install",
-          "dnf in",
-          "dnf reinstall",
-          "dnf rei",
-          "dnf install-n",
-          "dnf install-na",
-          "dnf install-nevra"      
-        ]
-         
-    some cmd 
-    install := indexof(command, installCommands[cmd])
-    install != -1
-    
-    clean := indexof(command, "dnf clean")
-    clean != -1
-    
-    install<clean
+
+	installCommands = [
+		"dnf install",
+		"dnf in",
+		"dnf reinstall",
+		"dnf rei",
+		"dnf install-n",
+		"dnf install-na",
+		"dnf install-nevra",
+	]
+
+	some cmd
+	install := indexof(command, installCommands[cmd])
+	install != -1
+
+	clean := indexof(command, "dnf clean")
+	clean != -1
+
+	install < clean
 }

--- a/assets/queries/dockerfile/missing_flag_from_dnf_install/query.rego
+++ b/assets/queries/dockerfile/missing_flag_from_dnf_install/query.rego
@@ -1,44 +1,44 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
 
-  resource.Cmd == "run"
- 	
-  values := resource.Value[0]
-	commands = split(values,"&&")
-    
-  some k
-    hasInstallCommandWithoutFlag(commands[k])
-    not hasYesFlag(commands[k])
-    
+	resource.Cmd == "run"
+
+	values := resource.Value[0]
+	commands = split(values, "&&")
+
+	some k
+	hasInstallCommandWithoutFlag(commands[k])
+	not hasYesFlag(commands[k])
+
 	result := {
-    			    "documentId": 		input.document[i].id,
-              "searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
-              "issueType":		 "IncorrectValue",
-              "keyExpectedValue": "When running `dnf install`, `-y` or `--asumme-yes` switch is set to avoid build failure ",
-              "keyActualValue": 	 sprintf("Command `FROM={{%s}}.RUN={{%s}}` doesn't have the `-y` or `--asumme-yes` switch set",[name,trim_space(commands[k])])
-            }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "When running `dnf install`, `-y` or `--asumme-yes` switch is set to avoid build failure ",
+		"keyActualValue": sprintf("Command `FROM={{%s}}.RUN={{%s}}` doesn't have the `-y` or `--asumme-yes` switch set", [name, trim_space(commands[k])]),
+	}
 }
 
-hasInstallCommandWithoutFlag(command){
+hasInstallCommandWithoutFlag(command) {
 	commandList = [
-		    "install", 
-        "groupinstall", 
-        "localinstall",
-        "reinstall",
-        "in",
-        "rei"
-        ]
-        
-  contains(command, "dnf")
+		"install",
+		"groupinstall",
+		"localinstall",
+		"reinstall",
+		"in",
+		"rei",
+	]
+
+	contains(command, "dnf")
 	contains(command, commandList[_])
 }
 
-hasYesFlag(command){
+hasYesFlag(command) {
 	contains(command, "-y")
 }
 
-hasYesFlag(command){
+hasYesFlag(command) {
 	contains(command, "--assume-yes")
 }

--- a/assets/queries/dockerfile/missing_user_instruction/query.rego
+++ b/assets/queries/dockerfile/missing_user_instruction/query.rego
@@ -1,20 +1,20 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name]
 
-  not hasUserInstruction(resource)
+	not hasUserInstruction(resource)
 
 	result := {
-    			    "documentId": 		  input.document[i].id,
-              "searchKey": 	      sprintf("FROM={{%s}}", [name]),
-              "issueType":		    "Missing Attribute",
-              "keyExpectedValue": "The 'Dockerfile' contains the 'USER' instruction",
-              "keyActualValue": 	 "The 'Dockerfile' does not contain any 'USER' instruction"
-            }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}", [name]),
+		"issueType": "Missing Attribute",
+		"keyExpectedValue": "The 'Dockerfile' contains the 'USER' instruction",
+		"keyActualValue": "The 'Dockerfile' does not contain any 'USER' instruction",
+	}
 }
 
 hasUserInstruction(resource) {
 	some j
-    	resource[j].Cmd == "user"
+	resource[j].Cmd == "user"
 }

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/query.rego
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/query.rego
@@ -1,37 +1,36 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
- 	
-  resource.Cmd == "run"
- 	
-  command := resource.Value[0]
-    
-  containsCommand(command)
-  not regex.match(`dnf\s+(-*[a-zA-Z]+\s*)*(in|rei)n?(stall)?(-*[a-z]+\s*)*\s*\w*(-|_|~|=)(\d+\.)(.+)`, command)
-    
+
+	resource.Cmd == "run"
+
+	command := resource.Value[0]
+
+	containsCommand(command)
+	not regex.match(`dnf\s+(-*[a-zA-Z]+\s*)*(in|rei)n?(stall)?(-*[a-z]+\s*)*\s*\w*(-|_|~|=)(\d+\.)(.+)`, command)
+
 	result := {
-    			    "documentId": 		input.document[i].id,
-              "searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
-              "issueType":		 "IncorrectValue",
-              "keyExpectedValue": "Package version is specified when using 'dnf install'",
-              "keyActualValue": 	 "Package version should be pinned when running ´dnf install´",
-            }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Package version is specified when using 'dnf install'",
+		"keyActualValue": "Package version should be pinned when running ´dnf install´",
+	}
 }
-	
+
 containsCommand(command) {
-	instructions := split(command,"&& ")
+	instructions := split(command, "&& ")
 
-  installCommands = [
-        "install",
-        "in",
-        "reinstall",
-        "rei",     
-      ]
-        
-  some i        
-	  contains(instructions[i], "dnf")
-  some j
-  	contains(instructions[i], installCommands[j]) 
+	installCommands = [
+		"install",
+		"in",
+		"reinstall",
+		"rei",
+	]
+
+	some i
+	contains(instructions[i], "dnf")
+	some j
+	contains(instructions[i], installCommands[j])
 }
-

--- a/assets/queries/dockerfile/missing_zypper_clean/query.rego
+++ b/assets/queries/dockerfile/missing_zypper_clean/query.rego
@@ -1,89 +1,89 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-  commands = document.command
-  some img
-  some c
-  commands[img][c].Cmd == "run"
+	commands = document.command
+	some img
+	some c
+	commands[img][c].Cmd == "run"
 
-  some j
-  command := commands[img][c].Value[j]
+	some j
+	command := commands[img][c].Value[j]
 
-  commandHasZypperUsage(command)
+	commandHasZypperUsage(command)
 
-  not hasCleanAfterInstall(commands[img], c, j)
+	not hasCleanAfterInstall(commands[img], c, j)
 	result := {
-                "documentId": 		document.id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "There should be a zypper clean after a zypper usage",
-                "keyActualValue": 	sprintf("The command '%s' does not have a zypper clean after it", [commands[img][c].Value[j]])
-              }
+		"documentId": document.id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "There should be a zypper clean after a zypper usage",
+		"keyActualValue": sprintf("The command '%s' does not have a zypper clean after it", [commands[img][c].Value[j]]),
+	}
 }
 
-hasCleanAfterInstall(commands, installCommandIndex, valueIndex){
-  some c
-  c > installCommandIndex
-  some i
-  commandHasZypperClean(commands[c].Value[i])
+hasCleanAfterInstall(commands, installCommandIndex, valueIndex) {
+	some c
+	c > installCommandIndex
+	some i
+	commandHasZypperClean(commands[c].Value[i])
 }
 
-hasCleanAfterInstall(commands, installCommandIndex, valueIndex){
-  some i
-  i > valueIndex
-  commandHasZypperClean(commands[installCommandIndex].Value[i])
+hasCleanAfterInstall(commands, installCommandIndex, valueIndex) {
+	some i
+	i > valueIndex
+	commandHasZypperClean(commands[installCommandIndex].Value[i])
 }
 
 # If a command has zypper install and clean in same line
 # assume that the clean comes after the install
-hasCleanAfterInstall(commands, installCommandIndex, valueIndex){
-  commandString := commands[installCommandIndex].Value[valueIndex]
-  commandHasZypperUsage(commandString)
-  commandHasZypperClean(commandString)
+hasCleanAfterInstall(commands, installCommandIndex, valueIndex) {
+	commandString := commands[installCommandIndex].Value[valueIndex]
+	commandHasZypperUsage(commandString)
+	commandHasZypperClean(commandString)
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper install")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper install")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper in")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper in")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper remove")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper remove")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper rm")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper rm")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper source-install")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper source-install")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper si")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper si")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper patch")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper patch")
+	index != -1
 }
 
-commandHasZypperClean(command){
-  index := indexof(command, "zypper clean")
-  index != -1
+commandHasZypperClean(command) {
+	index := indexof(command, "zypper clean")
+	index != -1
 }
 
-commandHasZypperClean(command){
-  index := indexof(command, "zypper cc")
-  index != -1
+commandHasZypperClean(command) {
+	index := indexof(command, "zypper cc")
+	index != -1
 }

--- a/assets/queries/dockerfile/missing_zypper_non_interactive_switch/query.rego
+++ b/assets/queries/dockerfile/missing_zypper_non_interactive_switch/query.rego
@@ -1,62 +1,62 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-  commands = document.command
-  some img
+	commands = document.command
+	some img
 	some c
-  commands[img][c].Cmd == "run"
+	commands[img][c].Cmd == "run"
 
-  some j
-  command := commands[img][c].Value[j]
+	some j
+	command := commands[img][c].Value[j]
 
-  commandHasZypperUsage(command)
-  not commandHasNonInteractiveSwitch(command)
+	commandHasZypperUsage(command)
+	not commandHasNonInteractiveSwitch(command)
 
 	result := {
-                "documentId": 		document.id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "zypper usages should have the non-interactive switch activated",
-                "keyActualValue": 	sprintf("The command '%s' does not have the non-interactive switch activated (-y | --no-confirm)", [commands[img][c].Original])
-              }
+		"documentId": document.id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "zypper usages should have the non-interactive switch activated",
+		"keyActualValue": sprintf("The command '%s' does not have the non-interactive switch activated (-y | --no-confirm)", [commands[img][c].Original]),
+	}
 }
 
-commandHasNonInteractiveSwitch(command){
-  regex.match("zypper \\w+ (-y|--no-confirm)", command)
+commandHasNonInteractiveSwitch(command) {
+	regex.match("zypper \\w+ (-y|--no-confirm)", command)
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper install")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper install")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper in")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper in")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper remove")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper remove")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper rm")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper rm")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper source-install")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper source-install")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper si")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper si")
+	index != -1
 }
 
-commandHasZypperUsage(command){
-  index := indexof(command, "zypper patch")
-  index != -1
+commandHasZypperUsage(command) {
+	index := indexof(command, "zypper patch")
+	index != -1
 }

--- a/assets/queries/dockerfile/multiple_cmd_instructions_listed/query.rego
+++ b/assets/queries/dockerfile/multiple_cmd_instructions_listed/query.rego
@@ -1,16 +1,15 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name]
-  cmdInst := [x | resource[j].Cmd == "cmd"; x := resource[j]]
-  count(cmdInst) > 1
-
+CxPolicy[result] {
+	resource := input.document[i].command[name]
+	cmdInst := [x | resource[j].Cmd == "cmd"; x := resource[j]]
+	count(cmdInst) > 1
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name, cmdInst[0].Original]),
-                "issueType":		"RedundantAttribute",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "There is only one CMD instruction",
-                "keyActualValue": 	sprintf("There are %d CMD instructions", [count(cmdInst)])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, cmdInst[0].Original]),
+		"issueType": "RedundantAttribute", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "There is only one CMD instruction",
+		"keyActualValue": sprintf("There are %d CMD instructions", [count(cmdInst)]),
+	}
 }

--- a/assets/queries/dockerfile/multiple_entrypoint_instructions_listed/query.rego
+++ b/assets/queries/dockerfile/multiple_entrypoint_instructions_listed/query.rego
@@ -1,17 +1,15 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name]
-  cmdInst := [x | resource[j].Cmd == "entrypoint"; x:=resource[j]]
-  count(cmdInst) > 1
-
+CxPolicy[result] {
+	resource := input.document[i].command[name]
+	cmdInst := [x | resource[j].Cmd == "entrypoint"; x := resource[j]]
+	count(cmdInst) > 1
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name, cmdInst[0].Original]),
-                "issueType":		"RedundantAttribute",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "There is only one ENTRYPOINT instruction",
-                "keyActualValue": 	sprintf("There are %d ENTRYPOINT instructions", [count(cmdInst)])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, cmdInst[0].Original]),
+		"issueType": "RedundantAttribute", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "There is only one ENTRYPOINT instruction",
+		"keyActualValue": sprintf("There are %d ENTRYPOINT instructions", [count(cmdInst)]),
+	}
 }
-

--- a/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/query.rego
+++ b/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/query.rego
@@ -1,29 +1,29 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]  
-  resource.Cmd == "cmd"
-  resource.JSON == false
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "cmd"
+	resource.JSON == false
 
 	result := {
-                "documentId":		    input.document[i].id,
-                "searchKey":		    sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		    "IncorrectValue", 
-                "keyExpectedValue":	sprintf("FROM={{%s}}.{{%s}} is in the JSON Notation", [name, resource.Original ]),
-                "keyActualValue":	  sprintf("FROM={{%s}}.{{%s}} isn't in the JSON Notation", [name, resource.Original])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} is in the JSON Notation", [name, resource.Original]),
+		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} isn't in the JSON Notation", [name, resource.Original]),
+	}
 }
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]  
-  resource.Cmd == "entrypoint"
-  resource.JSON == false
-  
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "entrypoint"
+	resource.JSON == false
+
 	result := {
-                "documentId":		    input.document[i].id,
-                "searchKey":		    sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		    "IncorrectValue", 
-                "keyExpectedValue":	sprintf("FROM={{%s}}.{{%s}} is in the JSON Notation", [name, resource.Original]),
-                "keyActualValue":	  sprintf("FROM={{%s}}.{{%s}} isn't in the JSON Notation", [name, resource.Original])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} is in the JSON Notation", [name, resource.Original]),
+		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} isn't in the JSON Notation", [name, resource.Original]),
+	}
 }

--- a/assets/queries/dockerfile/npm_install_without_pinned_version/query.rego
+++ b/assets/queries/dockerfile/npm_install_without_pinned_version/query.rego
@@ -1,101 +1,105 @@
 package Cx
 
-CxPolicy [ result ] {
-  runCmd := input.document[i].command[name][_]
-  isRunCmd(runCmd) 
-  
-  value := runCmd.Value
-  count(value) == 1 #command is in a single string
+CxPolicy[result] {
+	runCmd := input.document[i].command[name][_]
+	isRunCmd(runCmd)
 
-  cmd := value[0]
+	value := runCmd.Value
+	count(value) == 1 #command is in a single string
 
-  installCmd := ["npm install ","npm i ","npm add "][_]
-  searchIndex := indexof(cmd,installCmd)
+	cmd := value[0]
 
-  searchIndex != -1
+	installCmd := ["npm install ", "npm i ", "npm add "][_]
+	searchIndex := indexof(cmd, installCmd)
 
-  npmInstallCmd := trimCmdEnd(substring(cmd,searchIndex+count(installCmd),count(cmd)-searchIndex-count(installCmd)))
+	searchIndex != -1
 
-  not isValidInstall(npmInstallCmd)
+	npmInstallCmd := trimCmdEnd(substring(cmd, searchIndex + count(installCmd), (count(cmd) - searchIndex) - count(installCmd)))
+
+	not isValidInstall(npmInstallCmd)
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name,runCmd.Original]),
-                "issueType":		"IncorrectValue", 
-                "keyExpectedValue": sprintf("'%s' uses npm install with a pinned version", [runCmd.Original]),
-                "keyActualValue": 	sprintf("'%s' does not uses npm install with a pinned version", [runCmd.Original])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s' uses npm install with a pinned version", [runCmd.Original]),
+		"keyActualValue": sprintf("'%s' does not uses npm install with a pinned version", [runCmd.Original]),
+	}
 }
 
-CxPolicy [ result ] {
-  runCmd := input.document[i].command[name][_]
-  isRunCmd(runCmd) 
-  
-  value := runCmd.Value
-  count(value) > 1 #command is in several tokens
-  
-  npmInstallIndex := getNPMInstallCmdIdx(value)
-  npmInstallIndex != -1
-  npmInstallCmd := value[npmInstallIndex]
+CxPolicy[result] {
+	runCmd := input.document[i].command[name][_]
+	isRunCmd(runCmd)
 
-  not isValidInstallArray(value,npmInstallIndex)
-	
-  cmdFormatted := replace(runCmd.Original,"\"","'")
+	value := runCmd.Value
+	count(value) > 1 #command is in several tokens
+
+	npmInstallIndex := getNPMInstallCmdIdx(value)
+	npmInstallIndex != -1
+	npmInstallCmd := value[npmInstallIndex]
+
+	not isValidInstallArray(value, npmInstallIndex)
+
+	cmdFormatted := replace(runCmd.Original, "\"", "'")
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name,runCmd.Original]),
-                "issueType":		"IncorrectValue", 
-                "keyExpectedValue": sprintf("'%s' uses npm install with a pinned version", [cmdFormatted]),
-                "keyActualValue": 	sprintf("'%s' does not uses npm install with a pinned version", [cmdFormatted])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s' uses npm install with a pinned version", [cmdFormatted]),
+		"keyActualValue": sprintf("'%s' does not uses npm install with a pinned version", [cmdFormatted]),
+	}
 }
 
-isRunCmd(com) = true{
-  com.Cmd == "run"
+isRunCmd(com) {
+	com.Cmd == "run"
 }
 
 trimCmdEnd(cmd) = trimmed {
-  termOps := ["&&","||","|","&",";"]
+	termOps := ["&&", "||", "|", "&", ";"]
 
-  splitStr := split(cmd," ")
-  splitStr[i] == termOps[j] 
-  indexTerm := indexof(cmd,termOps[j])
-  trimmed := substring(cmd,0,count(cmd) - indexTerm)
-} else = cmd
+	splitStr := split(cmd, " ")
+	splitStr[i] == termOps[j]
+	indexTerm := indexof(cmd, termOps[j])
+	trimmed := substring(cmd, 0, count(cmd) - indexTerm)
+} else = cmd {
+	true
+}
 
 isValidInstall(install) {
-  install == ""
+	install == ""
 } else {
-  tokens := split(install," ")
-  validMatch(tokens[_])
+	tokens := split(install, " ")
+	validMatch(tokens[_])
 }
 
 validMatch(token) {
-  startswith(token,"git") # npm install from git repository
+	startswith(token, "git") # npm install from git repository
 } else {
-  hasScope := re_match("@.+\/.*",token)
-  hasScope
+	hasScope := re_match("@.+/.*", token)
+	hasScope
 
-  scopeEnd := indexof(token,"/")
-  packageID := substring(token,scopeEnd+1,count(token) - scopeEnd)
-  atIndex := indexof(packageID,"@")
-  atIndex != -1 #package must refer the version or tag
+	scopeEnd := indexof(token, "/")
+	packageID := substring(token, scopeEnd + 1, count(token) - scopeEnd)
+	atIndex := indexof(packageID, "@")
+	atIndex != -1 #package must refer the version or tag
 } else {
-  hasScope := re_match("@.+\/.*",token)
-  not hasScope
-  atIndex := indexof(token,"@")
-  atIndex != -1 #package must refer the version or tag
+	hasScope := re_match("@.+/.*", token)
+	not hasScope
+	atIndex := indexof(token, "@")
+	atIndex != -1 #package must refer the version or tag
 }
 
-isValidInstallArray(value,npmIdx) {
-  j >= npmIdx
-  j < count(value)
-  validMatch(value[j])
+isValidInstallArray(value, npmIdx) {
+	j >= npmIdx
+	j < count(value)
+	validMatch(value[j])
 }
 
 getNPMInstallCmdIdx(value) = idx {
-  install := ["install","i","add"]
-  value[i] == "npm"
-  value[i+1] == install[_]
-  idx := i+2
-} else = -1
+	install := ["install", "i", "add"]
+	value[i] == "npm"
+	value[plus(i, 1)] == install[_]
+	idx := i + 2
+} else = -1 {
+	true
+}

--- a/assets/queries/dockerfile/pin_versions_apt_get_delete/query.rego
+++ b/assets/queries/dockerfile/pin_versions_apt_get_delete/query.rego
@@ -1,36 +1,34 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
+	resource := input.document[i].command[name][install]
+	resource.Cmd == "run"
+	command := resource.Value[0]
 
-    resource := input.document[i].command[name][install]
-    resource.Cmd == "run"
-    command := resource.Value[0]
-	
-    contains(resource.Value[0], "apt-get install")
-    
-    not hasClean(resource.Value[0],install)
-    
+	contains(resource.Value[0], "apt-get install")
+
+	not hasClean(resource.Value[0], install)
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "After using apt-get install, it is needed to delete apt-get lists",
-                "keyActualValue": 	"After using apt-get install, the apt-get lists were not deleted"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "After using apt-get install, it is needed to delete apt-get lists",
+		"keyActualValue": "After using apt-get install, the apt-get lists were not deleted",
+	}
 }
 
-hasClean(resourceValue,install) = true {
-
+hasClean(resourceValue, install) {
 	listCommands := split(resourceValue, "&& ")
-    
-	startswith(listCommands[install],"apt-get install")
-    
-    some clean
-    	startswith(listCommands[clean],"apt-get clean")
 
-    some remove
-    startswith(listCommands[remove],"rm -rf")
-    
-    install < clean
-    clean < remove
+	startswith(listCommands[install], "apt-get install")
+
+	some clean
+	startswith(listCommands[clean], "apt-get clean")
+
+	some remove
+	startswith(listCommands[remove], "rm -rf")
+
+	install < clean
+	clean < remove
 }

--- a/assets/queries/dockerfile/pin_versions_apt_get_install/query.rego
+++ b/assets/queries/dockerfile/pin_versions_apt_get_install/query.rego
@@ -1,33 +1,31 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "run"
+	command := resource.Value[0]
 
-    resource := input.document[i].command[name][_]
-    resource.Cmd == "run"
-    command := resource.Value[0]
-	
-    contains(resource.Value[0], "apt-get install")
-    commandSplited := split(resource.Value[0], " ")
-    
-    "install" == commandSplited[index]
-    
-    index+1 <= count(commandSplited)
-    packages := array.slice(commandSplited,index+1,count(commandSplited))
-    
-    some pack
-    	not startswith(packages[pack],"-")
-    	noVersion(packages[pack])
-    	
+	contains(resource.Value[0], "apt-get install")
+	commandSplited := split(resource.Value[0], " ")
+
+	"install" == commandSplited[index]
+
+	index + 1 <= count(commandSplited)
+	packages := array.slice(commandSplited, index + 1, count(commandSplited))
+
+	some pack
+	not startswith(packages[pack], "-")
+	noVersion(packages[pack])
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
-                "issueType":		"MissingAttribute",
-                "keyExpectedValue": "When installing a package, its pin version should be defined",
-                "keyActualValue": 	"The pin version is not defined"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "When installing a package, its pin version should be defined",
+		"keyActualValue": "The pin version is not defined",
+	}
 }
 
-noVersion(pack) = true {
-	not contains(pack,"=")
+noVersion(pack) {
+	not contains(pack, "=")
 }

--- a/assets/queries/dockerfile/pip_install_keeping_cached_packages/query.rego
+++ b/assets/queries/dockerfile/pip_install_keeping_cached_packages/query.rego
@@ -1,29 +1,29 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
 
-  resource.Cmd == "run"
+	resource.Cmd == "run"
 
-  values := resource.Value[0]
+	values := resource.Value[0]
 
-  hasCacheFlag(values)
+	hasCacheFlag(values)
 
 	result := {
-    			    "documentId": 		input.document[i].id,
-              "searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
-              "issueType":		 "IncorrectValue",
-              "keyExpectedValue": "The '--no-cache-dir' flag is set when running 'pip install'",
-              "keyActualValue": 	 "The '--no-cache-dir' flag isn't set when running 'pip install'",
-            }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The '--no-cache-dir' flag is set when running 'pip install'",
+		"keyActualValue": "The '--no-cache-dir' flag isn't set when running 'pip install'",
+	}
 }
 
-hasCacheFlag(values){
-	commands = split(values,"&&")
+hasCacheFlag(values) {
+	commands = split(values, "&&")
 
 	some i
-    instruction := commands[i]
-    contains(instruction, "pip")
-    contains(instruction, "install")
-    not contains(instruction, "--no-cache-dir")
+	instruction := commands[i]
+	contains(instruction, "pip")
+	contains(instruction, "install")
+	not contains(instruction, "--no-cache-dir")
 }

--- a/assets/queries/dockerfile/run_command_cd_instead_of_workdir/query.rego
+++ b/assets/queries/dockerfile/run_command_cd_instead_of_workdir/query.rego
@@ -1,18 +1,15 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
-    resource.Cmd == "run"
-    contains(resource.Value[_], "cd ") 
+	resource.Cmd == "run"
+	contains(resource.Value[_], "cd ")
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "Using WORKDIR to change directory",
-                "keyActualValue": 	sprintf("RUN %s'", [resource.Value[0]])
-              } 
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "Using WORKDIR to change directory",
+		"keyActualValue": sprintf("RUN %s'", [resource.Value[0]]),
+	}
 }
-
-
-

--- a/assets/queries/dockerfile/run_using_apt/query.rego
+++ b/assets/queries/dockerfile/run_using_apt/query.rego
@@ -1,19 +1,19 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-  commands = document.command
-  some img
+	commands = document.command
+	some img
 	some c
-  commands[img][c].Cmd == "run"
-  some j
-  contains(commands[img][c].Value[j], "apt ")
+	commands[img][c].Cmd == "run"
+	some j
+	contains(commands[img][c].Value[j], "apt ")
 
 	result := {
-                "documentId": 		document.id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "RUN instructions should not use the 'apt' program",
-                "keyActualValue": 	"RUN instruction is invoking the 'apt' program"
-              }
+		"documentId": document.id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "RUN instructions should not use the 'apt' program",
+		"keyActualValue": "RUN instruction is invoking the 'apt' program",
+	}
 }

--- a/assets/queries/dockerfile/run_using_dnf_update/query.rego
+++ b/assets/queries/dockerfile/run_using_dnf_update/query.rego
@@ -1,28 +1,26 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
-    
-  resource.Cmd == "run"
-  containsCommand(resource) == true
-    
+
+	resource.Cmd == "run"
+	containsCommand(resource) == true
+
 	result := {
-    			      "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name,resource.Value[0]]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "Run instructions are not invoking 'dnf update'",
-                "keyActualValue": 	sprintf("Run instruction is executing the %s command", [resource.Value[0]]),
-            }
-  
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Run instructions are not invoking 'dnf update'",
+		"keyActualValue": sprintf("Run instruction is executing the %s command", [resource.Value[0]]),
+	}
 }
 
-containsCommand(cmds) = true {
+containsCommand(cmds) {
+	commands = [
+		"dnf update",
+		"dnf upgrade",
+		"dnf upgrade-minimal",
+	]
 
- commands = [
-    "dnf update",
-    "dnf upgrade",
-    "dnf upgrade-minimal"
-  ]
-    
-  contains(cmds.Value[_], commands[_])
+	contains(cmds.Value[_], commands[_])
 }

--- a/assets/queries/dockerfile/run_using_sudo/query.rego
+++ b/assets/queries/dockerfile/run_using_sudo/query.rego
@@ -1,15 +1,15 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
-    resource.Cmd == "run"
-    contains(resource.Value[_], "sudo ") 
+	resource.Cmd == "run"
+	contains(resource.Value[_], "sudo ")
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "RUN instruction doesn't contain sudo",
-                "keyActualValue": 	"RUN instruction contains sudo"
-              } 
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "RUN instruction doesn't contain sudo",
+		"keyActualValue": "RUN instruction contains sudo",
+	}
 }

--- a/assets/queries/dockerfile/run_using_upgrade_commands/query.rego
+++ b/assets/queries/dockerfile/run_using_upgrade_commands/query.rego
@@ -1,20 +1,18 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "run"
 
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "run"
-  
-  commands := {"apt-get upgrade", "apt-get dist-upgrade"}
-  
-  contains(resource.Value[x],commands[j])
-  
+	commands := {"apt-get upgrade", "apt-get dist-upgrade"}
 
-  result := {
-                "documentId": 		  input.document[i].id,
-                "searchKey":        sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		    "IncorrectValue",
-                "keyExpectedValue": sprintf("RUN instructions does not have '%s' command", [commands[j]]),
-                "keyActualValue": 	sprintf("RUN instructions have '%s' command", [commands[j]]),
-              }
+	contains(resource.Value[x], commands[j])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("RUN instructions does not have '%s' command", [commands[j]]),
+		"keyActualValue": sprintf("RUN instructions have '%s' command", [commands[j]]),
+	}
 }

--- a/assets/queries/dockerfile/run_using_wget_and_curl/query.rego
+++ b/assets/queries/dockerfile/run_using_wget_and_curl/query.rego
@@ -1,28 +1,27 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name]
-  wget := getWget(resource[_])
-  curl := getCurl(resource[_])
-  count(curl) > 0
-  count(wget) > 0
+CxPolicy[result] {
+	resource := input.document[i].command[name]
+	wget := getWget(resource[_])
+	curl := getCurl(resource[_])
+	count(curl) > 0
+	count(wget) > 0
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}",[ name, curl[0].Original]),
-                "issueType":		"RedundantAttribute",
-                "keyExpectedValue": "Exclusively using 'wget' or 'curl'",
-                "keyActualValue": 	"Using both 'wget' and 'curl'"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, curl[0].Original]),
+		"issueType": "RedundantAttribute",
+		"keyExpectedValue": "Exclusively using 'wget' or 'curl'",
+		"keyActualValue": "Using both 'wget' and 'curl'",
+	}
 }
 
 getWget(cmd) = wget {
 	cmd.Cmd == "run"
-    wget := [x | contains(cmd.Value[_], "wget "); x := cmd]
+	wget := [x | contains(cmd.Value[_], "wget "); x := cmd]
 }
 
 getCurl(cmd) = curl {
 	cmd.Cmd == "run"
-    curl := [x | contains(cmd.Value[_], "curl "); x := cmd]
+	curl := [x | contains(cmd.Value[_], "curl "); x := cmd]
 }
-

--- a/assets/queries/dockerfile/run_using_zypper_update/query.rego
+++ b/assets/queries/dockerfile/run_using_zypper_update/query.rego
@@ -1,36 +1,36 @@
 package Cx
 
-CxPolicy [ result ] {
-  document := input.document[i]
-  commands = document.command
-  some img
-  some c
-  commands[img][c].Cmd == "run"
-  some j
+CxPolicy[result] {
+	document := input.document[i]
+	commands = document.command
+	some img
+	some c
+	commands[img][c].Cmd == "run"
+	some j
 
-  isZypperUnsafeCommand(commands[img][c].Value[j])
+	isZypperUnsafeCommand(commands[img][c].Value[j])
 
 	result := {
-                "documentId": 		document.id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "RUN instructions should not use 'zypper update'",
-                "keyActualValue": 	sprintf("RUN instruction is invoking the '%s'", [commands[img][c].Value[j]])
-              }
+		"documentId": document.id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "RUN instructions should not use 'zypper update'",
+		"keyActualValue": sprintf("RUN instruction is invoking the '%s'", [commands[img][c].Value[j]]),
+	}
 }
 
-isZypperUnsafeCommand(command){
-  contains(command, "zypper update")
+isZypperUnsafeCommand(command) {
+	contains(command, "zypper update")
 }
 
-isZypperUnsafeCommand(command){
-  contains(command, "zypper dist-upgrade")
+isZypperUnsafeCommand(command) {
+	contains(command, "zypper dist-upgrade")
 }
 
-isZypperUnsafeCommand(command){
-  contains(command, "zypper dup")
+isZypperUnsafeCommand(command) {
+	contains(command, "zypper dup")
 }
 
-isZypperUnsafeCommand(command){
-  contains(command, "zypper up")
+isZypperUnsafeCommand(command) {
+	contains(command, "zypper up")
 }

--- a/assets/queries/dockerfile/run_utilities_and_posix_commands/query.rego
+++ b/assets/queries/dockerfile/run_utilities_and_posix_commands/query.rego
@@ -1,37 +1,33 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
-    
-  resource.Cmd == "run"
-  containsCommand(resource) == true
-    
+
+	resource.Cmd == "run"
+	containsCommand(resource) == true
+
 	result := {
-    			    "documentId": 		  input.document[i].id,
-              "searchKey": 	      sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
-              "issueType":		    "IncorrectValue",
-              "keyExpectedValue": "There are no dangerous commands or utilities being executed",
-              "keyActualValue": 	 sprintf("Run instruction is executing the %s command", [resource.Value[0]]),
-            }
-  
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "There are no dangerous commands or utilities being executed",
+		"keyActualValue": sprintf("Run instruction is executing the %s command", [resource.Value[0]]),
+	}
 }
 
+containsCommand(cmds) {
+	commands = [
+		"shutdown",
+		"service",
+		"ps",
+		"free",
+		"top",
+		"kill",
+		"mount",
+		"ifconfig",
+		"nano",
+		"vim",
+	]
 
-containsCommand(cmds) = true {
-
-  commands = [
-    "shutdown",
-    "service",
-    "ps",
-    "free",
-    "top",
-    "kill",
-    "mount",
-    "ifconfig",
-    "nano",
-    "vim"
-  ]
-
-  contains(cmds.Value[_], commands[_])
-
+	contains(cmds.Value[_], commands[_])
 }

--- a/assets/queries/dockerfile/secrets_stored_in_dockerfile/query.rego
+++ b/assets/queries/dockerfile/secrets_stored_in_dockerfile/query.rego
@@ -1,52 +1,49 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "env" 
-  checkSecret(resource) == true
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "env"
+	checkSecret(resource) == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.ENV={{%s}}", [name, resource.Value[0]]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": sprintf("'%s %s' doesn't exist", [resource.Cmd, resource.Value[0]]),
-                "keyActualValue": 	sprintf("'%s %s' exists", [resource.Cmd, resource.Value[0]])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.ENV={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": sprintf("'%s %s' doesn't exist", [resource.Cmd, resource.Value[0]]),
+		"keyActualValue": sprintf("'%s %s' exists", [resource.Cmd, resource.Value[0]]),
+	}
 }
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "label"
-  checkSecret(resource) == true
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "label"
+	checkSecret(resource) == true
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.LABEL={{%s}}", [name, resource.Value[0]]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": sprintf("'%s %s' doesn't exist", [resource.Cmd, resource.Value[0]]),
-                "keyActualValue": 	sprintf("'%s %s' exists", [resource.Cmd, resource.Value[0]])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.LABEL={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": sprintf("'%s %s' doesn't exist", [resource.Cmd, resource.Value[0]]),
+		"keyActualValue": sprintf("'%s %s' exists", [resource.Cmd, resource.Value[0]]),
+	}
 }
 
+checkSecret(cmd) {
+	secrets = [
+		"passwd",
+		"password",
+		"pass",
+		"admin_password",
+		"secret",
+		"key",
+		"access",
+		"api_secret",
+		"api_key",
+		"apikey",
+		"token",
+		"tkn",
+	]
 
-checkSecret(cmd) = true {
-
- secrets = [
-    "passwd",
-    "password",
-    "pass",
-    "admin_password",
-    "secret",
-    "key",
-    "access",
-    "api_secret",
-    "api_key",
-    "apikey",
-    "token",
-    "tkn"
-    ]
-    
-  value := cmd.Value[_]
-  contains(lower(value), secrets[_])
-
+	value := cmd.Value[_]
+	contains(lower(value), secrets[_])
 }

--- a/assets/queries/dockerfile/shell_pipe_without_pipefail_flag/query.rego
+++ b/assets/queries/dockerfile/shell_pipe_without_pipefail_flag/query.rego
@@ -1,114 +1,129 @@
 package Cx
 
-CxPolicy [ result ] {
-  commands := input.document[i].command[name]
-  runCmd := commands[j]
-  isRunCmd(runCmd) 
-  
-  value := runCmd.Value
-  count(value) == 1 #command is in a single string
+CxPolicy[result] {
+	commands := input.document[i].command[name]
+	runCmd := commands[j]
+	isRunCmd(runCmd)
 
-  cmd := value[0]
+	value := runCmd.Value
+	count(value) == 1 #command is in a single string
 
-  shells := ["zsh","bash","ash", "/bin/zsh", "/bin/bash", "/bin/ash"]
+	cmd := value[0]
 
-  searchIndex := indexof(cmd,shells[shell])
+	shells := ["zsh", "bash", "ash", "/bin/zsh", "/bin/bash", "/bin/ash"]
 
-  searchIndex != -1
+	searchIndex := indexof(cmd, shells[shell])
 
-  hasPipe(substring(cmd,searchIndex,count(cmd)-searchIndex))
+	searchIndex != -1
 
-  not hasPipefail(commands,shells[shell],j)
+	hasPipe(substring(cmd, searchIndex, count(cmd) - searchIndex))
 
-
-	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name,runCmd.Original]),
-                "issueType":		"MissingAttribute", 
-                "keyExpectedValue": sprintf("'%s' has pipefail option set for pipe command with shell %s.", [runCmd.Original, shells[shell]]),
-                "keyActualValue": 	sprintf("'%s' does not have pipefail option set for pipe command with shell %s.", [runCmd.Original,shells[shell]])
-              }
-}
-
-CxPolicy [ result ] {
-  commands := input.document[i].command[name]
-  runCmd := commands[j]
-  isRunCmd(runCmd) 
-  
-  value := runCmd.Value
-  count(value) > 1 #command is in several tokens
-  
-  shellIdx := getShellIdx(value)
-  shellIdx != -1
-  hasPipeInArray(value,shellIdx)
-
-  not hasPipefail(commands,value[shellIdx],j)
-
-  cmdFormatted := replace(runCmd.Original,"\"","'")
+	not hasPipefail(commands, shells[shell], j)
 
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [name,runCmd.Original]),
-                "issueType":		"MissingAttribute", 
-                "keyExpectedValue": sprintf("'%s' has pipefail option set for pipe command with shell %s.", [cmdFormatted, value[shellIdx]]),
-                "keyActualValue": 	sprintf("'%s' does not have pipefail option set for pipe command with shell %s.", [cmdFormatted,value[shellIdx]])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'%s' has pipefail option set for pipe command with shell %s.", [runCmd.Original, shells[shell]]),
+		"keyActualValue": sprintf("'%s' does not have pipefail option set for pipe command with shell %s.", [runCmd.Original, shells[shell]]),
+	}
 }
 
-isRunCmd(com) = true{
-  com.Cmd == "run"
-} else = false
+CxPolicy[result] {
+	commands := input.document[i].command[name]
+	runCmd := commands[j]
+	isRunCmd(runCmd)
+
+	value := runCmd.Value
+	count(value) > 1 #command is in several tokens
+
+	shellIdx := getShellIdx(value)
+	shellIdx != -1
+	hasPipeInArray(value, shellIdx)
+
+	not hasPipefail(commands, value[shellIdx], j)
+
+	cmdFormatted := replace(runCmd.Original, "\"", "'")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, runCmd.Original]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'%s' has pipefail option set for pipe command with shell %s.", [cmdFormatted, value[shellIdx]]),
+		"keyActualValue": sprintf("'%s' does not have pipefail option set for pipe command with shell %s.", [cmdFormatted, value[shellIdx]]),
+	}
+}
+
+isRunCmd(com) {
+	com.Cmd == "run"
+} else = false {
+	true
+}
 
 hasPipe(cmd) {
-  splitStr := split(cmd," ")
-  some i
-    splitStr[i] == "|"
-    not findTermOpBeforeIdx(splitStr,i)
-} else = false
+	splitStr := split(cmd, " ")
+	some i
+	splitStr[i] == "|"
+	not findTermOpBeforeIdx(splitStr, i)
+} else = false {
+	true
+}
 
-findTermOpBeforeIdx(tokens,maxIdx) {
-  termOps := ["&&","||","&",";"]
-  some i
-    tokens[i] == termOps[_]
-    i < maxIdx
-} else = false
+findTermOpBeforeIdx(tokens, maxIdx) {
+	termOps := ["&&", "||", "&", ";"]
+	some i
+	tokens[i] == termOps[_]
+	i < maxIdx
+} else = false {
+	true
+}
 
 getShellIdx(value) = idx {
-  shells := ["zsh","bash","ash", "/bin/zsh", "/bin/bash", "/bin/ash"]
-  some i
-    value[i] == shells[_]
-    idx := i
-} else = -1
+	shells := ["zsh", "bash", "ash", "/bin/zsh", "/bin/bash", "/bin/ash"]
+	some i
+	value[i] == shells[_]
+	idx := i
+} else = -1 {
+	true
+}
 
-hasPipeInArray(arr,initCmdIdx) {
-  some i
-    i > initCmdIdx
-    arr[i] == "|"
-    not findTermOpBetweenIdxs(arr,initCmdIdx,i)
-} else = false
+hasPipeInArray(arr, initCmdIdx) {
+	some i
+	i > initCmdIdx
+	arr[i] == "|"
+	not findTermOpBetweenIdxs(arr, initCmdIdx, i)
+} else = false {
+	true
+}
 
-findTermOpBetweenIdxs(arr,startIdx,endIdx) {
-  termOps := ["&&","||","&",";"]
-  some i
-    arr[i] == termOps[_]
-    i > startIdx
-    i < endIdx
-} else = false
+findTermOpBetweenIdxs(arr, startIdx, endIdx) {
+	termOps := ["&&", "||", "&", ";"]
+	some i
+	arr[i] == termOps[_]
+	i > startIdx
+	i < endIdx
+} else = false {
+	true
+}
 
-hasPipefail(commands,shellName,idx) {
-  some i
-    shell := commands[i]
-    shell.Cmd == "shell"
-    tokens := shell.Value
-    shellIdx := shellMatch(tokens,shellName)
-    shellIdx != -1
-    tokens[shellIdx+1] == "-o"
-    tokens[shellIdx+2] == "pipefail"
-    i < idx
-} else = false
+hasPipefail(commands, shellName, idx) {
+	some i
+	shell := commands[i]
+	shell.Cmd == "shell"
+	tokens := shell.Value
+	shellIdx := shellMatch(tokens, shellName)
+	shellIdx != -1
+	tokens[plus(shellIdx, 1)] == "-o"
+	tokens[plus(shellIdx, 2)] == "pipefail"
+	i < idx
+} else = false {
+	true
+}
 
-shellMatch(tokens,shellName) = shellIdx {
-  contains(tokens[shellIdx],shellName)
+shellMatch(tokens, shellName) = shellIdx {
+	contains(tokens[shellIdx], shellName)
 } else = shellIdx {
-  contains(shellName,tokens[shellIdx])
-} else = -1
+	contains(shellName, tokens[shellIdx])
+} else = -1 {
+	true
+}

--- a/assets/queries/dockerfile/unix_ports_out_of_range/query.rego
+++ b/assets/queries/dockerfile/unix_ports_out_of_range/query.rego
@@ -1,22 +1,22 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	command := input.document[i].command[name][_]
 	command.Cmd == "expose"
 
 	containsPortOutOfRange(command.Value)
 
 	result := {
-                "documentId":		input.document[i].id,
-                "searchKey":		sprintf("FROM={{%s}}.{{%s}}", [name, command.Original]),
-                "issueType":		"IncorrectValue", 
-                "keyExpectedValue":	"'EXPOSE' does not contain ports out of range [0, 65535]",
-                "keyActualValue":	"'EXPOSE' contains ports out of range [0, 65535]"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, command.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'EXPOSE' does not contain ports out of range [0, 65535]",
+		"keyActualValue": "'EXPOSE' contains ports out of range [0, 65535]",
+	}
 }
 
 containsPortOutOfRange(ports) {
 	some p
-    	port := to_number(split(ports[p], "/")[0])
-      port > 65535
+	port := to_number(split(ports[p], "/")[0])
+	port > 65535
 }

--- a/assets/queries/dockerfile/unpinned_package_version_in_apk_add/query.rego
+++ b/assets/queries/dockerfile/unpinned_package_version_in_apk_add/query.rego
@@ -1,20 +1,20 @@
 package Cx
 
-CxPolicy [ result ] {
-  from := input.document[i].command[j]
-  instruction := from[k]
+CxPolicy[result] {
+	from := input.document[i].command[j]
+	instruction := from[k]
 
-  instruction.Cmd == "run"
-  
-  contains(instruction.Value[0], "apk add")
-  not regex.match(`.*apk\s+add\s+(--[a-z]+\s)*(-[a-zA-z]{1}\s)*\s*[^- || --][A-Za-z0-9_-]+=(.+)`, instruction.Value[0])
-  searchKey := replace(instruction.Original, "     ", ".")
+	instruction.Cmd == "run"
 
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("%s", [searchKey]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": "RUN instruction with 'apk add <package>' should use package pinning form 'apk add <package>=<version>'",
-    "keyActualValue": sprintf("RUN instruction %s does not use package pinning form", [instruction.Value[0]])
-  } 
+	contains(instruction.Value[0], "apk add")
+	not regex.match(`.*apk\s+add\s+(--[a-z]+\s)*(-[a-zA-z]{1}\s)*\s*[^- || --][A-Za-z0-9_-]+=(.+)`, instruction.Value[0])
+	searchKey := replace(instruction.Original, "     ", ".")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s", [searchKey]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "RUN instruction with 'apk add <package>' should use package pinning form 'apk add <package>=<version>'",
+		"keyActualValue": sprintf("RUN instruction %s does not use package pinning form", [instruction.Value[0]]),
+	}
 }

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/query.rego
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/query.rego
@@ -1,21 +1,21 @@
 package Cx
 
-CxPolicy [ result ] {
-  from := input.document[i].command[j]
-  instruction := from[k]
+CxPolicy[result] {
+	from := input.document[i].command[j]
+	instruction := from[k]
 
-  instruction.Cmd == "run"
+	instruction.Cmd == "run"
 
-  contains(instruction.Value[0], "pip install")
-  not contains(instruction.Value[0], " -r ")
-  not regex.match(`pip\s+install\s+(--[a-z]+\s+)*(-[a-zA-z]{1}\s+)*\s*[^- || --][A-Za-z0-9_-]+=(.+)`, instruction.Value[0])
-  searchKey := replace(instruction.Original, "     ", ".")
+	contains(instruction.Value[0], "pip install")
+	not contains(instruction.Value[0], " -r ")
+	not regex.match(`pip\s+install\s+(--[a-z]+\s+)*(-[a-zA-z]{1}\s+)*\s*[^- || --][A-Za-z0-9_-]+=(.+)`, instruction.Value[0])
+	searchKey := replace(instruction.Original, "     ", ".")
 
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("%s", [searchKey]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": "RUN instruction with 'pip install <package>' should use package pinning form 'pip install <package>=<version>'",
-    "keyActualValue": sprintf("RUN instruction %s does not use package pinning form", [instruction.Value[0]])
-  }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s", [searchKey]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "RUN instruction with 'pip install <package>' should use package pinning form 'pip install <package>=<version>'",
+		"keyActualValue": sprintf("RUN instruction %s does not use package pinning form", [instruction.Value[0]]),
+	}
 }

--- a/assets/queries/dockerfile/update_instruction_alone/query.rego
+++ b/assets/queries/dockerfile/update_instruction_alone/query.rego
@@ -1,37 +1,36 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	resource := input.document[i].command[name][_]
- 	resource.Cmd == "run"
- 	command := resource.Value[0]
+	resource.Cmd == "run"
+	command := resource.Value[0]
 
-  contains(command, "update")
-  not updateFollowedByInstall(command)
+	contains(command, "update")
+	not updateFollowedByInstall(command)
 
 	result := {
-    			      "documentId": 		input.document[i].id,
-              	"searchKey": 	    sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
-              	"issueType":		 "IncorrectValue",
-              	"keyExpectedValue": "Instruction 'RUN <package-manager> update' is followed by 'RUN <package-manager> install' ",
-              	"keyActualValue": 	 "Instruction 'RUN <package-manager> update' isn't followed by 'RUN <package-manager> install in the same 'RUN' statement",
-            }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Instruction 'RUN <package-manager> update' is followed by 'RUN <package-manager> install' ",
+		"keyActualValue": "Instruction 'RUN <package-manager> update' isn't followed by 'RUN <package-manager> install in the same 'RUN' statement",
+	}
 }
 
 updateFollowedByInstall(command) {
+	commandList = [
+		"install",
+		"source-install",
+		"reinstall",
+		"groupinstall",
+		"localinstall",
+	]
 
-  commandList = [
-    			    "install",
-				      "source-install",
-				      "reinstall",
-				      "groupinstall",
-				      "localinstall",
-              ]
+	update := indexof(command, "update")
+	update != -1
 
-  update := indexof(command, "update")
-  update != -1
+	install := indexof(command, commandList[_])
+	install != -1
 
-  install := indexof(command, commandList[_])
-  install != -1
-
-  update<install
+	update < install
 }

--- a/assets/queries/dockerfile/use_of_apk_upgrade/query.rego
+++ b/assets/queries/dockerfile/use_of_apk_upgrade/query.rego
@@ -1,16 +1,16 @@
 package Cx
 
-CxPolicy [ result ] {
-  instruction := input.document[i].command[name][j]
+CxPolicy[result] {
+	instruction := input.document[i].command[name][j]
 
-  instruction.Cmd == "run"
-  regex.match(`.*apk.*upgrade`, instruction.Value[0])
+	instruction.Cmd == "run"
+	regex.match(`.*apk.*upgrade`, instruction.Value[0])
 
-  result := {
-    "documentId": input.document[i].id,
-    "searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, instruction.Value[0]]),
-    "issueType": "IncorrectValue",
-    "keyExpectedValue": sprintf("RUN command '%s' should not have apk upgrade instruction", [instruction.Value[0]]),
-    "keyActualValue": sprintf("RUN '%s' has apk upgrade instruction", [instruction.Value[0]])
-  }
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, instruction.Value[0]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("RUN command '%s' should not have apk upgrade instruction", [instruction.Value[0]]),
+		"keyActualValue": sprintf("RUN '%s' has apk upgrade instruction", [instruction.Value[0]]),
+	}
 }

--- a/assets/queries/dockerfile/using_platform_with_from/query.rego
+++ b/assets/queries/dockerfile/using_platform_with_from/query.rego
@@ -1,15 +1,15 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  contains(resource.Flags[j], "--platform")
-  contains(resource.Cmd, "from")
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	contains(resource.Flags[j], "--platform")
+	contains(resource.Cmd, "from")
 
 	result := {
-                "documentId": 		  input.document[i].id,
-                "searchKey":        sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		    "IncorrectValue",
-                "keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} doesn't use the flag '--platform'", [name, resource.Original]),
-                "keyActualValue": 	sprintf("FROM={{%s}}.{{%s}} uses the flag '--platform'", [name, resource.Original])
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} doesn't use the flag '--platform'", [name, resource.Original]),
+		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} uses the flag '--platform'", [name, resource.Original]),
+	}
 }

--- a/assets/queries/dockerfile/workdir_path_not_absolute/query.rego
+++ b/assets/queries/dockerfile/workdir_path_not_absolute/query.rego
@@ -1,15 +1,15 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "workdir"
-  not regex.match("(^\/[A-z0-9-_+].*)|(^[A-z0-9-_+]:\\\\.*)|(^\\$[A-z0-9-_+].*)",resource.Value[0])
-  
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "workdir"
+	not regex.match("(^/[A-z0-9-_+].*)|(^[A-z0-9-_+]:\\\\.*)|(^\\$[A-z0-9-_+].*)", resource.Value[0])
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey": 	    sprintf("FROM={{%s}}.WORKDIR={{%s}}", [name, resource.Value[0]]),
-                "issueType":		"IncorrectValue",  #"MissingAttribute" / "RedundantAttribute"
-                "keyExpectedValue": "'WORKDIR' Command has absolute path",
-                "keyActualValue": 	"'WORKDIR' Command doesn't have absolute path"
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.WORKDIR={{%s}}", [name, resource.Value[0]]),
+		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"keyExpectedValue": "'WORKDIR' Command has absolute path",
+		"keyActualValue": "'WORKDIR' Command doesn't have absolute path",
+	}
 }

--- a/assets/queries/dockerfile/yum_clean_all_missing/query.rego
+++ b/assets/queries/dockerfile/yum_clean_all_missing/query.rego
@@ -1,30 +1,29 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  resource.Cmd == "run"
-  contains(resource.Value[j], "yum")
-  
-  not containsCleanAfterYum(resource.Value[j])
-  
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	resource.Cmd == "run"
+	contains(resource.Value[j], "yum")
+
+	not containsCleanAfterYum(resource.Value[j])
+
 	result := {
-                "documentId": 		input.document[i].id,
-                "searchKey":        sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} does have 'yum clean all' after 'yum install' command", [name, resource.Original]),
-                "keyActualValue": 	sprintf("FROM={{%s}}.{{%s}} doesn't have 'yum clean all' after 'yum install' command", [name, resource.Original]),
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} does have 'yum clean all' after 'yum install' command", [name, resource.Original]),
+		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} doesn't have 'yum clean all' after 'yum install' command", [name, resource.Original]),
+	}
 }
 
 containsCleanAfterYum(command) {
-
 	contains(command, "yum clean all")
 
-  install := indexof(command, "yum install")
-  install != -1
+	install := indexof(command, "yum install")
+	install != -1
 
-  clean := indexof(command, "yum clean all")
-  clean != -1
+	clean := indexof(command, "yum clean all")
+	clean != -1
 
-  install < clean
+	install < clean
 }

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
@@ -1,19 +1,19 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  cmd := ["yum install","yum groupinstall", "yum localinstall"]
-  flag := ["-y", "--assumeyes"]
-  
-  some x
-  contains(resource.Value[j], cmd[x])
-  not contains(resource.Value[j], flag[x])
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	cmd := ["yum install", "yum groupinstall", "yum localinstall"]
+	flag := ["-y", "--assumeyes"]
+
+	some x
+	contains(resource.Value[j], cmd[x])
+	not contains(resource.Value[j], flag[x])
 
 	result := {
-                "documentId": 		  input.document[i].id,
-                "searchKey":        sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		    "IncorrectValue",
-                "keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} avoids manual input", [name, resource.Original]),
-                "keyActualValue": 	sprintf("FROM={{%s}}.{{%s}} doesn't avoid manual input", [name, resource.Original]),
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} avoids manual input", [name, resource.Original]),
+		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} doesn't avoid manual input", [name, resource.Original]),
+	}
 }

--- a/assets/queries/dockerfile/yum_install_without_version/query.rego
+++ b/assets/queries/dockerfile/yum_install_without_version/query.rego
@@ -1,30 +1,29 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-  commands = document.command
-  some img
+	commands = document.command
+	some img
 	some c
-  commands[img][c].Cmd == "run"
-  some j
+	commands[img][c].Cmd == "run"
+	some j
 
-  isYumInstall(commands[img][c].Value[j])
-  not isYumInstallWithVersion(commands[img][c].Value[j])
+	isYumInstall(commands[img][c].Value[j])
+	not isYumInstallWithVersion(commands[img][c].Value[j])
 
 	result := {
-                "documentId": 		document.id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "The package version should always be specified when using yum install",
-                "keyActualValue": 	sprintf("No version is specified in '%s'", [commands[img][c].Original])
-              }
+		"documentId": document.id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The package version should always be specified when using yum install",
+		"keyActualValue": sprintf("No version is specified in '%s'", [commands[img][c].Original]),
+	}
 }
 
-isYumInstall(command){
-  contains(command, "yum install")
+isYumInstall(command) {
+	contains(command, "yum install")
 }
 
-isYumInstallWithVersion(command){
-  regex.match("yum install (--?[a-z]+ )*\\w+-([0-9]+\\.)+[0-9]+", command)
+isYumInstallWithVersion(command) {
+	regex.match("yum install (--?[a-z]+ )*\\w+-([0-9]+\\.)+[0-9]+", command)
 }
-

--- a/assets/queries/dockerfile/yum_update_disabled/query.rego
+++ b/assets/queries/dockerfile/yum_update_disabled/query.rego
@@ -1,16 +1,16 @@
 package Cx
 
-CxPolicy [ result ] {
-  resource := input.document[i].command[name][_]
-  cmd := ["yum update", "yum update-to", "yum upgrade", "yum upgrade-to"]
-  some x
-  contains(resource.Value[j], cmd[x])
-  
+CxPolicy[result] {
+	resource := input.document[i].command[name][_]
+	cmd := ["yum update", "yum update-to", "yum upgrade", "yum upgrade-to"]
+	some x
+	contains(resource.Value[j], cmd[x])
+
 	result := {
-                "documentId": 		  input.document[i].id,
-                "searchKey":        sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
-                "issueType":		    "IncorrectValue",
-                "keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} doesn't enables yum update", [name, resource.Original]),
-                "keyActualValue": 	sprintf("FROM={{%s}}.{{%s}} does enable yum update", [name, resource.Original]),
-              }
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} doesn't enables yum update", [name, resource.Original]),
+		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} does enable yum update", [name, resource.Original]),
+	}
 }

--- a/assets/queries/dockerfile/zypper_install_without_version/query.rego
+++ b/assets/queries/dockerfile/zypper_install_without_version/query.rego
@@ -1,34 +1,33 @@
 package Cx
 
-CxPolicy [ result ] {
+CxPolicy[result] {
 	document := input.document[i]
-  commands = document.command
-  some img
+	commands = document.command
+	some img
 	some c
-  commands[img][c].Cmd == "run"
-  some j
+	commands[img][c].Cmd == "run"
+	some j
 
-  isZypperInstall(commands[img][c].Value[j])
-  not isZypperInstallWithVersion(commands[img][c].Value[j])
+	isZypperInstall(commands[img][c].Value[j])
+	not isZypperInstallWithVersion(commands[img][c].Value[j])
 
 	result := {
-                "documentId": 		document.id,
-                "searchKey": 	    sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
-                "issueType":		"IncorrectValue",
-                "keyExpectedValue": "The package version should always be specified when using zypper install",
-                "keyActualValue": 	sprintf("No version is specified in '%s'", [commands[img][c].Value[j]])
-              }
+		"documentId": document.id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [img, commands[img][c].Original]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The package version should always be specified when using zypper install",
+		"keyActualValue": sprintf("No version is specified in '%s'", [commands[img][c].Value[j]]),
+	}
 }
 
-isZypperInstall(command){
-  contains(command, "zypper install")
+isZypperInstall(command) {
+	contains(command, "zypper install")
 }
 
-isZypperInstall(command){
-  contains(command, "zypper in")
+isZypperInstall(command) {
+	contains(command, "zypper in")
 }
 
-isZypperInstallWithVersion(command){
-  regex.match("zypper in(stall)? (-[a-z]+ )*\\w+(>|<|=|>=|<=)([0-9]+\\.)+[0-9]+", command)
+isZypperInstallWithVersion(command) {
+	regex.match("zypper in(stall)? (-[a-z]+ )*\\w+(>|<|=|>=|<=)([0-9]+\\.)+[0-9]+", command)
 }
-


### PR DESCRIPTION
Signed-off-by: Rogério Peixoto <rogerio.peixoto@checkmarx.com>

Closes #1816

### Platform
*Docker*

### Description
*Run `opa fmt --write` for all dockerfile rego query files*

```
#!/usr/bin/env bash
shopt -s extglob
COUNT=0
for rego in echo ./assets/queries/dockerfile/**/*.rego; do
  echo $rego
  opa fmt -w $rego
  COUNT=$(( COUNT + 1 ))
done
echo "Formatted $COUNT queries"
```
