### PR TITLE
Update S3 Bucket Versioning Not Enabled query for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/s3_bucket_versioning_not_enabled/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_versioning_not_enabled/query.rego
@@ -3,7 +3,8 @@ package Cx
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::S3::Bucket"
-	not resource.Properties.VersioningConfiguration
+    object.get(resource, "Properties", "undefined") != "undefined"
+    object.get(resource.Properties, "VersioningConfiguration", "undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,


### PR DESCRIPTION
Closes #2064

**Proposed Changes**

- Adding verification to check if attribute "Properties" is present, as to prevent unnecessary triggering of query;
- Replace verification of "VersioningConfiguration" existence with a "object.get" method verification.

I submit this contribution under Apache-2.0 license.
