### PR TITLE
Correcting typos and mistakes in queries for AWS CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/aws_lambda_functions_with_full_privileges/query.rego
+++ b/assets/queries/cloudFormation/aws_lambda_functions_with_full_privileges/query.rego
@@ -17,8 +17,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.Policies.PolicyDocument", [role]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.Policies.PolicyDocument is not giving admin privileges to Resources.%s ", [role, name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.Policies.PolicyDocument is giving admin privileges to Resources.%s ", [role, name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.Policies.PolicyDocument does not give admin privileges to Resources.%s ", [role, name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.Policies.PolicyDocument gives admin privileges to Resources.%s ", [role, name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/ebs_volume_encryption_key_rule/query.rego
+++ b/assets/queries/cloudFormation/ebs_volume_encryption_key_rule/query.rego
@@ -11,9 +11,9 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.properties", [key]),
+		"searchKey": sprintf("Resources.%s.Properties", [key]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.properties.KmsKeyId should be defined", [key]),
-		"keyActualValue": sprintf("Resources.%s.properties.KmsKeyId is undefined", [key]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.KmsKeyId should be defined", [key]),
+		"keyActualValue": sprintf("Resources.%s.Properties.KmsKeyId is undefined", [key]),
 	}
 }

--- a/assets/queries/cloudFormation/ebs_volume_encryption_key_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ebs_volume_encryption_key_rule/test/positive_expected_result.json
@@ -1,7 +1,7 @@
 [
-	{
-		"queryName": "EBS Volume Encryption Key Rule",
-		"severity": "MEDIUM",
-		"line": 4
-	}
+  {
+    "queryName": "EBS Volume Encryption Key Rule",
+    "severity": "MEDIUM",
+    "line": 6
+  }
 ]

--- a/assets/queries/cloudFormation/elasticache_with_disabled_at_rest_encryption/query.rego
+++ b/assets/queries/cloudFormation/elasticache_with_disabled_at_rest_encryption/query.rego
@@ -9,10 +9,10 @@ CxPolicy[result] {
 	properties.AtRestEncryptionEnabled == false
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.properties.AtRestEncryptionEnabled", [key]),
+		"searchKey": sprintf("Resources.%s.Properties.AtRestEncryptionEnabled", [key]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.properties.AtRestEncryptionEnabled should be true", [key]),
-		"keyActualValue": sprintf("Resources.%s.properties.AtRestEncryptionEnabled is false", [key]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.AtRestEncryptionEnabled should be true", [key]),
+		"keyActualValue": sprintf("Resources.%s.Properties.AtRestEncryptionEnabled is false", [key]),
 	}
 }
 
@@ -26,9 +26,9 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.properties", [key]),
+		"searchKey": sprintf("Resources.%s.Properties", [key]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.properties.AtRestEncryptionEnabled should be defined", [key]),
-		"keyActualValue": sprintf("Resources.%s.properties.AtRestEncryptionEnabled is undefined", [key]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.AtRestEncryptionEnabled should be defined", [key]),
+		"keyActualValue": sprintf("Resources.%s.Properties.AtRestEncryptionEnabled is undefined", [key]),
 	}
 }

--- a/assets/queries/cloudFormation/elasticache_with_disabled_at_rest_encryption/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/elasticache_with_disabled_at_rest_encryption/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
-	{
-		"queryName": "ElastiCache with disabled at Rest Encryption",
-		"severity": "HIGH",
-		"line": 4
-	},
-	{
-		"queryName": "ElastiCache with disabled at Rest Encryption",
-		"severity": "HIGH",
-		"line": 33
-	}
+  {
+    "queryName": "ElastiCache with disabled at Rest Encryption",
+    "severity": "HIGH",
+    "line": 10
+  },
+  {
+    "queryName": "ElastiCache with disabled at Rest Encryption",
+    "severity": "HIGH",
+    "line": 37
+  }
 ]

--- a/assets/queries/cloudFormation/s3_bucket_acl_allows_read_to_all_users/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_acl_allows_read_to_all_users/query.rego
@@ -12,6 +12,6 @@ CxPolicy[result] {
 		"searchKey": sprintf("Resources.%s.Properties.AccessControl", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "S3 bucket should not have a public readable ACL",
-		"keyActualValue": sprintf("S3 bucket named '%s' has ACL set to '%s'", [object.get(resource.Properties, "BucketName", "undefined"), properties.AccessControl]),
+		"keyActualValue": sprintf("S3 bucket '%s' has ACL set to '%s'", [name, properties.AccessControl]),
 	}
 }

--- a/assets/queries/cloudFormation/sns_topic_without_subscriber/query.rego
+++ b/assets/queries/cloudFormation/sns_topic_without_subscriber/query.rego
@@ -9,9 +9,9 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.AlarmActions.Ref", [nameSNS]),
+		"searchKey": sprintf("Resources.%s.Properties", [nameSNS]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.Subscription' is setted)", [nameSNS]),
-		"keyActualValue": sprintf("'Resources.%s.Properties.Subscription' is not setted)", [nameSNS]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.Subscription' is set)", [nameSNS]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.Subscription' is not set)", [nameSNS]),
 	}
 }

--- a/assets/queries/cloudFormation/workspace_without_encryption/query.rego
+++ b/assets/queries/cloudFormation/workspace_without_encryption/query.rego
@@ -33,7 +33,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("Resources.%s.Properties", [workspaceName]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("Resources.%s.Properties should have the property UserVolumeEncryptionEnabled set to true", [workspaceName]),
-		"keyActualValue": sprintf("Resources.%s.Properties does not have de UserVolumeEncryptionEnabled property set", [workspaceName]),
+		"keyActualValue": sprintf("Resources.%s.Properties does not have the UserVolumeEncryptionEnabled property set", [workspaceName]),
 	}
 }
 


### PR DESCRIPTION
Closes #1945

**Proposed Changes**

- In query "EBS Volume Encryption Key Rule", corrected typo "properties" to "Properties" in searchKey;
- In query "Workspace Without Encryption", fixed typo in keyActualValue;
- In query "ElastiCache with disabled at Rest Encryption", corrected typo "properties" to "Properties" in searchKey;
- In query "SNS Topic Without Subscriber", removed "AlarmActions.Ref" from searchKey;
- In query "S3 Bucket ACL Allows Read to AllUsers", changed keyActualValue;
- In query "AWS Lambda Functions With Full Privileges", corrected grammatical error in keyExpectedValue and keyActualValue;
- Also changed necessary "positive_expected_result.json".
