### PR TITLE
Exclude specific results by similarity ID 

### DIFF
--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -44,7 +44,8 @@ KICS is able to infer the format without the need of file extension.
   "exclude-paths": "exclude paths or files from scan",
   "no-progress": false,
   "type": "type of queries to use in the scan",
-  "payload-path": "file path to store source internal representation in JSON format"
+  "payload-path": "file path to store source internal representation in JSON format",
+  "exclude-results": "exclude results by providing a list of similarity IDs of a result"
 }
 ```
 
@@ -60,6 +61,7 @@ exclude-paths: "exclude paths or files from scan"
 no-progress: false
 type: "type of queries to use in the scan"
 payload-path: "file path to store source internal representation in JSON format"
+exclude-results: "exclude results by providing a list of similarity IDs of a result"
 ```
 
 #### TOML Format
@@ -74,6 +76,7 @@ exclude-paths = "exclude paths or files from scan"
 no-progress = false
 type = "type of queries to use in the scan"
 payload-path = "file path to store source internal representation in JSON format"
+exclude-results = "exclude results by providing a list of similarity IDs of a result"
 ```
 
 #### HCL Format
@@ -88,12 +91,13 @@ payload-path = "file path to store source internal representation in JSON format
 "queries-path" = "path to directory with queries (default ./assets/queries) (default './assets/queries')"
 "type" = "type of queries to use in the scan"
 "verbose" = true
+"exclude-results" = "exclude results by providing a list of similarity IDs of a result"
 ```
 
 ---
 
 
-## How to Use 
+## How to Use
 You can enclose all your configurations in a file and use it in two different ways.
 
 #### Command Argument File

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ Flags:
   -e, --exclude-paths strings     exclude paths or files from scan
                                   The arg should be quoted and uses comma as separator
                                   example: './shouldNotScan/*,somefile.txt'
-  -s, --exclude-results strings   exclude results by providing the similarity ID of a result
+  -x, --exclude-results strings   exclude results by providing the similarity ID of a result
                                   The arg should be quoted and uses comma as separator
                                   example: 'fec62a97d569662093dbb9739360942fc2a0c47bedec0bfcae05dc9d899d3ebe,31263s5696620s93dbb973d9360942fc2a...'
   -h, --help                      help for scan

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,14 +5,14 @@ There are multiple ways to get KICS up and running:
 
 #### Docker
 
-KICS is available as a <a href="https://hub.docker.com/r/checkmarx/kics" target="_blank">Docker image</a> and can be used as follows:  
+KICS is available as a <a href="https://hub.docker.com/r/checkmarx/kics" target="_blank">Docker image</a> and can be used as follows:
 
 To scan a directory/file on your host you have to mount it as a volume to the container and specify the path on the container filesystem with the -p KICS parameter (see Scan Command Options section below)
 
 ```txt
-docker pull checkmarx/kics:latest  
+docker pull checkmarx/kics:latest
 docker run -v {​​​​path_to_host_folder_to_scan}​​​​:/path checkmarx/kics:latest scan -p "/path" -o "/path/results.json"
-```  
+```
 
 You can provide your own path to the queries directory with `-q` CLI option (see CLI Options section below), otherwise the default directory will be used The default *./assets/queries* is built-in in the image.
 
@@ -27,7 +27,7 @@ So all you need is:
 1. Go to <a href="https://github.com/Checkmarx/kics/releases/latest" target="_blank">KICS releases</a>
 1. Download KICS binaries based on your OS
 1. Extract files
-1. Run kics executable with the cli options as described below (note that kics binary should be located in the same directory as queries directory)  
+1. Run kics executable with the cli options as described below (note that kics binary should be located in the same directory as queries directory)
    ```
    ./kics scan -p <path-of-your-project-to-scan> -o <output-results.json>
    ```
@@ -35,14 +35,14 @@ So all you need is:
 #### Build from Sources
 
 1. Download and install Go from <a href="https://golang.org/dl/" target="_blank">https://golang.org/dl/</a>
-1. Clone the repository:  
+1. Clone the repository:
    ```
    git clone https://github.com/Checkmarx/kics.git
-   ```  
+   ```
    ```
    cd kics
    ```
-1. Kick a scan!  
+1. Kick a scan!
    ```
    go run ./cmd/console/main.go scan -p <path-of-your-project-to-scan> -o <output-results.json>
    ```
@@ -62,19 +62,28 @@ version     Displays the current version
 #### Scan Command Options
 
 ```txt
-    --config string         path to configuration file
--e, --exclude-paths         exclude paths or files from scan
-                            The arg should be quoted and uses comma as separator
-                            example: './shouldNotScan/*,somefile.txt'
--h, --help                  help
--l, --log-file              log to file info.log
-    --no-progress             hides scan's progress bar
--o, --output-path string    file path to store result in json format
--p, --path string           path to file or directory to scan
--d, --payload-path string   file path to store source internal representation in JSON format
--q, --queries-path string   path to directory with queries (default "./assets/queries")
--t, --type                  type of queries to use in the scan
--v, --verbose               verbose scan
+Executes a scan analysis
+
+Usage:
+  kics scan [flags]
+
+Flags:
+      --config string             path to configuration file
+  -e, --exclude-paths strings     exclude paths or files from scan
+                                  The arg should be quoted and uses comma as separator
+                                  example: './shouldNotScan/*,somefile.txt'
+  -s, --exclude-results strings   exclude results by providing the similarity ID of a result
+                                  The arg should be quoted and uses comma as separator
+                                  example: 'fec62a97d569662093dbb9739360942fc2a0c47bedec0bfcae05dc9d899d3ebe,31263s5696620s93dbb973d9360942fc2a...'
+  -h, --help                      help for scan
+  -l, --log-file                  log to file info.log
+      --no-progress               hides scan's progress bar
+  -o, --output-path string        file path to store result in json format
+  -p, --path string               path to file or directory to scan
+  -d, --payload-path string       file path to store source internal representation in JSON format
+  -q, --queries-path string       path to directory with queries (default ./assets/queries) (default "./assets/queries")
+  -t, --type strings              type of queries to use in the scan
+  -v, --verbose                   verbose scan
 ```
 
 The other commands have no further options.

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -30,16 +30,17 @@ import (
 )
 
 var (
-	path        string
-	queryPath   string
-	outputPath  string
-	payloadPath string
-	excludePath []string
-	cfgFile     string
-	verbose     bool
-	logFile     bool
-	noProgress  bool
-	types       []string
+	path           string
+	queryPath      string
+	outputPath     string
+	payloadPath    string
+	excludePath    []string
+	excludeResults []string
+	cfgFile        string
+	verbose        bool
+	logFile        bool
+	noProgress     bool
+	types          []string
 )
 
 var scanCmd = &cobra.Command{
@@ -122,6 +123,13 @@ func initScanCmd() {
 	scanCmd.Flags().BoolVarP(&logFile, "log-file", "l", false, "log to file info.log")
 	scanCmd.Flags().StringSliceVarP(&types, "type", "t", []string{""}, "type of queries to use in the scan")
 	scanCmd.Flags().BoolVarP(&noProgress, "no-progress", "", false, "hides scan's progress bar")
+	scanCmd.Flags().StringSliceVarP(&excludeResults,
+		"exclude-results",
+		"s",
+		[]string{},
+		`exclude results by providing the similarity ID of a result
+		The arg should be quoted and uses comma as separator
+		example: 'fec62a97d569662093dbb9739360942fc2a0c47bedec0bfcae05dc9d899d3ebe,31263s5696620s93dbb973d9360942fc2a...'`)
 
 	if err := scanCmd.MarkFlagRequired("path"); err != nil {
 		sentry.CaptureException(err)
@@ -173,6 +181,14 @@ func getFileSystemSourceProvider() (*source.FileSystemSourceProvider, error) {
 	return filesSource, nil
 }
 
+func getExcludeResultsMap(excludeResults []string) map[string]bool {
+	excludeResultsMap := make(map[string]bool)
+	for _, er := range excludeResults {
+		excludeResultsMap[er] = true
+	}
+	return excludeResultsMap
+}
+
 func scan() error {
 	fmt.Printf("Scanning with %s\n\n", getVersion())
 
@@ -186,7 +202,9 @@ func scan() error {
 
 	t := &tracker.CITracker{}
 
-	inspector, err := engine.NewInspector(ctx, querySource, engine.DefaultVulnerabilityBuilder, t)
+	excludeResultsMap := getExcludeResultsMap(excludeResults)
+
+	inspector, err := engine.NewInspector(ctx, querySource, engine.DefaultVulnerabilityBuilder, t, excludeResultsMap)
 	if err != nil {
 		return err
 	}

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -125,7 +125,7 @@ func initScanCmd() {
 	scanCmd.Flags().BoolVarP(&noProgress, "no-progress", "", false, "hides scan's progress bar")
 	scanCmd.Flags().StringSliceVarP(&excludeResults,
 		"exclude-results",
-		"s",
+		"x",
 		[]string{},
 		`exclude results by providing the similarity ID of a result
 The arg should be quoted and uses comma as separator

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -128,8 +128,8 @@ func initScanCmd() {
 		"s",
 		[]string{},
 		`exclude results by providing the similarity ID of a result
-		The arg should be quoted and uses comma as separator
-		example: 'fec62a97d569662093dbb9739360942fc2a0c47bedec0bfcae05dc9d899d3ebe,31263s5696620s93dbb973d9360942fc2a...'`)
+The arg should be quoted and uses comma as separator
+example: 'fec62a97d569662093dbb9739360942fc2a0c47bedec0bfcae05dc9d899d3ebe,31263s5696620s93dbb973d9360942fc2a...'`)
 
 	if err := scanCmd.MarkFlagRequired("path"); err != nil {
 		sentry.CaptureException(err)

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -326,7 +326,6 @@ func (c *Inspector) decodeQueryResults(ctx *QueryContext, results rego.ResultSet
 		} else {
 			vulnerabilities = append(vulnerabilities, vulnerability)
 		}
-
 	}
 
 	if failedDetectLine {

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -337,7 +337,6 @@ func TestNewInspector(t *testing.T) { // nolint
 			},
 		},
 	})
-
 	type args struct {
 		ctx            context.Context
 		source         QueriesSource

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -164,12 +164,33 @@ func TestInspect(t *testing.T) { //nolint
 		},
 	})
 
+	mockedFileMetadataDocument := map[string]interface{}{
+		"id":   nil,
+		"file": nil,
+		"command": map[string]interface{}{
+			"openjdk:10-jdk": []map[string]interface{}{
+				{
+					"Cmd":       "add",
+					"EndLine":   8,
+					"JSON":      false,
+					"Original":  "ADD ${JAR_FILE} app.jar",
+					"StartLine": 8,
+					"SubCmd":    "",
+					"Value": []string{
+						"app.jar",
+					},
+				},
+			},
+		},
+	}
+
 	type fields struct {
 		queries              []*preparedQuery
 		vb                   VulnerabilityBuilder
 		tracker              Tracker
 		enableCoverageReport bool
 		coverageReport       cover.Report
+		excludeResults       map[string]bool
 	}
 	type args struct {
 		ctx    context.Context
@@ -184,47 +205,29 @@ func TestInspect(t *testing.T) { //nolint
 		wantErr bool
 	}{
 		{
-			name: "Test",
+			name: "TestInspect",
 			fields: fields{
 				queries:              opaQueries,
 				vb:                   DefaultVulnerabilityBuilder,
 				tracker:              &tracker.CITracker{},
 				enableCoverageReport: true,
 				coverageReport:       cover.Report{},
+				excludeResults:       map[string]bool{},
 			},
 			args: args{
 				ctx:    ctx,
 				scanID: "scanID",
 				files: model.FileMetadatas{
 					{
-						ID:     "3a3be8f7-896e-4ef8-9db3-d6c19e60510b",
-						ScanID: "scanID",
-						Document: map[string]interface{}{
-							"id":   nil,
-							"file": nil,
-							"command": map[string]interface{}{
-								"openjdk:10-jdk": []map[string]interface{}{
-									{
-										"Cmd":       "add",
-										"EndLine":   8,
-										"JSON":      false,
-										"Original":  "ADD ${JAR_FILE} app.jar",
-										"StartLine": 8,
-										"SubCmd":    "",
-										"Value": []string{
-											"app.jar",
-										},
-									},
-								},
-							},
-						},
+						ID:           "3a3be8f7-896e-4ef8-9db3-d6c19e60510b",
+						ScanID:       "scanID",
+						Document:     mockedFileMetadataDocument,
 						OriginalData: "orig_data",
 						Kind:         "DOCKERFILE",
 						FileName:     "assets/queries/dockerfile/add_instead_of_copy/test/positive.dockerfile",
 					},
 				},
 			},
-			// 27ef060e0ced4e40b94f2c5a8c330e9be5b9534ce41a4cc2f737bca66f2ce788
 			want: []model.Vulnerability{
 				{
 					ID:               0,
@@ -246,6 +249,33 @@ func TestInspect(t *testing.T) { //nolint
 			},
 			wantErr: false,
 		},
+		{
+			name: "TestInspectExcludeResult",
+			fields: fields{
+				queries:              opaQueries,
+				vb:                   DefaultVulnerabilityBuilder,
+				tracker:              &tracker.CITracker{},
+				enableCoverageReport: true,
+				coverageReport:       cover.Report{},
+				excludeResults:       map[string]bool{"fec62a97d569662093dbb9739360942fc2a0c47bedec0bfcae05dc9d899d3ebe": true},
+			},
+			args: args{
+				ctx:    ctx,
+				scanID: "scanID",
+				files: model.FileMetadatas{
+					{
+						ID:           "3a3be8f7-896e-4ef8-9db3-d6c19e60510b",
+						ScanID:       "scanID",
+						Document:     mockedFileMetadataDocument,
+						OriginalData: "orig_data",
+						Kind:         "DOCKERFILE",
+						FileName:     "assets/queries/dockerfile/add_instead_of_copy/test/positive.dockerfile",
+					},
+				},
+			},
+			want:    []model.Vulnerability{},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -256,6 +286,7 @@ func TestInspect(t *testing.T) { //nolint
 				tracker:              tt.fields.tracker,
 				enableCoverageReport: tt.fields.enableCoverageReport,
 				coverageReport:       tt.fields.coverageReport,
+				excludeResults:       tt.fields.excludeResults,
 			}
 			got, err := c.Inspect(tt.args.ctx, tt.args.scanID, tt.args.files, true, filepath.FromSlash("assets/queries/"))
 			if tt.wantErr {
@@ -308,10 +339,11 @@ func TestNewInspector(t *testing.T) { // nolint
 	})
 
 	type args struct {
-		ctx     context.Context
-		source  QueriesSource
-		vb      VulnerabilityBuilder
-		tracker Tracker
+		ctx            context.Context
+		source         QueriesSource
+		vb             VulnerabilityBuilder
+		tracker        Tracker
+		excludeResults map[string]bool
 	}
 	tests := []struct {
 		name    string
@@ -322,10 +354,11 @@ func TestNewInspector(t *testing.T) { // nolint
 		{
 			name: "test_new_inspector",
 			args: args{
-				ctx:     context.Background(),
-				vb:      vbs,
-				tracker: track,
-				source:  sources,
+				ctx:            context.Background(),
+				vb:             vbs,
+				tracker:        track,
+				source:         sources,
+				excludeResults: map[string]bool{},
 			},
 			want: &Inspector{
 				vb:      vbs,
@@ -337,7 +370,7 @@ func TestNewInspector(t *testing.T) { // nolint
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewInspector(tt.args.ctx, tt.args.source, tt.args.vb, tt.args.tracker)
+			got, err := NewInspector(tt.args.ctx, tt.args.source, tt.args.vb, tt.args.tracker, tt.args.excludeResults)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewInspector() error: got = %v,\n wantErr = %v", err, tt.wantErr)
 				return

--- a/test/queries_content_test.go
+++ b/test/queries_content_test.go
@@ -197,6 +197,7 @@ func testQueryHasGoodReturnParams(t *testing.T, entry queryEntry) {
 			return model.Vulnerability{}, nil
 		},
 		trk,
+		map[string]bool{},
 	)
 	require.Nil(t, err)
 	require.NotNil(t, inspector)

--- a/test/queries_test.go
+++ b/test/queries_test.go
@@ -107,7 +107,12 @@ func testQuery(tb testing.TB, entry queryEntry, filesPath []string, expectedVuln
 			return q, nil
 		})
 
-	inspector, err := engine.NewInspector(ctx, queriesSource, engine.DefaultVulnerabilityBuilder, &tracker.CITracker{})
+	inspector, err := engine.NewInspector(ctx,
+		queriesSource,
+		engine.DefaultVulnerabilityBuilder,
+		&tracker.CITracker{},
+		map[string]bool{})
+
 	require.Nil(tb, err)
 	require.NotNil(tb, inspector)
 

--- a/test/similarity_id_test.go
+++ b/test/similarity_id_test.go
@@ -285,7 +285,12 @@ func createInspectorAndGetVulnerabilities(ctx context.Context, t testing.TB,
 			return q, nil
 		})
 
-	inspector, err := engine.NewInspector(ctx, queriesSource, engine.DefaultVulnerabilityBuilder, &tracker.CITracker{})
+	inspector, err := engine.NewInspector(ctx,
+		queriesSource,
+		engine.DefaultVulnerabilityBuilder,
+		&tracker.CITracker{},
+		map[string]bool{})
+
 	require.Nil(t, err)
 	require.NotNil(t, inspector)
 


### PR DESCRIPTION
Closes #2046

**Proposed Changes**

- Adding `--exclude-results` flag (shorthand `-x`) that can be provided several times or with a comma-separated string list of similarity IDs that will be removed from the scan results

Original Sample Results:
![image](https://user-images.githubusercontent.com/75368139/108846057-145ca880-75d6-11eb-90bc-099fccb0b87a.png)

After removing all results:
![image](https://user-images.githubusercontent.com/75368139/108845978-fa22ca80-75d5-11eb-8d0a-8c438d359549.png)

With configuration file:
![image](https://user-images.githubusercontent.com/75368139/108847614-d19bd000-75d7-11eb-9a07-342633e21332.png)

```json
{
  "path": "assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy",
  "verbose": true,
  "log-file": true,
  "queries-path": "assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy",
  "output-path": "results.json",
  "exclude-results": "362003f669e5e8cd5306d90b022818de771eaed92efd46cf31412863d03fbb76"
}
```

I submit this contribution under Apache-2.0 license.
