### PR TITLE
Correcting SearchKey Depth for CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/aws_lambda_function_without_tags/query.rego
+++ b/assets/queries/cloudFormation/aws_lambda_function_without_tags/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": document.id,
-		"searchKey": sprintf("Resources.%s", [name]),
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "All Lambda Functions have associated tags",
 		"keyActualValue": "A Lambda Function is missing associated tags",

--- a/assets/queries/cloudFormation/aws_lambda_function_without_tags/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/aws_lambda_function_without_tags/test/positive_expected_result.json
@@ -1,7 +1,7 @@
 [
-	{
-		"queryName": "AWS Lambda Function Without Tags",
-		"severity": "MEDIUM",
-		"line": 50
-	}
+  {
+    "queryName": "AWS Lambda Function Without Tags",
+    "severity": "MEDIUM",
+    "line": 52
+  }
 ]

--- a/assets/queries/cloudFormation/aws_lambda_functions_tracing_disabled/query.rego
+++ b/assets/queries/cloudFormation/aws_lambda_functions_tracing_disabled/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": document.id,
-		"searchKey": sprintf("Resources.%s", [name]),
+		"searchKey": sprintf("Resources.%s.Properties.TracingConfig.Mode", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "TracingConfig.Mode is set to 'Active'",
 		"keyActualValue": "TracingConfig.Mode is set to 'PassThrough'",
@@ -25,7 +25,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": document.id,
-		"searchKey": sprintf("Resources.%s", [name]),
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Property 'TracingConfig' is defined",
 		"keyActualValue": "Property 'TracingConfig' is undefined",

--- a/assets/queries/cloudFormation/aws_lambda_functions_tracing_disabled/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/aws_lambda_functions_tracing_disabled/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
-	{
-		"queryName": "AWS Lambda Functions Tracing Disabled",
-		"severity": "MEDIUM",
-		"line": 5
-	},
-	{
-		"queryName": "AWS Lambda Functions Tracing Disabled",
-		"severity": "MEDIUM",
-		"line": 40
-	}
+  {
+    "queryName": "AWS Lambda Functions Tracing Disabled",
+    "severity": "MEDIUM",
+    "line": 37
+  },
+  {
+    "queryName": "AWS Lambda Functions Tracing Disabled",
+    "severity": "MEDIUM",
+    "line": 42
+  }
 ]

--- a/assets/queries/cloudFormation/elastic_search_domain_encryption_at_rest_disabled/query.rego
+++ b/assets/queries/cloudFormation/elastic_search_domain_encryption_at_rest_disabled/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.EncryptionAtRestOptions", [name]),
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is defined", [name]),
 		"keyActualValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is undefined", [name]),
@@ -27,7 +27,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.EncryptionAtRestOptions", [name]),
+		"searchKey": sprintf("Resources.%s.Properties.EncryptionAtRestOptions.Enabled", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is enabled", [name]),
 		"keyActualValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is disabled", [name]),

--- a/assets/queries/cloudFormation/elastic_search_domain_encryption_at_rest_disabled/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/elastic_search_domain_encryption_at_rest_disabled/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
-	{
-		"queryName": "Elastic Search Domain Encryption At Rest Disabled",
-		"severity": "MEDIUM",
-		"line": 15
-	},
-	{
-		"queryName": "Elastic Search Domain Encryption At Rest Disabled",
-		"severity": "MEDIUM",
-		"line": 43
-	}
+  {
+    "queryName": "Elastic Search Domain Encryption At Rest Disabled",
+    "severity": "MEDIUM",
+    "line": 16
+  },
+  {
+    "queryName": "Elastic Search Domain Encryption At Rest Disabled",
+    "severity": "MEDIUM",
+    "line": 43
+  }
 ]

--- a/assets/queries/cloudFormation/ingress_with_port_range/query.rego
+++ b/assets/queries/cloudFormation/ingress_with_port_range/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.FromPort", [name]),
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("Resources.%s.Properties.FromPort is equal to Resources.%s.Properties.ToPort", [name, name]),
 		"keyActualValue": sprintf("Resources.%s.Properties.FromPort is not equal to Resources.%s.Properties.ToPort", [name, name]),
@@ -27,7 +27,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.SecurityGroupIngress.FromPort", [name]),
+		"searchKey": sprintf("Resources.%s.Properties.SecurityGroupIngress", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].FromPort is equal to Resources.%s.Properties.SecurityGroupIngress[%d].ToPort", [name, index, name, index]),
 		"keyActualValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].FromPort is not equal to Resources.%s.Properties.SecurityGroupIngress[%d].ToPort", [name, index, name, index]),

--- a/assets/queries/cloudFormation/ingress_with_port_range/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ingress_with_port_range/test/positive_expected_result.json
@@ -1,13 +1,12 @@
 [
-	{
-		"queryName": "AWS Security Group Ingress With Port Range",
-		"severity": "MEDIUM",
-		"line": 11
-	},
-
-	{
-		"queryName": "AWS Security Group Ingress With Port Range",
-		"severity": "MEDIUM",
-		"line": 40
-	}
+  {
+    "queryName": "AWS Security Group Ingress With Port Range",
+    "severity": "MEDIUM",
+    "line": 8
+  },
+  {
+    "queryName": "AWS Security Group Ingress With Port Range",
+    "severity": "MEDIUM",
+    "line": 37
+  }
 ]

--- a/assets/queries/cloudFormation/rds_backup_retention_period_insufficient/query.rego
+++ b/assets/queries/cloudFormation/rds_backup_retention_period_insufficient/query.rego
@@ -23,7 +23,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s", [name]),
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingValue",
 		"keyExpectedValue": sprintf("The RDS DBCluster '%s' resource doesn't define the minimum backup retention period of 7 days", [name]),
 		"keyActualValue": sprintf("The RDS DBCluster '%s' resource has the default backup retention period of 1 day which is less than the minimum of 7 days", [name]),
@@ -46,7 +46,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s", [name]),
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingValue",
 		"keyExpectedValue": sprintf("The RDS DBInstance '%s' resource doesn't define the minimum backup retention period of 7 days", [name]),
 		"keyActualValue": sprintf("The RDS DBInstance '%s' resource has the default backup retention period of 1 day which is less than the minimum of 7 days", [name]),

--- a/assets/queries/cloudFormation/rds_backup_retention_period_insufficient/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/rds_backup_retention_period_insufficient/test/positive_expected_result.json
@@ -1,22 +1,22 @@
 [
-	{
-		"queryName": "RDS Backup Retention Period Insufficient",
-		"severity": "MEDIUM",
-		"line": 53
-	},
-	{
-		"queryName": "RDS Backup Retention Period Insufficient",
-		"severity": "MEDIUM",
-		"line": 146
-	},
-	{
-		"queryName": "RDS Backup Retention Period Insufficient",
-		"severity": "MEDIUM",
-		"line": 171
-	},
-	{
-		"queryName": "RDS Backup Retention Period Insufficient",
-		"severity": "MEDIUM",
-		"line": 231
-	}
+  {
+    "queryName": "RDS Backup Retention Period Insufficient",
+    "severity": "MEDIUM",
+    "line": 53
+  },
+  {
+    "queryName": "RDS Backup Retention Period Insufficient",
+    "severity": "MEDIUM",
+    "line": 146
+  },
+  {
+    "queryName": "RDS Backup Retention Period Insufficient",
+    "severity": "MEDIUM",
+    "line": 173
+  },
+  {
+    "queryName": "RDS Backup Retention Period Insufficient",
+    "severity": "MEDIUM",
+    "line": 233
+  }
 ]

--- a/assets/queries/cloudFormation/rds_db_instance_with_deletion_protection_disabled/query.rego
+++ b/assets/queries/cloudFormation/rds_db_instance_with_deletion_protection_disabled/query.rego
@@ -26,7 +26,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.DeletionProtection", [name]),
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("Resources.%s.Properties.DeletionProtection is defined", [name]),
 		"keyActualValue": sprintf("Resources.%s.Properties.DeletionProtection is undefined", [name]),

--- a/assets/queries/cloudFormation/rds_multi_az_deployment_disabled/query.rego
+++ b/assets/queries/cloudFormation/rds_multi_az_deployment_disabled/query.rego
@@ -23,7 +23,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s", [name]),
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("The RDS DBInstance '%s' should have Multi-Availability Zone enabled", [name]),
 		"keyActualValue": sprintf("The RDS DBInstance '%s' MultiAZ property is undefined and by default disabled", [name]),

--- a/assets/queries/cloudFormation/rds_multi_az_deployment_disabled/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/rds_multi_az_deployment_disabled/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
-	{
-		"queryName": "RDS Multi-AZ Deployment Disabled",
-		"severity": "MEDIUM",
-		"line": 128
-	},
-	{
-		"queryName": "RDS Multi-AZ Deployment Disabled",
-		"severity": "MEDIUM",
-		"line": 146
-	}
+  {
+    "queryName": "RDS Multi-AZ Deployment Disabled",
+    "severity": "MEDIUM",
+    "line": 128
+  },
+  {
+    "queryName": "RDS Multi-AZ Deployment Disabled",
+    "severity": "MEDIUM",
+    "line": 148
+  }
 ]

--- a/assets/queries/cloudFormation/sns_topic_should_specify_kms_master_key_id/query.rego
+++ b/assets/queries/cloudFormation/sns_topic_should_specify_kms_master_key_id/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.KmsMasterKeyId", [name]),
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("Resources.%s.Properties.KmsMasterKeyId is defined", [name]),
 		"keyActualValue": sprintf("Resources.%s.Properties.KmsMasterKeyId is undefined", [name]),


### PR DESCRIPTION
Closes #1927

**Proposed Changes**

- In query "Elastic Search Domain Encryption At Rest Disabled", removed "EncryptionAtRestOptions" from searchKey;
- In query "RDS DBInstance With Deletion Protection Disabled", removed "DeletionProtection" from searchKey;
- In query "AWS Security Group Ingress With Port Range", removed "FromPort" from searchKeys;
- In query "Sns Topic Should Specify KmsMasterKeyId Attribute", removed "KmsMasterKeyId" from searchKey;
- In query "RDS Multi-AZ Deployment Disabled", added "Properties" to searchKey;
- In query "RDS Backup Retention Period Insufficient", added "Properties" to searchKey;
- In query "AWS Lambda Function Without Tags", added "Properties" to searchKey;
- In query "AWS Lambda Functions Tracing Disabled", added "Properties" and "Properties.TracingConfig.Mode" to searchKey;
- Complementing these changes, also corrected necessary "positive_expected_result.json" files.
