### PR TITLE
Refactor Service With External Load Balance query #2006

### DIFF
--- a/assets/queries/k8s/service_with_external_load_balance/query.rego
+++ b/assets/queries/k8s/service_with_external_load_balance/query.rego
@@ -40,6 +40,10 @@ CxPolicy[result] {
 }
 
 checkLoadBalancer(annotation) {
+    annotation["networking.gke.io/load-balancer-type"] == "Internal"
+}
+
+checkLoadBalancer(annotation) {
     annotation["cloud.google.com/load-balancer-type"] == "Internal"
 }
 

--- a/assets/queries/k8s/service_with_external_load_balance/query.rego
+++ b/assets/queries/k8s/service_with_external_load_balance/query.rego
@@ -5,30 +5,35 @@ CxPolicy[result] {
 	service.kind == "Service"
 	metadata := service.metadata
 
-	not CheckIfDestinationPortExists(service)
+    service.spec.type == "LoadBalancer"
+    service.spec.selector.app
+
+	documents := input.document
+	pod := [pod | documents[index].spec.template.metadata.labels.app == service.spec.selector.app; pod = documents[index]]
+	count(pod) != 0
+	checkLabels(pod, service.spec.selector.app)
+	res := checkPorts(pod, service.spec.ports[k].targetPort)
+	res == true
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name=%s.spec", [metadata.name]),
+		"searchKey": sprintf("metadata.name={{%s}}.spec", [metadata.name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("metadata.name=%s is not exposing a workload", [metadata.name]),
-		"keyActualValue": sprintf("metadata.name=%s is exposing a workload", [metadata.name]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}} is not exposing a workload", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name={{%s}} is exposing a workload", [metadata.name]),
 	}
 }
 
-CheckIfDestinationPortExists(service) = result {
-	documents := input.document
-	pod := [pod | documents[index].spec.template.metadata.labels.app == service.spec.selector.app; pod = documents[index]]
-	service.spec.type == "LoadBalancer"
 
-	result := contains(pod, service.spec.selector.app)
-	contains(pod, service.spec.ports[k].targetPort)
-}
-
-contains(array, string) {
+checkLabels(array, string) = labels {
 	array[a].spec.template.metadata.labels.app == string
+    labels := 1
+} else {
+	labels := 0
 }
-
-contains(array, string) {
+checkPorts(array, string) = port {
 	array[a].spec.template.spec.containers[c].ports[p].containerPort == string
+    port := 1
+} else {
+	port := 0
 }

--- a/assets/queries/k8s/service_with_external_load_balance/test/negative.yaml
+++ b/assets/queries/k8s/service_with_external_load_balance/test/negative.yaml
@@ -42,3 +42,18 @@ spec:
   type: LoadBalancer
   selector:
     app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-service 04
+  annotations:
+    networking.gke.io/load-balancer-type: 'Internal'
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: LoadBalancer
+  selector:
+    app: nginx

--- a/assets/queries/k8s/service_with_external_load_balance/test/negative.yaml
+++ b/assets/queries/k8s/service_with_external_load_balance/test/negative.yaml
@@ -1,35 +1,44 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: my-service
+  name: sample-service 01
+  annotations:
+    cloud.google.com/load-balancer-type: 'Internal'
 spec:
-  selector:
-    app: nginx
   ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 9376
-  clusterIP: 10.0.171.239
+    - port: 80
+      targetPort: 80
+      protocol: TCP
   type: LoadBalancer
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-  labels:
-    app: nginx
-spec:
-  replicas: 3
   selector:
-    matchLabels:
-      app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.14.2
-        ports:
-        - containerPort: 9376
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-service 02
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: 'true'
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: LoadBalancer
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-service 03
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: 'true'
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: LoadBalancer
+  selector:
+    app: nginx

--- a/assets/queries/k8s/service_with_external_load_balance/test/positive.yaml
+++ b/assets/queries/k8s/service_with_external_load_balance/test/positive.yaml
@@ -1,35 +1,27 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: my-service
+  name: sample-service 04
 spec:
-  selector:
-    app: nginx
   ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 1234
-  clusterIP: 10.0.171.239
+    - port: 80
+      targetPort: 80
+      protocol: TCP
   type: LoadBalancer
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-  labels:
-    app: nginx
-spec:
-  replicas: 3
   selector:
-    matchLabels:
-      app: nginx
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.14.2
-        ports:
-        - containerPort: 9376
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-service 05
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: 'false'
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: LoadBalancer
+  selector:
+    app: nginx

--- a/assets/queries/k8s/service_with_external_load_balance/test/positive.yaml
+++ b/assets/queries/k8s/service_with_external_load_balance/test/positive.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: sample-service 04
+  name: sample-service 05
 spec:
   ports:
     - port: 80
@@ -25,3 +25,49 @@ spec:
   type: LoadBalancer
   selector:
     app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-service 06
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: 'false'
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: LoadBalancer
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-service 07
+  annotations:
+    networking.gke.io/load-balancer-type: 'External'
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: LoadBalancer
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-service 08
+  annotations:
+    cloud.google.com/load-balancer-type: 'External'
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: LoadBalancer
+  selector:
+    app: nginx
+

--- a/assets/queries/k8s/service_with_external_load_balance/test/positive_expected_result.json
+++ b/assets/queries/k8s/service_with_external_load_balance/test/positive_expected_result.json
@@ -8,5 +8,20 @@
 		"queryName": "Service With External Load Balance",
 		"severity": "MEDIUM",
 		"line": 18
+	},
+  {
+		"queryName": "Service With External Load Balance",
+		"severity": "MEDIUM",
+		"line": 33
+	},
+  {
+		"queryName": "Service With External Load Balance",
+		"severity": "MEDIUM",
+		"line": 48
+	},
+  {
+		"queryName": "Service With External Load Balance",
+		"severity": "MEDIUM",
+		"line": 63
 	}
 ]

--- a/assets/queries/k8s/service_with_external_load_balance/test/positive_expected_result.json
+++ b/assets/queries/k8s/service_with_external_load_balance/test/positive_expected_result.json
@@ -2,6 +2,11 @@
 	{
 		"queryName": "Service With External Load Balance",
 		"severity": "MEDIUM",
-		"line": 5
+		"line": 4
+	},
+  {
+		"queryName": "Service With External Load Balance",
+		"severity": "MEDIUM",
+		"line": 18
 	}
 ]


### PR DESCRIPTION
Closes #2006 

**Proposed Changes**

- Refactor Query
- The query has many false positives, this is because the query never detects if the Service using an external Load Balancer provider by cloud provider.

