### PR TITLE
Fixed queries with results pointing to wrong lines. Closes #2000

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_encryption_at_rest/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_encryption_at_rest/query.rego
@@ -3,13 +3,30 @@ package Cx
 #default of block_public_policy is false
 CxPolicy[result] {
 	bucket := input.document[i].resource.aws_s3_bucket[name]
-	not bucket.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default
+    object.get(bucket,"server_side_encryption_configuration","undefined") != "undefined"
+	sse := bucket.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default
+
+    sse.sse_algorithm != "AE256"
+    object.get(sse,"kms_master_key_id","undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_s3_bucket[%s].server_side_encryption_configuration.rule.apply_server_side_encryption_by_default", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "'server_side_encryption_configuration.rule.apply_server_side_encryption_by_default' exists",
-		"keyActualValue": "'server_side_encryption_configuration.rule.apply_server_side_encryption_by_default' is missing",
+		"keyExpectedValue": "'server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.kms_master_key_id' exists",
+		"keyActualValue": "'server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.kms_master_key_id' is missing",
+	}
+}
+
+CxPolicy[result] {
+	bucket := input.document[i].resource.aws_s3_bucket[name]
+    object.get(bucket,"server_side_encryption_configuration","undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_s3_bucket[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'aws_s3_bucket.server_side_encryption_configuration' exists",
+		"keyActualValue": "'aws_s3_bucket.server_side_encryption_configuration' is missing",
 	}
 }

--- a/assets/queries/terraform/aws/s3_bucket_without_encryption_at_rest/test/negative.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_encryption_at_rest/test/negative.tf
@@ -11,7 +11,8 @@ resource "aws_s3_bucket" "b" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm = ""
+        kms_master_key_id = aws_kms_key.mykey.arn
+        sse_algorithm     = "aws:kms"
       }
     }
   }

--- a/assets/queries/terraform/aws/s3_bucket_without_encryption_at_rest/test/positive.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_encryption_at_rest/test/positive.tf
@@ -10,6 +10,9 @@ resource "aws_s3_bucket" "b" {
 
   server_side_encryption_configuration {
     rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "aws:kms"
+      }
     }
   }
 

--- a/assets/queries/terraform/aws/s3_bucket_without_encryption_at_rest/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_without_encryption_at_rest/test/positive_expected_result.json
@@ -2,6 +2,6 @@
 	{
 		"queryName": "S3 bucket without encryption at REST",
 		"severity": "HIGH",
-		"line": 12
+		"line": 13
 	}
 ]

--- a/assets/queries/terraform/aws/s3_bucket_without_versioning/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_versioning/query.rego
@@ -3,7 +3,7 @@ package Cx
 #default of mfa_delete is false
 CxPolicy[result] {
 	b := input.document[i].resource.aws_s3_bucket[name]
-	not b.versioning
+    object.get(b,"versioning","undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
@@ -23,8 +23,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_s3_bucket[%s].versioning", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "'versioning' is equal 'true'",
-		"keyActualValue": "'versioning' is missing",
+		"keyExpectedValue": "'versioning.enabled' is equal 'true'",
+		"keyActualValue": "'versioning.enabled' is missing",
 	}
 }
 

--- a/assets/queries/terraform/gcp/ssh_access_is_unrestricted/query.rego
+++ b/assets/queries/terraform/gcp/ssh_access_is_unrestricted/query.rego
@@ -6,11 +6,11 @@ CxPolicy[result] {
 	firewall.source_ranges[_] == "0.0.0.0/0" # Allow traffic from anywhere
 	allowed := getAllowed(firewall)
 
-	isSSHport(allowed[_])
+	ports := isSSHport(allowed[j])
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("google_compute_firewall[%s].allow.ports", [name]),
+		"searchKey": sprintf("google_compute_firewall[%s].allow.ports=%s", [name,ports]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'google_compute_firewall[%s].allow.ports' does not include SSH port 22", [name]),
 		"keyActualValue": sprintf("'google_compute_firewall[%s].allow.ports' includes SSH port 22", [name]),
@@ -35,19 +35,21 @@ getAllowed(firewall) = allowed {
 	allowed := [firewall.allow]
 }
 
-isSSHport(allow) {
+isSSHport(allow) = ports {
 	some j
 	contains(allow.ports[j], "-")
 	port_bounds := split(allow.ports[j], "-")
 	low_bound := to_number(port_bounds[0])
 	high_bound := to_number(port_bounds[1])
 	isInBounds(low_bound, high_bound)
+    ports := allow.ports[j]
 }
 
-isSSHport(allow) {
+isSSHport(allow) = ports {
 	some j
 	contains(allow.ports[j], "-") == false
 	to_number(allow.ports[j]) == 22
+    ports := allow.ports[j]
 }
 
 isInBounds(low, high) {


### PR DESCRIPTION
Closes #2000

**Proposed Changes**

| Queries Changed | Changes |
|---------------------|----------|
| SSH Access Is Not Restricted From The Internet | Improved searchKey to locate the correct ports attribute |
| S3 bucket without versioning | Improved keyValues and attribute existence check with object.get() |
| S3 bucket without encryption at REST | Refactored query to correctly evaluate attributes and identify the proper lines. Samples and expected results were also changed for the refactor |