### PR TITLE
Update 'Block Workload Mounting OS Directory' query for Kubernetes

### DIFF
--- a/assets/queries/k8s/block_workload_mounting_os_dir/query.rego
+++ b/assets/queries/k8s/block_workload_mounting_os_dir/query.rego
@@ -5,7 +5,7 @@ CxPolicy[result] {
 	metadata := resource.metadata
 	resource.kind == "Pod"
 	volumes := resource.spec.volumes
-	isOSDir(volumes[_].hostPath.path)
+	isOSDir(volumes[j].hostPath.path)
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("metadata.name=%s.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),
@@ -29,7 +29,7 @@ CxPolicy[result] {
 	resource.kind != "Pod"
 	spec := resource.spec.template.spec
 	volumes := spec.volumes
-	isOSDir(volumes[_].hostPath.path)
+	isOSDir(volumes[j].hostPath.path)
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("metadata.name=%s.spec.template.spec.volumes.name=%s.hostPath.path", [metadata.name, volumes[j].name]),

--- a/assets/queries/k8s/block_workload_mounting_os_dir/test/positive_expected_result.json
+++ b/assets/queries/k8s/block_workload_mounting_os_dir/test/positive_expected_result.json
@@ -1,62 +1,57 @@
 [
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 66
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 70
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 112
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 115
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 145
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 175
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 193
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 203
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 229
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 250
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 265
-	},
-	{
-		"queryName": "Block Workload Mounting OS Directory",
-		"severity": "MEDIUM",
-		"line": 280
-	}
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 66
+  },
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 112
+  },
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 115
+  },
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 145
+  },
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 175
+  },
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 193
+  },
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 203
+  },
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 229
+  },
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 250
+  },
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 265
+  },
+  {
+    "queryName": "Block Workload Mounting OS Directory",
+    "severity": "MEDIUM",
+    "line": 280
+  }
 ]


### PR DESCRIPTION
Closes #1917

**Proposed Changes**

- replaced `[_]` with `[j]` 

