### PR TITLE
Passing version number as ldflags during build 

### DIFF
--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -28,8 +28,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-${{ github.ref }}
     - name: Get short SHA
-      id: getsha
-      run: echo "::set-output name=shortsha::$(echo ${GITHUB_SHA} | cut -c1-8)"
+      run: echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-8)" >> $GITHUB_ENV
     - name: Build
       id: docker_build
       uses: docker/build-push-action@v2
@@ -41,7 +40,7 @@ jobs:
         push: false
         tags:  kics:${{ github.sha }}
         build-args: |
-          VERSION=${{ steps.getsha.shortsha }}
+          VERSION=${GITHUB_SHA_SHORT}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
     - name: Image digest

--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -27,6 +27,9 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.ref }}
         restore-keys: |
           ${{ runner.os }}-buildx-${{ github.ref }}
+    - name: Get short SHA
+      id: getsha
+      run: echo "::set-output name=shortsha::$(echo ${GITHUB_SHA} | cut -c1-8)"
     - name: Build
       id: docker_build
       uses: docker/build-push-action@v2
@@ -37,6 +40,8 @@ jobs:
         builder: ${{ steps.buildx.outputs.name }}
         push: false
         tags:  kics:${{ github.sha }}
+        build-args: |
+          VERSION=${{ steps.getsha.shortsha }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
     - name: Image digest

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -98,3 +98,5 @@ jobs:
           repository: checkmarx/kics
           tag_with_ref: false
           tags: nightly
+          build-args: |
+            VERSION=nightly-${{ github.sha }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -9,18 +9,15 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
@@ -44,7 +41,7 @@ jobs:
           release_name: nightly-${{ github.sha }}
           draft: false
           prerelease: true
-      - name: dislay assets
+      - name: Display assets
         run: |
           ls -l /home/runner/work/kics/kics/dist
       - name: Upload Release Asset Linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,18 +9,15 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.15
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,14 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+      - name: Get RELEASE_VERSION
+        run: echo "RELEASE_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
       - name: Push to Docker Hub
         uses: docker/build-push-action@v1
         with:
@@ -39,3 +40,5 @@ jobs:
           repository: checkmarx/kics
           tag_with_ref: true
           tags: latest
+          build-args: |
+            VERSION=${RELEASE_VERSION}

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -9,9 +9,10 @@ builds:
       - windows
     goarch:
       - amd64
+    ldflags:
+      - -X github.com/Checkmarx/kics/internal/console.Version={{.Version}}-{{.ShortCommit}}
 archives:
-  -
-    builds: [kics]
+  - builds: [kics]
     format_overrides:
       - goos: windows
         format: zip
@@ -19,9 +20,10 @@ archives:
       amd64: x64
       386: x32
     files:
+      - LICENSE
       - assets/queries
       - assets/libraries
 release:
   prerelease: true
 snapshot:
-  name_template: "nightly"
+  name_template: nightly

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,9 +9,10 @@ builds:
       - windows
     goarch:
       - amd64
+    ldflags:
+      - -X github.com/Checkmarx/kics/internal/console.Version={{.Version}}
 archives:
-  -
-    builds: [kics]
+  - builds: [kics]
     format_overrides:
       - goos: windows
         format: zip
@@ -19,5 +20,6 @@ archives:
       amd64: x64
       386: x32
     files:
+      - LICENSE
       - assets/queries
       - assets/libraries

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 
 
 ENV GOPRIVATE=github.com/Checkmarx/*
+ARG VERSION=development
 
 #Copy go mod and sum files
 COPY go.mod .
@@ -22,7 +23,9 @@ COPY . .
 
 USER root
 # Build the Go app
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o bin/kics cmd/console/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+  -ldflags "-X github.com/Checkmarx/kics/internal/console.Version=${VERSION}" -a -installsuffix cgo \
+  -o bin/kics cmd/console/main.go
 USER Checkmarx
 
 #Healthcheck the container

--- a/internal/console/version.go
+++ b/internal/console/version.go
@@ -6,7 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const currentVersion = "Keeping Infrastructure as Code Secure v1.1.3"
+// Version - current KICS version
+var Version = "dev"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
@@ -18,5 +19,5 @@ var versionCmd = &cobra.Command{
 }
 
 func getVersion() string {
-	return currentVersion
+	return fmt.Sprintf("Keeping Infrastructure as Code Secure %s", Version)
 }

--- a/internal/console/version_test.go
+++ b/internal/console/version_test.go
@@ -14,6 +14,6 @@ func TestVersionCommand(t *testing.T) {
 		out, err := test.CaptureCommandOutput(versionCmd, nil)
 
 		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf("%s\n", currentVersion), out)
+		require.Equal(t, fmt.Sprintf("%s\n", getVersion()), out)
 	})
 }


### PR DESCRIPTION
Closes #2081

**Proposed Changes**
- passing current version during build time with `ldflags`
- when a tag is created and pushed the workflow will trigger and goreleaser will retrieve latest tag and use it as the ldflag parameter Version
- nigthly builds will have the version named as **nightly-<COMMIT_SHORT_SHA>**
- when using `go run` to execute kics the fallback hardcoded version `dev` will be displayed. 
- docker builds will require `--build-arg VERSION=myVersion` otherwise it will fallback to `development` default arg value e.g: 
```docker build --build-arg VERSION=$(git describe --tags --always --dirty ) -t Checmarx/kics:$(git describe --tags --always --dirty ) .```

I submit this contribution under Apache-2.0 license.
