### PR TITLE
Update api_gateway_without_cloudwatch_log query Closes #1999

### DIFF
--- a/assets/queries/terraform/aws/api_gateway_without_cloudwatch_log/test/positive.tf
+++ b/assets/queries/terraform/aws/api_gateway_without_cloudwatch_log/test/positive.tf
@@ -1,7 +1,7 @@
 resource "aws_api_gateway_stage" "example" {
-  depends_on = [aws_cloudwatch_log_group.example]
+  depends_on = [aws_cloudwatch_log_group.example2]
 
-  stage_name = "prod"
+  stage_name = "example"
 }
 
 resource "aws_cloudwatch_log_group" "example2" {


### PR DESCRIPTION
Closes #1999 

**Proposed Changes**

- Fixed this query not giving a positive in this folder positive.tf file, because the 'aws_api_gateway_stage' resource of the positive.tf is getting the 'aws_cloudwatch_log_group' resources from the negative.tf and positive.tf , so we needed to put a different stage_name in the 'aws_api_gateway_stage' resource in the positive.tf.
