### PR TITLE
Adding StringHandling and Correcting queries that don't handle strings for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 	getTraffic(entry1) == getTraffic(entry2)
 
 	# Same rule number
-	entry1.Properties.RuleNumber == entry2.Properties.RuleNumber
+	compareRuleNumber(entry1, entry2)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -37,4 +37,28 @@ getTraffic(entry) = "egress" {
 	object.get(entry.Properties, "Egress", "undefined") == true
 } else = "ingress" {
 	true
+}
+
+compareRuleNumber(entry1, entry2){
+    is_string(entry1.Properties.RuleNumber)
+    is_string(entry2.Properties.RuleNumber)
+    entry1.Properties.RuleNumber == entry2.Properties.RuleNumber
+}
+
+compareRuleNumber(entry1, entry2){
+    is_number(entry1.Properties.RuleNumber)
+    is_string(entry2.Properties.RuleNumber)
+    entry1.Properties.RuleNumber == to_number(entry2.Properties.RuleNumber)
+}
+
+compareRuleNumber(entry1, entry2){
+    is_string(entry1.Properties.RuleNumber)
+    is_number(entry2.Properties.RuleNumber)
+    to_number(entry1.Properties.RuleNumber) == entry2.Properties.RuleNumber
+}
+
+compareRuleNumber(entry1, entry2){
+    is_number(entry1.Properties.RuleNumber)
+    is_number(entry2.Properties.RuleNumber)
+    entry1.Properties.RuleNumber == entry2.Properties.RuleNumber
 }

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
@@ -40,25 +40,7 @@ getTraffic(entry) = "egress" {
 }
 
 compareRuleNumber(entry1, entry2){
-    is_string(entry1.Properties.RuleNumber)
-    is_string(entry2.Properties.RuleNumber)
-    entry1.Properties.RuleNumber == entry2.Properties.RuleNumber
-}
-
-compareRuleNumber(entry1, entry2){
-    is_number(entry1.Properties.RuleNumber)
-    is_string(entry2.Properties.RuleNumber)
-    entry1.Properties.RuleNumber == to_number(entry2.Properties.RuleNumber)
-}
-
-compareRuleNumber(entry1, entry2){
-    is_string(entry1.Properties.RuleNumber)
-    is_number(entry2.Properties.RuleNumber)
-    to_number(entry1.Properties.RuleNumber) == entry2.Properties.RuleNumber
-}
-
-compareRuleNumber(entry1, entry2){
-    is_number(entry1.Properties.RuleNumber)
-    is_number(entry2.Properties.RuleNumber)
-    entry1.Properties.RuleNumber == entry2.Properties.RuleNumber
+    ruleNumberEntry1 := to_number(entry1.Properties.RuleNumber)
+    ruleNumberEntry2 := to_number(entry2.Properties.RuleNumber)
+    ruleNumberEntry1 == ruleNumberEntry2
 }

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive.yaml
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive.yaml
@@ -27,3 +27,30 @@ Resources:
        Egress: true
        RuleAction: allow
        CidrBlock: 0.0.0.0/0
+  MyNACL2:
+    Type: AWS::EC2::NetworkAcl
+    Properties:
+       VpcId: vpc-1122334455aabbccdd
+  InboundRule2:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL2
+       RuleNumber: 112
+       Protocol: 6
+       Ingress: true
+       RuleAction: allow
+       CidrBlock: 172.16.0.0/24
+       PortRange:
+         From: 22
+         To: 22
+  OutboundRule2:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+       NetworkAclId:
+         Ref: MyNACL2
+       RuleNumber: "112"
+       Protocol: -1
+       Ingress: true
+       RuleAction: allow
+       CidrBlock: 0.0.0.0/0

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/test/positive_expected_result.json
@@ -1,12 +1,22 @@
 [
-	{
-		"queryName": "EC2 Network ACL Duplicate Rule",
-		"severity": "LOW",
-		"line": 12
-	},
-	{
-		"queryName": "EC2 Network ACL Duplicate Rule",
-		"severity": "LOW",
-		"line": 25
-	}
+  {
+    "queryName": "EC2 Network ACL Duplicate Rule",
+    "severity": "LOW",
+    "line": 12
+  },
+  {
+    "queryName": "EC2 Network ACL Duplicate Rule",
+    "severity": "LOW",
+    "line": 25
+  },
+  {
+    "queryName": "EC2 Network ACL Duplicate Rule",
+    "severity": "LOW",
+    "line": 39
+  },
+  {
+    "queryName": "EC2 Network ACL Duplicate Rule",
+    "severity": "LOW",
+    "line": 52
+  }
 ]

--- a/assets/queries/cloudFormation/ec2_network_acl_protocols/query.rego
+++ b/assets/queries/cloudFormation/ec2_network_acl_protocols/query.rego
@@ -33,3 +33,23 @@ checkValue(protocol) {
 	is_number(protocol)
 	protocol == 58
 }
+
+checkValue(protocol) {
+	is_string(protocol)
+	protocol == "6"
+}
+
+checkValue(protocol) {
+	is_string(protocol)
+	protocol == "17"
+}
+
+checkValue(protocol) {
+	is_string(protocol)
+	protocol == "1"
+}
+
+checkValue(protocol) {
+	is_string(protocol)
+	protocol == "58"
+}

--- a/assets/queries/cloudFormation/ec2_network_acl_protocols/query.rego
+++ b/assets/queries/cloudFormation/ec2_network_acl_protocols/query.rego
@@ -15,41 +15,21 @@ CxPolicy[result] {
 }
 
 checkValue(protocol) {
-	is_number(protocol)
+	to_number(protocol)
 	protocol == 6
 }
 
 checkValue(protocol) {
-	is_number(protocol)
+	to_number(protocol)
 	protocol == 17
 }
 
 checkValue(protocol) {
-	is_number(protocol)
+	to_number(protocol)
 	protocol == 1
 }
 
 checkValue(protocol) {
-	is_number(protocol)
+	to_number(protocol)
 	protocol == 58
-}
-
-checkValue(protocol) {
-	is_string(protocol)
-	protocol == "6"
-}
-
-checkValue(protocol) {
-	is_string(protocol)
-	protocol == "17"
-}
-
-checkValue(protocol) {
-	is_string(protocol)
-	protocol == "1"
-}
-
-checkValue(protocol) {
-	is_string(protocol)
-	protocol == "58"
 }

--- a/assets/queries/cloudFormation/gamelift_fleet_ec2_inbound_permissions_with_port_range/query.rego
+++ b/assets/queries/cloudFormation/gamelift_fleet_ec2_inbound_permissions_with_port_range/query.rego
@@ -6,66 +6,9 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 
-	is_string(properties.EC2InboundPermissions[index].FromPort)
-    is_string(properties.EC2InboundPermissions[index].ToPort)
-    properties.EC2InboundPermissions[index].FromPort != properties.EC2InboundPermissions[index].ToPort
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.EC2InboundPermissions", [name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
-		"keyActualValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is not equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].Resources[name]
-	resource.Type == "AWS::GameLift::Fleet"
-
-	properties := resource.Properties
-
-	is_number(properties.EC2InboundPermissions[index].FromPort)
-    is_number(properties.EC2InboundPermissions[index].ToPort)
-    properties.EC2InboundPermissions[index].FromPort != properties.EC2InboundPermissions[index].ToPort
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.EC2InboundPermissions", [name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
-		"keyActualValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is not equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].Resources[name]
-	resource.Type == "AWS::GameLift::Fleet"
-
-	properties := resource.Properties
-
-	is_string(properties.EC2InboundPermissions[index].FromPort)
-    is_number(properties.EC2InboundPermissions[index].ToPort)
-    to_number(properties.EC2InboundPermissions[index].FromPort) != properties.EC2InboundPermissions[index].ToPort
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.EC2InboundPermissions", [name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
-		"keyActualValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is not equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].Resources[name]
-	resource.Type == "AWS::GameLift::Fleet"
-
-	properties := resource.Properties
-
-	is_number(properties.EC2InboundPermissions[index].FromPort)
-    is_string(properties.EC2InboundPermissions[index].ToPort)
-    properties.EC2InboundPermissions[index].FromPort != to_number(properties.EC2InboundPermissions[index].ToPort)
+	fromPort := to_number(properties.EC2InboundPermissions[index].FromPort)
+    toPort := to_number(properties.EC2InboundPermissions[index].ToPort)
+    fromPort != toPort
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/gamelift_fleet_ec2_inbound_permissions_with_port_range/query.rego
+++ b/assets/queries/cloudFormation/gamelift_fleet_ec2_inbound_permissions_with_port_range/query.rego
@@ -6,7 +6,66 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 
-	properties.EC2InboundPermissions[index].FromPort != properties.EC2InboundPermissions[index].ToPort
+	is_string(properties.EC2InboundPermissions[index].FromPort)
+    is_string(properties.EC2InboundPermissions[index].ToPort)
+    properties.EC2InboundPermissions[index].FromPort != properties.EC2InboundPermissions[index].ToPort
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.EC2InboundPermissions", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
+		"keyActualValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is not equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::GameLift::Fleet"
+
+	properties := resource.Properties
+
+	is_number(properties.EC2InboundPermissions[index].FromPort)
+    is_number(properties.EC2InboundPermissions[index].ToPort)
+    properties.EC2InboundPermissions[index].FromPort != properties.EC2InboundPermissions[index].ToPort
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.EC2InboundPermissions", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
+		"keyActualValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is not equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::GameLift::Fleet"
+
+	properties := resource.Properties
+
+	is_string(properties.EC2InboundPermissions[index].FromPort)
+    is_number(properties.EC2InboundPermissions[index].ToPort)
+    to_number(properties.EC2InboundPermissions[index].FromPort) != properties.EC2InboundPermissions[index].ToPort
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.EC2InboundPermissions", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
+		"keyActualValue": sprintf("Resources.%s.Properties.EC2InboundPermissions[%d].FromPort is not equal to Resources.%s.Properties.EC2InboundPermissions[%d].ToPort", [name, index, name, index]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::GameLift::Fleet"
+
+	properties := resource.Properties
+
+	is_number(properties.EC2InboundPermissions[index].FromPort)
+    is_string(properties.EC2InboundPermissions[index].ToPort)
+    properties.EC2InboundPermissions[index].FromPort != to_number(properties.EC2InboundPermissions[index].ToPort)
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/gamelift_fleet_ec2_inbound_permissions_with_port_range/test/positive.yaml
+++ b/assets/queries/cloudFormation/gamelift_fleet_ec2_inbound_permissions_with_port_range/test/positive.yaml
@@ -1,18 +1,35 @@
 Resources:
-  FleetResource:
+  FleetResource1:
     Type: AWS::GameLift::Fleet
     Properties:
       BuildId: !Ref BuildResource
       CertificateConfiguration:
         CertificateType: DISABLED
-      Description: Description of my Game Fleet
+      Description: Description of my Game Fleet1
       DesiredEc2Instances: 1
       EC2InboundPermissions:
         - FromPort: '1234'
           ToPort: '134'
           IpRange: 0.0.0.0/24
           Protocol: TCP
+        - FromPort: 1356
+          ToPort: 1578
+          IpRange: 192.168.0.0/24
+          Protocol: UDP
+  FleetResource3:
+    Type: AWS::GameLift::Fleet
+    Properties:
+      BuildId: !Ref BuildResource
+      CertificateConfiguration:
+        CertificateType: DISABLED
+      Description: Description of my Game Fleet3
+      DesiredEc2Instances: 1
+      EC2InboundPermissions:
+        - FromPort: 1234
+          ToPort: '134'
+          IpRange: 0.0.0.0/24
+          Protocol: TCP
         - FromPort: '1356'
-          ToPort: '1578'
+          ToPort: 1578
           IpRange: 192.168.0.0/24
           Protocol: UDP

--- a/assets/queries/cloudFormation/gamelift_fleet_ec2_inbound_permissions_with_port_range/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/gamelift_fleet_ec2_inbound_permissions_with_port_range/test/positive_expected_result.json
@@ -1,13 +1,22 @@
 [
-	{
-		"queryName": "AWS GameLift Fleet EC2InboundPermissions With Port Range",
-		"severity": "MEDIUM",
-		"line": 10
-	},
-
-	{
-		"queryName": "AWS GameLift Fleet EC2InboundPermissions With Port Range",
-		"severity": "MEDIUM",
-		"line": 10
-	}
+  {
+    "queryName": "AWS GameLift Fleet EC2InboundPermissions With Port Range",
+    "severity": "MEDIUM",
+    "line": 10
+  },
+  {
+    "queryName": "AWS GameLift Fleet EC2InboundPermissions With Port Range",
+    "severity": "MEDIUM",
+    "line": 10
+  },
+  {
+    "queryName": "AWS GameLift Fleet EC2InboundPermissions With Port Range",
+    "severity": "MEDIUM",
+    "line": 27
+  },
+  {
+    "queryName": "AWS GameLift Fleet EC2InboundPermissions With Port Range",
+    "severity": "MEDIUM",
+    "line": 27
+  }
 ]


### PR DESCRIPTION
Closes #1985

**Proposed Changes**

- In query "EC2 Network ACL Duplicate Rule", added methods for the different formats the value can appear, namely as a string or number;
- In query "EC2 permissive network ACL protocols", added methods for when the value is in a string format and not in number format;
- In query "AWS GameLift Fleet EC2InboundPermissions With Port Range", added variations of the query for the different formats, namely string and number.
