### PR TITLE
Update EC2 Network ACL Duplicate Rule query for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
@@ -34,9 +34,21 @@ getRef(obj) = obj.Ref {
 }
 
 getTraffic(entry) = "egress" {
-	object.get(entry.Properties, "Egress", "undefined") == true
+	entry.Properties.Egress == true
+} else = "egress" {
+	lower(entry.Properties.Egress) == "true"
 } else = "ingress" {
-	true
+	lower(entry.Properties.Egress) == "false"
+} else = "ingress" {
+	entry.Properties.Egress == false
+} else = "egress" {
+	lower(entry.Properties.Ingress) == "false"
+} else = "ingress" {
+	lower(entry.Properties.Ingress) == "true"
+} else = "ingress" {
+	entry.Properties.Ingress == true
+} else = "egress" {
+	entry.Properties.Ingress == false
 }
 
 compareRuleNumber(entry1, entry2){

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
@@ -4,7 +4,7 @@ CxPolicy[result] {
 	entry1 := input.document[i].Resources[name]
 	entry1.Type == "AWS::EC2::NetworkAclEntry"
 
-	entry2 := input.document[_].Resources[_]
+	entry2 := input.document[i].Resources[_]
 	entry2.Type == "AWS::EC2::NetworkAclEntry"
 
 	entry1 != entry2
@@ -34,21 +34,13 @@ getRef(obj) = obj.Ref {
 }
 
 getTraffic(entry) = "egress" {
-	entry.Properties.Egress == true
+	lower(sprintf("%v",[entry.Properties.Egress])) == "true"
+} else = "ingress" {
+	lower(sprintf("%v",[entry.Properties.Egress])) == "false"
 } else = "egress" {
-	lower(entry.Properties.Egress) == "true"
+	lower(sprintf("%v",[entry.Properties.Ingress])) == "false"
 } else = "ingress" {
-	lower(entry.Properties.Egress) == "false"
-} else = "ingress" {
-	entry.Properties.Egress == false
-} else = "egress" {
-	lower(entry.Properties.Ingress) == "false"
-} else = "ingress" {
-	lower(entry.Properties.Ingress) == "true"
-} else = "ingress" {
-	entry.Properties.Ingress == true
-} else = "egress" {
-	entry.Properties.Ingress == false
+	lower(sprintf("%v",[entry.Properties.Ingress])) == "true"
 }
 
 compareRuleNumber(entry1, entry2){


### PR DESCRIPTION
Closes #2107

**Proposed Changes**

- Updating "getTraffic()" method to consider more formats in which a value can be.

I submit this contribution under Apache-2.0 license.
