### PR TITLE
Update AWS Lambda Functions with Full Privileges query for AWS CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/aws_lambda_functions_with_full_privileges/query.rego
+++ b/assets/queries/cloudFormation/aws_lambda_functions_with_full_privileges/query.rego
@@ -11,37 +11,65 @@ CxPolicy[result] {
 	role := fullRole[0]
 	resources[role]
 
-	checkPolicies(resources[role].Properties.Policies)
+	policyName := checkPolicies(resources[role].Properties.Policies)
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.Policies.PolicyDocument", [role]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.Policies.PolicyDocument does not give admin privileges to Resources.%s ", [role, name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.Policies.PolicyDocument gives admin privileges to Resources.%s ", [role, name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.Policies[%s].PolicyDocument does not give admin privileges to Resources.%s ", [role, policyName, name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.Policies[%s].PolicyDocument gives admin privileges to Resources.%s ", [role, policyName, name]),
 	}
 }
 
-checkPolicies(policies) {
+CxPolicy[result] {
+	resources := input.document[i].Resources
+	resource := resources[name]
+
+	resource.Type == "AWS::Lambda::Function"
+
+	# check if the role referenced in the lambda function properties is defined in the same template
+	fullRole := split(resource.Properties.Role, ".")
+	role := fullRole[0]
+	resources[role]
+
+	policyName := checkPoliciesActionArray(resources[role].Properties.Policies)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.Policies.PolicyDocument", [role]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.Policies[%s].PolicyDocument does not give admin privileges to Resources.%s ", [role, policyName, name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.Policies[%s].PolicyDocument gives admin privileges to Resources.%s ", [role, policyName, name]),
+	}
+}
+
+checkPolicies(policies) = policyName {
 	some j, k
 	statement := policies[j].PolicyDocument.Statement[k]
 	statement.Effect == "Allow"
 	checkResource(statement)
 	checkAction(statement)
+    policyName := policies[j].PolicyName
+}
+
+checkPoliciesActionArray(policies) = policyName {
+	some j, k
+	statement := policies[j].PolicyDocument.Statement[k]
+	statement.Effect == "Allow"
+	checkResource(statement)
+	checkActionArray(statement)
+    policyName := policies[j].PolicyName
 }
 
 checkResource(statement) {
-	statement.Resource == "*"
+	contains(statement.Resource, "*")
 }
 
-checkResource(statement) {
-	endswith(statement.Resource, "*")
-}
-
-checkAction(statement) {
-	statement.Action[_] == "*"
+checkActionArray(statement) {
+	contains(statement.Action[_], "*")
 }
 
 checkAction(statement) {
-	endswith(statement.Action[_], "*")
+	contains(statement.Action, "*")
 }


### PR DESCRIPTION
Closes #2028

**Proposed Changes**

- Updated the query to handle "Action" arrays as well as single "Action";
- Added the name of the policy that triggers error;
- Simplified methods "checkResource" and "checkAction".