### PR TITLE
Improve logging to record scan elapsed time

### DIFF
--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/Checkmarx/kics/internal/storage"
 	"github.com/Checkmarx/kics/internal/tracker"
@@ -45,9 +46,7 @@ func initScanCmd() {
 	}
 }
 
-func scan() error {
-	fmt.Printf("Scanning with %s\n\n", getVersion())
-
+func setupLogs() error {
 	consoleLogger := zerolog.ConsoleWriter{Out: ioutil.Discard}
 	fileLogger := zerolog.ConsoleWriter{Out: ioutil.Discard}
 
@@ -65,6 +64,17 @@ func scan() error {
 
 	mw := io.MultiWriter(consoleLogger, fileLogger)
 	log.Logger = log.Output(mw)
+	return nil
+}
+
+func scan() error {
+	fmt.Printf("Scanning with %s\n\n", getVersion())
+
+	if err := setupLogs(); err != nil {
+		return err
+	}
+
+	scanStartTime := time.Now()
 
 	querySource := &query.FilesystemSource{
 		Source: queryPath,
@@ -117,6 +127,8 @@ func scan() error {
 		return err
 	}
 
+	elapsed := time.Since(scanStartTime)
+
 	counters := model.Counters{
 		ScannedFiles:           t.FoundFiles,
 		ParsedFiles:            t.ParsedFiles,
@@ -138,6 +150,10 @@ func scan() error {
 	if err := printResult(&summary); err != nil {
 		return err
 	}
+
+	elapsedStrFormat := "Scan duration %v\n"
+	fmt.Printf(elapsedStrFormat, elapsed)
+	log.Info().Msgf(elapsedStrFormat, elapsed)
 
 	if summary.FailedToExecuteQueries > 0 {
 		os.Exit(1)

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -151,7 +151,7 @@ func scan() error {
 		return err
 	}
 
-	elapsedStrFormat := "Scan duration %v\n"
+	elapsedStrFormat := "Scan duration: %v\n"
 	fmt.Printf(elapsedStrFormat, elapsed)
 	log.Info().Msgf(elapsedStrFormat, elapsed)
 


### PR DESCRIPTION
Signed-off-by: Rogério Peixoto <rogerio.peixoto@checkmarx.com>

Closes #1805

**Proposed Changes**
- Logs and stdout now outputs the scan time duration in order to provide additional info
