### PR TITLE
fix: terraform/aws kinesis firehose ss3 rule issue #1858

### DIFF
--- a/assets/queries/terraform/aws/kinesis_sse_not_configured/query.rego
+++ b/assets/queries/terraform/aws/kinesis_sse_not_configured/query.rego
@@ -4,7 +4,7 @@ CxPolicy[result] {
 	resource := input.document[i].resource.aws_kinesis_firehose_delivery_stream[name]
 
 	resource.kinesis_source_configuration
-
+    not resource.kinesis_source_configuration.kinesis_stream_arn
 	resource.server_side_encryption.enabled == true
 
 	result := {
@@ -20,6 +20,7 @@ CxPolicy[result] {
 	resource := input.document[i].resource.aws_kinesis_firehose_delivery_stream[name]
 
 	not resource.server_side_encryption
+    not resource.kinesis_source_configuration.kinesis_stream_arn
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/terraform/aws/kinesis_sse_not_configured/test/negative.tf
+++ b/assets/queries/terraform/aws/kinesis_sse_not_configured/test/negative.tf
@@ -3,13 +3,10 @@ resource "aws_kinesis_firehose_delivery_stream" "example6" {
   name        = "${aws_s3_bucket.logs.bucket}-firehose"
   destination = "extended_s3"
 
-
-
   server_side_encryption {
-
-    enabled = true
+    enabled  = true
     key_type = "CUSTOMER_MANAGED_CMK"
-    key_arn = "qwewewre"
+    key_arn  = "qwewewre"
   }
 }
 
@@ -20,11 +17,8 @@ resource "aws_kinesis_firehose_delivery_stream" "example9" {
   name        = "${aws_s3_bucket.logs.bucket}-firehose"
   destination = "extended_s3"
 
-
-
   server_side_encryption {
-
-    enabled = true
+    enabled  = true
     key_type = "AWS_OWNED_CMK"
   }
 }

--- a/assets/queries/terraform/aws/kinesis_sse_not_configured/test/positive.tf
+++ b/assets/queries/terraform/aws/kinesis_sse_not_configured/test/positive.tf
@@ -4,64 +4,43 @@ resource "aws_kinesis_firehose_delivery_stream" "example" {
 
   kinesis_source_configuration {
     kinesis_stream_arn = "${aws_kinesis_stream.cloudwatch-logs.arn}"
-    role_arn = "${aws_iam_role.firehose_role.arn}"
-  }
-
-  server_side_encryption {
-
-    enabled = true
-    key_type = "AWS_OWNED_CMK"
+    role_arn           = "${aws_iam_role.firehose_role.arn}"
   }
 }
-
-
-
 
 
 resource "aws_kinesis_firehose_delivery_stream" "example2" {
   name        = "${aws_s3_bucket.logs.bucket}-firehose"
   destination = "extended_s3"
-
 }
-
 
 
 resource "aws_kinesis_firehose_delivery_stream" "example3" {
   name        = "${aws_s3_bucket.logs.bucket}-firehose"
   destination = "extended_s3"
 
-
   server_side_encryption {
-
     enabled = false
   }
 }
-
-
 
 
 resource "aws_kinesis_firehose_delivery_stream" "example4" {
   name        = "${aws_s3_bucket.logs.bucket}-firehose"
   destination = "extended_s3"
 
-
   server_side_encryption {
-
-    enabled = true
+    enabled  = true
     key_type = "AWS_OWN"
   }
 }
-
-
 
 resource "aws_kinesis_firehose_delivery_stream" "example5" {
   name        = "${aws_s3_bucket.logs.bucket}-firehose"
   destination = "extended_s3"
 
-
   server_side_encryption {
-
-    enabled = true
+    enabled  = true
     key_type = "CUSTOMER_MANAGED_CMK"
   }
 }

--- a/assets/queries/terraform/aws/kinesis_sse_not_configured/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/kinesis_sse_not_configured/test/positive_expected_result.json
@@ -1,42 +1,22 @@
 [
-	{
-		"queryName": "Kinesis SSE Not Configured",
-		"severity": "HIGH",
-		"line": 12
-	},
-
-
-        {
-		"queryName": "Kinesis SSE Not Configured",
-		"severity": "HIGH",
-		"line": 21
-	},
-
-
-
-    {
-		"queryName": "Kinesis SSE Not Configured",
-		"severity": "HIGH",
-		"line": 36
-	},
-
-
-
-        {
-		"queryName": "Kinesis SSE Not Configured",
-		"severity": "HIGH",
-		"line": 51
-	},
-
-
-
-    {
-		"queryName": "Kinesis SSE Not Configured",
-		"severity": "HIGH",
-		"line": 62
-	}
-
-
-
+  {
+    "queryName": "Kinesis SSE Not Configured",
+    "severity": "HIGH",
+    "line": 12
+  },
+  {
+    "queryName": "Kinesis SSE Not Configured",
+    "severity": "HIGH",
+    "line": 23
+  },
+  {
+    "queryName": "Kinesis SSE Not Configured",
+    "severity": "HIGH",
+    "line": 34
+  },
+  {
+    "queryName": "Kinesis SSE Not Configured",
+    "severity": "HIGH",
+    "line": 42
+  }
 ]
-


### PR DESCRIPTION
When an encrypted Kinesis Data Stream is used as datasource to a Kinesis Firehose, then it can't and must not need to have sse enabled

cf AWS details: https://docs.aws.amazon.com/firehose/latest/dev/encryption.html

cf terraform details:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream

Closes #1858

**Proposed Changes**

- Add policy check to allow server_side_encryption optionto be unset on aws_kinesis_firehose_delivery_stream when kinesis_source_configuration exists
