### PR TITLE
Fixed terraform queries with 'MissingAttribute' missing. Closes #1929

### DIFF
--- a/assets/queries/terraform/aws/db_instance_auto_minor_version_upgrade_is_disabled/query.rego
+++ b/assets/queries/terraform/aws/db_instance_auto_minor_version_upgrade_is_disabled/query.rego
@@ -2,7 +2,8 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_db_instance[name]
-	not resource.auto_minor_version_upgrade
+	object.get(resource,"auto_minor_version_upgrade","undefined") != "undefined"
+    not resource.auto_minor_version_upgrade
 
 	result := {
 		"documentId": input.document[i].id,
@@ -12,3 +13,4 @@ CxPolicy[result] {
 		"keyActualValue": "'aws_db_instance.auto_minor_version_upgrade'  is 'false'",
 	}
 }
+

--- a/assets/queries/terraform/aws/db_instance_iam_database_authentication_enabled/query.rego
+++ b/assets/queries/terraform/aws/db_instance_iam_database_authentication_enabled/query.rego
@@ -2,6 +2,7 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_db_instance[name]
+	object.get(resource,"iam_database_authentication_enabled","undefined") != "undefined"
 	not resource.iam_database_authentication_enabled
 
 	result := {
@@ -10,5 +11,18 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'aws_db_instance.iam_database_authentication_enabled' is true",
 		"keyActualValue": "'aws_db_instance.iam_database_authentication_enabled' is false",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_db_instance[name]
+	object.get(resource,"iam_database_authentication_enabled","undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_db_instance[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'aws_db_instance.iam_database_authentication_enabled' is set",
+		"keyActualValue": "'aws_db_instance.iam_database_authentication_enabled' is undefined",
 	}
 }

--- a/assets/queries/terraform/aws/db_instance_storage_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/db_instance_storage_not_encrypted/query.rego
@@ -2,14 +2,31 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_db_instance[name]
-	not resource.storage_encrypted
-	not resource.kms_key_id
+    object.get(resource,"storage_encrypted","undefined") != "undefined"
+    not resource.storage_encrypted
+
+	object.get(resource,"kms_key_id","undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_db_instance[%s].storage_encrypted", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'aws_db_instance.storage_encrypted'  is true",
+		"keyExpectedValue": "'aws_db_instance.storage_encrypted' is true",
 		"keyActualValue": "'aws_db_instance.storage_encrypted' is false",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_db_instance[name]
+    object.get(resource,"storage_encrypted","undefined") == "undefined"
+
+	object.get(resource,"kms_key_id","undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_db_instance[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'aws_db_instance.storage_encrypted' is set",
+		"keyActualValue": "'aws_db_instance.storage_encrypted' is undefined",
 	}
 }

--- a/assets/queries/terraform/aws/ebs_volume_snapshot_encrypted/query.rego
+++ b/assets/queries/terraform/aws/ebs_volume_snapshot_encrypted/query.rego
@@ -2,6 +2,7 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_ebs_snapshot[name]
+	object.get(resource,"encrypted","undefined") != "undefined"
 	not resource.encrypted
 
 	result := {
@@ -10,5 +11,18 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'aws_ebs_snapshot.encrypted' is true",
 		"keyActualValue": "'aws_ebs_snapshot.encrypted' is false",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_ebs_snapshot[name]
+	object.get(resource,"encrypted","undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ebs_snapshot[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'aws_ebs_snapshot.encrypted' is set",
+		"keyActualValue": "'aws_ebs_snapshot.encrypted' is undefined",
 	}
 }

--- a/assets/queries/terraform/aws/efs_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/efs_not_encrypted/query.rego
@@ -2,13 +2,28 @@ package Cx
 
 CxPolicy[result] {
 	efs := input.document[i].resource.aws_efs_file_system[name]
-	not efs.encrypted
+    object.get(efs,"encrypted","undefined") != "undefined"
+
+    not efs.encrypted
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_efs_file_system[%s].encrypted", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_efs_file_system[%s].encrypted' is true", [name]),
+		"keyActualValue": sprintf("aws_efs_file_system[%s].encrypted' is false", [name]),
+	}
+}
+
+CxPolicy[result] {
+	efs := input.document[i].resource.aws_efs_file_system[name]
+    object.get(efs,"encrypted","undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_efs_file_system[%s]", [name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_efs_file_system[%s].encrypted' is true", [name]),
-		"keyActualValue": sprintf("aws_efs_file_system[%s].encrypted' is false", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_efs_file_system[%s].encrypted' is set", [name]),
+		"keyActualValue": sprintf("aws_efs_file_system[%s].encrypted' is undefined", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/efs_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/efs_not_encrypted/test/positive_expected_result.json
@@ -7,6 +7,6 @@
 	{
 		"queryName": "EFS Is Not Encrypted",
 		"severity": "HIGH",
-		"line": 9
+		"line": 11
 	}
 ]

--- a/assets/queries/terraform/aws/launch_configuration_is_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/launch_configuration_is_not_encrypted/query.rego
@@ -2,14 +2,28 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_launch_configuration[name]
-	value := object.get(resource, "ebs_block_device", "undefined") == "undefined"
+    object.get(resource.ebs_block_device, "encrypted", "undefined") != "undefined"
 	not resource.ebs_block_device.encrypted
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("aws_launch_configuration[%s].ebs_block_device", [name]),
+		"searchKey": sprintf("aws_launch_configuration[%s].ebs_block_device.encrypted", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_launch_configuration[%s].ebs_block_device.encrypted is true", [name]),
 		"keyActualValue": sprintf("aws_launch_configuration[%s].ebs_block_device.encrypted is false", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_launch_configuration[name]
+	object.get(resource, "ebs_block_device", "undefined") != "undefined"
+	object.get(resource.ebs_block_device, "encrypted", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_launch_configuration[%s].ebs_block_device", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_launch_configuration[%s].ebs_block_device.encrypted is set", [name]),
+		"keyActualValue": sprintf("aws_launch_configuration[%s].ebs_block_device.encrypted is undefined", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/launch_configuration_is_not_encrypted/test/positive.tf
+++ b/assets/queries/terraform/aws/launch_configuration_is_not_encrypted/test/positive.tf
@@ -28,14 +28,3 @@ resource "aws_launch_configuration" "as_conf2" {
     encrypted = false
   }
 }
-
-resource "aws_launch_configuration" "as_conf3" {
-  image_id      = data.aws_ami.ubuntu.id
-  instance_type = "m4.large"
-  spot_price    = "0.001"
-  user_data_base64 = "c29tZUtleQ==" # someKey
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}

--- a/assets/queries/terraform/aws/launch_configuration_is_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/launch_configuration_is_not_encrypted/test/positive_expected_result.json
@@ -7,11 +7,6 @@
 	{
 		"queryName": "Launch Configuration Is Not Encrypted",
 		"severity": "HIGH",
-		"line": 26
-	},
-	{
-		"queryName": "Launch Configuration Is Not Encrypted",
-		"severity": "HIGH",
-		"line": 32
+		"line": 28
 	}
 ]

--- a/assets/queries/terraform/aws/unprotected_sqs_queue/query.rego
+++ b/assets/queries/terraform/aws/unprotected_sqs_queue/query.rego
@@ -2,14 +2,13 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_sqs_queue[name]
-	object.get(resource, "kms_master_key_id", "not found") == "not found"
+	object.get(resource, "kms_master_key_id", "undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_sqs_queue[%s].kms_master_key_id", [name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'kms_master_key_id' exists",
-		"keyActualValue": "'kms_master_key_id' is missing",
-		"value": resource.name,
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'aws_sqs_queue.kms_master_key_id' is set",
+		"keyActualValue": "'aws_sqs_queue.kms_master_key_id' is undefined",
 	}
 }

--- a/assets/queries/terraform/aws/unprotected_sqs_queue/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/unprotected_sqs_queue/test/positive_expected_result.json
@@ -2,7 +2,6 @@
   {
     "queryName": "Unprotected SQS Queue",
     "severity": "LOW",
-    "line": 2,
-    "value": "terraform-example-queue"
+    "line": 2
   }
 ]

--- a/assets/queries/terraform/azure/key_vault_soft_delete_enabled/query.rego
+++ b/assets/queries/terraform/azure/key_vault_soft_delete_enabled/query.rego
@@ -2,13 +2,27 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].resource.azurerm_key_vault[name]
+    object.get(resource,"soft_delete_enabled","undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("azurerm_key_vault[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'azurerm_key_vault.soft_delete_enabled' is set",
+		"keyActualValue": "'azurerm_key_vault.soft_delete_enabled' is undefined",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.azurerm_key_vault[name]
+    object.get(resource,"soft_delete_enabled","undefined") != "undefined"
 	not resource.soft_delete_enabled
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("azurerm_key_vault[%s].soft_delete_enabled", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'soft_delete_enabled' is 'true'",
-		"keyActualValue": "'soft_delete_enabled' is 'false'",
+		"keyExpectedValue": "'azurerm_key_vault.soft_delete_enabled' is 'true'",
+		"keyActualValue": "'azurerm_key_vault.soft_delete_enabled' is 'false'",
 	}
 }

--- a/assets/queries/terraform/gcp/project_wide_ssh_keys_are_enabled/query.rego
+++ b/assets/queries/terraform/gcp/project_wide_ssh_keys_are_enabled/query.rego
@@ -4,6 +4,7 @@ CxPolicy[result] {
 	compute := input.document[i].resource.google_compute_instance[name]
 	metadata := compute.metadata
 	ssh_keys_enabled := object.get(metadata, "block-project-ssh-keys", "undefined")
+    ssh_keys_enabled != "undefined"
 	not isTrue(ssh_keys_enabled)
 
 	result := {
@@ -17,7 +18,7 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	compute := input.document[i].resource.google_compute_instance[name]
-	not compute.metadata
+	object.get(compute,"metadata","undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
@@ -25,6 +26,19 @@ CxPolicy[result] {
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("google_compute_instance[%s].metadata is set", [name]),
 		"keyActualValue": sprintf("google_compute_instance[%s].metadata is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	compute := input.document[i].resource.google_compute_instance[name]
+	object.get(compute.metadata,"block-project-ssh-keys","undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("google_compute_instance[%s].metadata", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("google_compute_instance[%s].metadata.block-project-ssh-keys is set", [name]),
+		"keyActualValue": sprintf("google_compute_instance[%s].metadata.block-project-ssh-keys is undefined", [name]),
 	}
 }
 


### PR DESCRIPTION
Closes #1929

**Proposed Changes**

| Query Changed | Changes |
|-----------------|--------------|
| Auto Minor Version Upgrade Is Set To False | Add verification when the attribute is missing instead of incorrect |
| IAM Database Auth Not Enabled | Add verification when the attribute is missing instead of incorrect |
| DB Instance Storage Not Encrypted |  Add verification when the attribute is missing instead of incorrect and improve attribute retrieval with *object.get()* |
| Volume Snapshot Not Encrypted | Add verification when the attribute is missing instead of incorrect |
| EFS Is Not Encrypted | Add verification when the attribute is missing instead of incorrect. Fixed *searchKey* and expected result line |
| Launch Configuration Is Not Encrypted |  Add verification when the attribute is missing instead of incorrect. Fixed *searchKey*, positive sample and expected results line |
| Unprotected SQS Queue | Refactired result to present MissingAttribute instead of IncorrectValue and fixed expected result |
| Key Vault Soft Delete is Enabled | Add verification when the attribute is missing instead of incorrect. Refactored keyExpected/Actual values |
| Project-wide SSH Keys Are Enabled In VM Instances | Add verification when the attribute is missing instead of incorrect |