### PR TITLE
Empty vulnerability results when KICS fails to compute similarity ID

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -112,6 +112,11 @@ jobs:
       uses: sergeysova/jq-action@v2
       with:
         cmd: jq '.queries_total' ${PWD}/assets/queries/results.json | xargs -i{} test {} -gt 0
+    - name: Assert total_results > 0 in results.json
+      id: assert_total_results
+      uses: sergeysova/jq-action@v2
+      with:
+        cmd: jq '.total_results' ${PWD}/assets/queries/results.json | xargs -i{} test {} -gt 0
     - name: Assert files_scanned > 0 in results.json
       id: assert_files_scanned
       uses: sergeysova/jq-action@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -112,11 +112,11 @@ jobs:
       uses: sergeysova/jq-action@v2
       with:
         cmd: jq '.queries_total' ${PWD}/assets/queries/results.json | xargs -i{} test {} -gt 0
-    - name: Assert total_results > 0 in results.json
-      id: assert_total_results
+    - name: Assert total_counter > 0 in results.json
+      id: assert_total_counter
       uses: sergeysova/jq-action@v2
       with:
-        cmd: jq '.total_results' ${PWD}/assets/queries/results.json | xargs -i{} test {} -gt 0
+        cmd: jq '.total_counter' ${PWD}/assets/queries/results.json | xargs -i{} test {} -gt 0
     - name: Assert files_scanned > 0 in results.json
       id: assert_files_scanned
       uses: sergeysova/jq-action@v2

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -121,6 +121,7 @@ func scan() error {
 		ScannedFiles:           t.FoundFiles,
 		ParsedFiles:            t.ParsedFiles,
 		TotalQueries:           t.LoadedQueries,
+		TotalResults:           t.TotalResults,
 		FailedToExecuteQueries: t.LoadedQueries - t.ExecutedQueries,
 		FailedSimilarityID:     t.FailedSimilarityID,
 	}

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -121,7 +121,6 @@ func scan() error {
 		ScannedFiles:           t.FoundFiles,
 		ParsedFiles:            t.ParsedFiles,
 		TotalQueries:           t.LoadedQueries,
-		TotalResults:           t.TotalResults,
 		FailedToExecuteQueries: t.LoadedQueries - t.ExecutedQueries,
 		FailedSimilarityID:     t.FailedSimilarityID,
 	}

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -122,6 +122,7 @@ func scan() error {
 		ParsedFiles:            t.ParsedFiles,
 		TotalQueries:           t.LoadedQueries,
 		FailedToExecuteQueries: t.LoadedQueries - t.ExecutedQueries,
+		FailedSimilarityID:     t.FailedSimilarityID,
 	}
 
 	summary := model.CreateSummary(counters, result, scanID)

--- a/internal/tracker/ci.go
+++ b/internal/tracker/ci.go
@@ -6,7 +6,6 @@ type CITracker struct {
 	FoundFiles         int
 	ParsedFiles        int
 	FailedSimilarityID int
-	TotalResults       int
 }
 
 func (c *CITracker) TrackQueryLoad() {
@@ -23,11 +22,6 @@ func (c *CITracker) TrackFileFound() {
 
 func (c *CITracker) TrackFileParse() {
 	c.ParsedFiles++
-}
-
-// TrackTotalResults - increment total results found
-func (c *CITracker) TrackTotalResults() {
-	c.TotalResults++
 }
 
 // FailedDetectLine - queries that fail to detect line are counted as failed to execute queries

--- a/internal/tracker/ci.go
+++ b/internal/tracker/ci.go
@@ -6,6 +6,7 @@ type CITracker struct {
 	FoundFiles         int
 	ParsedFiles        int
 	FailedSimilarityID int
+	TotalResults       int
 }
 
 func (c *CITracker) TrackQueryLoad() {
@@ -22,6 +23,11 @@ func (c *CITracker) TrackFileFound() {
 
 func (c *CITracker) TrackFileParse() {
 	c.ParsedFiles++
+}
+
+// TrackTotalResults - increment total results found
+func (c *CITracker) TrackTotalResults() {
+	c.TotalResults++
 }
 
 // FailedDetectLine - queries that fail to detect line are counted as failed to execute queries

--- a/internal/tracker/ci.go
+++ b/internal/tracker/ci.go
@@ -1,10 +1,11 @@
 package tracker
 
 type CITracker struct {
-	LoadedQueries   int
-	ExecutedQueries int
-	FoundFiles      int
-	ParsedFiles     int
+	LoadedQueries      int
+	ExecutedQueries    int
+	FoundFiles         int
+	ParsedFiles        int
+	FailedSimilarityID int
 }
 
 func (c *CITracker) TrackQueryLoad() {
@@ -26,4 +27,9 @@ func (c *CITracker) TrackFileParse() {
 // FailedDetectLine - queries that fail to detect line are counted as failed to execute queries
 func (c *CITracker) FailedDetectLine() {
 	c.ExecutedQueries--
+}
+
+// FailedComputeSimilarityID - queries that failed to compute similarity ID
+func (c *CITracker) FailedComputeSimilarityID() {
+	c.FailedSimilarityID++
 }

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -39,7 +39,6 @@ type QueriesSource interface {
 type Tracker interface {
 	TrackQueryLoad()
 	TrackQueryExecution()
-	TrackTotalResults()
 	FailedDetectLine()
 	FailedComputeSimilarityID()
 }
@@ -256,7 +255,6 @@ func (c *Inspector) decodeQueryResults(ctx QueryContext, results rego.ResultSet)
 		}
 
 		vulnerabilities = append(vulnerabilities, vulnerability)
-		c.tracker.TrackTotalResults()
 	}
 
 	if failedDetectLine {

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	// UndetectedVulnerabilityLine is the defaul line for a failed to detect line issue
+	// UndetectedVulnerabilityLine is the default line for a failed to detect line issue
 	UndetectedVulnerabilityLine = -1
 	DefaultQueryID              = "Undefined"
 	DefaultQueryName            = "Anonymous"
@@ -29,7 +29,7 @@ const (
 var ErrNoResult = errors.New("query: not result")
 var ErrInvalidResult = errors.New("query: invalid result format")
 
-type VulnerabilityBuilder func(ctx QueryContext, v interface{}) (model.Vulnerability, error)
+type VulnerabilityBuilder func(ctx QueryContext, tracker Tracker, v interface{}) (model.Vulnerability, error)
 
 type QueriesSource interface {
 	GetQueries() ([]model.QueryMetadata, error)
@@ -40,6 +40,7 @@ type Tracker interface {
 	TrackQueryLoad()
 	TrackQueryExecution()
 	FailedDetectLine()
+	FailedComputeSimilarityID()
 }
 
 type preparedQuery struct {
@@ -240,7 +241,7 @@ func (c *Inspector) decodeQueryResults(ctx QueryContext, results rego.ResultSet)
 	vulnerabilities := make([]model.Vulnerability, 0, len(queryResultItems))
 	failedDetectLine := false
 	for _, queryResultItem := range queryResultItems {
-		vulnerability, err := c.vb(ctx, queryResultItem)
+		vulnerability, err := c.vb(ctx, c.tracker, queryResultItem)
 		if err != nil {
 			sentry.CaptureException(err)
 			log.Err(err).

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -39,6 +39,7 @@ type QueriesSource interface {
 type Tracker interface {
 	TrackQueryLoad()
 	TrackQueryExecution()
+	TrackTotalResults()
 	FailedDetectLine()
 	FailedComputeSimilarityID()
 }
@@ -255,6 +256,7 @@ func (c *Inspector) decodeQueryResults(ctx QueryContext, results rego.ResultSet)
 		}
 
 		vulnerabilities = append(vulnerabilities, vulnerability)
+		c.tracker.TrackTotalResults()
 	}
 
 	if failedDetectLine {

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -25,7 +25,7 @@ const (
 	valuePartsLength = 2
 )
 
-var DefaultVulnerabilityBuilder = func(ctx QueryContext, v interface{}) (model.Vulnerability, error) {
+var DefaultVulnerabilityBuilder = func(ctx QueryContext, tracker Tracker, v interface{}) (model.Vulnerability, error) {
 	vOjb, ok := v.(map[string]interface{})
 	if !ok {
 		return model.Vulnerability{}, ErrInvalidResult
@@ -125,7 +125,8 @@ var DefaultVulnerabilityBuilder = func(ctx QueryContext, v interface{}) (model.V
 
 	similarityID, err = ComputeSimilarityID(file.FileName, queryID, searchKey, searchValue)
 	if err != nil {
-		return model.Vulnerability{}, err
+		logWithFields.Err(err).Send()
+		tracker.FailedComputeSimilarityID()
 	}
 
 	return model.Vulnerability{

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -31,6 +31,7 @@ type Counters struct {
 	FailedToScanFiles      int `json:"files_failed_to_scan"`
 	TotalQueries           int `json:"queries_total"`
 	FailedToExecuteQueries int `json:"queries_failed_to_execute"`
+	FailedSimilarityID     int `json:"queries_failed_to_compute_similarity_id"`
 }
 
 type Summary struct {

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -30,6 +30,7 @@ type Counters struct {
 	ParsedFiles            int `json:"files_parsed"`
 	FailedToScanFiles      int `json:"files_failed_to_scan"`
 	TotalQueries           int `json:"queries_total"`
+	TotalResults           int `json:"total_results"`
 	FailedToExecuteQueries int `json:"queries_failed_to_execute"`
 	FailedSimilarityID     int `json:"queries_failed_to_compute_similarity_id"`
 }

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -1,9 +1,9 @@
 package model
 
 type SeveritySummary struct {
-	ScanID           string           `json:"scanId"`
-	SeverityCounters map[Severity]int `json:"severityCounters"`
-	TotalCounter     int              `json:"totalCounter"`
+	ScanID           string           `json:"scan_id"`
+	SeverityCounters map[Severity]int `json:"severity_counters"`
+	TotalCounter     int              `json:"total_counter"`
 }
 
 type VulnerableFile struct {
@@ -30,7 +30,6 @@ type Counters struct {
 	ParsedFiles            int `json:"files_parsed"`
 	FailedToScanFiles      int `json:"files_failed_to_scan"`
 	TotalQueries           int `json:"queries_total"`
-	TotalResults           int `json:"total_results"`
 	FailedToExecuteQueries int `json:"queries_failed_to_execute"`
 	FailedSimilarityID     int `json:"queries_failed_to_compute_similarity_id"`
 }

--- a/test/queries_content_test.go
+++ b/test/queries_content_test.go
@@ -83,10 +83,12 @@ func testQueryHasGoodReturnParams(t *testing.T, entry queryEntry) {
 			return q, nil
 		})
 
+	trk := &tracker.CITracker{}
+
 	inspector, err := engine.NewInspector(
 		ctx,
 		queriesSource,
-		func(ctx engine.QueryContext, v interface{}) (model.Vulnerability, error) {
+		func(ctx engine.QueryContext, trk engine.Tracker, v interface{}) (model.Vulnerability, error) {
 			m, ok := v.(map[string]interface{})
 			require.True(t, ok)
 
@@ -101,7 +103,7 @@ func testQueryHasGoodReturnParams(t *testing.T, entry queryEntry) {
 
 			return model.Vulnerability{}, nil
 		},
-		&tracker.CITracker{},
+		trk,
 	)
 	require.Nil(t, err)
 	require.NotNil(t, inspector)


### PR DESCRIPTION
Closes #1828

**Proposed Changes**

- default vulnerability builder logs the error during the similarity ID computation attempt and moves on to create the vulnerability
- adding failed to compute similarity id counter into the scan summary
- adding integration tests assertion to verify if results are greater than zero

Results output format:
```txt
{
  "files_scanned": 156,
  "files_parsed": 152,
  "files_failed_to_scan": 0,
  "queries_total": 790,
  "queries_failed_to_execute": 3,
  "queries_failed_to_compute_similarity_id": 493,
  "queries": [
        {
        "query_name": "DB Security Group Higher than 256",
        "query_id": "ea0ed1c7-9aef-4464-b7c7-94c762da3640",
        "severity": "HIGH",
        "files": [
            {
                "file_name": "/home/rcbop/git/amazon.aws/tests/integration/targets/ec2_group/tasks/diff_mode.yml",
                "similarity_id": "",
                "line": -1,
                "issue_type": "IncorrectValue",
                "search_key": "name={{{{ ec2_group_name }}}}.rules.cidr_ip",
                "search_value": "",
                "expected_value": "'name={{{{ ec2_group_name }}}}.rules.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]",
                "actual_value": "'name={{{{ ec2_group_name }}}}.rules.cidr_ip' is [0.0.0.0/0]",
                "value": null
            }
        ]
        }
        ...
    ]
}

```
