### PR TITLE
Update Query Access Key Is Not Rotated Within 90 Days for CloudFormation #1856

### DIFF
--- a/assets/queries/cloudFormation/access_key_not_rotated_within_90_days/query.rego
+++ b/assets/queries/cloudFormation/access_key_not_rotated_within_90_days/query.rego
@@ -2,6 +2,7 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
+    resource.Type == "AWS::Config::ConfigRule"
 	not hasAccessKeyRotationRule(resource)
 
 	result := {
@@ -50,7 +51,6 @@ CxPolicy[result] {
 }
 
 hasAccessKeyRotationRule(configRule) {
-	configRule.Type == "AWS::Config::ConfigRule"
 	configRule.Properties.Source.SourceIdentifier == "ACCESS_KEYS_ROTATED"
 } else = false {
 	true


### PR DESCRIPTION
Closes #1856

**Proposed Changes**

- Fixed with Type Check on line 5 of the query, instead of checking inside the function.
