### PR TITLE
Update redshift_not_encrypted query for Ansible #1910

### DIFF
--- a/assets/libraries/ansible/library.rego
+++ b/assets/libraries/ansible/library.rego
@@ -7,3 +7,11 @@ getTasks(document) = result {
 	result := [body | playbook := document.playbooks[_]; body := playbook]
 	count(result) != 0
 }
+
+isAnsibleTrue(answer) {
+	lower(answer) == "yes"
+} else {
+	lower(answer) == "true"
+} else {
+	answer == true
+}

--- a/assets/queries/ansible/aws/redshift_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/redshift_not_encrypted/query.rego
@@ -16,8 +16,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, module[m]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "redshift.encrypted should be set to true",
-		"keyActualValue": "redshift.encrypted is undefined",
+		"keyExpectedValue": sprintf("%s.encrypted should be set to true", [module[m]]),
+		"keyActualValue": sprintf("%s.encrypted is undefined", [module[m]]),
 	}
 }
 
@@ -35,8 +35,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.encrypted", [task.name, module[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "redshift.encrypted should be set to true",
-		"keyActualValue": "redshift.encrypted is set to false",
+		"keyExpectedValue": sprintf("%s.encrypted should be set to true", [module[m]]),
+		"keyActualValue": sprintf("%s.encrypted is set to false", [module[m]]),
 	}
 }
 

--- a/assets/queries/ansible/aws/redshift_not_encrypted/test/negative.yaml
+++ b/assets/queries/ansible/aws/redshift_not_encrypted/test/negative.yaml
@@ -2,6 +2,7 @@
 - name: Basic cluster provisioning example
   community.aws.redshift:
     identifier: tf-redshift-cluster
+    command: create
     db_name: mydb
     username: foo
     password: Mustbe8characters
@@ -11,6 +12,7 @@
 - name: Basic cluster provisioning example2
   community.aws.redshift:
     identifier: tf-redshift-cluster
+    command: create
     db_name: mydb
     username: foo
     password: Mustbe8characters

--- a/assets/queries/ansible/aws/redshift_not_encrypted/test/positive.yaml
+++ b/assets/queries/ansible/aws/redshift_not_encrypted/test/positive.yaml
@@ -1,6 +1,7 @@
 - name: Basic cluster provisioning example
   community.aws.redshift:
     identifier: tf-redshift-cluster
+    command: create
     db_name: mydb
     username: foo
     password: Mustbe8characters
@@ -9,6 +10,7 @@
 - name: Basic cluster provisioning example2
   community.aws.redshift:
     identifier: tf-redshift-cluster
+    command: create
     db_name: mydb
     username: foo
     password: Mustbe8characters
@@ -18,6 +20,7 @@
 - name: Basic cluster provisioning example3
   community.aws.redshift:
     identifier: tf-redshift-cluster
+    command: create
     db_name: mydb
     username: foo
     password: Mustbe8characters

--- a/assets/queries/ansible/aws/redshift_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/redshift_not_encrypted/test/positive_expected_result.json
@@ -1,17 +1,17 @@
 [
-	{
-		"queryName": "Redshift Not Encrypted",
-		"severity": "HIGH",
-		"line": 2
-	},
-	{
-		"queryName": "Redshift Not Encrypted",
-		"severity": "HIGH",
-		"line": 17
-	},
-	{
-		"queryName": "Redshift Not Encrypted",
-		"severity": "HIGH",
-		"line": 26
-	}
+  {
+    "queryName": "Redshift Not Encrypted",
+    "severity": "HIGH",
+    "line": 2
+  },
+  {
+    "queryName": "Redshift Not Encrypted",
+    "severity": "HIGH",
+    "line": 19
+  },
+  {
+    "queryName": "Redshift Not Encrypted",
+    "severity": "HIGH",
+    "line": 29
+  }
 ]


### PR DESCRIPTION
Closes #1910 

**Proposed Changes**

- Check if the 'command' field is equal to 'create' when 'encrypted' field is undefined
- Check if the 'command' field is equal to 'create' or 'modify' when 'encrypted' field is defined and false
- Change issue type to 'IncorrectValue' instead of 'WrongValue'
- Check both full path and only the module's name when searching the correct task (`community.aws.redshift` or `redshift`)