### PR TITLE
Update 'Memory Limits Are Not Defined' and 'Memory Requests Are Not Defined' queries for Kubernetes

### DIFF
--- a/assets/queries/k8s/memory_limits_not_defined/query.rego
+++ b/assets/queries/k8s/memory_limits_not_defined/query.rego
@@ -10,25 +10,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits.memory", [metadata.name, c, containers[c].name]),
+		"searchKey": sprintf("metadata.name={{%s}}.spec.containers[%d].name=%s.resources.limits.memory", [metadata.name, c, containers[c].name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits.memory is defined", [metadata.name, c, containers[c].name]),
 		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits.memory is undefined", [metadata.name, c, containers[c].name]),
-	}
-}
-
-CxPolicy[result] {
-	metadata := input.document[i].metadata
-	spec := input.document[i].spec
-	exists_containers := object.get(spec, "containers", "undefined") != "undefined"
-	not exists_containers
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name=%s.spec.containers", [metadata.name]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers is defined", [metadata.name]),
-		"keyActualValue": sprintf("metadata.name=%s.spec.containers is undefined", [metadata.name]),
 	}
 }
 
@@ -44,7 +29,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources", [metadata.name, c, containers[c].name]),
+		"searchKey": sprintf("metadata.name={{%s}}.spec.containers[%d].name=%s.resources", [metadata.name, c, containers[c].name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are defined", [metadata.name, c, containers[c].name]),
 		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are undefined", [metadata.name, c, containers[c].name]),
@@ -67,9 +52,68 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits", [metadata.name, c, containers[c].name]),
+		"searchKey": sprintf("metadata.name={{%s}}.spec.containers[%d].name=%s.resources.limits", [metadata.name, c, containers[c].name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits are defined", [metadata.name, c, containers[c].name]),
 		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.limits are undefined", [metadata.name, c, containers[c].name]),
+	}
+}
+
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	initContainers := spec.initContainers
+	limits := initContainers[c].resources.limits
+	exists_memory := object.get(limits, "memory", "undefined") != "undefined"
+	not exists_memory
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.spec.initContainers[%d].name=%s.resources.limits.memory", [metadata.name, c, initContainers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources.limits.memory is defined", [metadata.name, c, initContainers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources.limits.memory is undefined", [metadata.name, c, initContainers[c].name]),
+	}
+}
+
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	exists_containers := object.get(spec, "initContainers", "undefined") != "undefined"
+	exists_containers
+
+	initContainers := spec.initContainers
+	exists_resources := object.get(initContainers[c], "resources", "undefined") != "undefined"
+	not exists_resources
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.spec.initContainers[%d].name=%s.resources", [metadata.name, c, initContainers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources are defined", [metadata.name, c, initContainers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources are undefined", [metadata.name, c, initContainers[c].name]),
+	}
+}
+
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	exists_containers := object.get(spec, "initContainers", "undefined") != "undefined"
+	exists_containers
+
+	initContainers := spec.initContainers
+	exists_resources := object.get(initContainers[c], "resources", "undefined") != "undefined"
+	exists_resources
+
+	resources := spec.initContainers[c].resources
+	exists_limits := object.get(resources, "limits", "undefined") != "undefined"
+	not exists_limits
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.spec.initContainers[%d].name=%s.resources.limits", [metadata.name, c, initContainers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources.limits are defined", [metadata.name, c, initContainers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources.limits are undefined", [metadata.name, c, initContainers[c].name]),
 	}
 }

--- a/assets/queries/k8s/memory_limits_not_defined/test/positive.yaml
+++ b/assets/queries/k8s/memory_limits_not_defined/test/positive.yaml
@@ -52,13 +52,11 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: memory-demo-3
+  name: memory-demo-23
   namespace: mem-example
 spec:
-  securityContext:
-    runAsUser: 1000
-    runAsGroup: 3000
-    fsGroup: 2000
-  volumes:
-    - name: sec-ctx-vol
-      emptyDir: { }
+  initContainers:
+  - name: memory-demo-ctr
+    image: polinux/stress
+    command: ["stress"]
+    args: ["--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]

--- a/assets/queries/k8s/memory_limits_not_defined/test/positive_expected_result.json
+++ b/assets/queries/k8s/memory_limits_not_defined/test/positive_expected_result.json
@@ -1,22 +1,22 @@
 [
-	{
-		"queryName": "Memory Limits Are Not Defined",
-		"severity": "MEDIUM",
-		"line": 6
-	},
-	{
-		"queryName": "Memory Limits Are Not Defined",
-		"severity": "MEDIUM",
-		"line": 26
-	},
-	{
-		"queryName": "Memory Limits Are Not Defined",
-		"severity": "MEDIUM",
-		"line": 43
-	},
-	{
-		"queryName": "Memory Limits Are Not Defined",
-		"severity": "MEDIUM",
-		"line": 57
-	}
+  {
+    "queryName": "Memory Limits Are Not Defined",
+    "severity": "MEDIUM",
+    "line": 6
+  },
+  {
+    "queryName": "Memory Limits Are Not Defined",
+    "severity": "MEDIUM",
+    "line": 26
+  },
+  {
+    "queryName": "Memory Limits Are Not Defined",
+    "severity": "MEDIUM",
+    "line": 43
+  },
+  {
+    "queryName": "Memory Limits Are Not Defined",
+    "severity": "MEDIUM",
+    "line": 57
+  }
 ]

--- a/assets/queries/k8s/memory_requests_not_defined/query.rego
+++ b/assets/queries/k8s/memory_requests_not_defined/query.rego
@@ -10,25 +10,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests.memory", [metadata.name, c, containers[c].name]),
+		"searchKey": sprintf("metadata.name={{%s}}.spec.containers[%d].name=%s.resources.requests.memory", [metadata.name, c, containers[c].name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests.memory is defined", [metadata.name, c, containers[c].name]),
 		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests.memory is undefined", [metadata.name, c, containers[c].name]),
-	}
-}
-
-CxPolicy[result] {
-	metadata := input.document[i].metadata
-	spec := input.document[i].spec
-	exists_containers := object.get(spec, "containers", "undefined") != "undefined"
-	not exists_containers
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name=%s.spec", [metadata.name]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("metadata.name=%s.spec is defined", [metadata.name]),
-		"keyActualValue": sprintf("metadata.name=%s.spec is undefined", [metadata.name]),
 	}
 }
 
@@ -44,7 +29,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources", [metadata.name, c, containers[c].name]),
+		"searchKey": sprintf("metadata.name={{%s}}.spec.containers[%d].name=%s.resources", [metadata.name, c, containers[c].name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are defined", [metadata.name, c, containers[c].name]),
 		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources are undefined", [metadata.name, c, containers[c].name]),
@@ -67,9 +52,68 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests", [metadata.name, c, containers[c].name]),
+		"searchKey": sprintf("metadata.name={{%s}}.spec.containers[%d].name=%s.resources.requests", [metadata.name, c, containers[c].name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests are defined", [metadata.name, c, containers[c].name]),
 		"keyActualValue": sprintf("metadata.name=%s.spec.containers[%d].name=%s.resources.requests are undefined", [metadata.name, c, containers[c].name]),
+	}
+}
+
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	initContainers := spec.initContainers
+	requests := initContainers[c].resources.requests
+	exists_memory := object.get(requests, "memory", "undefined") != "undefined"
+	not exists_memory
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.spec.initContainers[%d].name=%s.resources.requests.memory", [metadata.name, c, initContainers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources.requests.memory is defined", [metadata.name, c, initContainers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources.requests.memory is undefined", [metadata.name, c, initContainers[c].name]),
+	}
+}
+
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	exists_containers := object.get(spec, "initContainers", "undefined") != "undefined"
+	exists_containers
+
+	initContainers := spec.initContainers
+	exists_resources := object.get(initContainers[c], "resources", "undefined") != "undefined"
+	not exists_resources
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.spec.initContainers[%d].name=%s.resources", [metadata.name, c, initContainers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources are defined", [metadata.name, c, initContainers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources are undefined", [metadata.name, c, initContainers[c].name]),
+	}
+}
+
+CxPolicy[result] {
+	metadata := input.document[i].metadata
+	spec := input.document[i].spec
+	exists_containers := object.get(spec, "initContainers", "undefined") != "undefined"
+	exists_containers
+
+	initContainers := spec.initContainers
+	exists_resources := object.get(initContainers[c], "resources", "undefined") != "undefined"
+	exists_resources
+
+	resources := spec.initContainers[c].resources
+	exists_requests := object.get(resources, "requests", "undefined") != "undefined"
+	not exists_requests
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.spec.initContainers[%d].name=%s.resources.requests", [metadata.name, c, initContainers[c].name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources.requests are defined", [metadata.name, c, initContainers[c].name]),
+		"keyActualValue": sprintf("metadata.name=%s.spec.initContainers[%d].name=%s.resources.requests are undefined", [metadata.name, c, initContainers[c].name]),
 	}
 }

--- a/assets/queries/k8s/memory_requests_not_defined/test/positive.yaml
+++ b/assets/queries/k8s/memory_requests_not_defined/test/positive.yaml
@@ -51,13 +51,11 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: memory-demo-3
+  name: memory-demo-23
   namespace: mem-example
 spec:
-  securityContext:
-    runAsUser: 1000
-    runAsGroup: 3000
-    fsGroup: 2000
-  volumes:
-    - name: sec-ctx-vol
-      emptyDir: { }
+  initContainers:
+  - name: memory-demo-ctr
+    image: polinux/stress
+    command: ["stress"]
+    args: ["--vm", "1", "--vm-bytes", "150M", "--vm-hang", "1"]

--- a/assets/queries/k8s/memory_requests_not_defined/test/positive_expected_result.json
+++ b/assets/queries/k8s/memory_requests_not_defined/test/positive_expected_result.json
@@ -1,22 +1,22 @@
 [
-	{
-		"queryName": "Memory Requests Are Not Defined",
-		"severity": "MEDIUM",
-		"line": 6
-	},
-	{
-		"queryName": "Memory Requests Are Not Defined",
-		"severity": "MEDIUM",
-		"line": 25
-	},
-	{
-		"queryName": "Memory Requests Are Not Defined",
-		"severity": "MEDIUM",
-		"line": 42
-	},
-	{
-		"queryName": "Memory Requests Are Not Defined",
-		"severity": "MEDIUM",
-		"line": 56
-	}
+  {
+    "queryName": "Memory Requests Are Not Defined",
+    "severity": "MEDIUM",
+    "line": 6
+  },
+  {
+    "queryName": "Memory Requests Are Not Defined",
+    "severity": "MEDIUM",
+    "line": 25
+  },
+  {
+    "queryName": "Memory Requests Are Not Defined",
+    "severity": "MEDIUM",
+    "line": 42
+  },
+  {
+    "queryName": "Memory Requests Are Not Defined",
+    "severity": "MEDIUM",
+    "line": 56
+  }
 ]


### PR DESCRIPTION
Closes #1928 

**Proposed Changes**

In both queries:
- Removed the rule that verifies if a container is defined, which is not always mandatory
- Added rules to verify the contents of 'initContainers'
- Added some positive examples

