### PR TITLE
Update S3 Bucket Should Have Bucket Policy query for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/query.rego
@@ -5,13 +5,14 @@ CxPolicy[result] {
 	resource.Type == "AWS::S3::Bucket"
 	bucket := resource.Properties.BucketName
 	not bucketName(bucket)
-
+    not bucketName(name)
+	
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.BucketName", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.BucketName' should be the same as 'AWS::S3::BucketPolicy' Bucket Ref", [name]),
-		"keyActualValue": sprintf("'Resources.%s.Properties.BucketName' is not the same as 'AWS::S3::BucketPolicy' Bucket Ref", [name]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.BucketName' or 'Resources.[%s]' should be the same as 'AWS::S3::BucketPolicy' Bucket Ref", [name, name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.BucketName' or 'Resources.[%s]' are not the same as 'AWS::S3::BucketPolicy' Bucket Ref", [name, name]),
 	}
 }
 
@@ -33,6 +34,16 @@ bucketName(bucketName) {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::S3::BucketPolicy"
 	bucket := resource.Properties.Bucket
+    not contains(bucket, "!Ref")
+	bucket == bucketName
+}
+
+bucketName(bucketName) {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::S3::BucketPolicy"
+	bucket := resource.Properties.Bucket
+    contains(bucket, "!Ref")
+    bucketN := replace(bucket, "!Ref ", "")
 	bucket == bucketName
 }
 

--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/negative.yaml
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/negative.yaml
@@ -27,3 +27,29 @@ Resources:
                 'aws:Referer':
                   - 'http://www.example.com/*'
                   - 'http://example.net/*'
+  S3Bucket9:
+    Type: 'AWS::S3::Bucket'
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: docexamplebucket
+  SampleBucketPolicy10:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref docexamplebucket
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 's3:GetObject'
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'arn:aws:s3:::'
+                  - Ref: docexamplebucket
+                  - /*
+            Principal: '*'
+            Condition:
+              StringLike:
+                'aws:Referer':
+                  - 'http://www.example.com/*'
+                  - 'http://example.net/*'

--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/positive.yaml
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/positive.yaml
@@ -53,3 +53,29 @@ Resources:
                 'aws:Referer':
                   - 'http://www.example.com/*'
                   - 'http://example.net/*'
+  S3Bucket7:
+    Type: 'AWS::S3::Bucket'
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: docexamplebucket5
+  SampleBucketPolicy8:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref docexamplebucketfail2
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 's3:GetObject'
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'arn:aws:s3:::'
+                  - Ref: docexamplebucket1
+                  - /*
+            Principal: '*'
+            Condition:
+              StringLike:
+                'aws:Referer':
+                  - 'http://www.example.com/*'
+                  - 'http://example.net/*'

--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/positive_expected_result.json
@@ -1,12 +1,17 @@
 [
-	{
-		"queryName": "S3 Bucket Should Have Bucket Policy",
-		"severity": "MEDIUM",
-		"line": 8
-	},
-	{
-		"queryName": "S3 Bucket Should Have Bucket Policy",
-		"severity": "MEDIUM",
-		"line": 34
-	}
+  {
+    "queryName": "S3 Bucket Should Have Bucket Policy",
+    "severity": "MEDIUM",
+    "line": 8
+  },
+  {
+    "queryName": "S3 Bucket Should Have Bucket Policy",
+    "severity": "MEDIUM",
+    "line": 34
+  },
+  {
+    "queryName": "S3 Bucket Should Have Bucket Policy",
+    "severity": "MEDIUM",
+    "line": 60
+  }
 ]


### PR DESCRIPTION
Closes #2116

**Proposed Changes**

- Adding missing reference handling;
- Adding new validation, namely, that the reference in a Bucket Policy also doesn't match the name of the resource, instead of just the "BucketName" property.

I submit this contribution under Apache-2.0 license.
