### PR TITLE
Update And Correct RouterTable with Default Routing query for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/routertable_with_default_routing/query.rego
+++ b/assets/queries/cloudFormation/routertable_with_default_routing/query.rego
@@ -23,13 +23,30 @@ CxPolicy[result] {
 	resource.Type == "AWS::EC2::Route"
 
 	properties := resource.Properties
-	object.get(properties, "GatewayId", "undefined") == "undefined"
+	properties.DestinationIpv6CidrBlock == "::/0"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.DestinationIpv6CidrBlock", [key]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.DestinationIpv6CidrBlock is different from the default value", [key]),
+		"keyActualValue": sprintf("Resources.%s.Properties.DestinationIpv6CidrBlock is ::/0", [key]),
+	}
+}
+
+CxPolicy[result] {
+	document := input.document[i]
+	resource := document.Resources[key]
+	resource.Type == "AWS::EC2::Route"
+
+	properties := resource.Properties
+	object.get(properties, "NatGatewayId", "undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [key]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.GatewayId is defined", [key]),
-		"keyActualValue": sprintf("Resources.%s.Properties.GatewayId is undefined", [key]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.NatGatewayId is defined", [key]),
+		"keyActualValue": sprintf("Resources.%s.Properties.NatGatewayId is undefined", [key]),
 	}
 }

--- a/assets/queries/cloudFormation/routertable_with_default_routing/test/negative.yaml
+++ b/assets/queries/cloudFormation/routertable_with_default_routing/test/negative.yaml
@@ -52,4 +52,4 @@ Resources:
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 172.16.0.0/24
-      GatewayId: !Ref InternetGateway
+      NatGatewayId: !Ref InternetGateway

--- a/assets/queries/cloudFormation/routertable_with_default_routing/test/positive.yaml
+++ b/assets/queries/cloudFormation/routertable_with_default_routing/test/positive.yaml
@@ -52,3 +52,17 @@ Resources:
     Properties:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: id
+  PublicRoute2:
+    Type: AWS::EC2::Route
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationIpv6CidrBlock: ::/0
+      NatGatewayId: id
+  PublicRoute3:
+    Type: AWS::EC2::Route
+    DependsOn: AttachGateway
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 10.1.10.0/24

--- a/assets/queries/cloudFormation/routertable_with_default_routing/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/routertable_with_default_routing/test/positive_expected_result.json
@@ -1,12 +1,17 @@
 [
-	{
-		"queryName": "RouterTable with Default Routing",
-		"severity": "MEDIUM",
-		"line": 54
-	},
-	{
-		"queryName": "RouterTable with Default Routing",
-		"severity": "MEDIUM",
-		"line": 52
-	}
+  {
+    "queryName": "RouterTable with Default Routing",
+    "severity": "MEDIUM",
+    "line": 54
+  },
+  {
+    "queryName": "RouterTable with Default Routing",
+    "severity": "MEDIUM",
+    "line": 66
+  },
+  {
+    "queryName": "RouterTable with Default Routing",
+    "severity": "MEDIUM",
+    "line": 61
+  }
 ]


### PR DESCRIPTION
Closes #2058

**Proposed Changes**

- Added check with "DestinationIpv6CidrBlock";
- Corrected query to check "NatGatewayId" instead of "GatewayId" as per the documentation.

I submit this contribution under Apache-2.0 license.
