### PR TITLE
enable building for mac (darwin)

### DIFF
--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -4,6 +4,7 @@ builds:
   - main: ./cmd/console/main.go
     binary: kics
     goos:
+      - darwin
       - linux
       - windows
     goarch:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ builds:
   - main: ./cmd/console/main.go
     binary: kics
     goos:
+      - darwin
       - linux
       - windows
     goarch:


### PR DESCRIPTION
Closes #1678

**Proposed Changes**

- Enabled building for darwin

Testing on macOS Catalina 10.15.7

```
✗ ./bin/kics scan -p . -o result.json
Scanning with Keeping Infrastructure as Code Secure v1.1.2
[...]
Results Summary:
HIGH: 4041
MEDIUM: 4979
LOW: 1449
INFO: 87
TOTAL: 10556

Scan duration: 1m47.145168159s
```