### PR TITLE
Enhanced config flag #2077

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,5 @@
 # Log Files
 *.log
 
-# Configuration file
-kics.config
-*config.*
-
 # ci/cd binaries
 .bin

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@
 *.log
 
 # Configuration file
-config.*
+kics.config
+*config.*
 
 # ci/cd binaries
 .bin

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Checkmarx/kics
 go 1.15
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/agnivade/levenshtein v1.1.0
 	github.com/getsentry/sentry-go v0.10.0
 	github.com/golang/mock v1.4.4

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/google/go-cmp v0.5.0 // indirect
 	github.com/google/uuid v1.2.0
+	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/mailru/easyjson v0.7.7
 	github.com/moby/buildkit v0.8.1
 	github.com/open-policy-agent/opa v0.26.0
+	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.20.0
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -805,6 +805,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.0 h1:Keo9qb7iRJs2voHvunFtuuYFsbWeOBh8/P9v/kVMFtw=
 github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/peterh/liner v0.0.0-20170211195444-bf27d3ba8e1d/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=

--- a/internal/console/helpers/helpers_test.go
+++ b/internal/console/helpers/helpers_test.go
@@ -227,55 +227,81 @@ func TestFileAnalyzer(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		arg  string
-		want string
+		name    string
+		arg     string
+		want    string
+		wantErr bool
 	}{
 		{
-			name: "file_analizer_json",
-			arg:  "test/fixtures/config_test/kics.json",
-			want: "json",
+			name:    "file_analizer_json",
+			arg:     "test/fixtures/config_test/kics.json",
+			want:    "json",
+			wantErr: false,
 		},
 		{
-			name: "file_analizer_json_no_extension",
-			arg:  "test/fixtures/config_test/kics.config_json",
-			want: "json",
+			name:    "file_analizer_json_no_extension",
+			arg:     "test/fixtures/config_test/kics.config_json",
+			want:    "json",
+			wantErr: false,
 		},
 		{
-			name: "file_analizer_yaml",
-			arg:  "test/fixtures/config_test/kics.yaml",
-			want: "yaml",
+			name:    "file_analizer_yaml",
+			arg:     "test/fixtures/config_test/kics.yaml",
+			want:    "yaml",
+			wantErr: false,
 		},
 		{
-			name: "file_analizer_yaml_no_extension",
-			arg:  "test/fixtures/config_test/kics.config_yaml",
-			want: "yaml",
+			name:    "file_analizer_yaml_no_extension",
+			arg:     "test/fixtures/config_test/kics.config_yaml",
+			want:    "yaml",
+			wantErr: false,
 		},
 		{
-			name: "file_analizer_hcl",
-			arg:  "test/fixtures/config_test/kics.hcl",
-			want: "hcl",
+			name:    "file_analizer_hcl",
+			arg:     "test/fixtures/config_test/kics.hcl",
+			want:    "hcl",
+			wantErr: false,
 		},
 		{
-			name: "file_analizer_hcl_no_extension",
-			arg:  "test/fixtures/config_test/kics.config_hcl",
-			want: "hcl",
+			name:    "file_analizer_hcl_no_extension",
+			arg:     "test/fixtures/config_test/kics.config_hcl",
+			want:    "hcl",
+			wantErr: false,
 		},
 		{
-			name: "file_analizer_toml",
-			arg:  "test/fixtures/config_test/kics.toml",
-			want: "toml",
+			name:    "file_analizer_toml",
+			arg:     "test/fixtures/config_test/kics.toml",
+			want:    "toml",
+			wantErr: false,
 		},
 		{
-			name: "file_analizer_toml_no_extension",
-			arg:  "test/fixtures/config_test/kics.config_toml",
-			want: "toml",
+			name:    "file_analizer_toml_no_extension",
+			arg:     "test/fixtures/config_test/kics.config_toml",
+			want:    "toml",
+			wantErr: false,
+		},
+		{
+			name:    "file_analizer_js_incorrect",
+			arg:     "test/fixtures/config_test/kics.config_js",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "file_analizer_js_no_extension_incorrect",
+			arg:     "test/fixtures/config_test/kics.js",
+			want:    "",
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FileAnalyzer(tt.arg); !reflect.DeepEqual(got, tt.want) {
+			got, err := FileAnalyzer(tt.arg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FileAnalyzer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("FileAnalyzer() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/console/helpers/helpers_test.go
+++ b/internal/console/helpers/helpers_test.go
@@ -292,6 +292,12 @@ func TestFileAnalyzer(t *testing.T) {
 			want:    "",
 			wantErr: true,
 		},
+		{
+			name:    "file_analizer_js_wrong_extension",
+			arg:     "test/fixtures/config_test/kics_wrong.js",
+			want:    "yaml",
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/console/helpers/helpers_test.go
+++ b/internal/console/helpers/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -216,6 +217,67 @@ func TestProgressBar(t *testing.T) {
 			wg.Wait()
 			splittedOut := strings.Split(out.String(), "\r")
 			require.Equal(t, tt.want, splittedOut[len(splittedOut)-1])
+		})
+	}
+}
+
+func TestFileAnalyzer(t *testing.T) {
+	if err := test.ChangeCurrentDir("kics"); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{
+			name: "file_analizer_json",
+			arg:  "test/fixtures/config_test/kics.json",
+			want: "json",
+		},
+		{
+			name: "file_analizer_json_no_extension",
+			arg:  "test/fixtures/config_test/kics.config_json",
+			want: "json",
+		},
+		{
+			name: "file_analizer_yaml",
+			arg:  "test/fixtures/config_test/kics.yaml",
+			want: "yaml",
+		},
+		{
+			name: "file_analizer_yaml_no_extension",
+			arg:  "test/fixtures/config_test/kics.config_yaml",
+			want: "yaml",
+		},
+		{
+			name: "file_analizer_hcl",
+			arg:  "test/fixtures/config_test/kics.hcl",
+			want: "hcl",
+		},
+		{
+			name: "file_analizer_hcl_no_extension",
+			arg:  "test/fixtures/config_test/kics.config_hcl",
+			want: "hcl",
+		},
+		{
+			name: "file_analizer_toml",
+			arg:  "test/fixtures/config_test/kics.toml",
+			want: "toml",
+		},
+		{
+			name: "file_analizer_toml_no_extension",
+			arg:  "test/fixtures/config_test/kics.config_toml",
+			want: "toml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FileAnalyzer(tt.arg); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FileAnalyzer() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -55,8 +55,12 @@ var scanCmd = &cobra.Command{
 
 func initializeConfig(cmd *cobra.Command) error {
 	if cfgFile == "" {
-		if _, err := os.Stat(filepath.ToSlash("kics.config")); os.IsNotExist(err) {
-			return nil
+		_, err := os.Stat(filepath.ToSlash("kics.config"))
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
 		}
 		cfgFile = filepath.ToSlash("kics.config")
 	}
@@ -64,7 +68,11 @@ func initializeConfig(cmd *cobra.Command) error {
 	base := filepath.Base(cfgFile)
 	v.SetConfigName(base)
 	v.AddConfigPath(filepath.Dir(cfgFile))
-	v.SetConfigType(consoleHelpers.FileAnalyzer(cfgFile))
+	ext, err := consoleHelpers.FileAnalyzer(cfgFile)
+	if err != nil {
+		return err
+	}
+	v.SetConfigType(ext)
 	if err := v.ReadInConfig(); err != nil {
 		return err
 	}

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -55,14 +55,14 @@ var scanCmd = &cobra.Command{
 
 func initializeConfig(cmd *cobra.Command) error {
 	if cfgFile == "" {
-		_, err := os.Stat(filepath.ToSlash("kics.config"))
+		_, err := os.Stat(filepath.ToSlash(filepath.Join(path, "kics.config")))
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil
 			}
 			return err
 		}
-		cfgFile = filepath.ToSlash("kics.config")
+		cfgFile = filepath.ToSlash(filepath.Join(path, "kics.config"))
 	}
 	v := viper.New()
 	base := filepath.Base(cfgFile)

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -46,10 +46,7 @@ var scanCmd = &cobra.Command{
 	Use:   "scan",
 	Short: "Executes a scan analysis",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if cfgFile != "" {
-			return initializeConfig(cmd)
-		}
-		return nil
+		return initializeConfig(cmd)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return scan()
@@ -57,13 +54,17 @@ var scanCmd = &cobra.Command{
 }
 
 func initializeConfig(cmd *cobra.Command) error {
+	if cfgFile == "" {
+		if _, err := os.Stat(filepath.ToSlash("kics.config")); os.IsNotExist(err) {
+			return nil
+		}
+		cfgFile = filepath.ToSlash("kics.config")
+	}
 	v := viper.New()
 	base := filepath.Base(cfgFile)
-	if strings.LastIndex(base, ".") > -1 {
-		base = base[:strings.LastIndex(base, ".")]
-	}
 	v.SetConfigName(base)
 	v.AddConfigPath(filepath.Dir(cfgFile))
+	v.SetConfigType(consoleHelpers.FileAnalyzer(cfgFile))
 	if err := v.ReadInConfig(); err != nil {
 		return err
 	}

--- a/test/fixtures/config_test/kics.config_hcl
+++ b/test/fixtures/config_test/kics.config_hcl
@@ -1,0 +1,9 @@
+"exclude-paths" = "exclude paths or files from scan"
+"log-file" = true
+"no-progress" = false
+"output-path" = "file path to store result in json format"
+"path" = "path to file or directory to scan"
+"payload-path" = "file path to store source internal representation in JSON format"
+"queries-path" = "path to directory with queries (default ./assets/queries) (default './assets/queries')"
+"type" = "type of queries to use in the scan"
+"verbose" = true

--- a/test/fixtures/config_test/kics.config_hcl
+++ b/test/fixtures/config_test/kics.config_hcl
@@ -1,9 +1,13 @@
-"exclude-paths" = "exclude paths or files from scan"
-"log-file" = true
-"no-progress" = false
-"output-path" = "file path to store result in json format"
-"path" = "path to file or directory to scan"
-"payload-path" = "file path to store source internal representation in JSON format"
-"queries-path" = "path to directory with queries (default ./assets/queries) (default './assets/queries')"
-"type" = "type of queries to use in the scan"
-"verbose" = true
+io_mode = "async"
+
+service "http" "web_proxy" {
+  listen_addr = "127.0.0.1:8080"
+
+  process "main" {
+    command = ["/usr/local/bin/awesome-app", "server"]
+  }
+
+  process "mgmt" {
+    command = ["/usr/local/bin/awesome-app", "mgmt"]
+  }
+}

--- a/test/fixtures/config_test/kics.config_js
+++ b/test/fixtures/config_test/kics.config_js
@@ -1,0 +1,7 @@
+var config = {
+  path: "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
+  verbose: true,
+  'log-file': true,
+  'queries-path': "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
+  type: "CloudFormation,Dockerfile"
+};

--- a/test/fixtures/config_test/kics.config_json
+++ b/test/fixtures/config_test/kics.config_json
@@ -1,0 +1,7 @@
+{
+  "path": "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
+  "verbose": true,
+  "log-file": true,
+  "queries-path": "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
+  "type": "CloudFormation,Dockerfile"
+}

--- a/test/fixtures/config_test/kics.config_toml
+++ b/test/fixtures/config_test/kics.config_toml
@@ -1,0 +1,12 @@
+title = "TOML Example"
+
+[config]
+path = "path to file or directory to scan"
+verbose = true
+log-file = true
+queries-path = "path to directory with queries (default ./assets/queries) (default './assets/queries')"
+output-path = "file path to store result in json format"
+exclude-paths = "exclude paths or files from scan"
+no-progress = false
+type = "type of queries to use in the scan"
+payload-path = "file path to store source internal representation in JSON format"

--- a/test/fixtures/config_test/kics.config_yaml
+++ b/test/fixtures/config_test/kics.config_yaml
@@ -1,0 +1,9 @@
+path: "path to file or directory to scan"
+verbose: true
+log-file: true
+queries-path: "path to directory with queries (default ./assets/queries) (default './assets/queries')"
+output-path: "file path to store result in json format"
+exclude-paths: "exclude paths or files from scan"
+no-progress: false
+type: "type of queries to use in the scan"
+payload-path: "file path to store source internal representation in JSON format"

--- a/test/fixtures/config_test/kics.hcl
+++ b/test/fixtures/config_test/kics.hcl
@@ -1,0 +1,9 @@
+"exclude-paths" = "exclude paths or files from scan"
+"log-file" = true
+"no-progress" = false
+"output-path" = "file path to store result in json format"
+"path" = "path to file or directory to scan"
+"payload-path" = "file path to store source internal representation in JSON format"
+"queries-path" = "path to directory with queries (default ./assets/queries) (default './assets/queries')"
+"type" = "type of queries to use in the scan"
+"verbose" = true

--- a/test/fixtures/config_test/kics.hcl
+++ b/test/fixtures/config_test/kics.hcl
@@ -1,9 +1,13 @@
-"exclude-paths" = "exclude paths or files from scan"
-"log-file" = true
-"no-progress" = false
-"output-path" = "file path to store result in json format"
-"path" = "path to file or directory to scan"
-"payload-path" = "file path to store source internal representation in JSON format"
-"queries-path" = "path to directory with queries (default ./assets/queries) (default './assets/queries')"
-"type" = "type of queries to use in the scan"
-"verbose" = true
+io_mode = "async"
+
+service "http" "web_proxy" {
+  listen_addr = "127.0.0.1:8080"
+
+  process "main" {
+    command = ["/usr/local/bin/awesome-app", "server"]
+  }
+
+  process "mgmt" {
+    command = ["/usr/local/bin/awesome-app", "mgmt"]
+  }
+}

--- a/test/fixtures/config_test/kics.js
+++ b/test/fixtures/config_test/kics.js
@@ -1,0 +1,7 @@
+var config = {
+  path: "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
+  verbose: true,
+  'log-file': true,
+  'queries-path': "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
+  type: "CloudFormation,Dockerfile"
+};

--- a/test/fixtures/config_test/kics.js
+++ b/test/fixtures/config_test/kics.js
@@ -1,7 +1,7 @@
 var config = {
   path: "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
   verbose: true,
-  'log-file': true,
-  'queries-path': "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
+  "log-file": true,
+  "queries-path": "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
   type: "CloudFormation,Dockerfile"
 };

--- a/test/fixtures/config_test/kics.json
+++ b/test/fixtures/config_test/kics.json
@@ -1,0 +1,7 @@
+{
+  "path": "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
+  "verbose": true,
+  "log-file": true,
+  "queries-path": "assets/queries/cloudFormation/unauthorized_api_calls_without_alarms",
+  "type": "CloudFormation,Dockerfile"
+}

--- a/test/fixtures/config_test/kics.toml
+++ b/test/fixtures/config_test/kics.toml
@@ -1,0 +1,12 @@
+title = "TOML Example"
+
+[config]
+path = "path to file or directory to scan"
+verbose = true
+log-file = true
+queries-path = "path to directory with queries (default ./assets/queries) (default './assets/queries')"
+output-path = "file path to store result in json format"
+exclude-paths = "exclude paths or files from scan"
+no-progress = false
+type = "type of queries to use in the scan"
+payload-path = "file path to store source internal representation in JSON format"

--- a/test/fixtures/config_test/kics.yaml
+++ b/test/fixtures/config_test/kics.yaml
@@ -1,0 +1,9 @@
+path: "path to file or directory to scan"
+verbose: true
+log-file: true
+queries-path: "path to directory with queries (default ./assets/queries) (default './assets/queries')"
+output-path: "file path to store result in json format"
+exclude-paths: "exclude paths or files from scan"
+no-progress: false
+type: "type of queries to use in the scan"
+payload-path: "file path to store source internal representation in JSON format"

--- a/test/fixtures/config_test/kics_wrong.js
+++ b/test/fixtures/config_test/kics_wrong.js
@@ -1,0 +1,9 @@
+path: "path to file or directory to scan"
+verbose: true
+log - file: true
+queries - path: "path to directory with queries (default ./assets/queries) (default './assets/queries')"
+output - path: "file path to store result in json format"
+exclude - paths: "exclude paths or files from scan"
+no - progress: false
+type: "type of queries to use in the scan"
+payload - path: "file path to store source internal representation in JSON format"


### PR DESCRIPTION
Closes #2077

**Proposed Changes**

- Kics Can now be called without flags and will get the configurations from the 'kics.config' file inside the root of kics
-Kics will now check the contents of the config file and determine its extension 
-If there is no 'kics.config' file in the root of kics, kicks must be run with flags, or with the '--config' flag with the path to a configuration file 

I submit this contribution under Apache-2.0 license.
