### PR TITLE
Update Workspace Without Encryption query for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/workspace_without_encryption/query.rego
+++ b/assets/queries/cloudFormation/workspace_without_encryption/query.rego
@@ -3,7 +3,7 @@ package Cx
 CxPolicy[result] {
 	document := input.document[i]
 	some workspaceName
-	document.Resources[policyName].Type == "AWS::WorkSpaces::Workspace"
+	document.Resources[workspaceName].Type == "AWS::WorkSpaces::Workspace"
 	workspace := document.Resources[workspaceName]
 
 	# The UserVolumeEncryptionEnabled property is defined, but is set to false
@@ -22,7 +22,7 @@ CxPolicy[result] {
 CxPolicy[result] {
 	document := input.document[i]
 	some workspaceName
-	document.Resources[policyName].Type == "AWS::WorkSpaces::Workspace"
+	document.Resources[workspaceName].Type == "AWS::WorkSpaces::Workspace"
 	workspace := document.Resources[workspaceName]
 
 	# The UserVolumeEncryptionEnabled property is not defined


### PR DESCRIPTION
Closes #2095

**Proposed Changes**

- Correcting a mistake where "policyName" is used instead of "workspaceName".

I submit this contribution under Apache-2.0 license.
