### PR TITLE
Goreleaser is not including assets/libraries to the distribution packages

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -5,7 +5,7 @@ builds:
     binary: kics
     goos:
       - linux
-      - windows 
+      - windows
     goarch:
       - amd64
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ builds:
     binary: kics
     goos:
       - linux
-      - windows 
+      - windows
     goarch:
       - amd64
 archives:
@@ -19,5 +19,6 @@ archives:
       386: x32
     files:
       - assets/queries
+      - assets/libraries
 release:
   prerelease: auto


### PR DESCRIPTION
Closes #1886

**Proposed Changes**

- adding assets/libraries to files in `.goreleaser.yml`
