### PR TITLE
fix bug with curly brackets and rename bad variables #2001

### DIFF
--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -177,13 +177,14 @@ func detectDockerLine(file *model.FileMetadata, searchKey string, logWithFields 
 	isBreak := false
 	foundAtLeastOne := false
 	currentLine := 0
-	extractedString := nameRegexDocker.FindAllStringSubmatch(searchKey, -1)
-	test := searchKey
+	var extractedString [][]string
+	extractedString = getBracketValues(searchKey, extractedString, "")
+	sKey := searchKey
 	for idx, str := range extractedString {
-		test = strings.Replace(test, str[0], `{{`+strconv.Itoa(idx)+`}}`, -1)
+		sKey = strings.Replace(sKey, str[0], `{{`+strconv.Itoa(idx)+`}}`, -1)
 	}
 
-	for _, key := range strings.Split(test, ".") {
+	for _, key := range strings.Split(sKey, ".") {
 		substr1, substr2 := generateSubstrings(key, extractedString)
 
 		foundAtLeastOne, currentLine, isBreak = detectCurrentLine(lines, substr1, substr2, currentLine, foundAtLeastOne)
@@ -208,8 +209,8 @@ func detectLine(file *model.FileMetadata, searchKey string, logWithFields *zerol
 	foundAtLeastOne := false
 	currentLine := 0
 	isBreak := false
-
-	extractedString := nameRegexDocker.FindAllStringSubmatch(searchKey, -1)
+	var extractedString [][]string
+	extractedString = getBracketValues(searchKey, extractedString, "")
 	sanitizedSubstring := searchKey
 	for idx, str := range extractedString {
 		sanitizedSubstring = strings.Replace(sanitizedSubstring, str[0], `{{`+strconv.Itoa(idx)+`}}`, -1)
@@ -349,8 +350,8 @@ func getKeyWithCurlyBrackets(key string, extractedString [][]string, parts []str
 	var substr1, substr2 string
 	extractedPart := nameRegexDocker.FindStringSubmatch(key)
 	if len(extractedPart) == valuePartsLength {
-		for idx, test := range parts {
-			if extractedPart[0] == test {
+		for idx, key := range parts {
+			if extractedPart[0] == key {
 				switch idx {
 				case (len(parts) - 2):
 					i, _ := strconv.Atoi(extractedPart[1])
@@ -419,4 +420,30 @@ func multiLineSpliter(textSplit []string, key string, idx int) string {
 		textSplit[idx] = multiLineSpliter(textSplit, textSplit[idx], idx)
 	}
 	return textSplit[idx]
+}
+
+// getKeyWithCurlyBrackets gets values inside "{{ }}" ignoring any "{{" or "}}" inside
+func getBracketValues(expr string, list [][]string, restOfString string) [][]string {
+	var tempList []string
+	firstOpen := strings.Index(expr, "{{")
+	firstClose := strings.Index(expr, "}}")
+	switchVal := firstClose - firstOpen
+	if switchVal == 0 { // if there is no "{{" and no "}}"
+		if expr != "" {
+			tempList = append(tempList, fmt.Sprintf("{{%s}}", expr), expr)
+			list = append(list, tempList)
+		}
+		if restOfString == "" {
+			return list // if there is no more string to read from return value of list
+		}
+		list = getBracketValues(restOfString, list, "") // recursive call to the rest of the string
+	} else if switchVal > 0 { // if the position of  the first "}}" is bigger than than the position of "{{"
+		list = getBracketValues(expr[firstOpen+2:firstClose], list, expr[firstClose+2:]) // recursive with the value inside of curly brackets
+	} else { // if the position of  the first "{{" is bigger than than the position of "}}"
+		nextClose := strings.Index(restOfString, "}}")
+		tempList = append(tempList, fmt.Sprintf("{{%s%s}}", expr, restOfString[nextClose:]), fmt.Sprintf("%s%s", expr, restOfString[nextClose:]))
+		list = append(list, tempList)
+		list = getBracketValues(restOfString[nextClose+2:], list, "") // recursive call to the rest of the string
+	}
+	return list
 }

--- a/pkg/engine/vulnerability_builder_test.go
+++ b/pkg/engine/vulnerability_builder_test.go
@@ -452,3 +452,77 @@ func TestDefaultVulnerabilityBuilder(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBracketValues(t *testing.T) {
+	type args struct {
+		expr string
+	}
+	tests := []struct {
+		name string
+		args args
+		want [][]string
+	}{
+		{
+			name: "no_brackets",
+			args: args{
+				expr: "password",
+			},
+			want: [][]string{
+				{
+					"{{password}}",
+					"password",
+				},
+			},
+		},
+		{
+			name: "single_brackets",
+			args: args{
+				expr: "{{password}}",
+			},
+			want: [][]string{
+				{
+					"{{password}}",
+					"password",
+				},
+			},
+		},
+		{
+			name: "double_brackets",
+			args: args{
+				expr: "{{ {{password}} }}",
+			},
+			want: [][]string{
+				{
+					"{{ {{password}}}}",
+					" {{password}}",
+				},
+			},
+		},
+		{
+			name: "multiple_brackets",
+			args: args{
+				expr: "FROM={{open-jdk}}.{{ {{password}} }}",
+			},
+			want: [][]string{
+				{
+					"{{open-jdk}}",
+					"open-jdk",
+				},
+				{
+					"{{ {{password}}}}",
+					" {{password}}",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		var got [][]string
+		t.Run(tt.name, func(t *testing.T) {
+			got = getBracketValues(tt.args.expr, got, "")
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DefaultVulnerabilityBuilder() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2001 

**Proposed Changes**

- Use the function 'getBracketValues()' to get values instead of regex

I submit this contribution under Apache-2.0 license.
