### PR TITLE
Improve logging and reporting to show failed queries

### DIFF
--- a/internal/console/helpers.go
+++ b/internal/console/helpers.go
@@ -17,18 +17,16 @@ func wordWrap(s, identation string, limit int) string {
 		return s
 	}
 
-	strSlice := strings.Fields(s)
-	var result string = ""
+	wordSlice := strings.Fields(s)
+	var result string
 
-	for len(strSlice) >= 1 {
-		result = result + identation + strings.Join(strSlice[:limit], " ") + "\r\n"
+	for len(wordSlice) >= 1 {
+		result = result + identation + strings.Join(wordSlice[:limit], " ") + "\r\n"
 
-		strSlice = strSlice[limit:]
-
-		if len(strSlice) < limit {
-			limit = len(strSlice)
+		wordSlice = wordSlice[limit:]
+		if len(wordSlice) < limit {
+			limit = len(wordSlice)
 		}
-
 	}
 	return result
 }

--- a/internal/console/helpers.go
+++ b/internal/console/helpers.go
@@ -11,17 +11,39 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// wordWrap Wraps text at the specified number of words
+func wordWrap(s, identation string, limit int) string {
+	if strings.TrimSpace(s) == "" {
+		return s
+	}
+
+	strSlice := strings.Fields(s)
+	var result string = ""
+
+	for len(strSlice) >= 1 {
+		result = result + identation + strings.Join(strSlice[:limit], " ") + "\r\n"
+
+		strSlice = strSlice[limit:]
+
+		if len(strSlice) < limit {
+			limit = len(strSlice)
+		}
+
+	}
+	return result
+}
+
 func printResult(summary *model.Summary, failedQueries map[string]error) error {
 	fmt.Printf("Files scanned: %d\n", summary.ScannedFiles)
 	fmt.Printf("Parsed files: %d\n", summary.ParsedFiles)
 	fmt.Printf("Queries loaded: %d\n", summary.TotalQueries)
 
-	fmt.Printf("Queries failed to execute: %d\n\n", summary.FailedToExecuteQueries)
-	for k, v := range failedQueries {
-		fmt.Printf("%s :: %s\n", k, v)
+	fmt.Printf("Queries failed to execute: %d\n", summary.FailedToExecuteQueries)
+	for queryName, err := range failedQueries {
+		fmt.Printf("\t- %s:\n", queryName)
+		fmt.Printf("%s", wordWrap(err.Error(), "\t\t", 5))
 	}
-
-	fmt.Printf("\nQueries results\n\n")
+	fmt.Printf("------------------------------------\n")
 	for _, q := range summary.Queries {
 		fmt.Printf("%s, Severity: %s, Results: %d\n", q.QueryName, q.Severity, len(q.Files))
 

--- a/internal/console/helpers.go
+++ b/internal/console/helpers.go
@@ -11,11 +11,17 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func printResult(summary *model.Summary) error {
+func printResult(summary *model.Summary, failedQueries map[string]error) error {
 	fmt.Printf("Files scanned: %d\n", summary.ScannedFiles)
 	fmt.Printf("Parsed files: %d\n", summary.ParsedFiles)
 	fmt.Printf("Queries loaded: %d\n", summary.TotalQueries)
+
 	fmt.Printf("Queries failed to execute: %d\n\n", summary.FailedToExecuteQueries)
+	for k, v := range failedQueries {
+		fmt.Printf("%s :: %s\n", k, v)
+	}
+
+	fmt.Printf("\nQueries results\n\n")
 	for _, q := range summary.Queries {
 		fmt.Printf("%s, Severity: %s, Results: %d\n", q.QueryName, q.Severity, len(q.Files))
 

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -147,7 +147,7 @@ func scan() error {
 		return err
 	}
 
-	if err := printResult(&summary); err != nil {
+	if err := printResult(&summary, inspector.GetFailedQueries()); err != nil {
 		return err
 	}
 

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -131,14 +131,16 @@ func NewInspector(
 			})
 		}
 	}
+	failedQueries := make(map[string]error)
 
 	log.Info().
 		Msgf("Inspector initialized, number of queries=%d\n", len(opaQueries))
 
 	return &Inspector{
-		queries: opaQueries,
-		vb:      vb,
-		tracker: tracker,
+		queries:       opaQueries,
+		vb:            vb,
+		tracker:       tracker,
+		failedQueries: failedQueries,
 	}, nil
 }
 


### PR DESCRIPTION
Closes #1803 

**Proposed Changes**

- Store a failed queries map inside the inspector.
- Prints a report of failed queries in stdout in the summary at the end of a scan.

Example output:
```
Scanning with Keeping Infrastructure as Code Secure v1.1.1

Files scanned: 12
Parsed files: 12
Queries loaded: 790
Queries failed to execute: 2
	- apt_get_without_no_recommends_flag:
		failed to evaluate query: apt_get_without_no_recommends_flag:59:
		eval_conflict_error: functions must not produce
		multiple outputs for same inputs
	- apt_get_without_yes_flag:
		failed to evaluate query: apt_get_without_yes_flag:59:
		eval_conflict_error: functions must not produce
		multiple outputs for same inputs

------------------------------------
MAINTAINER Instruction Being Used, Severity: HIGH, Results: 9
	../linux-images/challenge-base/trusty/Dockerfile:2
	../linux-images/challenge-base/xenial/Dockerfile:2
	../linux-images/challenge-dbms/Dockerfile:2
	../linux-images/challenge-graphics/Dockerfile:2
	../linux-images/challenge-postgresql/Dockerfile:2
	../linux-images/challenge-ros/Dockerfile:2
	../linux-images/challenge-ubuntu/Dockerfile:2
	../linux-images/challenge-web/Dockerfile:2
	../linux-images/challenge-web-tech/Dockerfile:3
Pip install Keeping Cached Packages, Severity: MEDIUM, Results: 7
	../linux-images/challenge-arch-evm/Dockerfile:8
	../linux-images/challenge-base/bionic/Dockerfile:3
	../linux-images/challenge-base/trusty/Dockerfile:4
	../linux-images/challenge-base/xenial/Dockerfile:4
	../linux-images/challenge-dbms/Dockerfile:18
	../linux-images/challenge-ubuntu/Dockerfile:4
	../linux-images/challenge-web/Dockerfile:4
Healthcheck Instruction Missing, Severity: LOW, Results: 12
	../linux-images/challenge-arch-evm/Dockerfile:1
	../linux-images/challenge-avr/Dockerfile:1
	../linux-images/challenge-base/bionic/Dockerfile:1
	../linux-images/challenge-base/trusty/Dockerfile:1
	../linux-images/challenge-base/xenial/Dockerfile:1
	../linux-images/challenge-dbms/Dockerfile:1
	../linux-images/challenge-graphics/Dockerfile:1
	../linux-images/challenge-postgresql/Dockerfile:1
	../linux-images/challenge-ros/Dockerfile:1
	../linux-images/challenge-ubuntu/Dockerfile:1
	../linux-images/challenge-web/Dockerfile:1
	../linux-images/challenge-web-tech/Dockerfile:2
Run Using Sudo, Severity: HIGH, Results: 2
	../linux-images/challenge-base/bionic/Dockerfile:3
	../linux-images/challenge-base/xenial/Dockerfile:4
Run Utilities And POSIX Commands, Severity: INFO, Results: 9
	../linux-images/challenge-base/bionic/Dockerfile:3
	../linux-images/challenge-base/trusty/Dockerfile:4
	../linux-images/challenge-base/trusty/Dockerfile:13
	../linux-images/challenge-base/xenial/Dockerfile:4
	../linux-images/challenge-dbms/Dockerfile:1
	../linux-images/challenge-ros/Dockerfile:4
	../linux-images/challenge-ubuntu/Dockerfile:4
	../linux-images/challenge-web-tech/Dockerfile:5
	../linux-images/challenge-web-tech/Dockerfile:13
Run Using 'wget' and 'curl', Severity: MEDIUM, Results: 3
	../linux-images/challenge-base/bionic/Dockerfile:3
	../linux-images/challenge-base/xenial/Dockerfile:4
	../linux-images/challenge-web-tech/Dockerfile:5
NPM Install Command Without Pinned Version, Severity: MEDIUM, Results: 1
	../linux-images/challenge-web-tech/Dockerfile:21
Missing User Instruction, Severity: HIGH, Results: 12
	../linux-images/challenge-arch-evm/Dockerfile:1
	../linux-images/challenge-avr/Dockerfile:1
	../linux-images/challenge-base/bionic/Dockerfile:1
	../linux-images/challenge-base/trusty/Dockerfile:1
	../linux-images/challenge-base/xenial/Dockerfile:1
	../linux-images/challenge-dbms/Dockerfile:1
	../linux-images/challenge-graphics/Dockerfile:1
	../linux-images/challenge-postgresql/Dockerfile:1
	../linux-images/challenge-ros/Dockerfile:1
	../linux-images/challenge-ubuntu/Dockerfile:1
	../linux-images/challenge-web/Dockerfile:1
	../linux-images/challenge-web-tech/Dockerfile:2
Apt Get Install Lists Were Not Deleted, Severity: INFO, Results: 5
	../linux-images/challenge-dbms/Dockerfile:18
	../linux-images/challenge-graphics/Dockerfile:5
	../linux-images/challenge-web-tech/Dockerfile:5
	../linux-images/challenge-web-tech/Dockerfile:7
	../linux-images/challenge-web-tech/Dockerfile:11
Image Version Not Explicit, Severity: MEDIUM, Results: 5
	../linux-images/challenge-avr/Dockerfile:1
	../linux-images/challenge-dbms/Dockerfile:1
	../linux-images/challenge-graphics/Dockerfile:1
	../linux-images/challenge-postgresql/Dockerfile:1
	../linux-images/challenge-web/Dockerfile:1
Add Instead of Copy, Severity: LOW, Results: 5
	../linux-images/challenge-ubuntu/Dockerfile:12
	../linux-images/challenge-ubuntu/Dockerfile:13
	../linux-images/challenge-ubuntu/Dockerfile:14
	../linux-images/challenge-ubuntu/Dockerfile:16
	../linux-images/challenge-ubuntu/Dockerfile:17
Not Using JSON In CMD And ENTRYPOINT Arguments, Severity: MEDIUM, Results: 2
	../linux-images/challenge-base/trusty/Dockerfile:26
	../linux-images/challenge-ubuntu/Dockerfile:25
Apt Get Install Pin Version Not Defined, Severity: MEDIUM, Results: 5
	../linux-images/challenge-dbms/Dockerfile:18
	../linux-images/challenge-graphics/Dockerfile:5
	../linux-images/challenge-web-tech/Dockerfile:5
	../linux-images/challenge-web-tech/Dockerfile:7
	../linux-images/challenge-web-tech/Dockerfile:11
Unpinned Package Version in Pip Install, Severity: MEDIUM, Results: 1
	../linux-images/challenge-web/Dockerfile:4

Results Summary:
HIGH: 23
MEDIUM: 24
LOW: 17
INFO: 14
TOTAL: 78

Scan duration: 3.2598912s

```