### PR TITLE
Update VPC Has FlowLog Disabled query for CloudFormation #1883

### DIFF
--- a/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/test/negative.yaml
+++ b/assets/queries/cloudFormation/ec2_public_instance_exposed_through_subnet/test/negative.yaml
@@ -78,10 +78,10 @@ Resources:
       RouteTableId: !Ref myRouteTable_2
   Ec2Instance_2:
     Type: AWS::EC2::Instance
-      Properties:
-        ImageId: ami-0ff8a91507f77f867
-        KeyName: !Ref Keyname
-        NetworkInterfaces:
-          - AssociatePublicIpAddress: true
-            DeviceIndex: "0"
-            SubnetId: !Ref mySubnet_2
+    Properties:
+      ImageId: ami-0ff8a91507f77f867
+      KeyName: !Ref Keyname
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: true
+          DeviceIndex: "0"
+          SubnetId: !Ref mySubnet_2

--- a/assets/queries/cloudFormation/ecs_cluster_at_rest_encryption/test/positive.yaml
+++ b/assets/queries/cloudFormation/ecs_cluster_at_rest_encryption/test/positive.yaml
@@ -146,7 +146,7 @@ Resources:
       Subnets:
         - !Ref Subnet1
     DependsOn: GatewayAttachment
-  VPC:
+  VPC2:
     Type: AWS::EC2::VPC
     Properties:
       CidrBlock: 10.0.0.0/24


### PR DESCRIPTION
Closes #1883 

**Proposed Changes**

- Indentation was wrong, so it was not recognizing the second sample on the negative yaml
- Had two samples, should be pointing to line 80 and 149, but since when running the test it becomes only one document, since two samples has the same name, it was fixed by changing the name.
