### PR TITLE
Remodeling queries to be more specific for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/elb_v2_alb_access_log_disabled/query.rego
+++ b/assets/queries/cloudFormation/elb_v2_alb_access_log_disabled/query.rego
@@ -4,23 +4,33 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ElasticLoadBalancingV2::LoadBalancer"
 	prop := resource.Properties
-	checkLbaAttr(prop)
+	
+    object.get(prop, "LoadBalancerAttributes", "undefined") == "undefined"
+
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.LoadBalancerAttributes' has LoadBalancerAttributes defined", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.LoadBalancerAttributes' doesn't have LoadBalancerAttributes defined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::ElasticLoadBalancingV2::LoadBalancer"
+	prop := resource.Properties
+	
+    not object.get(prop, "LoadBalancerAttributes", "undefined") == "undefined"
+	contains(prop.LoadBalancerAttributes, "access_logs.s3.enabled")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.LoadBalancerAttributes", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'Resources.%s.Properties.LoadBalancerAttributes' has access_logs.s3.enabled with Value true", [name]),
 		"keyActualValue": sprintf("'Resources.%s.Properties.LoadBalancerAttributes' doesn't have access_logs.s3.enabled with Value true", [name]),
 	}
-}
-
-checkLbaAttr(prop) {
-	object.get(prop, "LoadBalancerAttributes", "undefined") == "undefined"
-}
-
-checkLbaAttr(prop) {
-	not object.get(prop, "LoadBalancerAttributes", "undefined") == "undefined"
-	contains(prop.LoadBalancerAttributes, "access_logs.s3.enabled")
 }
 
 contains(arr, elem) {

--- a/assets/queries/cloudFormation/elb_v2_alb_access_log_disabled/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/elb_v2_alb_access_log_disabled/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
-	{
-		"queryName": "ELBv2 ALB Access Log Disabled",
-		"severity": "MEDIUM",
-		"line": 22
-	},
-	{
-		"queryName": "ELBv2 ALB Access Log Disabled",
-		"severity": "MEDIUM",
-		"line": 53
-	}
+  {
+    "queryName": "ELBv2 ALB Access Log Disabled",
+    "severity": "MEDIUM",
+    "line": 22
+  },
+  {
+    "queryName": "ELBv2 ALB Access Log Disabled",
+    "severity": "MEDIUM",
+    "line": 61
+  }
 ]

--- a/assets/queries/cloudFormation/s3_bucket_without_ssl_in_write_actions/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_without_ssl_in_write_actions/query.rego
@@ -8,6 +8,26 @@ CxPolicy[result] {
 
 	bucketName := resource
 
+	not bucketHasPolicy(bucketName, resources)
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("Resources.%s", [bucketName]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("Resources.%s bucket should have a policy that enforces SSL", [bucketName]),
+		"keyActualValue": sprintf("Resources.%s bucket doesn't have a policy", [bucketName]),
+	}
+}
+
+CxPolicy[result] {
+	document := input.document[i]
+	resources := document.Resources
+	some resource
+	resources[resource].Type == "AWS::S3::Bucket"
+
+	bucketName := resource
+
+    bucketHasPolicy(bucketName, resources)
 	not bucketHasPolicyWithValidSslVerification(bucketName, resources)
 
 	result := {
@@ -17,6 +37,15 @@ CxPolicy[result] {
 		"keyExpectedValue": sprintf("Resources.%s bucket should have a policy that enforces SSL", [bucketName]),
 		"keyActualValue": sprintf("Resources.%s bucket doesn't have a policy or has a policy that doesn't enforce SSL", [bucketName]),
 	}
+}
+
+bucketHasPolicy(bucketName, resources){
+    some resource
+	resources[resource].Type == "AWS::S3::BucketPolicy"
+
+	policy = resources[resource2]
+
+	policy.Properties.Bucket == bucketName
 }
 
 bucketHasPolicyWithValidSslVerification(bucketName, resources) {


### PR DESCRIPTION
Closes #1989

**Proposed Changes**

- In query "ELBv2 ALB Access Log Disabled", divided query into 2, one with "MissingAttribute" issue type and another with "IncorrectValue". Also, updated "positive_expected_result.json".
- In query "S3 Bucket Without SSL In Write Actions", divided query into 2, one with "MissingAttribute" issue type and another with "IncorrectValue".
