### PR TITLE
add cxflow scan exclusion to _test.go files

### DIFF
--- a/cx.configuration
+++ b/cx.configuration
@@ -7,7 +7,7 @@
     "engineConfiguration": "",
     "incremental": "false",
     "forceScan" : "true",
-    "fileExcludes": "pkg/model/model_easyjson.go",
+    "fileExcludes": "pkg/model/model_easyjson.go,*_test.go",
     "folderExcludes": "test"
   }
 }


### PR DESCRIPTION
Closes #1940 

**Proposed Changes**

- Adds *_test.go to the files excluded from sast scans
