### PR TITLE
Update getTasks on all Ansible queries

### DIFF
--- a/assets/libraries/ansible/library.rego
+++ b/assets/libraries/ansible/library.rego
@@ -27,24 +27,22 @@ getTasksFromBlocks(playbook) = result {
 		walk(playbook, [path, task])
 		is_object(task)
 		not task.block
-		valid_path(path)
+		validPath(path)
 	]
 } else = [playbook] {
 	true
 }
 
-valid_path(path) {
-	count(path) == 0
-} else {
-	count(path) % 2 == 0
-	valid_group(path[minus(count(path), 2)])
+validPath(path) {
+	count(path) > 1
+	validGroup(path[minus(count(path), 2)])
 }
 
-valid_group("block") = true
+validGroup("block") = true
 
-valid_group("always") = true
+validGroup("always") = true
 
-valid_group("rescue") = true
+validGroup("rescue") = true
 
 checkState(task) {
 	state := object.get(task, "state", "undefined")

--- a/assets/queries/ansible/aws/alb_protocol_is_http/query.rego
+++ b/assets/queries/ansible/aws/alb_protocol_is_http/query.rego
@@ -1,17 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	applicationLb := task["community.aws.elb_application_lb"]
-	clusterName := applicationLb.name
 
 	applicationLb.listeners[index].Protocol != "HTTPS"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.Protocol=%s", [task.name, applicationLb.listeners[index].Protocol]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'aws_elb_application_lb' Protocol should be 'HTTP'",
@@ -20,17 +18,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	applicationLb := task["community.aws.elb_application_lb"]
-	clusterName := applicationLb.name
 
 	applicationLb.listeners[index]
 	not MissingProtocol(applicationLb.listeners)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'aws_elb_application_lb' Protocol should be 'HTTP'",
@@ -41,4 +36,3 @@ CxPolicy[result] {
 MissingProtocol(listeners) {
 	listeners[_].Protocol
 }
-

--- a/assets/queries/ansible/aws/all_auth_users_get_read_access/query.rego
+++ b/assets/queries/ansible/aws/all_auth_users_get_read_access/query.rego
@@ -1,21 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	s3 := task["amazon.aws.aws_s3"]
-	s3Name := task.name
 
 	s3.permission == "authenticated-read"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.aws_s3}}.permission", [s3Name]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.aws_s3}}.permission", [task.name]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": "amazon.aws.aws_s3 should not have read access for all authenticated users",
 		"keyActualValue": "amazon.aws.aws_s3 has read access for all authenticated users",
 	}
 }
-

--- a/assets/queries/ansible/aws/all_users_group_gets_read_access/query.rego
+++ b/assets/queries/ansible/aws/all_users_group_gets_read_access/query.rego
@@ -1,18 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	s3 := task["amazon.aws.aws_s3"]
-	s3Name := task.name
 
 	hasPublicReadPermission(s3.permission)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.aws_s3}}.permission", [s3Name]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.aws_s3}}.permission", [task.name]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": "amazon.aws.aws_s3 should not have read access for all user groups",
 		"keyActualValue": "amazon.aws.aws_s3 has read access for all user groups",

--- a/assets/queries/ansible/aws/ami_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/ami_not_encrypted/query.rego
@@ -1,19 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ec2Ami := task["amazon.aws.ec2_ami"]
-	ec2AmiName := task.name
 	devMap := ec2Ami.device_mapping
 
 	object.get(devMap, "encrypted", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_ami}}", [ec2AmiName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_ami}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "amazon.aws.ec2_ami.device_mapping.device_name.encrypted should be set to true",
 		"keyActualValue": "amazon.aws.ec2_ami.device_mapping.device_name.encrypted is undefined",
@@ -21,20 +19,17 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ec2Ami := task["amazon.aws.ec2_ami"]
-	ec2AmiName := task.name
 	devMap := ec2Ami.device_mapping
+
 	not ansLib.isAnsibleTrue(devMap.encrypted)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_ami}}.device_mapping.encrypted", [ec2AmiName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_ami}}.device_mapping.encrypted", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "amazon.aws.ec2_ami.device_mapping.encrypted should be set to true",
 		"keyActualValue": "amazon.aws.ec2_ami.device_mapping.encrypted is set to false",
 	}
 }
-

--- a/assets/queries/ansible/aws/ami_shared_to_multiple_accounts/query.rego
+++ b/assets/queries/ansible/aws/ami_shared_to_multiple_accounts/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	amiIsShared(task["amazon.aws.ec2_ami"].launch_permissions)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.ec2_ami}}.launch_permissions", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "amazon.aws.ec2_ami.launch_permissions just allows one user to launch the AMI",

--- a/assets/queries/ansible/aws/api_gateway_endpoint_config_is_private/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_endpoint_config_is_private/query.rego
@@ -1,20 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	redshiftCluster := task["community.aws.aws_api_gateway"]
+
 	redshiftCluster.endpoint_type == "PRIVATE"
-	clusterName := task.name
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.aws_api_gateway}}.endpoint_type", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.aws_api_gateway}}.endpoint_type", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.aws_api_gateway.endpoint_type should be set to EDGE or REGIONAL",
 		"keyActualValue": "community.aws.aws_api_gateway.endpoint_type is PRIVATE",
 	}
 }
-

--- a/assets/queries/ansible/aws/api_gateway_has_cloudwatch_logging_disabled/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_has_cloudwatch_logging_disabled/query.rego
@@ -1,19 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsApiGateway := task["community.aws.cloudwatchlogs_log_group"]
+
 	object.get(awsApiGateway, "log_group_name", "undefined") == "undefined"
-	clusterName := task.name
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.cloudwatchlogs_log_group}}", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.cloudwatchlogs_log_group}}", [task.name]),
 		"issueType": "MissingValue",
 		"keyExpectedValue": "community.aws.cloudwatchlogs_log_grouptracing_enabled should contain log_group_name",
 		"keyActualValue": "community.aws.cloudwatchlogs_log_group does not contain log_group_name defined",
 	}
 }
-

--- a/assets/queries/ansible/aws/api_gateway_without_ssl_certificate/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_without_ssl_certificate/query.rego
@@ -1,17 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	modules := {"community.aws.aws_api_gateway", "aws_api_gateway"}
 
 	object.get(task[modules[index]], "validate_certs", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.validate_certs is set", [modules[index]]),
@@ -20,26 +18,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	modules := {"community.aws.aws_api_gateway", "aws_api_gateway"}
 
-	not isTrueOrYes(task[modules[index]].validate_certs)
+	not ansLib.isAnsibleTrue(task[modules[index]].validate_certs)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}.validate_certs", [task.name, modules[index]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.validate_certs is set to yes", [modules[index]]),
 		"keyActualValue": sprintf("%s.validate_certs is not set to yes", [modules[index]]),
 	}
-}
-
-isTrueOrYes(attribute) = allow {
-	possibilities := {"yes", true}
-	attribute == possibilities[j]
-
-	allow = true
 }

--- a/assets/queries/ansible/aws/api_gateway_xray_disabled/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_xray_disabled/query.rego
@@ -1,16 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	tracing := task["community.aws.aws_api_gateway"]
 
 	object.get(tracing, "tracing_enabled", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.aws_api_gateway}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.aws_api_gateway}}.tracing_enabled is defined", [task.name]),
@@ -19,27 +18,17 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	tracing := task["community.aws.aws_api_gateway"]
 	tracingValue := tracing.tracing_enabled
 
-	not isTracingEnabled(tracingValue)
+	not ansLib.isAnsibleTrue(tracingValue)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.aws_api_gateway}}.tracing_enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.aws_api_gateway}}.tracing_enabled is true", [task.name]),
 		"keyActualValue": sprintf("name=%s.{{community.aws.aws_api_gateway}}.tracing_enabled is false", [task.name]),
 	}
-}
-
-isTracingEnabled(value) {
-	lower(value) == "yes"
-} else {
-	lower(value) == "true"
-} else {
-	value == true
 }

--- a/assets/queries/ansible/aws/authentication_without_mfa/query.rego
+++ b/assets/queries/ansible/aws/authentication_without_mfa/query.rego
@@ -1,19 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	modules := {"community.aws.sts_assume_role", "sts_assume_role"}
-
 	attributes := {"mfa_serial_number", "mfa_token"}
 
 	object.get(task[modules[index]], attributes[j], "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.%s is set", [modules[index], attributes[j]]),

--- a/assets/queries/ansible/aws/cloudformation_stack_notifications_disabled/query.rego
+++ b/assets/queries/ansible/aws/cloudformation_stack_notifications_disabled/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["amazon.aws.cloudformation"], "notification_arns", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.cloudformation}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "amazon.aws.cloudformation.notification_arns is set",

--- a/assets/queries/ansible/aws/cloudformation_without_stack_policy/query.rego
+++ b/assets/queries/ansible/aws/cloudformation_without_stack_policy/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["amazon.aws.cloudformation"], "stack_policy", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.cloudformation}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "amazon.aws.cloudformation.stack_policy is set",

--- a/assets/queries/ansible/aws/cloudformation_without_template/query.rego
+++ b/assets/queries/ansible/aws/cloudformation_without_template/query.rego
@@ -1,11 +1,9 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	modules := {"community.aws.cloudformation_stack_set", "amazon.aws.cloudformation"}
 
 	object.get(task[modules[index]], "template_body", "undefined") == "undefined"
@@ -13,7 +11,7 @@ CxPolicy[result] {
 	object.get(task[modules[index]], "template", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s has template, template_body or template_url set", [modules[index]]),
@@ -22,18 +20,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	attributes := {"template_body", "template_url", "template"}
-
 	modules := {"community.aws.cloudformation_stack_set", "amazon.aws.cloudformation"}
 
 	count([x | obj := object.get(task[modules[index]], attributes[x], "undefined"); obj != "undefined"]) > 1
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s does not have more than one of the attributes template, template_body and template_url set", [modules[index]]),

--- a/assets/queries/ansible/aws/cloudfront_configuration_allows_http/query.rego
+++ b/assets/queries/ansible/aws/cloudfront_configuration_allows_http/query.rego
@@ -1,16 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cloudfrontDistribution := task["community.aws.cloudfront_distribution"]
 
 	cloudfrontDistribution.default_cache_behavior.viewer_protocol_policy = "allow-all"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.cloudfront_distribution}}.default_cache_behavior.viewer_protocol_policy", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'default_cache_behavior.viewer_protocol_policy' is equal to 'https-only' or 'redirect-to-https'",

--- a/assets/queries/ansible/aws/cloudfront_logging_is_disabled/query.rego
+++ b/assets/queries/ansible/aws/cloudfront_logging_is_disabled/query.rego
@@ -1,15 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cloudfront := task["community.aws.cloudfront_distribution"]
+
 	object.get(cloudfront, "logging", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.cloudfront_distribution}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.cloudfront_distribution}} logging is defined", [task.name]),
@@ -18,15 +18,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cloudfront := task["community.aws.cloudfront_distribution"]
 	loggingE := cloudfront.logging
+
 	not ansLib.isAnsibleTrue(loggingE.enabled)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.cloudfront_distribution}}.logging.enabled", [task.name2]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.cloudfront_distribution}}.logging.enabled is true", [task.name2]),

--- a/assets/queries/ansible/aws/cloudfront_without_waf/query.rego
+++ b/assets/queries/ansible/aws/cloudfront_without_waf/query.rego
@@ -1,20 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	redshiftCluster := task["community.aws.cloudfront_distribution"]
 
 	not redshiftCluster.web_acl_id
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.cloudfront_distribution}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'web_acl_id' exists",
 		"keyActualValue": "'web_acl_id' is missing",
 	}
 }
-

--- a/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_log_files_not_encrypted_with_kms/query.rego
@@ -1,17 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	modules := {"community.aws.cloudtrail", "cloudtrail"}
 
 	object.get(task[modules[index]], "kms_key_id", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.kms_key_id is set", [modules[index]]),

--- a/assets/queries/ansible/aws/cloudtrail_log_files_without_validation/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_log_files_without_validation/query.rego
@@ -1,17 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	modules := {"community.aws.cloudtrail", "cloudtrail"}
 	object.get(task[modules[index]], "enable_log_file_validation", "undefined") == "undefined"
 	object.get(task[modules[index]], "log_file_validation_enabled", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.enable_log_file_validation or %s.log_file_validation_enabled is defined", [modules[index], modules[index]]),
@@ -20,28 +19,19 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	modules := {"community.aws.cloudtrail", "cloudtrail"}
-
 	attributes := {"enable_log_file_validation", "log_file_validation_enabled"}
 
 	attr := object.get(task[modules[index]], attributes[j], "undefined")
 	attr != "undefined"
-	not isYesOrTrue(attr)
+	not ansLib.isAnsibleTrue(attr)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}.%s", [task.name, modules[index], attributes[j]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.%s is set to true or yes", [modules[index], attributes[j]]),
 		"keyActualValue": sprintf("%s.%s is not set to true or yes", [modules[index], attributes[j]]),
 	}
-}
-
-isYesOrTrue(attribute) {
-	options := {"yes", true, "true"}
-	attribute == options[j]
 }

--- a/assets/queries/ansible/aws/cloudtrail_logging_disabled/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_logging_disabled/query.rego
@@ -1,14 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	ansLib.isAnsibleFalse(task["community.aws.cloudtrail"].enable_logging)
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.cloudtrail}}.enable_logging", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.cloudtrail}}.enable_logging is true", [task.name]),

--- a/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/query.rego
@@ -1,14 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	ansLib.isAnsibleFalse(task["community.aws.cloudtrail"].is_multi_region_trail)
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.cloudtrail}}.is_multi_region_trail", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{community.aws.cloudtrail}}.is_multi_region_trail is true", [task.name]),

--- a/assets/queries/ansible/aws/cloudtrail_sns_topic_name_is_undefined/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_sns_topic_name_is_undefined/query.rego
@@ -1,34 +1,33 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	playbooks := ansLib.getTasks(input.document[i])
-	redis_cache := playbooks[j]
-	instance := redis_cache["community.aws.cloudtrail"]
+	task := ansLib.tasks[id][t]
+	instance := task["community.aws.cloudtrail"]
 
 	not instance.sns_topic_name
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.cloudtrail}}", [playbooks[j].name]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.cloudtrail}}", [task.name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.cloudtrail}}.sns_topic_name is set", [playbooks[j].name]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.cloudtrail}}.sns_topic_name is undefined", [playbooks[j].name]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.cloudtrail}}.sns_topic_name is set", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.cloudtrail}}.sns_topic_name is undefined", [task.name]),
 	}
 }
 
 CxPolicy[result] {
-	playbooks := ansLib.getTasks(input.document[i])
-	redis_cache := playbooks[j]
-	instance := redis_cache["community.aws.cloudtrail"]
+	task := ansLib.tasks[id][t]
+	instance := task["community.aws.cloudtrail"]
 
 	instance.sns_topic_name == null
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.cloudtrail}}.sns_topic_name", [playbooks[j].name]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.cloudtrail}}.sns_topic_name", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.cloudtrail}}.sns_topic_name is set", [playbooks[j].name]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.cloudtrail}}.sns_topic_name is empty", [playbooks[j].name]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.cloudtrail}}.sns_topic_name is set", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.cloudtrail}}.sns_topic_name is empty", [task.name]),
 	}
 }

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_days_specified/query.rego
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_days_specified/query.rego
@@ -1,16 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cloudwatchlogs := task["community.aws.cloudwatchlogs_log_group"]
 
 	not cloudwatchlogs.retention
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("{{community.aws.cloudwatchlogs_log_group}}.name=%s", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'retention_in_days' is set",

--- a/assets/queries/ansible/aws/cloudwatch_without_retention_period_specified/query.rego
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_period_specified/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["community.aws.cloudwatchlogs_log_group"], "retention", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.cloudwatchlogs_log_group}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.cloudwatchlogs_log_group.retention is set",
@@ -18,9 +17,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	value := task["community.aws.cloudwatchlogs_log_group"].retention
 
@@ -29,7 +26,7 @@ CxPolicy[result] {
 	count({x | validValues[x]; validValues[x] == value}) == 0
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.cloudwatchlogs_log_group}}.retention", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.cloudwatchlogs_log_group.retention is set and valid",

--- a/assets/queries/ansible/aws/codebuild_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/codebuild_not_encrypted/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["community.aws.aws_codebuild"], "encryption_key", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.aws_codebuild}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.aws_codebuild.encryption_key is set",

--- a/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/query.rego
+++ b/assets/queries/ansible/aws/config_configuration_aggregator_all_regions_not_enabled/query.rego
@@ -1,16 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cloudwatchlogs := task["community.aws.aws_config_aggregator"]
 
 	not ansLib.isAnsibleTrue(cloudwatchlogs.account_sources.all_aws_regions)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.aws_config_aggregator}}.account_sources.all_aws_regions", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'aws_config_aggregator.account_sources' should have all_aws_regions set to true",
@@ -19,15 +18,13 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cloudwatchlogs := task["community.aws.aws_config_aggregator"]
 
 	not ansLib.isAnsibleTrue(cloudwatchlogs.organization_source.all_aws_regions)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.aws_config_aggregator}}.organization_source.all_aws_regions", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'aws_config_aggregator.organization_source' should have all_aws_regions set to true",

--- a/assets/queries/ansible/aws/config_rule_for_encrypted_volumes_is_disabled/query.rego
+++ b/assets/queries/ansible/aws/config_rule_for_encrypted_volumes_is_disabled/query.rego
@@ -1,16 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	tasks := ansLib.tasks[id]
 	configRules := [t | tasks[_]["community.aws.aws_config_rule"]; t := tasks[x]]
 
 	not checkSource(configRules, "ENCRYPTED_VOLUMES")
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.aws_config_rule}}.source.identifier", [configRules[0].name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "There should be a aws_config_rule with source.identifier equal to 'ENCRYPTED_VOLUMES'",

--- a/assets/queries/ansible/aws/db_instance_storage_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/db_instance_storage_not_encrypted/query.rego
@@ -1,19 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	instance := task["community.aws.rds_instance"]
-	instanceName := task.name
 
 	object.get(instance, "storage_encrypted", "undefined") == "undefined"
 	object.get(instance, "kms_key_id", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.rds_instance}}", [instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.rds_instance}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.rds_instance.storage_encrypted should be set to true",
 		"keyActualValue": "community.aws.rds_instance.storage_encrypted is undefined",
@@ -21,18 +19,15 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	instance := task["community.aws.rds_instance"]
-	instanceName := task.name
 
 	not ansLib.isAnsibleTrue(instance.storage_encrypted)
 	object.get(instance, "kms_key_id", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.rds_instance}}.storage_encrypted", [instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.rds_instance}}.storage_encrypted", [task.name]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": "community.aws.rds_instance.storage_encrypted should be set to true",
 		"keyActualValue": "community.aws.rds_instance.storage_encrypted is set to false",

--- a/assets/queries/ansible/aws/db_security_group_has_public_ip/query.rego
+++ b/assets/queries/ansible/aws/db_security_group_has_public_ip/query.rego
@@ -1,40 +1,39 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	instanceList := tasks[_]
-	ec2_instance = instanceList.ec2_group
-	ec2_instanceName = ec2_instance.name
+	task := ansLib.tasks[id][t]
+	ec2_instance = task.ec2_group
+
 	count(ec2_instance.rules) > 0
 	elements := {elem | elem := ec2_instance.rules[j]; not checkPrivateIps(ec2_instance.rules[j].cidr_ip)}
 	count(elements) > 0
 	values := concat(",", {e | e := elements[p].cidr_ip; true})
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.rules.cidr_ip", [ec2_instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.rules.cidr_ip", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'name={{%s}}.rules.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]", [ec2_instanceName]),
-		"keyActualValue": sprintf("'name={{%s}}.rules.cidr_ip' is [%s]", [ec2_instanceName, values]),
+		"keyExpectedValue": sprintf("'name={{%s}}.rules.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]", [task.name]),
+		"keyActualValue": sprintf("'name={{%s}}.rules.cidr_ip' is [%s]", [task.name, values]),
 	}
 }
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	instanceList := tasks[_]
-	ec2_instance = instanceList.ec2_group
-	ec2_instanceName = ec2_instance.name
+	task := ansLib.tasks[id][t]
+	ec2_instance = task.ec2_group
+
 	elements := {elem | elem := ec2_instance.rules_egress[j]; not checkPrivateIps(ec2_instance.rules_egress[j].cidr_ip)}
 	count(elements) > 0
 	values := concat(",", {e | e := elements[p].cidr_ip; true})
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.rules_egress.cidr_ip", [ec2_instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.rules_egress.cidr_ip", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'name={{%s}}.rules_egress.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]", [ec2_instanceName]),
-		"keyActualValue": sprintf("'name={{%s}}.rules_egress.cidr_ip' is [%s]", [ec2_instanceName, values]),
+		"keyExpectedValue": sprintf("'name={{%s}}.rules_egress.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]", [task.name]),
+		"keyActualValue": sprintf("'name={{%s}}.rules_egress.cidr_ip' is [%s]", [task.name, values]),
 	}
 }
 

--- a/assets/queries/ansible/aws/db_security_group_higher_than_256/query.rego
+++ b/assets/queries/ansible/aws/db_security_group_higher_than_256/query.rego
@@ -1,22 +1,22 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	instanceList := tasks[_]
-	ec2_instance = instanceList.ec2_group
-	ec2_instanceName = ec2_instance.name
+	task := ansLib.tasks[id][t]
+	ec2_instance = task.ec2_group
+
 	count(ec2_instance.rules) > 0
 	elements := {elem | elem := ec2_instance.rules[j]; checkOver256(ec2_instance.rules[j].cidr_ip)}
 	count(elements) > 0
 	values := concat(",", {e | e := elements[p].cidr_ip; true})
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.rules.cidr_ip", [ec2_instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.rules.cidr_ip", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'name={{%s}}.rules.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]", [ec2_instanceName]),
-		"keyActualValue": sprintf("'name={{%s}}.rules.cidr_ip' is [%s]", [ec2_instanceName, values]),
+		"keyExpectedValue": sprintf("'name={{%s}}.rules.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]", [task.name]),
+		"keyActualValue": sprintf("'name={{%s}}.rules.cidr_ip' is [%s]", [task.name, values]),
 	}
 }
 

--- a/assets/queries/ansible/aws/db_security_group_with_public_scope/query.rego
+++ b/assets/queries/ansible/aws/db_security_group_with_public_scope/query.rego
@@ -1,43 +1,40 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	instanceList := tasks[_]
-	ec2_instance = instanceList.ec2_group
-	ec2_instanceName = ec2_instance.name
+	task := ansLib.tasks[id][t]
+	ec2_instance = task.ec2_group
+
 	count(ec2_instance.rules) > 0
 	elements := {elem | elem := ec2_instance.rules[j]; isPublicScope(ec2_instance.rules[j].cidr_ip)}
 	count(elements) > 0
 	values := concat(",", {e | e := elements[p].cidr_ip; true})
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.rules.cidr_ip", [ec2_instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.rules.cidr_ip", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'name={{%s}}.rules.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]", [ec2_instanceName]),
-		"keyActualValue": sprintf("'name={{%s}}.rules.cidr_ip' is [%s]", [ec2_instanceName, values]),
+		"keyExpectedValue": sprintf("'name={{%s}}.rules.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]", [task.name]),
+		"keyActualValue": sprintf("'name={{%s}}.rules.cidr_ip' is [%s]", [task.name, values]),
 	}
 }
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	instanceList := tasks[_]
-	ec2_instance = instanceList.ec2_group
-	ec2_instanceName = ec2_instance.name
+	task := ansLib.tasks[id][t]
+	ec2_instance = task.ec2_group
+
 	elements := {elem | elem := ec2_instance.rules_egress[j]; isPublicScope(ec2_instance.rules_egress[j].cidr_ip)}
 	count(elements) > 0
 	values := concat(",", {e | e := elements[p].cidr_ip; true})
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.rules_egress.cidr_ip", [ec2_instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.rules_egress.cidr_ip", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'name={{%s}}.rules_egress.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]", [ec2_instanceName]),
-		"keyActualValue": sprintf("'name={{%s}}.rules_egress.cidr_ip' is [%s]", [ec2_instanceName, values]),
+		"keyExpectedValue": sprintf("'name={{%s}}.rules_egress.cidr_ip' is one of [10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12]", [task.name]),
+		"keyActualValue": sprintf("'name={{%s}}.rules_egress.cidr_ip' is [%s]", [task.name, values]),
 	}
 }
 
-isPublicScope(ipVal) {
-	ipVal == "0.0.0.0/0"
-}
+isPublicScope("0.0.0.0/0") = true

--- a/assets/queries/ansible/aws/default_security_group_does_not_restrict_all_traffic/query.rego
+++ b/assets/queries/ansible/aws/default_security_group_does_not_restrict_all_traffic/query.rego
@@ -1,12 +1,11 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	group := task["amazon.aws.ec2_group"]
-	groupName := task.name
+
 	searchKey := getCidrBlock(group)
 
 	splitted := regex.split("{{|}}", searchKey)
@@ -14,8 +13,8 @@ CxPolicy[result] {
 	errorValue := splitted[1]
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.%s", [groupName, searchKey]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.%s", [task.name, searchKey]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": sprintf("amazon.aws.ec2_group.%s should not contain the value '%s'", [errorPath, errorValue]),
 		"keyActualValue": sprintf("amazon.aws.ec2_group.%s contains value '%s'", [errorPath, errorValue]),

--- a/assets/queries/ansible/aws/ebs_encryption_disabled/query.rego
+++ b/assets/queries/ansible/aws/ebs_encryption_disabled/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	ansLib.isAnsibleFalse(task["amazon.aws.ec2_vol"].encrypted)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.ec2_vol}}.encrypted", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "AWS EBS encryption should be enabled",
@@ -18,14 +17,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["amazon.aws.ec2_vol"], "encrypted", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.ec2_vol}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "AWS EBS encryption should be defined",

--- a/assets/queries/ansible/aws/ec2_instance_has_hardcoded_access_key/query.rego
+++ b/assets/queries/ansible/aws/ec2_instance_has_hardcoded_access_key/query.rego
@@ -2,15 +2,13 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	user_data := task["community.aws.ec2_instance"].user_data
 
 	re_match("([^A-Z0-9])[A-Z0-9]{20}([^A-Z0-9])", user_data)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ec2_instance}}.user_data", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'community.aws.ec2_instance.user_data' doesn't contain access key",
@@ -19,15 +17,13 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	user_data := task["community.aws.ec2_instance"].user_data
 
 	re_match("[A-Za-z0-9/+=]{40}([^A-Za-z0-9/+=])", user_data)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ec2_instance}}.user_data", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'community.aws.ec2_instance.user_data' doesn't contain access key",

--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/query.rego
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/query.rego
@@ -1,18 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	ipValue := task["amazon.aws.ec2"].assign_public_ip
-	HasPublicIP(ipValue)
+	ansLib.isAnsibleTrue(ipValue)
 
 	# There is no default value for assign_public_ip
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.ec2}}.assign_public_ip", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{amazon.aws.ec2}}.assign_public_ip is false, 'no' or undefined", [task.name]),
@@ -21,17 +20,15 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	ipValue := task["community.aws.ec2_launch_template"].network_interfaces.associate_public_ip_address
-	HasPublicIP(ipValue)
+	ansLib.isAnsibleTrue(ipValue)
 
 	# There is no default value for associate_public_ip_address
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ec2_launch_template}}.network_interfaces.associate_public_ip_address", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.ec2_launch_template}}.network_interfaces.associate_public_ip_address is false, 'no' or undefined", [task.name]),
@@ -40,28 +37,18 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	ipValue := task["community.aws.ec2_instance"].network.assign_public_ip
-	HasPublicIP(ipValue)
+	ansLib.isAnsibleTrue(ipValue)
 
 	# There is no default value for assign_public_ip
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ec2_instance}}.network.assign_public_ip", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.ec2_instance}}.network.assign_public_ip is false, 'no' or undefined", [task.name]),
 		"keyActualValue": sprintf("name=%s.{{community.aws.ec2_instance}}.network.assign_public_ip is '%s'", [task.name, ipValue]),
 	}
-}
-
-HasPublicIP(value) {
-	lower(value) == "yes"
-} else {
-	lower(value) == "true"
-} else {
-	value == true
 }

--- a/assets/queries/ansible/aws/ecr_image_tag_not_immutable/query.rego
+++ b/assets/queries/ansible/aws/ecr_image_tag_not_immutable/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["community.aws.ecs_ecr"], "image_tag_mutability", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ecs_ecr}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.ecs_ecr.image_tag_mutability is set ",
@@ -18,14 +17,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task["community.aws.ecs_ecr"].image_tag_mutability != "immutable"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ecs_ecr}}.image_tag_mutability", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.ecs_ecr.image_tag_mutability is set to 'immutable'",

--- a/assets/queries/ansible/aws/ecr_repository_has_public_access/query.rego
+++ b/assets/queries/ansible/aws/ecr_repository_has_public_access/query.rego
@@ -1,18 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	stat := task["community.aws.ecs_ecr"].policy.Statement[j]
+
 	stat.Effect == "Allow"
 	stat.Principal == "*"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ecs_ecr}}.policy.Statement.Principal='*'", [task.name]),
-		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'Statement.Principal' isn't '*'",
 		"keyActualValue": "'Statement.Principal' is '*'",
 	}

--- a/assets/queries/ansible/aws/ecs_service_admin_role_is_present/query.rego
+++ b/assets/queries/ansible/aws/ecs_service_admin_role_is_present/query.rego
@@ -1,19 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ecs := task["community.aws.ecs_service"]
-	ecsName := task.name
 
 	is_string(ecs.role)
 	contains(lower(ecs.role), "admin")
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.ecs_service}}.role", [ecsName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.ecs_service}}.role", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.ecs_service.role is not an admin role",
 		"keyActualValue": "community.aws.ecs_service.role is an admin role",

--- a/assets/queries/ansible/aws/ecs_task_definition_container_has_password/query.rego
+++ b/assets/queries/ansible/aws/ecs_task_definition_container_has_password/query.rego
@@ -1,16 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	password := ["password", "pw", "pass"]
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cont := task["community.aws.ecs_taskdefinition"].containers[j]
+	password := ["password", "pw", "pass"]
+
 	checkPassword(cont.env, password)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ecs_taskdefinition}}.containers.name={{%s}}.env", [task.name, cont.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'community.aws.ecs_taskdefinition.containers.env' doesn't have 'password' value",

--- a/assets/queries/ansible/aws/ecs_task_definition_network_mode_not_recommended/query.rego
+++ b/assets/queries/ansible/aws/ecs_task_definition_network_mode_not_recommended/query.rego
@@ -1,16 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	task["community.aws.ecs_taskdefinition"].network_mode != "awsvpc"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ecs_taskdefinition}}.network_mode", [task.name]),
-		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'community.aws.ecs_taskdefinition.network_mode' is 'awsvpc'",
 		"keyActualValue": sprintf("'community.aws.ecs_taskdefinition.network_mode' is '%s'", [task["community.aws.ecs_taskdefinition"].network_mode]),
 	}

--- a/assets/queries/ansible/aws/efs_is_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/efs_is_not_encrypted/query.rego
@@ -1,18 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	fs := task["community.aws.efs"]
-	fsName := task.name
 
 	object.get(fs, "encrypt", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.efs}}", [fsName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.efs}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.efs.encrypt should be set to true",
 		"keyActualValue": "community.aws.efs.encrypt is undefined",
@@ -20,17 +18,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	fs := task["community.aws.efs"]
-	fsName := task.name
 
 	not ansLib.isAnsibleTrue(fs.encrypt)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.efs}}.encrypt", [fsName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.efs}}.encrypt", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.efs.encrypt should be set to true",
 		"keyActualValue": "community.aws.efs.encrypt is set to false",

--- a/assets/queries/ansible/aws/elasticsearch_encryption_with_kms_is_disabled/query.rego
+++ b/assets/queries/ansible/aws/elasticsearch_encryption_with_kms_is_disabled/query.rego
@@ -1,26 +1,19 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	elasticsearch = tasks[_][j]
-	elasticsearchBody = elasticsearch.ec2_elasticsearch
-	elasticsearchName = elasticsearchBody.name
-	not is_disabled(elasticsearchBody.encryption_at_rest_enabled)
-	object.get(elasticsearchBody, "encryption_at_rest_kms_key_id", "undefined") == "undefined"
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{encryption_at_rest_kms_key_id}}", [elasticsearchName]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name={{%s}}.encryption_at_rest_kms_key_id should be defined", [elasticsearchName]),
-		"keyActualValue": sprintf("name={{%s}}.encryption_at_rest_kms_key_id is undefined", [elasticsearchName]),
-	}
-}
+	task = ansLib.tasks[id][t]
+	elasticsearch = task.ec2_elasticsearch
 
-is_disabled(value) {
-	negativeValue = {"False", false, "false", "No", "no"}
-	value == negativeValue[_]
-} else = false {
-	true
+	not ansLib.isAnsibleFalse(elasticsearch.encryption_at_rest_enabled)
+	object.get(elasticsearch, "encryption_at_rest_kms_key_id", "undefined") == "undefined"
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.ec2_elasticsearch.{{encryption_at_rest_kms_key_id}}", [task.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("name={{%s}}.ec2_elasticsearch.encryption_at_rest_kms_key_id should be defined", [task.name]),
+		"keyActualValue": sprintf("name={{%s}}.ec2_elasticsearch.encryption_at_rest_kms_key_id is undefined", [task.name]),
+	}
 }

--- a/assets/queries/ansible/aws/elasticsearch_encryption_with_kms_is_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/elasticsearch_encryption_with_kms_is_disabled/test/positive_expected_result.json
@@ -1,7 +1,7 @@
 [
-	{
-		"queryName": "ElasticSearch Encryption With KMS Is Disabled",
-		"severity": "MEDIUM",
-		"line": 5
-	}
+  {
+    "queryName": "ElasticSearch Encryption With KMS Is Disabled",
+    "severity": "MEDIUM",
+    "line": 4
+  }
 ]

--- a/assets/queries/ansible/aws/elasticsearch_not_encrypted_at_rest/query.rego
+++ b/assets/queries/ansible/aws/elasticsearch_not_encrypted_at_rest/query.rego
@@ -1,43 +1,33 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	elasticsearch = tasks[_][j]
-	elasticsearchBody = elasticsearch.ec2_elasticsearch
-	elasticsearchName = elasticsearchBody.name
-	is_disabled(elasticsearchBody.encryption_at_rest_enabled)
+	task = ansLib.tasks[id][t]
+	elasticsearch = task.ec2_elasticsearch
+
+	ansLib.isAnsibleFalse(elasticsearch.encryption_at_rest_enabled)
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{encryption_at_rest_enabled}}", [elasticsearchName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.ec2_elasticsearch.{{encryption_at_rest_enabled}}", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name={{%s}}.encryption_at_rest_enabled should be enabled", [elasticsearchName]),
-		"keyActualValue": sprintf("name={{%s}}.encryption_at_rest_enabled is disabled", [elasticsearchName]),
+		"keyExpectedValue": sprintf("name={{%s}}.ec2_elasticsearch.encryption_at_rest_enabled should be enabled", [task.name]),
+		"keyActualValue": sprintf("name={{%s}}.ec2_elasticsearch.encryption_at_rest_enabled is disabled", [task.name]),
 	}
 }
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	elasticsearch = tasks[_][j]
-	elasticsearchBody = elasticsearch.ec2_elasticsearch
-	elasticsearchName = elasticsearchBody.name
-	object.get(elasticsearchBody, "encryption_at_rest_enabled", "undefined") == "undefined"
+	task = ansLib.tasks[id][t]
+	elasticsearch = task.ec2_elasticsearch
+
+	object.get(elasticsearch, "encryption_at_rest_enabled", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}", [elasticsearchName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.ec2_elasticsearch", [task.name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("name={{%s}}.encryption_at_rest_enabled should be set and enabled", [elasticsearchName]),
-		"keyActualValue": sprintf("name={{%s}}.encryption_at_rest_enabled is undefined", [elasticsearchName]),
+		"keyExpectedValue": sprintf("name={{%s}}.ec2_elasticsearch.encryption_at_rest_enabled should be set and enabled", [task.name]),
+		"keyActualValue": sprintf("name={{%s}}.ec2_elasticsearch.encryption_at_rest_enabled is undefined", [task.name]),
 	}
 }
-
-is_disabled(value) {
-	negativeValue = {"False", false, "false", "No", "no"}
-	value == negativeValue[_]
-} else = false {
-	true
-}
-

--- a/assets/queries/ansible/aws/elasticsearch_not_encrypted_at_rest/test/positive.yaml
+++ b/assets/queries/ansible/aws/elasticsearch_not_encrypted_at_rest/test/positive.yaml
@@ -20,7 +20,7 @@
         access_policies: "{{ lookup('file', 'files/cluster_policies.json') | from_json }}"
         encryption_at_rest_enabled : false
         profile: "myawsaccount"
-    - name: "Create ElasticSearch cluster"
+    - name: "Create second ElasticSearch cluster"
       ec2_elasticsearch:
         name: "my-cluster-2"
         elasticsearch_version: "2.3"

--- a/assets/queries/ansible/aws/elasticsearch_not_encrypted_at_rest/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/elasticsearch_not_encrypted_at_rest/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
-	{
-		"queryName": "ElasticSearch Not Encrypted At Rest",
-		"severity": "MEDIUM",
-		"line": 21
-	},
-	{
-		"queryName": "ElasticSearch Not Encrypted At Rest",
-		"severity": "MEDIUM",
-		"line": 25
-	}
+  {
+    "queryName": "ElasticSearch Not Encrypted At Rest",
+    "severity": "MEDIUM",
+    "line": 21
+  },
+  {
+    "queryName": "ElasticSearch Not Encrypted At Rest",
+    "severity": "MEDIUM",
+    "line": 24
+  }
 ]

--- a/assets/queries/ansible/aws/elb_using_insecure_protocols/query.rego
+++ b/assets/queries/ansible/aws/elb_using_insecure_protocols/query.rego
@@ -1,18 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_application_lb"]
-	elbName := task.name
 
 	object.get(elb, "listeners", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}", [elbName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.elb_application_lb.listeners is defined",
 		"keyActualValue": "community.aws.elb_application_lb.listeners is undefined",
@@ -20,17 +18,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_application_lb"]
-	elbName := task.name
 
 	object.get(elb.listeners[j], "SslPolicy", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.%s", [elbName, j]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.%s", [task.name, j]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.elb_application_lb.listeners.SslPolicy is defined",
 		"keyActualValue": "community.aws.elb_application_lb.listeners.SslPolicy is undefined",
@@ -38,17 +33,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_application_lb"]
-	elbName := task.name
 
 	check_vulnerability(elb.listeners[j].SslPolicy)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.%s", [elbName, j]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.%s", [task.name, j]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.elb_application_lb.listeners.SslPolicy is not a weak cipher",
 		"keyActualValue": "community.aws.elb_application_lb.listeners.SslPolicy is a weak cipher",
@@ -56,17 +48,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_network_lb"]
-	elbName := task.name
 
 	object.get(elb, "listeners", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}", [elbName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.elb_network_lb.listeners is defined",
 		"keyActualValue": "community.aws.elb_network_lb.listeners is undefined",
@@ -74,17 +63,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_network_lb"]
-	elbName := task.name
 
 	object.get(elb.listeners[j], "SslPolicy", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}.listeners.%s", [elbName, j]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}.listeners.%s", [task.name, j]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.elb_network_lb.listeners.SslPolicy is defined",
 		"keyActualValue": "community.aws.elb_network_lb.listeners.SslPolicy is undefined",
@@ -92,17 +78,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_network_lb"]
-	elbName := task.name
 
 	check_vulnerability(elb.listeners[j].SslPolicy)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}.listeners.%s", [elbName, j]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}.listeners.%s", [task.name, j]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.elb_network_lb.listeners.SslPolicy is not a weak cipher",
 		"keyActualValue": "community.aws.elb_network_lb.listeners.SslPolicy is a weak cipher",

--- a/assets/queries/ansible/aws/elb_using_weak_ciphers/query.rego
+++ b/assets/queries/ansible/aws/elb_using_weak_ciphers/query.rego
@@ -1,18 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_application_lb"]
-	elbName := task.name
 
 	object.get(elb, "listeners", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}", [elbName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.elb_application_lb.listeners is defined",
 		"keyActualValue": "community.aws.elb_application_lb.listeners is undefined",
@@ -20,17 +18,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_application_lb"]
-	elbName := task.name
 
 	object.get(elb.listeners[j], "SslPolicy", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.%s", [elbName, j]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.%s", [task.name, j]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.elb_application_lb.listeners.SslPolicy is defined",
 		"keyActualValue": "community.aws.elb_application_lb.listeners.SslPolicy is undefined",
@@ -38,17 +33,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_application_lb"]
-	elbName := task.name
 
 	check_vulnerability(elb.listeners[j].SslPolicy)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.%s", [elbName, j]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_application_lb}}.listeners.%s", [task.name, j]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.elb_application_lb.listeners.SslPolicy is not a weak cipher",
 		"keyActualValue": "community.aws.elb_application_lb.listeners.SslPolicy is a weak cipher",
@@ -56,17 +48,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_network_lb"]
-	elbName := task.name
 
 	object.get(elb, "listeners", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}", [elbName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.elb_network_lb.listeners is defined",
 		"keyActualValue": "community.aws.elb_network_lb.listeners is undefined",
@@ -74,17 +63,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_network_lb"]
-	elbName := task.name
 
 	object.get(elb.listeners[j], "SslPolicy", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}.listeners.%s", [elbName, j]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}.listeners.%s", [task.name, j]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.elb_network_lb.listeners.SslPolicy is defined",
 		"keyActualValue": "community.aws.elb_network_lb.listeners.SslPolicy is undefined",
@@ -92,17 +78,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	elb := task["community.aws.elb_network_lb"]
-	elbName := task.name
 
 	check_vulnerability(elb.listeners[j].SslPolicy)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}.listeners.%s", [elbName, j]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.elb_network_lb}}.listeners.%s", [task.name, j]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.elb_network_lb.listeners.SslPolicy is not a weak cipher",
 		"keyActualValue": "community.aws.elb_network_lb.listeners.SslPolicy is a weak cipher",

--- a/assets/queries/ansible/aws/fully_open_ingress/query.rego
+++ b/assets/queries/ansible/aws/fully_open_ingress/query.rego
@@ -1,12 +1,10 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	group := task["amazon.aws.ec2_group"]
-	groupName := task.name
 
 	searchKey := getCidrBlock(group)
 
@@ -15,8 +13,8 @@ CxPolicy[result] {
 	errorValue := splitted[1]
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.%s", [groupName, searchKey]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.%s", [task.name, searchKey]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": sprintf("amazon.aws.ec2_group.%s should not contain the value '%s'", [errorPath, errorValue]),
 		"keyActualValue": sprintf("amazon.aws.ec2_group.%s contains value '%s'", [errorPath, errorValue]),

--- a/assets/queries/ansible/aws/http_port_open/query.rego
+++ b/assets/queries/ansible/aws/http_port_open/query.rego
@@ -1,13 +1,13 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	fromPort := task["amazon.aws.ec2_group"].rules[index].from_port
 	toPort := task["amazon.aws.ec2_group"].rules[index].to_port
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 80
 	fromPort != -1
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	toPort >= portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules doesn't open the http port (%s)", [task.name, portNumber]),
@@ -24,17 +24,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 80
 	ports == portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the http port (%s)", [task.name, portNumber]),
@@ -43,11 +42,10 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 80
 	mports := split(ports, "-")
@@ -55,7 +53,7 @@ CxPolicy[result] {
 	to_number(mports[1]) >= portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the http port (%s)", [task.name, portNumber]),
@@ -64,11 +62,10 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports[_]
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 80
 	mports := split(ports, "-")
@@ -76,7 +73,7 @@ CxPolicy[result] {
 	to_number(mports[1]) >= portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the http port (%s)", [task.name, portNumber]),
@@ -85,17 +82,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports[_]
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 80
 	ports == portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the http port (%s)", [task.name, portNumber]),
@@ -104,17 +100,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	fromPort := task["amazon.aws.ec2_group"].rules[index].from_port
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 80
 	fromPort == -1
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.from_port", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.from_port doesn't open the http port (%s)", [task.name, portNumber]),
@@ -123,17 +118,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	toPort := task["amazon.aws.ec2_group"].rules[index].to_port
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 80
 	toPort == -1
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.to_port", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.to_port doesn't open the http port (%s)", [task.name, portNumber]),

--- a/assets/queries/ansible/aws/https_traffic_disabled/query.rego
+++ b/assets/queries/ansible/aws/https_traffic_disabled/query.rego
@@ -1,14 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	task["community.aws.cloudfront_distribution"].default_cache_behavior.viewer_protocol_policy == "allow-all"
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.cloudfront_distribution}}.default_cache_behavior.viewer_protocol_policy", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.cloudfront_distribution}}.default_cache_behavior.viewer_protocol_policy is 'https-only' or 'redirect-to-https'", [task.name]),
@@ -17,13 +17,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	task["community.aws.cloudfront_distribution"].cache_behaviors.viewer_protocol_policy == "allow-all"
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.cloudfront_distribution}}.cache_behaviors.viewer_protocol_policy", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.cloudfront_distribution}}.cache_behaviors.viewer_protocol_policy is 'https-only' or 'redirect-to-https'", [task.name]),

--- a/assets/queries/ansible/aws/iam_access_key_is_exposed/query.rego
+++ b/assets/queries/ansible/aws/iam_access_key_is_exposed/query.rego
@@ -1,19 +1,19 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	iamuserObj = tasks[_]
-	iamuserObjBody = iamuserObj["community.aws.iam"]
-	iamuserObjName = iamuserObj.name
-	lower(iamuserObjBody.access_key_state) == "active"
-	not contains(lower(iamuserObjBody.name),"root")
+	task = ansLib.tasks[id][t]
+	iamuser = task["community.aws.iam"]
+
+	lower(iamuser.access_key_state) == "active"
+	not contains(lower(iamuser.name), "root")
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam}}.access_key_state", [iamuserObjName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam}}.access_key_state", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}}.{{community.aws.iam}}.name is 'root' for an active access key", [iamuserObjName]),
-		"keyActualValue": sprintf("{{%s}}.{{community.aws.iam}}.name is '%s' for an active access key", [iamuserObjName, iamuserObjBody.name]),
+		"keyExpectedValue": sprintf("{{%s}}.{{community.aws.iam}}.name is 'root' for an active access key", [task.name]),
+		"keyActualValue": sprintf("{{%s}}.{{community.aws.iam}}.name is '%s' for an active access key", [task.name, iamuser.name]),
 	}
 }

--- a/assets/queries/ansible/aws/iam_database_auth_not_enabled/query.rego
+++ b/assets/queries/ansible/aws/iam_database_auth_not_enabled/query.rego
@@ -1,42 +1,33 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	rds_instance := tasks[_]
-	rds_instanceBody := rds_instance["community.aws.rds_instance"]
-	rds_instanceName := rds_instance.name
-	is_disabled(rds_instanceBody.enable_iam_database_authentication)
+	task := ansLib.tasks[id][t]
+	rds_instance := task["community.aws.rds_instance"]
+
+	ansLib.isAnsibleFalse(rds_instance.enable_iam_database_authentication)
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.enable_iam_database_authentication", [rds_instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.enable_iam_database_authentication", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}}.enable_iam_database_authentication should be enabled.", [rds_instanceName]),
-		"keyActualValue": sprintf("{{%s}}.enable_iam_database_authentication is disabled", [rds_instanceName]),
+		"keyExpectedValue": sprintf("{{%s}}.enable_iam_database_authentication should be enabled.", [task.name]),
+		"keyActualValue": sprintf("{{%s}}.enable_iam_database_authentication is disabled", [task.name]),
 	}
 }
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	rds_instance := tasks[_]
-	rds_instanceBody := rds_instance["community.aws.rds_instance"]
-	rds_instanceName := rds_instance.name
-	object.get(rds_instanceBody, "enable_iam_database_authentication", "undefined") == "undefined"
+	task := ansLib.tasks[id][t]
+	rds_instance := task["community.aws.rds_instance"]
+
+	object.get(rds_instance, "enable_iam_database_authentication", "undefined") == "undefined"
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}", [rds_instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}", [task.name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("{{%s}}.enable_iam_database_authentication should be defined", [rds_instanceName]),
-		"keyActualValue": sprintf("{{%s}}.enable_iam_database_authentication is undefined", [rds_instanceName]),
+		"keyExpectedValue": sprintf("{{%s}}.enable_iam_database_authentication should be defined", [task.name]),
+		"keyActualValue": sprintf("{{%s}}.enable_iam_database_authentication is undefined", [task.name]),
 	}
 }
-
-is_disabled(value) {
-	negativeValue = {"False", false, "false", "No", "no"}
-	value == negativeValue[_]
-} else = false {
-	true
-}
-

--- a/assets/queries/ansible/aws/iam_password_without_lowercase_letter/query.rego
+++ b/assets/queries/ansible/aws/iam_password_without_lowercase_letter/query.rego
@@ -1,44 +1,33 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-	policyBody := task["community.aws.iam_password_policy"]
-	object.get(policyBody, "require_lowercase", "undefined") == "undefined"
-	policyName := task.name
+	task := ansLib.tasks[id][t]
+	policy := task["community.aws.iam_password_policy"]
+
+	object.get(policy, "require_lowercase", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_lowercase", [policyName]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_lowercase", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_lowercase' set and true", [policyName]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_lowercase' undefined", [policyName]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_lowercase' set and true", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_lowercase' undefined", [task.name]),
 	}
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-	policyBody := task["community.aws.iam_password_policy"]
-	checkFalse(policyBody.require_lowercase)
-	policyName := task.name
+	task := ansLib.tasks[id][t]
+	policy := task["community.aws.iam_password_policy"]
+
+	ansLib.isAnsibleFalse(policy.require_lowercase)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_lowercase", [policyName]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_lowercase", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_lowercase is true", [policyName]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_lowercase is false", [policyName]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_lowercase is true", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_lowercase is false", [task.name]),
 	}
-}
-
-checkFalse(lowercase) {
-	lower(lowercase) == "no"
-} else {
-	lower(lowercase) == "false"
-} else {
-	lowercase == false
 }

--- a/assets/queries/ansible/aws/iam_password_without_numbers/query.rego
+++ b/assets/queries/ansible/aws/iam_password_without_numbers/query.rego
@@ -1,44 +1,33 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-	policyBody := task["community.aws.iam_password_policy"]
-	object.get(policyBody, "require_numbers", "undefined") == "undefined"
-	policyName := task.name
+	task := ansLib.tasks[id][t]
+	policy := task["community.aws.iam_password_policy"]
+
+	object.get(policy, "require_numbers", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_numbers", [policyName]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_numbers", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_numbers' set and true", [policyName]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_numbers' undefined", [policyName]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_numbers' set and true", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_numbers' undefined", [task.name]),
 	}
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-	policyBody := task["community.aws.iam_password_policy"]
-	checkFalse(policyBody.require_numbers)
-	policyName := task.name
+	task := ansLib.tasks[id][t]
+	policy := task["community.aws.iam_password_policy"]
+
+	ansLib.isAnsibleFalse(policy.require_numbers)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_numbers", [policyName]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_numbers", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_numbers is true", [policyName]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_numbers is false", [policyName]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_numbers is true", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_numbers is false", [task.name]),
 	}
-}
-
-checkFalse(require_numbers) {
-	lower(require_numbers) == "no"
-} else {
-	lower(require_numbers) == "false"
-} else {
-	require_numbers == false
 }

--- a/assets/queries/ansible/aws/iam_password_without_uppercase_letter/query.rego
+++ b/assets/queries/ansible/aws/iam_password_without_uppercase_letter/query.rego
@@ -1,44 +1,33 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-	policyBody := task["community.aws.iam_password_policy"]
-	object.get(policyBody, "require_uppercase", "undefined") == "undefined"
-	policyName := task.name
+	task := ansLib.tasks[id][t]
+	policy := task["community.aws.iam_password_policy"]
+
+	object.get(policy, "require_uppercase", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_uppercase", [policyName]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_uppercase", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_uppercase' set and true", [policyName]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_uppercase' undefined", [policyName]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_uppercase' set and true", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}} have 'require_uppercase' undefined", [task.name]),
 	}
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-	policyBody := task["community.aws.iam_password_policy"]
-	checkFalse(policyBody.require_uppercase)
-	policyName := task.name
+	task := ansLib.tasks[id][t]
+	policy := task["community.aws.iam_password_policy"]
+
+	ansLib.isAnsibleFalse(policy.require_uppercase)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_uppercase", [policyName]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_uppercase", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_uppercase is true", [policyName]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_uppercase is false", [policyName]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_uppercase is true", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.iam_password_policy}}.require_uppercase is false", [task.name]),
 	}
-}
-
-checkFalse(uppercase) {
-	lower(uppercase) == "no"
-} else {
-	lower(uppercase) == "false"
-} else {
-	uppercase == false
 }

--- a/assets/queries/ansible/aws/iam_password_without_valid_minimum_length/query.rego
+++ b/assets/queries/ansible/aws/iam_password_without_valid_minimum_length/query.rego
@@ -1,18 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	firstPolicy = tasks[_]
-	policyBody = firstPolicy["community.aws.iam_password_policy"]
-	policyName = firstPolicy.name
+	task = ansLib.tasks[id][t]
+	policy = task["community.aws.iam_password_policy"]
 
-	not getName(policyBody)
+	not getName(policy)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_password_policy}}", [policyName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_password_policy}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'min_pw_length/minimum_password_length' is set and no less than 8",
 		"keyActualValue": "'min_pw_length/minimum_password_length' is undefined",
@@ -20,18 +18,15 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	firstPolicy = tasks[_]
-	policyBody = firstPolicy["community.aws.iam_password_policy"]
-	policyName = firstPolicy.name
+	task = ansLib.tasks[id][t]
+	policy = task["community.aws.iam_password_policy"]
 
-	variableName = getName(policyBody)
-	to_number(policyBody[variableName]) < 8
+	variableName = getName(policy)
+	to_number(policy[variableName]) < 8
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_password_policy}}.{{min_pw_length}}", [policyName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_password_policy}}.{{min_pw_length}}", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'%s' is set and no less than 8", [variableName]),
 		"keyActualValue": sprintf("'%s' is less than 8", [variableName]),

--- a/assets/queries/ansible/aws/iam_policies_attached_to_user/query.rego
+++ b/assets/queries/ansible/aws/iam_policies_attached_to_user/query.rego
@@ -1,17 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsApiGateway := task["community.aws.iam_managed_policy"]
 	ansLib.checkState(awsApiGateway)
+
 	lower(awsApiGateway.iam_type) == "user"
-	clusterName := task.name
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.iam_type", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.iam_type", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.iam_managed_policy.iam_type should be configured with group or role",
 		"keyActualValue": "community.aws.iam_managed_policy.iam_type is configured with user",

--- a/assets/queries/ansible/aws/iam_policies_with_full_privileges/query.rego
+++ b/assets/queries/ansible/aws/iam_policies_with_full_privileges/query.rego
@@ -1,20 +1,20 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsApiGateway := task["community.aws.iam_managed_policy"]
-	contains(awsApiGateway.state, "present")
+	ansLib.checkState(awsApiGateway)
+
 	resource := awsApiGateway.policy.Statement[_].Resource
 	contains(resource, "*")
 	action := awsApiGateway.policy.Statement[_].Action[j]
 	contains(action, "*")
-	clusterName := task.name
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.policy.Statement.Action", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.policy.Statement.Action", [task.name]),
 		"issueType": "MissingValue",
 		"keyExpectedValue": "community.aws.iam_managed_policy.policy.Statement.Action not contains '*'",
 		"keyActualValue": "community.aws.iam_managed_policy.policy.Statement.Action contains '*'",

--- a/assets/queries/ansible/aws/iam_policy_allows_all_in_policy_statement/query.rego
+++ b/assets/queries/ansible/aws/iam_policy_allows_all_in_policy_statement/query.rego
@@ -1,19 +1,19 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsApiGateway := task["community.aws.iam_managed_policy"]
 	ansLib.checkState(awsApiGateway)
+
 	statement := awsApiGateway.policy.Statement[_]
 	contains(statement.Resource, "*")
 	contains(statement.Effect, "Allow")
-	clusterName := task.name
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.policy.Statement.Resource", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.policy.Statement.Resource", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.iam_managed_policy.policy.Statement.Resource not equal '*'",
 		"keyActualValue": "community.aws.iam_managed_policy.policy.Statement.Resource equal '*'",
@@ -21,19 +21,18 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsApiGateway := task["community.aws.iam_managed_policy"]
 	ansLib.checkState(awsApiGateway.state)
+
 	policy := json_unmarshal(awsApiGateway.policy)
 	statement := policy.Statement[_]
 	contains(statement.Resource, "*")
 	contains(statement.Effect, "Allow")
-	clusterName := task.name
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.Statement.Principal.AWS", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.Statement.Principal.AWS", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.iam_managed_policy.policy.Statement.Principal.AWS should not contain ':root",
 		"keyActualValue": "community.aws.iam_managed_policy.policy.Statement.Principal.AWS contains ':root'",
@@ -49,4 +48,3 @@ json_unmarshal(s) = result {
 	s != null
 	result := json.unmarshal(s)
 }
-

--- a/assets/queries/ansible/aws/iam_role_allows_all_principals_to_assume/query.rego
+++ b/assets/queries/ansible/aws/iam_role_allows_all_principals_to_assume/query.rego
@@ -1,22 +1,22 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsApiGateway := task["community.aws.iam_managed_policy"]
-	contains(awsApiGateway.state, "present")
+	ansLib.checkState(awsApiGateway)
+
 	policy := json_unmarshal(awsApiGateway.policy)
 	statement := policy.Statement[_]
 	resource := statement.Principal.AWS
 	contains(resource, "arn:aws:iam::")
 	contains(resource, ":root")
 	not contains(statement.Effect, "Deny")
-	clusterName := task.name
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.Statement.Principal.AWS", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.Statement.Principal.AWS", [task.name]),
 		"issueType": "IncorrectAttribute",
 		"keyExpectedValue": "community.aws.iam_managed_policy.policy.Statement.Principal.AWS should not contain ':root",
 		"keyActualValue": "community.aws.iam_managed_policy.policy.Statement.Principal.AWS contains ':root'",
@@ -24,20 +24,19 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsApiGateway := task["community.aws.iam_managed_policy"]
-	contains(awsApiGateway.state, "present")
+	ansLib.checkState(awsApiGateway)
+
 	statement := awsApiGateway.policy.Statement[_]
 	resource := statement.Principal[j].AWS
 	contains(resource, "arn:aws:iam::")
 	contains(resource, ":root")
 	not contains(statement.Effect, "Deny")
-	clusterName := task.name
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.Statement.Principal.AWS", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.Statement.Principal.AWS", [task.name]),
 		"issueType": "IncorrectAttribute",
 		"keyExpectedValue": "community.aws.iam_managed_policy.policy.Statement.Principal.AWS should not contain ':root",
 		"keyActualValue": "community.aws.iam_managed_policy.policy.Statement.Principal.AWS contains ':root'",

--- a/assets/queries/ansible/aws/iam_role_allows_public_assume/query.rego
+++ b/assets/queries/ansible/aws/iam_role_allows_public_assume/query.rego
@@ -1,20 +1,20 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsApiGateway := task["community.aws.iam_managed_policy"]
-	contains(awsApiGateway.state, "present")
+	ansLib.checkState(awsApiGateway)
+
 	statement := awsApiGateway.policy.Statement[_]
 	resource := statement.Principal[j].AWS
 	contains(resource, "*")
 	not statement.Effect
-	clusterName := task.name
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.Statement.Principal.AWS", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.Statement.Principal.AWS", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.iam_managed_policy.policy.Statement.Principal.AWS should not contain '*'",
 		"keyActualValue": "community.aws.iam_managed_policy.policy.Statement.Principal.AWS contains '*'",
@@ -22,19 +22,18 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsApiGateway := task["community.aws.iam_managed_policy"]
-	contains(awsApiGateway.state, "present")
+	ansLib.checkState(awsApiGateway)
+
 	statement := awsApiGateway.policy.Statement[_]
 	resource := statement.Principal[j].AWS
 	contains(resource, "*")
 	not contains(statement.Effect, "Deny")
-	clusterName := task.name
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.Statement.Principal.AWS", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_managed_policy}}.Statement.Principal.AWS", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.iam_managed_policy.policy.Statement.Principal.AWS should not contain '*'",
 		"keyActualValue": "community.aws.iam_managed_policy.policy.Statement.Principal.AWS contains '*'",

--- a/assets/queries/ansible/aws/incorrect_password_policy_expiration/query.rego
+++ b/assets/queries/ansible/aws/incorrect_password_policy_expiration/query.rego
@@ -1,19 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	pwPolicy := task["community.aws.iam_password_policy"]
-	pwPolicyName := task.name
 
 	searchKey := checkPwMaxAge(pwPolicy)
 	searchKey != "none"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_password_policy}}%s", [pwPolicyName, searchKey]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_password_policy}}%s", [task.name, searchKey]),
 		"issueType": issueType(searchKey),
 		"keyExpectedValue": "community.aws.iam_password_policy should have the property 'pw_max_age/password_max_age' lower than 90",
 		"keyActualValue": "community.aws.iam_password_policy has the property 'pw_max_age/password_max_age' unassigned or greater than 90",

--- a/assets/queries/ansible/aws/instance_with_no_vpc/query.rego
+++ b/assets/queries/ansible/aws/instance_with_no_vpc/query.rego
@@ -1,17 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	modules := {"community.aws.ec2_instance", "amazon.aws.ec2"}
 
 	object.get(task[modules[index]], "vpc_subnet_id", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.vpc_subnet_id is set", [modules[index]]),

--- a/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/query.rego
+++ b/assets/queries/ansible/aws/kinesis_not_encrypted_with_kms/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["community.aws.kinesis_stream"], "encryption_type", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.kinesis_stream}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.kinesis_stream.encryption_type is set",
@@ -18,14 +17,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["community.aws.kinesis_stream"], "encryption_state", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.kinesis_stream}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.kinesis_stream.encryption_state is set",
@@ -34,14 +31,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task["community.aws.kinesis_stream"].encryption_state != "enabled"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.kinesis_stream}}.encryption_state", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.kinesis_stream.encryption_state is set to enabled",
@@ -50,14 +45,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task["community.aws.kinesis_stream"].encryption_type == "NONE"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.kinesis_stream}}.encryption_type", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.kinesis_stream.encryption_type is set and not NONE",
@@ -66,15 +59,13 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task["community.aws.kinesis_stream"].encryption_type == "KMS"
 	object.get(task["community.aws.kinesis_stream"], "key_id", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.kinesis_stream}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.kinesis_stream.key_id is set",

--- a/assets/queries/ansible/aws/kms_key_with_vulnerable_policy/query.rego
+++ b/assets/queries/ansible/aws/kms_key_with_vulnerable_policy/query.rego
@@ -1,18 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	aws_kms := task["community.aws.aws_kms"]
-	policy_exists := object.get(aws_kms, "policy", "undefined") != "undefined"
 
+	policy_exists := object.get(aws_kms, "policy", "undefined") != "undefined"
 	statement = aws_kms.policy.Statement[_]
 	check_permission(statement) == true
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.aws_kms}}.policy", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.aws_kms}}.policy is correct", [task.name]),

--- a/assets/queries/ansible/aws/lambda_hardcoded_aws_access_key/query.rego
+++ b/assets/queries/ansible/aws/lambda_hardcoded_aws_access_key/query.rego
@@ -1,19 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	awsLambda := tasks[_]
-	awsLambdaBody := awsLambda["community.aws.lambda"]
+	task := ansLib.tasks[id][t]
+	lambda := task["community.aws.lambda"]
 
-	awsLambdaName := awsLambda.name
-	regex.match(`^[A-Za-z0-9/+=]{40}$`, awsLambdaBody.aws_access_key)
+	regex.match(`^[A-Za-z0-9/+=]{40}$`, lambda.aws_access_key)
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.aws_access_key", [awsLambdaName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.lambda}}.aws_access_key", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}}.aws_access_key should not be in plaintext.", [awsLambdaName]),
-		"keyActualValue": sprintf("{{%s}}aws_access_key is in plaintext ", [awsLambdaName, awsLambdaBody.name]),
+		"keyExpectedValue": sprintf("{{%s}}.{{community.aws.lambda}}.aws_access_key should not be in plaintext", [task.name]),
+		"keyActualValue": sprintf("{{%s}}.{{community.aws.lambda}}.aws_access_key is in plaintext", [task.name]),
 	}
 }

--- a/assets/queries/ansible/aws/lambda_without_xray_tracing/query.rego
+++ b/assets/queries/ansible/aws/lambda_without_xray_tracing/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["community.aws.lambda"], "tracing_mode", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.lambda}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.lambda.tracing_mode is set",
@@ -18,14 +17,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task["community.aws.lambda"].tracing_mode != "Active"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.lambda}}.tracing_mode", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.lambda.tracing_mode is set to 'Active'",

--- a/assets/queries/ansible/aws/launch_configuration_is_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/launch_configuration_is_not_encrypted/query.rego
@@ -1,21 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["community.aws.ec2_lc"]
-	clusterName := task.name
-
 	volumes := cluster.volumes
 	volume := volumes[v]
+
 	object.get(volume, "encrypted", "undefined") == "undefined"
-	deviceName := volume.device_name
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.ec2_lc}}.volumes.device_name={{%s}}", [clusterName, deviceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.ec2_lc}}.volumes.device_name={{%s}}", [task.name, volume.device_name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.redshift.encrypted should be set to true",
 		"keyActualValue": "community.aws.redshift.encrypted is undefined",
@@ -23,21 +20,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["community.aws.ec2_lc"]
-	clusterName := task.name
-
 	volumes := cluster.volumes
 	volume := volumes[v]
 
 	not ansLib.isAnsibleTrue(volume.encrypted)
-	deviceName := volume.device_name
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.ec2_lc}}.volumes.device_name={{%s}}.encrypted", [clusterName, deviceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.ec2_lc}}.volumes.device_name={{%s}}.encrypted", [task.name, volume.device_name]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": "community.aws.ec2_lc.volumes[*].encrypted should be set to true",
 		"keyActualValue": "community.aws.ec2_lc.volumes[*].encrypted is set to false",

--- a/assets/queries/ansible/aws/memcached_disabled/query.rego
+++ b/assets/queries/ansible/aws/memcached_disabled/query.rego
@@ -1,14 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	task["community.aws.elasticache"].engine == "redis"
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.elasticache}}.engine", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.elasticache}}.engine enables Memcached", [task.name]),

--- a/assets/queries/ansible/aws/no_password_reuse_prevention/query.rego
+++ b/assets/queries/ansible/aws/no_password_reuse_prevention/query.rego
@@ -1,19 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	pwPolicy := task["community.aws.iam_password_policy"]
-	pwPolicyName := task.name
 
 	searchKey := checkPwReusePrevent(pwPolicy)
 	searchKey != "none"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_password_policy}}%s", [pwPolicyName, searchKey]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_password_policy}}%s", [task.name, searchKey]),
 		"issueType": issueType(searchKey),
 		"keyExpectedValue": "community.aws.iam_password_policy should have the property 'password_reuse_prevent' greater than 0",
 		"keyActualValue": "community.aws.iam_password_policy has the property 'password_reuse_prevent' unassigned or assigned to 0",

--- a/assets/queries/ansible/aws/not_encrypted_data_in_launch_configuration/query.rego
+++ b/assets/queries/ansible/aws/not_encrypted_data_in_launch_configuration/query.rego
@@ -1,17 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	modules := {"community.aws.ec2_lc", "ec2_lc"}
 
 	object.get(task[modules[index]], "volumes", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.volumes is set", [modules[index]]),
@@ -20,16 +18,13 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	modules := {"community.aws.ec2_lc", "ec2_lc"}
 
 	object.get(task[modules[index]].volumes[j], "encrypted", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.volumes", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.volumes[%d].encrypted is set", [modules[index], j]),
@@ -38,27 +33,17 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	modules := {"community.aws.ec2_lc", "ec2_lc"}
 
 	object.get(task[modules[index]].volumes[j], "ephemeral", "undefined") == "undefined"
-	isNoOrFalse(task[modules[index]].volumes[j].encrypted)
+	ansLib.isAnsibleFalse(task[modules[index]].volumes[j].encrypted)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.volumes", [task.name, modules[index]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.volumes[%d].encrypted is set to true or yes", [modules[index], j]),
 		"keyActualValue": sprintf("%s.volumes[%d].encrypted is not set to true or yes", [modules[index], j]),
 	}
-}
-
-isNoOrFalse(attribute) = allow {
-	possibilities := {"no", false}
-	attribute == possibilities[j]
-
-	allow = true
 }

--- a/assets/queries/ansible/aws/public_ecr_policy/query.rego
+++ b/assets/queries/ansible/aws/public_ecr_policy/query.rego
@@ -1,16 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cloudwatchlogs := task["community.aws.ecs_ecr"]
 	pol := cloudwatchlogs.policy.Statement[index].Principal
+
 	re_match("\\*", pol)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ecs_ecr}}.policy", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Principal' is not equal to '*'",
@@ -19,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cloudwatchlogs := task["community.aws.ecs_ecr"]
 	pol := cloudwatchlogs.policy
+
 	re_match("\"Principal\"\\ *:\\ *\"\\*\"", pol)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.ecs_ecr}}.policy", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'policy.Principal' is not equal '*'",

--- a/assets/queries/ansible/aws/public_lambda_via_api_gateway/query.rego
+++ b/assets/queries/ansible/aws/public_lambda_via_api_gateway/query.rego
@@ -1,18 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	lambda := task.lambda_policy
+
 	lambdaAction(lambda.action)
 	principalAllowAPIGateway(lambda.principal)
 	re_match("/\\*/\\*$", lambda.source_arn)
-	clusterName := task.name
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{lambda_policy}}.source_arn", [clusterName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{lambda_policy}}.source_arn", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "lambda_policy.source_arn should not be equal to '/*/*'",
 		"keyActualValue": "lambda_policy.source_arn is equal to '/*/*'",

--- a/assets/queries/ansible/aws/public_port_wide/query.rego
+++ b/assets/queries/ansible/aws/public_port_wide/query.rego
@@ -1,11 +1,9 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	fromPort := task["amazon.aws.ec2_group"].rules[index].from_port
 	toPort := task["amazon.aws.ec2_group"].rules[index].to_port
 
@@ -15,7 +13,7 @@ CxPolicy[result] {
 	isEntireNetwork(cidr)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("amazon.aws.ec2_group.rules[%d] doesn't have public port wide", [index]),
@@ -24,10 +22,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	fromPort := task["amazon.aws.ec2_group"].rules[index].from_port
 	toPort := task["amazon.aws.ec2_group"].rules[index].to_port
 
@@ -37,7 +32,7 @@ CxPolicy[result] {
 	isEntireNetwork(cidr)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("amazon.aws.ec2_group.rules[%d] doesn't have public port wide", [index]),

--- a/assets/queries/ansible/aws/rds_auto_minor_version_upgrade_disabled/query.rego
+++ b/assets/queries/ansible/aws/rds_auto_minor_version_upgrade_disabled/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	ansLib.isAnsibleFalse(task["community.aws.rds_instance"].auto_minor_version_upgrade)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.rds_instance}}.auto_minor_version_upgrade", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "AWS RDS instance feature auto_minor_version_upgrade should be true",
@@ -18,14 +17,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["community.aws.rds_instance"], "auto_minor_version_upgrade", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.rds_instance}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "AWS RDS instance feature auto_minor_version_upgrade should be true",

--- a/assets/queries/ansible/aws/rds_ca_certificate_identifier_is_expired/query.rego
+++ b/assets/queries/ansible/aws/rds_ca_certificate_identifier_is_expired/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task["community.aws.rds_instance"], "ca_certificate_identifier", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.rds_instance}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "RDS instance ca_certificate_identifier should be defined",
@@ -18,14 +17,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task["community.aws.rds_instance"].ca_certificate_identifier != "rds-ca-2019"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.rds_instance}}.ca_certificate_identifier", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": ".publicly_accessible is false",

--- a/assets/queries/ansible/aws/rds_instance_storage_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/rds_instance_storage_not_encrypted/query.rego
@@ -1,15 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	instance := task["community.aws.rds_instance"]
+
 	not checkEncryption(instance)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.rds_instance}}.storage_encrypted", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_rds_instance.storage_encrypted is true or aws_rds_instance.kms_key_id is defined",

--- a/assets/queries/ansible/aws/rds_publicly_accessible/query.rego
+++ b/assets/queries/ansible/aws/rds_publicly_accessible/query.rego
@@ -1,13 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	ansLib.isAnsibleTrue(task["community.aws.rds_instance"].publicly_accessible)
+
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.rds_instance}}.publicly_accessible", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module's parameter community.aws.rds_instance.publicly_accessible should be false in task: '%s'", [task.name]),
@@ -16,12 +17,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	ansLib.isAnsibleTrue(task["community.aws.rds"].publicly_accessible)
+
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.rds}}.publicly_accessible", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("module's parameter community.aws.rds.publicly_accessible should be false in task: '%s'", [task.name]),

--- a/assets/queries/ansible/aws/rds_without_backup/query.rego
+++ b/assets/queries/ansible/aws/rds_without_backup/query.rego
@@ -1,18 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	instance := task["community.aws.rds_instance"]
-	instanceName := task.name
 
 	object.get(instance, "backup_retention_period", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.rds_instance}}", [instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.rds_instance}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "community.aws.rds_instance should have the property 'backup_retention_period' greater than 0",
 		"keyActualValue": "community.aws.rds_instance has the property 'backup_retention_period' unassigned",
@@ -20,17 +18,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	instance := task["community.aws.rds_instance"]
-	instanceName := task.name
 
 	instance.backup_retention_period == 0
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.rds_instance}}.backup_retention_period", [instanceName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.rds_instance}}.backup_retention_period", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.rds_instance should have the property 'backup_retention_period' greater than 0",
 		"keyActualValue": "community.aws.rds_instance has the property 'backup_retention_period' assigned to 0",

--- a/assets/queries/ansible/aws/redis_not_compliant/query.rego
+++ b/assets/queries/ansible/aws/redis_not_compliant/query.rego
@@ -1,15 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	min_version_string = "4.0.10"
+
 	eval_version_number(task["community.aws.elasticache"].cache_engine_version) < eval_version_number(min_version_string)
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.elasticache}}.cache_engine_version", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.elasticache}}.cache_engine_version is compliant with the AWS PCI DSS requirements", [task.name]),

--- a/assets/queries/ansible/aws/redshift_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/redshift_not_encrypted/query.rego
@@ -3,9 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	module := ["redshift", "community.aws.redshift"]
 	redshiftCluster := task[module[m]]
 
@@ -13,7 +11,7 @@ CxPolicy[result] {
 	object.get(redshiftCluster, "encrypted", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, module[m]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.encrypted should be set to true", [module[m]]),
@@ -22,9 +20,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	module := ["redshift", "community.aws.redshift"]
 	redshiftCluster := task[module[m]]
 
@@ -32,7 +28,7 @@ CxPolicy[result] {
 	not ansLib.isAnsibleTrue(redshiftCluster.encrypted)
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.encrypted", [task.name, module[m]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.encrypted should be set to true", [module[m]]),

--- a/assets/queries/ansible/aws/redshift_publicly_accessible/query.rego
+++ b/assets/queries/ansible/aws/redshift_publicly_accessible/query.rego
@@ -1,13 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	ansLib.isAnsibleTrue(task["community.aws.redshift"].publicly_accessible)
+
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.redshift}}.publicly_accessible", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_redshift_cluster.publicly_accessible is false",
@@ -16,12 +17,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	ansLib.isAnsibleTrue(task.redshift.publicly_accessible)
+
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.redshift.publicly_accessible", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_redshift_cluster.publicly_accessible is false",

--- a/assets/queries/ansible/aws/remote_desktop_port_open/query.rego
+++ b/assets/queries/ansible/aws/remote_desktop_port_open/query.rego
@@ -1,13 +1,13 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	fromPort := task["amazon.aws.ec2_group"].rules[index].from_port
 	toPort := task["amazon.aws.ec2_group"].rules[index].to_port
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 3389
 	fromPort != -1
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	toPort >= portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules doesn't open the remote desktop port (%s)", [task.name, portNumber]),
@@ -24,17 +24,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 3389
 	ports == portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the remote desktop port (%s)", [task.name, portNumber]),
@@ -43,11 +42,10 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 3389
 	mports := split(ports, "-")
@@ -55,7 +53,7 @@ CxPolicy[result] {
 	to_number(mports[1]) >= portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the remote desktop port (%s)", [task.name, portNumber]),
@@ -64,11 +62,10 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports[_]
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 3389
 	mports := split(ports, "-")
@@ -76,7 +73,7 @@ CxPolicy[result] {
 	to_number(mports[1]) >= portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the remote desktop port (%s)", [task.name, portNumber]),
@@ -85,17 +82,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports[_]
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 3389
 	ports == portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the remote desktop port (%s)", [task.name, portNumber]),
@@ -104,17 +100,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	fromPort := task["amazon.aws.ec2_group"].rules[index].from_port
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 3389
 	fromPort == -1
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.from_port", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.from_port doesn't open the remote desktop port (%s)", [task.name, portNumber]),
@@ -123,17 +118,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	toPort := task["amazon.aws.ec2_group"].rules[index].to_port
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 3389
 	toPort == -1
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.to_port", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.to_port doesn't open the remote desktop port (%s)", [task.name, portNumber]),

--- a/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/query.rego
+++ b/assets/queries/ansible/aws/root_account_has_associated_active_access_keys/query.rego
@@ -1,12 +1,10 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	iam := task["community.aws.iam"]
-	iamName := task.name
 
 	is_string(iam.access_key_state)
 	lower(iam.access_key_state) == "active"
@@ -15,8 +13,8 @@ CxPolicy[result] {
 	contains(lower(iam.name), "root")
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam}}", [iamName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam}}", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.iam is not active for a root account",
 		"keyActualValue": "community.aws.iam is active for a root account",

--- a/assets/queries/ansible/aws/route53_record_undefined/query.rego
+++ b/assets/queries/ansible/aws/route53_record_undefined/query.rego
@@ -1,14 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	object.get(task["community.aws.route53"], "value", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.route53}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_route53.value is defined",
@@ -17,25 +17,15 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-	valueIsEmpty(task["community.aws.route53"].value)
+	task := ansLib.tasks[id][t]
+
+	ansLib.checkValue(task["community.aws.route53"].value)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.route53}}.value", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_route53.value is not empty",
 		"keyActualValue": "aws_route53.value is empty",
 	}
-}
-
-valueIsEmpty(value) {
-	value == null
-}
-
-valueIsEmpty(value) {
-	value != null
-	count(value) <= 0
 }

--- a/assets/queries/ansible/aws/s3_bucket_access_allowed_all/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_access_allowed_all/query.rego
@@ -1,17 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	policy := task["amazon.aws.s3_bucket"].policy
-	statement = policy.Statement[_]
+	statement := policy.Statement[_]
+
 	statement.Principal == "*"
 	statement.Effect == "Allow"
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.s3_bucket}}.policy.Statement", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{amazon.aws.s3_bucket}}.policy.Statement doesn't make the bucket accessible to all AWS Accounts", [task.name]),

--- a/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_delete_action_from_all_principals/query.rego
@@ -1,22 +1,20 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["amazon.aws.s3_bucket"]
-	bucketName := task.name
 
 	bucket.policy.Statement[_].Effect == "Allow"
 	contains(lower(bucket.policy.Statement[_].Action), "delete")
 	bucket.policy.Statement[_].Principal == "*"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow Delete Action From All Principals", [bucketName]),
-		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows Delete Action From All Principals", [bucketName]),
+		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow Delete Action From All Principals", [bucket.name]),
+		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows Delete Action From All Principals", [bucket.name]),
 	}
 }

--- a/assets/queries/ansible/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_get_action_from_all_principals/query.rego
@@ -1,22 +1,20 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["amazon.aws.s3_bucket"]
-	bucketName := task.name
 
 	bucket.policy.Statement[_].Effect == "Allow"
 	contains(lower(bucket.policy.Statement[_].Action), "get")
 	bucket.policy.Statement[_].Principal == "*"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow Get Action From All Principals", [bucketName]),
-		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows Get Action From All Principals", [bucketName]),
+		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow Get Action From All Principals", [bucket.name]),
+		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows Get Action From All Principals", [bucket.name]),
 	}
 }

--- a/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_list_action_from_all_principals/query.rego
@@ -1,22 +1,20 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["amazon.aws.s3_bucket"]
-	bucketName := task.name
 
 	bucket.policy.Statement[_].Effect == "Allow"
 	contains(lower(bucket.policy.Statement[_].Action), "list")
 	bucket.policy.Statement[_].Principal == "*"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow List Action From All Principals", [bucketName]),
-		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows List Action From All Principals", [bucketName]),
+		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow List Action From All Principals", [bucket.name]),
+		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows List Action From All Principals", [bucket.name]),
 	}
 }

--- a/assets/queries/ansible/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
@@ -1,22 +1,20 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["amazon.aws.s3_bucket"]
-	bucketName := task.name
 
 	bucket.policy.Statement[_].Effect == "Allow"
 	contains(lower(bucket.policy.Statement[_].Action), "put")
 	bucket.policy.Statement[_].Principal == "*"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow Put Action From All Principals", [bucketName]),
-		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows Put Action From All Principals", [bucketName]),
+		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow Put Action From All Principals", [bucket.name]),
+		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows Put Action From All Principals", [bucket.name]),
 	}
 }

--- a/assets/queries/ansible/aws/s3_bucket_allows_write_acp_action_from_all_principals/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_allows_write_acp_action_from_all_principals/query.rego
@@ -1,13 +1,10 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["amazon.aws.s3_bucket"]
-	taskName := task.name
-	bucketName := bucket.name
 
 	bucket.policy.Statement[_].Effect == "Allow"
 	contains(lower(bucket.policy.Statement[_].Action), "write")
@@ -15,10 +12,10 @@ CxPolicy[result] {
 	bucket.policy.Statement[_].Principal == "*"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [taskName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow WriteACP Action From All Principals", [bucketName]),
-		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows WriteACP Action From All Principals", [bucketName]),
+		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow WriteACP Action From All Principals", [bucket.name]),
+		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows WriteACP Action From All Principals", [bucket.name]),
 	}
 }

--- a/assets/queries/ansible/aws/s3_bucket_rules_with_master_key_id_null/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_rules_with_master_key_id_null/query.rego
@@ -1,10 +1,9 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	s3_bucket := task["amazon.aws.s3_bucket"]
 	encryption := s3_bucket.encryption
 
@@ -12,8 +11,8 @@ CxPolicy[result] {
 	not s3_bucket.encryption_key_id
 
 	result := {
-		"documentId": document.id,
-		"searchKey": sprintf("name=%s.{{amazon.aws.s3_bucket}}.encryption", [tasks[t].name]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{amazon.aws.s3_bucket}}.encryption", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "amazon.aws.s3_bucket.encryption_key_id is defined",
 		"keyActualValue": "amazon.aws.s3_bucket.encryption_key_id is undefined",
@@ -21,28 +20,18 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	s3_bucket := task["amazon.aws.s3_bucket"]
 	encryption := s3_bucket.encryption
 
 	encryption != "AES256"
-	check_key_id(s3_bucket)
+	ansLib.checkValue(s3_bucket)
 
 	result := {
-		"documentId": document.id,
-		"searchKey": sprintf("name=%s.{{amazon.aws.s3_bucket}}.encryption", [tasks[t].name]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{amazon.aws.s3_bucket}}.encryption", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "amazon.aws.s3_bucket.encryption_key_id is defined",
 		"keyActualValue": "amazon.aws.s3_bucket.encryption_key_id is empty or null",
 	}
-}
-
-check_key_id(bucket) {
-	bucket.encryption_key_id == ""
-}
-
-check_key_id(bucket) {
-	bucket.encryption_key_id == null
 }

--- a/assets/queries/ansible/aws/s3_bucket_with_all_permissions/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_with_all_permissions/query.rego
@@ -1,9 +1,9 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	s3_bucket := task["amazon.aws.s3_bucket"]
 
 	policy := s3_bucket.policy
@@ -14,7 +14,7 @@ CxPolicy[result] {
 	contains(action, "*")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{s3_bucket}}.policy.Statement", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Action' doesn't contain '*' when 'Effect' is 'Allow'",
@@ -23,8 +23,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	s3_bucket := task["amazon.aws.s3_bucket"]
 
 	policy := s3_bucket.policy
@@ -35,7 +34,7 @@ CxPolicy[result] {
 	contains(action[_], "*")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{s3_bucket}}.policy", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'policy.Statement.Action' doesn't contain '*' when 'Effect' is 'Allow'",

--- a/assets/queries/ansible/aws/s3_bucket_with_any_principal/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_with_any_principal/query.rego
@@ -1,21 +1,19 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["amazon.aws.s3_bucket"]
-	bucketName := task.name
 
 	bucket.policy.Statement[_].Effect == "Allow"
 	bucket.policy.Statement[_].Principal == "*"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [bucketName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.policy.Statement", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow Action From All Principals", [bucketName]),
-		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows Action From All Principals", [bucketName]),
+		"keyExpectedValue": sprintf("amazon.aws.s3_bucket[%s] does not allow Action From All Principals", [bucket.name]),
+		"keyActualValue": sprintf("amazon.aws.s3_bucket[%s] allows Action From All Principals", [bucket.name]),
 	}
 }

--- a/assets/queries/ansible/aws/s3_bucket_with_public_access/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_with_public_access/query.rego
@@ -1,14 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	contains(task["amazon.aws.aws_s3"].permission, "public")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.aws_s3}}.permission", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("amazon_aws_aws_s3.permission is %s", [task["amazon.aws.aws_s3"].permission]),

--- a/assets/queries/ansible/aws/s3_bucket_without_encryption/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_without_encryption/query.rego
@@ -1,18 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	s3_bucket := task["amazon.aws.s3_bucket"]
 
 	s3_bucket.encryption == "none"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.encryption", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_s3_bucket.encryption is %s", [s3_bucket.encryption]),
-		"keyActualValue": "aws_s3_bucket.encryption is none",
+		"keyExpectedValue": "aws_s3_bucket.encryption is not 'none'",
+		"keyActualValue": "aws_s3_bucket.encryption is 'none'",
 	}
 }

--- a/assets/queries/ansible/aws/s3_bucket_without_logging/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_without_logging/query.rego
@@ -1,17 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["amazon.aws.s3_bucket"]
-	bucketName := bucket.name
-	bucket.debug_botocore_endpoint_logs == false
+
+	ansLib.isAnsibleFalse(bucket.debug_botocore_endpoint_logs)
 
 	result := {
-		"documentId": document.id,
-		"searchKey": "amazon.aws.s3_bucket.debug_botocore_endpoint_logs",
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.debug_botocore_endpoint_logs", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_s3_bucket.debug_botocore_endpoint_logs is true",
 		"keyActualValue": "aws_s3_bucket.debug_botocore_endpoint_logs is false",
@@ -19,17 +18,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["amazon.aws.s3_bucket"]
-	bucketName := bucket.name
 
 	object.get(bucket, "debug_botocore_endpoint_logs", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
-		"searchKey": "amazon.aws.s3_bucket.debug_botocore_endpoint_logs",
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_s3_bucket.debug_botocore_endpoint_logs is defined",
 		"keyActualValue": "aws_s3_bucket.debug_botocore_endpoint_logs is undefined",

--- a/assets/queries/ansible/aws/s3_bucket_without_logging/test/positive.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_without_logging/test/positive.yaml
@@ -1,5 +1,6 @@
 ---
-- amazon.aws.s3_bucket:
+- name: "Create S3 bucket"
+  amazon.aws.s3_bucket:
     name: mys3bucket
     state: present
     debug_botocore_endpoint_logs: false

--- a/assets/queries/ansible/aws/s3_bucket_without_logging/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/s3_bucket_without_logging/test/positive_expected_result.json
@@ -1,7 +1,7 @@
 [
-	{
-		"queryName": "S3 Bucket Without Logging",
-		"severity": "LOW",
-		"line": 5
-	}
+  {
+    "queryName": "S3 Bucket Without Logging",
+    "severity": "LOW",
+    "line": 6
+  }
 ]

--- a/assets/queries/ansible/aws/s3_bucket_without_versioning/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_without_versioning/query.rego
@@ -1,18 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["amazon.aws.s3_bucket"]
-	bucketName := task.name
 
 	object.get(bucket, "versioning", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}", [bucketName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "amazon.aws.s3_bucket should have versioning set to true",
 		"keyActualValue": "amazon.aws.s3_bucket does not have versioning (defaults to false)",
@@ -20,16 +18,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["amazon.aws.s3_bucket"]
-	bucketName := task.name
+
 	not ansLib.isAnsibleTrue(bucket.versioning)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.versioning", [bucketName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.s3_bucket}}.versioning", [task.name]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": "amazon.aws.s3_bucket should have versioning set to true",
 		"keyActualValue": "amazon.aws.s3_bucket does has versioning set to false",

--- a/assets/queries/ansible/aws/secure_ciphers_not_used/query.rego
+++ b/assets/queries/ansible/aws/secure_ciphers_not_used/query.rego
@@ -1,15 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-	ansLib.isAnsibleFalse(task["community.aws.cloudfront_distribution"].viewer_certificate.cloudfront_default_certificate)
-	not checkMinPortocolVersion(task["community.aws.cloudfront_distribution"].viewer_certificate.minimum_protocol_version)
+	task := ansLib.tasks[id][t]
+	cloudfront_distribution := task["community.aws.cloudfront_distribution"]
+
+	ansLib.isAnsibleFalse(cloudfront_distribution.viewer_certificate.cloudfront_default_certificate)
+	not checkMinPortocolVersion(cloudfront_distribution.viewer_certificate.minimum_protocol_version)
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.cloudfront_distribution}}.viewer_certificate.minimum_protocol_version", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.cloudfront_distribution}}.viewer_certificate.minimum_protocol_version is TLSv1.1 or TLSv1.2", [task.name]),
@@ -17,10 +18,6 @@ CxPolicy[result] {
 	}
 }
 
-checkMinPortocolVersion(version) {
-	version == "TLSv1.1"
-}
+checkMinPortocolVersion("TLSv1.1") = true
 
-checkMinPortocolVersion(version) {
-	version == "TLSv1.2"
-}
+checkMinPortocolVersion("TLSv1.2") = true

--- a/assets/queries/ansible/aws/security_group_ingress_not_restricted/query.rego
+++ b/assets/queries/ansible/aws/security_group_ingress_not_restricted/query.rego
@@ -1,21 +1,20 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task["amazon.aws.ec2_group"].rules[index].from_port == 0
 	task["amazon.aws.ec2_group"].rules[index].to_port == 0
 
-	not isvalidProto(task["amazon.aws.ec2_group"].rules[index])
+	not isValidProto(task["amazon.aws.ec2_group"].rules[index])
 
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
 	isEntireNetwork(cidr)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("amazon.aws.ec2_group.rules[%d] is restricted", [index]),
@@ -24,20 +23,18 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task["amazon.aws.ec2_group"].rules[index].from_port == 0
 	task["amazon.aws.ec2_group"].rules[index].to_port == 0
 
-	not isvalidProto(task["amazon.aws.ec2_group"].rules[index])
+	not isValidProto(task["amazon.aws.ec2_group"].rules[index])
 
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ipv6
 	isEntireNetwork(cidr)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("amazon.aws.ec2_group.rules[%d] is restricted", [index]),
@@ -64,7 +61,7 @@ isEntireNetwork(cidr) = allow {
 	allow = true
 }
 
-isvalidProto(proto) {
+isValidProto(proto) {
 	isString := is_string(proto)
 	protos = {"tcp", "udp", "icmp", "icmpv6"}
 
@@ -73,7 +70,7 @@ isvalidProto(proto) {
 	allow = true
 }
 
-isvalidProto(proto) {
+isValidProto(proto) {
 	isString := is_number(proto)
 	protos = {1, 6, 17, 58}
 

--- a/assets/queries/ansible/aws/sns_topic_is_publicly_accessible_for_subscription/query.rego
+++ b/assets/queries/ansible/aws/sns_topic_is_publicly_accessible_for_subscription/query.rego
@@ -1,17 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	snsTopicCommunity := task["community.aws.sns_topic"]
-	snsTopicName := task.name
+
 	object.get(snsTopicCommunity, "subscriptions", "undefined") != "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.sns_topic}}", [snsTopicName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.sns_topic}}", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "community.aws.sns_topic.subscriptions should be undefined",
 		"keyActualValue": "community.aws.sns_topic.subscriptions is defined",
@@ -19,16 +18,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	snsTopic := task.sns_topic
-	snsTopicName := task.name
+
 	object.get(snsTopic, "subscriptions", "undefined") != "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{sns_topic}}", [snsTopicName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{sns_topic}}", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "sns_topic.subscriptions should be undefined",
 		"keyActualValue": "sns_topic.subscriptions is defined",

--- a/assets/queries/ansible/aws/sql_analysis_services_port_2383_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/aws/sql_analysis_services_port_2383_is_publicly_accessible/query.rego
@@ -1,20 +1,19 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsEc2 := task["amazon.aws.ec2_group"]
 	rules := awsEc2.rules[j]
 	port := rules.ports[k]
+
 	rules.cidr_ip == "0.0.0.0/0"
 	rules.proto == "tcp"
-	portNumber := 2383
-	port == portNumber
+	port == 2383
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.ec2_group}}.rules.cidr_ip", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{amazon.aws.ec2_group}}.rules.cidr_ip is not public", [task.name]),
@@ -23,18 +22,17 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsEc2 := task["amazon.aws.ec2_group"]
 	rules := awsEc2.rules[j]
 	port := ["to_port", "from_port"]
+
 	rules[port[z]] == -1
 	rules.proto == "tcp"
 	rules.cidr_ip == "0.0.0.0/0"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.ec2_group}}.rules.%s", [task.name, port[z]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{amazon.aws.ec2_group}}.rules.%s is different than -1 (all ports are open)", [task.name, port[z]]),
@@ -43,17 +41,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsEc2 := task["amazon.aws.ec2_group"]
 	rules := awsEc2.rules[j]
+
 	rules.proto == "tcp"
 	rules.cidr_ip == "0.0.0.0/0"
 	checkRange(rules.to_port, rules.from_port)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{amazon.aws.ec2_group}}.rules 'from_port' - 'to_port' range does not contain port 2383", [task.name]),
@@ -62,11 +59,10 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	awsEc2 := task["amazon.aws.ec2_group"]
 	rules := awsEc2.rules[j]
+
 	rules.proto == "tcp"
 	rules.cidr_ip == "0.0.0.0/0"
 	contains(rules.ports[w], "-")
@@ -74,7 +70,7 @@ CxPolicy[result] {
 	checkRange(to_number(trim_space(aux[1])), to_number(trim_space(aux[0])))
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.ec2_group}}.rules.%s", [task.name, rules.ports[w]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{amazon.aws.ec2_group}}.rules.%s range does not contain port '2383'", [task.name, rules.ports[w]]),

--- a/assets/queries/ansible/aws/sqs_policy_allows_all_actions/query.rego
+++ b/assets/queries/ansible/aws/sqs_policy_allows_all_actions/query.rego
@@ -1,19 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	sqsPolicy := task["community.aws.sqs_queue"]
-	sqsPolicyName := task.name
+
 	contains(sqsPolicy.policy.Statement[_].Action, "*")
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Statement", [sqsPolicyName]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Statement", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Statement should not contain Action equal to '*'", [sqsPolicyName]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Statement contains Action equal to '*'", [sqsPolicyName]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Statement should not contain Action equal to '*'", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Statement contains Action equal to '*'", [task.name]),
 	}
 }

--- a/assets/queries/ansible/aws/sqs_policy_with_public_access/query.rego
+++ b/assets/queries/ansible/aws/sqs_policy_with_public_access/query.rego
@@ -1,41 +1,38 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	sqsPolicy := task["community.aws.sqs_queue"]
-	sqsPolicyName := task.name
+
 	contains(sqsPolicy.policy.Statement[_].Principal, "*")
 	contains(sqsPolicy.policy.Statement[_].Effect, "Allow")
 	contains(sqsPolicy.policy.Statement[_].Action, "*")
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal", [sqsPolicyName]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal should not be equal to '*'", [sqsPolicyName]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal is equal to '*'", [sqsPolicyName]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal should not be equal to '*'", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal is equal to '*'", [task.name]),
 	}
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	sqsPolicy := task["community.aws.sqs_queue"]
-	sqsPolicyName := task.name
+
 	contains(sqsPolicy.policy.Statement[_].Effect, "Allow")
 	contains(sqsPolicy.policy.Statement[_].Action, "*")
 	checkPrincipal(sqsPolicy.policy.Statement[_].Principal[j])
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal.AWS", [sqsPolicyName]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal.AWS", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal.AWS should not be equal to '*'", [sqsPolicyName]),
-		"keyActualValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal.AWS is equal to '*'", [sqsPolicyName]),
+		"keyExpectedValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal.AWS should not be equal to '*'", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal.AWS is equal to '*'", [task.name]),
 	}
 }
 

--- a/assets/queries/ansible/aws/sqs_queue_exposed/query.rego
+++ b/assets/queries/ansible/aws/sqs_queue_exposed/query.rego
@@ -1,14 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	isAccessible(task["community.aws.sqs_queue"])
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.sqs_queue}}.policy.Principal doesn't get the queue publicly accessible", [task.name]),

--- a/assets/queries/ansible/aws/sqs_with_sse_disabled/query.rego
+++ b/assets/queries/ansible/aws/sqs_with_sse_disabled/query.rego
@@ -1,15 +1,15 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	sqs_queue := task["community.aws.sqs_queue"]
 
 	object.get(sqs_queue, "kms_master_key_id", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{community.aws.sqs_queue}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'kms_master_key_id' is defined",

--- a/assets/queries/ansible/aws/ssh_in_public_scope/query.rego
+++ b/assets/queries/ansible/aws/ssh_in_public_scope/query.rego
@@ -1,21 +1,18 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	currentFromPort := task["amazon.aws.ec2_group"].rules[index].from_port
 	currentToPort := task["amazon.aws.ec2_group"].rules[index].to_port
-
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
 
 	isSSH(currentFromPort, currentToPort)
 	not isPrivate(cidr)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("amazon.aws.ec2_group.rules[%d] SSH' (Port:22) is not public", [index]),
@@ -24,20 +21,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	currentFromPort := task["amazon.aws.ec2_group"].rules[index].from_port
 	currentToPort := task["amazon.aws.ec2_group"].rules[index].to_port
-
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ipv6
 
 	isSSH(currentFromPort, currentToPort)
 	not isPrivate(cidr)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("amazon.aws.ec2_group.rules[%d] SSH' (Port:22) is not public", [index]),

--- a/assets/queries/ansible/aws/ssh_port_open/query.rego
+++ b/assets/queries/ansible/aws/ssh_port_open/query.rego
@@ -1,13 +1,13 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	fromPort := task["amazon.aws.ec2_group"].rules[index].from_port
 	toPort := task["amazon.aws.ec2_group"].rules[index].to_port
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 22
 	fromPort != -1
@@ -15,7 +15,7 @@ CxPolicy[result] {
 	toPort >= portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules doesn't open the ssh port (%s)", [task.name, portNumber]),
@@ -24,17 +24,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 22
 	ports == portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the ssh port (%s)", [task.name, portNumber]),
@@ -43,11 +42,10 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 22
 	mports := split(ports, "-")
@@ -55,7 +53,7 @@ CxPolicy[result] {
 	to_number(mports[1]) >= portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the ssh port (%s)", [task.name, portNumber]),
@@ -64,11 +62,10 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports[_]
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 22
 	mports := split(ports, "-")
@@ -76,7 +73,7 @@ CxPolicy[result] {
 	to_number(mports[1]) >= portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the ssh port (%s)", [task.name, portNumber]),
@@ -85,17 +82,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ports := task["amazon.aws.ec2_group"].rules[index].ports[_]
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 22
 	ports == portNumber
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.ports doesn't open the ssh port (%s)", [task.name, portNumber]),
@@ -104,17 +100,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	fromPort := task["amazon.aws.ec2_group"].rules[index].from_port
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 22
 	fromPort == -1
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.from_port", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.from_port doesn't open the ssh port (%s)", [task.name, portNumber]),
@@ -123,17 +118,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	toPort := task["amazon.aws.ec2_group"].rules[index].to_port
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
+
 	cidr == "0.0.0.0/0"
 	portNumber := 22
 	toPort == -1
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.to_port", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules.to_port doesn't open the ssh port (%s)", [task.name, portNumber]),

--- a/assets/queries/ansible/aws/unchangeable_password/query.rego
+++ b/assets/queries/ansible/aws/unchangeable_password/query.rego
@@ -1,19 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	pwPolicy := task["community.aws.iam_password_policy"]
-	pwPolicyName := task.name
 
 	searchKey := checkAllowPass(pwPolicy)
 	searchKey != "none"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_password_policy}}%s", [pwPolicyName, searchKey]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.iam_password_policy}}%s", [task.name, searchKey]),
 		"issueType": issueType(searchKey),
 		"keyExpectedValue": "community.aws.iam_password_policy should have the property 'allow_pw_change/allow_password_change' true",
 		"keyActualValue": "community.aws.iam_password_policy has the property 'allow_pw_change/allow_password_change' undefined or false",

--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/query.rego
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/query.rego
@@ -1,20 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	currentPort := task["amazon.aws.ec2_group"].rules[index].from_port
-
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ip
 
 	not portIsKnown(currentPort)
 	isEntireNetwork(cidr)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("amazon.aws.ec2_group.rules[%d].from_port is known", [index]),
@@ -23,19 +20,15 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
-
+	task := ansLib.tasks[id][t]
 	currentPort := task["amazon.aws.ec2_group"].rules[index].from_port
-
 	cidr := task["amazon.aws.ec2_group"].rules[index].cidr_ipv6
 
 	not portIsKnown(currentPort)
 	isEntireNetwork(cidr)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_group}}.rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("amazon.aws.ec2_group.rules[%d].from_port is known", [index]),

--- a/assets/queries/ansible/aws/unprotected_s3_storage/query.rego
+++ b/assets/queries/ansible/aws/unprotected_s3_storage/query.rego
@@ -1,15 +1,14 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task["amazon.aws.s3_bucket"].encryption == "none"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{amazon.aws.s3_bucket}}.encryption", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "amazon.aws.s3_bucket.encryption is not none",

--- a/assets/queries/ansible/aws/unprotected_sql_queue/query.rego
+++ b/assets/queries/ansible/aws/unprotected_sql_queue/query.rego
@@ -1,18 +1,17 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document = input.document[i]
-	tasks := ansLib.getTasks(document)
-	sqsQueuePolicy = tasks[_]
-	sqsQueueBody = sqsQueuePolicy["community.aws.sqs_queue"]
-	sqsQueueName = sqsQueuePolicy.name
-	object.get(sqsQueueBody, "state", "present") == "present"
+	task := ansLib.tasks[id][t]
+	sqsQueue := task["community.aws.sqs_queue"]
+	ansLib.checkState(sqsQueue)
 
-	not sqsQueueBody.kms_master_key_id
+	not sqsQueue.kms_master_key_id
+
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{community.aws.sqs_queue}}.kms_master_key_id", [sqsQueueName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.sqs_queue}}.kms_master_key_id", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'kms_master_key_id' should be set",
 		"keyActualValue": "'kms_master_key_id' is undefined",

--- a/assets/queries/ansible/aws/user_data_contains_rsa_private_key/query.rego
+++ b/assets/queries/ansible/aws/user_data_contains_rsa_private_key/query.rego
@@ -1,16 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	user_data := task["community.aws.ec2_lc"].user_data
+
 	contains(user_data, "LS0tLS1CR")
 
 	result := {
-		"documentId": document.id,
-		"searchKey": "{{community.aws.ec2_lc}}.user_data",
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.ec2_lc}}.user_data", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.ec2_lc}}.user_data should not contain RSA Private Key", [task.name]),
 		"keyActualValue": sprintf("name=%s.{{community.aws.ec2_lc}}.user_data contains RSA Private Key", [task.name]),

--- a/assets/queries/ansible/aws/user_data_shell_script_is_encoded/query.rego
+++ b/assets/queries/ansible/aws/user_data_shell_script_is_encoded/query.rego
@@ -1,16 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	user_data := task["community.aws.ec2_lc"].user_data
+
 	decode_result := check_user_data(user_data)
 	startswith(decode_result, "#!/")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{community.aws.ec2_lc}}.user_data", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{community.aws.ec2_lc}}.user_data is not shell script", [task.name]),

--- a/assets/queries/ansible/aws/volume_clusters_not_encrypted/query.rego
+++ b/assets/queries/ansible/aws/volume_clusters_not_encrypted/query.rego
@@ -1,18 +1,16 @@
 package Cx
+
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	volume := task["amazon.aws.ec2_vol"]
-	volumeName := task.name
 
 	object.get(volume, "encrypted", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_vol}}", [volumeName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_vol}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "amazon.aws.ec2_vol.encrypted should be set to true",
 		"keyActualValue": "amazon.aws.ec2_vol.encrypted is undefined",
@@ -20,17 +18,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	volume := task["amazon.aws.ec2_vol"]
-	volumeName := task.name
 
 	not ansLib.isAnsibleTrue(volume.encrypted)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_vol}}.encrypt", [volumeName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{amazon.aws.ec2_vol}}.encrypt", [task.name]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": "amazon.aws.ec2_vol.encrypted should be set to true",
 		"keyActualValue": "amazon.aws.ec2_vol.encrypted is set to false",

--- a/assets/queries/ansible/azure/activity_log_retention_period_less_than_365/query.rego
+++ b/assets/queries/ansible/azure/activity_log_retention_period_less_than_365/query.rego
@@ -1,17 +1,17 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	azureMonitor := task.azure_rm_monitorlogprofile
-	monitorName := task.name
 	retentionPolicy := azureMonitor.retention_policy
-	not isAnsibleTrue(retentionPolicy.enabled)
+
+	not ansLib.isAnsibleTrue(retentionPolicy.enabled)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_monitorlogprofile}}.retention_policy.enabled", [monitorName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_monitorlogprofile}}.retention_policy.enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_monitorlogprofile.retention_policy.enabled is true or yes",
 		"keyActualValue": "azure_rm_monitorlogprofile.retention_policy.enabled is false or no",
@@ -19,19 +19,17 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	azureMonitor := task.azure_rm_monitorlogprofile
-	monitorName := task.name
 	retentionPolicy := azureMonitor.retention_policy
-	isAnsibleTrue(retentionPolicy.enabled)
+
+	ansLib.isAnsibleTrue(retentionPolicy.enabled)
 	retentionPolicy.days < 365
 	retentionPolicy.days > 0
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_monitorlogprofile}}.retention_policy.days", [monitorName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_monitorlogprofile}}.retention_policy.days", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_monitorlogprofile.retention_policy.days is greater than 365 days or 0 (indefinitely)",
 		"keyActualValue": "azure_rm_monitorlogprofile.retention_policy.days is lesser than 365 days or different than 0 (indefinitely)",
@@ -39,32 +37,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	azureMonitor := task.azure_rm_monitorlogprofile
-	monitorName := task.name
+
 	object.get(azureMonitor, "retention_policy", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_monitorlogprofile}}", [monitorName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_monitorlogprofile}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_monitorlogprofile.retention_policy is defined",
 		"keyActualValue": "azure_rm_monitorlogprofile.retention_policy is undefined",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
-}
-
-isAnsibleTrue(answer) {
-	lower(answer) == "yes"
-} else {
-	answer == true
 }

--- a/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/query.rego
+++ b/assets/queries/ansible/azure/ad_admin_not_configured_for_sql_server/query.rego
@@ -1,24 +1,17 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	task := getTasks(document)[t].azure_rm_sqlserver
+	task := ansLib.tasks[id][t].azure_rm_sqlserver
 
 	object.get(task, "ad_user", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_sqlserver}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'ad_user' is defined",
 		"keyActualValue": "'ad_user' is undefined",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/admin_user_is_enabled_for_container_registry/query.rego
+++ b/assets/queries/ansible/azure/admin_user_is_enabled_for_container_registry/query.rego
@@ -1,35 +1,18 @@
 package Cx
 
-CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-	containerReg := task["azure.azcollection.azure_rm_containerregistry"]
-	containerRegName := task.name
+import data.generic.ansible as ansLib
 
-	isAnsibleTrue(containerReg.admin_user_enabled)
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	containerReg := task["azure.azcollection.azure_rm_containerregistry"]
+
+	ansLib.isAnsibleTrue(containerReg.admin_user_enabled)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_containerregistry}}.admin_user_enabled", [containerRegName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_containerregistry}}.admin_user_enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure.azcollection.azure_rm_containerregistry.admin_user_enabled should be false or undefined (defaults to false)",
 		"keyActualValue": "azure.azcollection.azure_rm_containerregistry.admin_user_enabled is true",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
-}
-
-isAnsibleTrue(answer) {
-	lower(answer) == "yes"
-} else {
-	lower(answer) == "true"
-} else {
-	answer == true
 }

--- a/assets/queries/ansible/azure/aks_network_policy_misconfigured/query.rego
+++ b/assets/queries/ansible/azure/aks_network_policy_misconfigured/query.rego
@@ -1,14 +1,14 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	not isValidNetworkPolicy(task.azure_rm_aks.network_profile.network_policy)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.azure_rm_aks.network_profile.network_policy", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Azure AKS cluster network policy should be either 'calico' or 'azure'",
@@ -17,14 +17,12 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task.azure_rm_aks, "network_profile", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.azure_rm_aks", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Azure AKS cluster network profile should be defined",
@@ -33,28 +31,18 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task.azure_rm_aks, "network_profile", "undefined") == "undefined"
 	object.get(task.azure_rm_aks.network_profile, "network_policy", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.azure_rm_aks", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Azure AKS cluster network policy should be defined",
 		"keyActualValue": "Azure AKS cluster network policy is undefined",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }
 
 isValidNetworkPolicy(policy) {

--- a/assets/queries/ansible/azure/azurerm_container_registry_with_no_locks/query.rego
+++ b/assets/queries/ansible/azure/azurerm_container_registry_with_no_locks/query.rego
@@ -1,18 +1,16 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-
-    modules := {"azure.azcollection.azure_rm_containerregistry", "azure_rm_containerregistry"}
-
+	task := ansLib.tasks[id][t]
+	modules := {"azure.azcollection.azure_rm_containerregistry", "azure_rm_containerregistry"}
 	taskContainerRegistry := task[modules[index]]
 
 	not checkLocks(taskContainerRegistry)
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}.resource_group", [task.name, modules[index]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.resource_group is referenced by an existing lock", [modules[index]]),
@@ -20,17 +18,8 @@ CxPolicy[result] {
 	}
 }
 
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
-}
-
 checkLocks(taskContainerRegistry) {
-	document2 := input.document[x]
-	taskLock := getTasks(document2)[t2].azure_rm_lock
+	taskLock := ansLib.tasks[_][_].azure_rm_lock
 	contains(taskLock, taskContainerRegistry.resource_group)
 }
 

--- a/assets/queries/ansible/azure/blob_container_with_public_access/query.rego
+++ b/assets/queries/ansible/azure/blob_container_with_public_access/query.rego
@@ -1,26 +1,19 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	hasPublicAccess(task.azure_rm_storageblob.public_access)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_storageblob}}.public_access", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageblob.public_access is not set",
 		"keyActualValue": "azure_rm_storageblob.public_access is equal to 'blob' or 'container'",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }
 
 hasPublicAccess(access) {

--- a/assets/queries/ansible/azure/cosmosdb_account_ip_range_filter_not_set/query.rego
+++ b/assets/queries/ansible/azure/cosmosdb_account_ip_range_filter_not_set/query.rego
@@ -1,24 +1,17 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	task := getTasks(document)[t].azure_rm_cosmosdbaccount
+	task := ansLib.tasks[id][t].azure_rm_cosmosdbaccount
 
 	not task.ip_range_filter
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_cosmosdbaccount}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'azurerm_cosmosdb_account.ip_range_filter' is defined",
 		"keyActualValue": "'azurerm_cosmosdb_account.ip_range_filter' is undefined",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/cosmosdb_account_without_tags/query.rego
+++ b/assets/queries/ansible/azure/cosmosdb_account_without_tags/query.rego
@@ -1,25 +1,18 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
+
 	task.azure_rm_cosmosdbaccount
 	not task.azure_rm_cosmosdbaccount.tags
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_cosmosdbaccount}}.tags", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name=%s.{{azure_rm_cosmosdbaccount}}.tags is defined", [task.name]),
 		"keyActualValue": sprintf("name=%s.{{azure_rm_cosmosdbaccount}}.tags is undefined", [task.name]),
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/default_network_access_is_allowed/query.rego
+++ b/assets/queries/ansible/azure/default_network_access_is_allowed/query.rego
@@ -1,30 +1,20 @@
 package Cx
 
-CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-	storageAccount := task.azure_rm_storageaccount
-	storageAccountName := task.name
+import data.generic.ansible as ansLib
 
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	storageAccount := task.azure_rm_storageaccount
 	default_action := storageAccount.network_acls.default_action
 
 	is_string(default_action)
 	lower(default_action) == "allow"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_storageaccount}}.network_acls.default_action", [storageAccountName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_storageaccount}}.network_acls.default_action", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageaccount.network_acls.default_action is 'Deny'",
 		"keyActualValue": "azure_rm_storageaccount.network_acls.default_action is 'Allow'",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/firewall_rule_allows_too_many_hosts_to_access_redis_cache/query.rego
+++ b/assets/queries/ansible/azure/firewall_rule_allows_too_many_hosts_to_access_redis_cache/query.rego
@@ -1,9 +1,11 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	playbooks := getTasks(input.document[i])
-	redis_cache := playbooks[j]
-	instance := redis_cache.azure_rm_rediscachefirewallrule
+	task := ansLib.tasks[id][t]
+	instance := task.azure_rm_rediscachefirewallrule
+
 	occupied_hosts := getHosts(instance.start_ip_address)
 	all_hosts := getHosts(instance.end_ip_address)
 	available := abs(all_hosts - occupied_hosts)
@@ -11,11 +13,11 @@ CxPolicy[result] {
 	available > 255
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address", [playbooks[j].name]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address and end_ip_address allows up to 255 hosts", [playbooks[j].name]),
-		"keyActualValue": sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address and end_ip_address allow %s", [playbooks[j].name, available]),
+		"keyExpectedValue": sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address and end_ip_address allows up to 255 hosts", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address and end_ip_address allow %s", [task.name, available]),
 	}
 }
 
@@ -23,14 +25,7 @@ getHosts(ip) = nhosts {
 	nums := split(ip, ".")
 
 	# ip = x.y.z.w
-	# hosts = x * 2^24 + y * 2^16 + z * 2^8 + w 
+	# hosts = x * 2^24 + y * 2^16 + z * 2^8 + w
 	# 2^24 = 16777216  2^16 = 65536  2^8 = 256
 	nhosts := (((to_number(nums[0]) * 16777216) + (to_number(nums[1]) * 65536)) + (to_number(nums[2]) * 256)) + to_number(nums[3])
-}
-
-getTasks(document) = result {
-	result := document.playbooks[0].tasks
-} else = result {
-	object.get(document.playbooks[0], "tasks", "undefined") == "undefined"
-	result := document.playbooks
 }

--- a/assets/queries/ansible/azure/key_vault_soft_delete_is_disabled/query.rego
+++ b/assets/queries/ansible/azure/key_vault_soft_delete_is_disabled/query.rego
@@ -1,14 +1,15 @@
 package Cx
 
-CxPolicy[result] {
-	document := input.document[i]
-	task := getTasks(document)[t]
+import data.generic.ansible as ansLib
 
- 	keyvault := object.get(task.azure_rm_keyvault, "enable_soft_delete", "undefined")
-	isAnsibleFalse(keyvault)
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+
+	keyvault := object.get(task.azure_rm_keyvault, "enable_soft_delete", "undefined")
+	ansLib.isAnsibleFalse(keyvault)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{azure_rm_keyvault}}.enable_soft_delete", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_keyvault.enable_soft_delete is true",
@@ -17,32 +18,15 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 
 	object.get(task.azure_rm_keyvault, "enable_soft_delete", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{azure_rm_keyvault}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_keyvault.enable_soft_delete is defined",
 		"keyActualValue": "azure_rm_keyvault.enable_soft_delete is undefined",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
-}
-
-isAnsibleFalse(answer) {
-	lower(answer) == "no"
-} else {
-	lower(answer) == "false"
-} else {
-	answer == false
 }

--- a/assets/queries/ansible/azure/log_connections_is_not_set/query.rego
+++ b/assets/queries/ansible/azure/log_connections_is_not_set/query.rego
@@ -1,34 +1,22 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	pgConfig := task["azure.azcollection.azure_rm_postgresqlconfiguration"]
-	pgConfigName := task.name
 
 	is_string(pgConfig.name)
-	name := lower(pgConfig.name)
-
 	is_string(pgConfig.value)
-	value := upper(pgConfig.value)
 
-	name == "log_connections"
-	value != "ON"
+	lower(pgConfig.name) == "log_connections"
+	upper(pgConfig.value) != "ON"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value", [pgConfigName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure.azcollection.azure_rm_postgresqlconfiguration.value should be 'ON' when name is 'log_connections'",
 		"keyActualValue": "azure.azcollection.azure_rm_postgresqlconfiguration.value if 'OFF'",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/log_disconnections_is_not_set/query.rego
+++ b/assets/queries/ansible/azure/log_disconnections_is_not_set/query.rego
@@ -1,34 +1,22 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	pgConfig := task["azure.azcollection.azure_rm_postgresqlconfiguration"]
-	pgConfigName := task.name
 
 	is_string(pgConfig.name)
-	name := lower(pgConfig.name)
-
 	is_string(pgConfig.value)
-	value := upper(pgConfig.value)
 
-	name == "log_disconnections"
-	value != "ON"
+	lower(pgConfig.name) == "log_disconnections"
+	upper(pgConfig.value) != "ON"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value", [pgConfigName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure.azcollection.azure_rm_postgresqlconfiguration.value should be 'ON' when name is 'log_disconnections'",
 		"keyActualValue": "azure.azcollection.azure_rm_postgresqlconfiguration.value if 'OFF'",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/log_duration_is_not_set/query.rego
+++ b/assets/queries/ansible/azure/log_duration_is_not_set/query.rego
@@ -1,34 +1,22 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	pgConfig := task["azure.azcollection.azure_rm_postgresqlconfiguration"]
-	pgConfigName := task.name
 
 	is_string(pgConfig.name)
-	name := lower(pgConfig.name)
-
 	is_string(pgConfig.value)
-	value := upper(pgConfig.value)
 
-	name == "log_duration"
-	value != "ON"
+	lower(pgConfig.name) == "log_duration"
+	upper(pgConfig.value) != "ON"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value", [pgConfigName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value should be 'ON' for 'log_duration'", [pgConfigName]),
-		"keyActualValue": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value is 'OFF' for 'log_duration'", [pgConfigName]),
+		"keyExpectedValue": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value should be 'ON' for 'log_duration'", [task.name]),
+		"keyActualValue": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value is 'OFF' for 'log_duration'", [task.name]),
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/log_retention_is_not_set/query.rego
+++ b/assets/queries/ansible/azure/log_retention_is_not_set/query.rego
@@ -1,8 +1,9 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	task := getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	postgresql_configuration := task.azure_rm_postgresqlconfiguration
 
 	is_string(postgresql_configuration.name)
@@ -12,18 +13,10 @@ CxPolicy[result] {
 	lower(postgresql_configuration.value) != "on"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_postgresqlconfiguration}}.value", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'value' is equal to 'on'",
 		"keyActualValue": "'value' is not equal to 'on'",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/monitoring_log_profile_without_all_activities/query.rego
+++ b/assets/queries/ansible/azure/monitoring_log_profile_without_all_activities/query.rego
@@ -1,19 +1,18 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	azureMonitor := task.azure_rm_monitorlogprofile
-	monitorName := task.name
 	categories := azureMonitor.categories
-	elems = ["Write", "Action", "Delete"]
-	elem := elems[k]
+	elem := ["write", "action", "delete"][_]
+
 	not containsCategories(categories, elem)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_monitorlogprofile}}.categories", [monitorName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_monitorlogprofile}}.categories", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_monitorlogprofile.categories should have all categories, Write, Action and Delete",
 		"keyActualValue": "azure_rm_monitorlogprofile.categories does not have all categories, Write, Action and Delete",
@@ -21,32 +20,22 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	azureMonitor := task.azure_rm_monitorlogprofile
-	monitorName := task.name
+
 	object.get(azureMonitor, "categories", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_monitorlogprofile}}", [monitorName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_monitorlogprofile}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_monitorlogprofile.categories is defined",
 		"keyActualValue": "azure_rm_monitorlogprofile.categories is undefined",
 	}
 }
 
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
-}
-
 containsCategories(categories, elem) {
-	lower(categories[_]) == lower(elem)
+	lower(categories[_]) == elem
 } else = false {
 	true
 }

--- a/assets/queries/ansible/azure/postgre_sql_log_checkpoints_is_on/query.rego
+++ b/assets/queries/ansible/azure/postgre_sql_log_checkpoints_is_on/query.rego
@@ -1,34 +1,22 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	pgConfig := task["azure.azcollection.azure_rm_postgresqlconfiguration"]
-	pgConfigName := task.name
 
 	is_string(pgConfig.name)
-	name := lower(pgConfig.name)
-
 	is_string(pgConfig.value)
-	value := upper(pgConfig.value)
 
-	name == "log_checkpoints"
-	value != "ON"
+	lower(pgConfig.name) == "log_checkpoints"
+	upper(pgConfig.value) != "ON"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value", [pgConfigName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value", [task.name]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": "azure.azcollection.azure_rm_postgresqlconfiguration.value should be 'ON' when name is 'log_checkpoints'",
 		"keyActualValue": "azure.azcollection.azure_rm_postgresqlconfiguration.value if 'OFF'",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/postgre_sql_server_without_connection_throttling/query.rego
+++ b/assets/queries/ansible/azure/postgre_sql_server_without_connection_throttling/query.rego
@@ -1,34 +1,22 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	pgConfig := task["azure.azcollection.azure_rm_postgresqlconfiguration"]
-	pgConfigName := task.name
 
 	is_string(pgConfig.name)
-	name := lower(pgConfig.name)
-
 	is_string(pgConfig.value)
-	value := upper(pgConfig.value)
 
-	name == "connection_throttling"
-	value != "ON"
+	lower(pgConfig.name) == "connection_throttling"
+	upper(pgConfig.value) != "ON"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value", [pgConfigName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlconfiguration}}.value", [task.name]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": "azure.azcollection.azure_rm_postgresqlconfiguration.value should be 'ON' when name is 'connection_throttling'",
 		"keyActualValue": "azure.azcollection.azure_rm_postgresqlconfiguration.value if 'OFF'",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/public_storage_account/query.rego
+++ b/assets/queries/ansible/azure/public_storage_account/query.rego
@@ -1,14 +1,14 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task.azure_rm_storageaccount.network_acls.default_action == "Allow"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_storageaccount}}.network_acls.default_action", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageaccount.network_acls.default_action is not set",
@@ -17,9 +17,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task.azure_rm_storageaccount.network_acls.default_action == "Deny"
 
@@ -29,18 +27,10 @@ CxPolicy[result] {
 	ip_rules[j].value == "0.0.0.0/0"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_storageaccount}}.network_acls.ip_rules", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageaccount.network_acls.default_action is 'Deny' and azure_rm_storageaccount.network_acls.ip_rules does not contain value '0.0.0.0/0' ",
 		"keyActualValue": "azure_rm_storageaccount.network_acls.default_action is 'Deny' and azure_rm_storageaccount.network_acls.ip_rules contains value '0.0.0.0/0'",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/redis_cache_allows_non_ssl_connections/query.rego
+++ b/assets/queries/ansible/azure/redis_cache_allows_non_ssl_connections/query.rego
@@ -1,32 +1,18 @@
 package Cx
 
-CxPolicy[result] {
-	playbooks := getTasks(input.document[i])
-	redis_cache := playbooks[j]
-	instance := redis_cache.azure_rm_rediscache
+import data.generic.ansible as ansLib
 
-	isTrue(instance.enable_non_ssl_port)
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	instance := task.azure_rm_rediscache
+
+	ansLib.isAnsibleTrue(instance.enable_non_ssl_port)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name=%s.{{azure_rm_rediscache}}.enable_non_ssl_port", [playbooks[j].name]),
+		"documentId": id,
+		"searchKey": sprintf("name=%s.{{azure_rm_rediscache}}.enable_non_ssl_port", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("name=%s.{{azure_rm_rediscache}}.enable_non_ssl_port is false or undefined", [playbooks[j].name]),
-		"keyActualValue": sprintf("name=%s.{{azure_rm_rediscache}}.enable_non_ssl_port is true", [playbooks[j].name]),
+		"keyExpectedValue": sprintf("name=%s.{{azure_rm_rediscache}}.enable_non_ssl_port is false or undefined", [task.name]),
+		"keyActualValue": sprintf("name=%s.{{azure_rm_rediscache}}.enable_non_ssl_port is true", [task.name]),
 	}
-}
-
-isTrue(attribute) {
-	attribute == "yes"
-} else {
-	attribute == true
-} else = false {
-	true
-}
-
-getTasks(document) = result {
-	result := document.playbooks[0].tasks
-} else = result {
-	object.get(document.playbooks[0], "tasks", "undefined") == "undefined"
-	result := document.playbooks
 }

--- a/assets/queries/ansible/azure/redis_entirely_accessible/query.rego
+++ b/assets/queries/ansible/azure/redis_entirely_accessible/query.rego
@@ -1,26 +1,19 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	task := getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	firewall_rule := task.azure_rm_rediscachefirewallrule
 
 	firewall_rule.start_ip_address == "0.0.0.0"
 	firewall_rule.end_ip_address == "0.0.0.0"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'azure_rm_rediscachefirewallrule' start_ip and end_ip are not equal to '0.0.0.0'",
 		"keyActualValue": "'azure_rm_rediscachefirewallrule' start_ip and end_ip are equal to '0.0.0.0'",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/redis_publicly_accessible/query.rego
+++ b/assets/queries/ansible/azure/redis_publicly_accessible/query.rego
@@ -1,28 +1,21 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	task := getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	firewall_rule := task.azure_rm_rediscachefirewallrule
 
 	not privateIP(firewall_rule.start_ip_address)
 	not privateIP(firewall_rule.end_ip_address)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_rediscachefirewallrule}}.start_ip_address", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'azure_rm_rediscachefirewallrule' ip range is private",
 		"keyActualValue": "'azure_rm_rediscachefirewallrule' ip range is public",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }
 
 privateIP(ip) {

--- a/assets/queries/ansible/azure/security_group_is_not_configured/query.rego
+++ b/assets/queries/ansible/azure/security_group_is_not_configured/query.rego
@@ -1,18 +1,17 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	subnet := task.azure_rm_subnet
-	subnetName := task.name
 
 	object.get(subnet, "security_group", "undefined") == "undefined"
 	object.get(subnet, "security_group_name", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_subnet}}", [subnetName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_subnet}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure_rm_subnet.security_group is defined",
 		"keyActualValue": "azure_rm_subnet.security_group is undefined",
@@ -20,17 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	subnet := task.azure_rm_subnet
-	subnetName := task.name
 
-	checkString(subnet.security_group)
+	ansLib.checkValue(subnet.security_group)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_subnet}}.security_group", [subnetName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_subnet}}.security_group", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_subnet.security_group is not empty or null",
 		"keyActualValue": "azure_rm_subnet.security_group is empty or null",
@@ -38,35 +34,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	subnet := task.azure_rm_subnet
-	subnetName := task.name
 
-	checkString(subnet.security_group_name)
+	ansLib.checkValue(subnet.security_group_name)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_subnet}}.security_group_name", [subnetName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_subnet}}.security_group_name", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_subnet.security_group_name is not empty or null",
 		"keyActualValue": "azure_rm_subnet.security_group_name is empty or null",
 	}
-}
-
-checkString(string) {
-	string == null
-}
-
-checkString(string) {
-	count(string) == 0
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/query.rego
+++ b/assets/queries/ansible/azure/sql_server_accessibility_is_not_minimal/query.rego
@@ -1,43 +1,40 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-    modules = {"azure.azcollection.azure_rm_sqlfirewallrule","azure_rm_sqlfirewallrule"}
+	task := ansLib.tasks[id][t]
+	modules = {"azure.azcollection.azure_rm_sqlfirewallrule", "azure_rm_sqlfirewallrule"}
 	rule := task[modules[index]]
-	ruleName := task.name
 
 	rule.start_ip_address == "0.0.0.0"
 	rule.end_ip_address == "0.0.0.0"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{%s}}", [ruleName, modules[index]]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[index]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s.start_ip_address is different from '0.0.0.0' and azure_rm_sqlfirewallrule.end_ip_address is different from '0.0.0.0'",[modules[index]]),
-		"keyActualValue": sprintf("%s.start_ip_address is '0.0.0.0' and azure_rm_sqlfirewallrule.end_ip_address is '0.0.0.0'",[modules[index]]),
+		"keyExpectedValue": sprintf("%s.start_ip_address is different from '0.0.0.0' and azure_rm_sqlfirewallrule.end_ip_address is different from '0.0.0.0'", [modules[index]]),
+		"keyActualValue": sprintf("%s.start_ip_address is '0.0.0.0' and azure_rm_sqlfirewallrule.end_ip_address is '0.0.0.0'", [modules[index]]),
 	}
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-	modules = {"azure.azcollection.azure_rm_sqlfirewallrule","azure_rm_sqlfirewallrule"}
+	task := ansLib.tasks[id][t]
+	modules = {"azure.azcollection.azure_rm_sqlfirewallrule", "azure_rm_sqlfirewallrule"}
 	rule := task[modules[index]]
-	ruleName := task.name
+
 	startIP_value := calcValue(rule.start_ip_address)
 	endIP_value := calcValue(rule.end_ip_address)
 
 	abs(endIP_value - startIP_value) >= 256
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{%s}}", [ruleName, modules[index]]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[index]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("The difference between the value of '%s' .'end_ip_address' and .'start_ip_address' is lesser than 256",[modules[index]]),
-		"keyActualValue": sprintf("The difference between the value of '%s' .'end_ip_address' and .'start_ip_address' is greater than or equal to 256",[modules[index]]),
+		"keyExpectedValue": sprintf("The difference between the value of '%s' .'end_ip_address' and .'start_ip_address' is lesser than 256", [modules[index]]),
+		"keyActualValue": sprintf("The difference between the value of '%s' .'end_ip_address' and .'start_ip_address' is greater than or equal to 256", [modules[index]]),
 	}
 }
 
@@ -48,12 +45,4 @@ calcValue(val) = result {
 	#a.b.c.d
 	#a*16777216 + b*65536 + c*256 + d
 	result = (((to_number(ips[0]) * 16777216) + (to_number(ips[1]) * 65536)) + (to_number(ips[2]) * 256)) + to_number(ips[3])
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/sql_server_ingress_from_any_ip/query.rego
+++ b/assets/queries/ansible/azure/sql_server_ingress_from_any_ip/query.rego
@@ -1,31 +1,22 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-	modules = {"azure.azcollection.azure_rm_sqlfirewallrule","azure_rm_sqlfirewallrule"}
+	task := ansLib.tasks[id][t]
+	modules = {"azure.azcollection.azure_rm_sqlfirewallrule", "azure_rm_sqlfirewallrule"}
 	fwRule := task[modules[index]]
-	fwRuleName := task.name
 
 	fwRule.start_ip_address == "0.0.0.0"
 	isUnsafeEndIpAddress(fwRule.end_ip_address)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{%s}}.end_ip_address", [fwRuleName,modules[index]]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}.end_ip_address", [task.name, modules[index]]),
 		"issueType": "WrongValue",
-		"keyExpectedValue": sprintf("%s should not allow all IPs (range from start_ip_address to end_ip_address)",[modules[index]]),
-		"keyActualValue": sprintf("%s should allows all IPs",[modules[index]]),
+		"keyExpectedValue": sprintf("%s should not allow all IPs (range from start_ip_address to end_ip_address)", [modules[index]]),
+		"keyActualValue": sprintf("%s should allows all IPs", [modules[index]]),
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }
 
 isUnsafeEndIpAddress("0.0.0.0") = true

--- a/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/query.rego
+++ b/assets/queries/ansible/azure/sql_server_predictable_active_directory_admin_account_name/query.rego
@@ -1,68 +1,36 @@
 package Cx
 
-CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-	ad := task.azure_ad_serviceprincipal
-	adName := task.name
+import data.generic.ansible as ansLib
 
-	ad.ad_user
-	is_string(ad.ad_user)
-	count(ad.ad_user) == 0
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	ad := task.azure_ad_serviceprincipal
+
+	ansLib.checkValue(ad.ad_user)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_ad_serviceprincipal}}.ad_user", [adName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_ad_serviceprincipal}}.ad_user", [task.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "azure_ad_serviceprincipal.ad_user is not empty",
-		"keyActualValue": "azure_ad_serviceprincipal.ad_user is empty",
+		"keyExpectedValue": "azure_ad_serviceprincipal.ad_user is neither empty nor null",
+		"keyActualValue": "azure_ad_serviceprincipal.ad_user is empty or null",
 	}
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	ad := task.azure_ad_serviceprincipal
-	adName := task.name
-
-	ad.ad_user == null
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_ad_serviceprincipal}}.ad_user", [adName]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "azure_ad_serviceprincipal.ad_user is not null",
-		"keyActualValue": "azure_ad_serviceprincipal.ad_user is null",
-	}
-}
-
-CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-	ad := task.azure_ad_serviceprincipal
-	adName := task.name
 
 	is_string(ad.ad_user)
 	check_predictable(ad.ad_user)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_ad_serviceprincipal}}.ad_user", [adName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_ad_serviceprincipal}}.ad_user", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_ad_serviceprincipal.ad_user is not predictable",
 		"keyActualValue": "azure_ad_serviceprincipal.ad_user is predictable",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }
 
 check_predictable(name) {

--- a/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/query.rego
+++ b/assets/queries/ansible/azure/sql_server_predictable_admin_account_name/query.rego
@@ -1,17 +1,16 @@
 package Cx
 
-CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-	server := task.azure_rm_sqlserver
-	serverName := task.name
+import data.generic.ansible as ansLib
 
-	checkSize(server.admin_username)
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	server := task.azure_rm_sqlserver
+
+	ansLib.checkValue(server.admin_username)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_sqlserver}}.admin_username", [serverName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_sqlserver}}.admin_username", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_sqlserver.admin_username is not empty",
 		"keyActualValue": "azure_rm_sqlserver.admin_username is empty",
@@ -19,43 +18,23 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	server := task.azure_rm_sqlserver
-	serverName := task.name
 
 	is_string(server.admin_username)
 	check_predictable(server.admin_username)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure_rm_sqlserver}}.admin_username", [serverName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure_rm_sqlserver}}.admin_username", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_sqlserver.admin_username is not predictable",
 		"keyActualValue": "azure_rm_sqlserver.admin_username is predictable",
 	}
 }
 
-checkSize(username) {
-	is_string(username)
-	count(username) == 0
-}
-
-checkSize(username) {
-	username == null
-}
-
 check_predictable(username) {
 	predictable_names := {"admin", "administrator", "root", "user", "azure_admin", "azure_administrator", "guest"}
 	some i
 	lower(username) == predictable_names[i]
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/sql_server_with_public_access/query.rego
+++ b/assets/queries/ansible/azure/sql_server_with_public_access/query.rego
@@ -1,29 +1,20 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-    modules = {"azure.azcollection.azure_rm_sqlfirewallrule","azure_rm_sqlfirewallrule"}
+	task := ansLib.tasks[id][t]
+	modules = {"azure.azcollection.azure_rm_sqlfirewallrule", "azure_rm_sqlfirewallrule"}
 	fwRule := task[modules[index]]
-	fwRuleName := task.name
 
 	fwRule.start_ip_address == "0.0.0.0"
 	fwRule.end_ip_address == "0.0.0.0"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{%s}}.end_ip_address", [fwRuleName, modules[index]]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}.end_ip_address", [task.name, modules[index]]),
 		"issueType": "WrongValue",
-		"keyExpectedValue": sprintf("%s should not allow all IPs (range from start_ip_address to end_ip_address)",[modules[index]]),
-		"keyActualValue": sprintf("%s should allows all IPs",[modules[index]]),
+		"keyExpectedValue": sprintf("%s should not allow all IPs (range from start_ip_address to end_ip_address)", [modules[index]]),
+		"keyActualValue": sprintf("%s should allows all IPs", [modules[index]]),
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/ssl_connection_is_enabled/query.rego
+++ b/assets/queries/ansible/azure/ssl_connection_is_enabled/query.rego
@@ -1,17 +1,16 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	storageAccount := task["azure.azcollection.azure_rm_mysqlserver"]
-	storageAccountName := task.name
 
 	object.get(storageAccount, "enforce_ssl", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_mysqlserver}}", [storageAccountName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_mysqlserver}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure.azcollection.azure_rm_mysqlserver should have enforce_ssl set to true",
 		"keyActualValue": "azure.azcollection.azure_rm_mysqlserver does not have enforce_ssl (defaults to false)",
@@ -19,34 +18,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	storageAccount := task["azure.azcollection.azure_rm_mysqlserver"]
-	storageAccountName := task.name
-	not isAnsibleTrue(storageAccount.enforce_ssl)
+
+	not ansLib.isAnsibleTrue(storageAccount.enforce_ssl)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_mysqlserver}}.enforce_ssl", [storageAccountName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_mysqlserver}}.enforce_ssl", [task.name]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": "azure.azcollection.azure_rm_mysqlserver should have enforce_ssl set to true",
 		"keyActualValue": "azure.azcollection.azure_rm_mysqlserver does has enforce_ssl set to false",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
-}
-
-isAnsibleTrue(answer) {
-	lower(answer) == "yes"
-} else {
-	lower(answer) == "true"
-} else {
-	answer == true
 }

--- a/assets/queries/ansible/azure/ssl_enforce_is_disabled/query.rego
+++ b/assets/queries/ansible/azure/ssl_enforce_is_disabled/query.rego
@@ -1,17 +1,16 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	storageAccount := task["azure.azcollection.azure_rm_postgresqlserver"]
-	storageAccountName := task.name
 
 	object.get(storageAccount, "enforce_ssl", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlserver}}", [storageAccountName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlserver}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "azure.azcollection.azure_rm_postgresqlserver should have enforce_ssl set to true",
 		"keyActualValue": "azure.azcollection.azure_rm_postgresqlserver does not have enforce_ssl (defaults to false)",
@@ -19,34 +18,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	storageAccount := task["azure.azcollection.azure_rm_postgresqlserver"]
-	storageAccountName := task.name
-	not isAnsibleTrue(storageAccount.enforce_ssl)
+
+	not ansLib.isAnsibleTrue(storageAccount.enforce_ssl)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlserver}}.enforce_ssl", [storageAccountName]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{azure.azcollection.azure_rm_postgresqlserver}}.enforce_ssl", [task.name]),
 		"issueType": "WrongValue",
 		"keyExpectedValue": "azure.azcollection.azure_rm_postgresqlserver should have enforce_ssl set to true",
 		"keyActualValue": "azure.azcollection.azure_rm_postgresqlserver does has enforce_ssl set to false",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
-}
-
-isAnsibleTrue(answer) {
-	lower(answer) == "yes"
-} else {
-	lower(answer) == "true"
-} else {
-	answer == true
 }

--- a/assets/queries/ansible/azure/storage_account_not_forcing_https/query.rego
+++ b/assets/queries/ansible/azure/storage_account_not_forcing_https/query.rego
@@ -1,54 +1,35 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-	modules = {"azure.azcollection.azure_rm_storageaccount","azure_rm_storageaccount"}
+	task := ansLib.tasks[id][t]
+	modules = {"azure.azcollection.azure_rm_storageaccount", "azure_rm_storageaccount"}
 	storageAccount := task[modules[index]]
-	storageAccountName := task.name
 
 	object.get(storageAccount, "https_only", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{%s}}", [storageAccountName, modules[index]]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("%s.https_only is defined",[modules[index]]),
-		"keyActualValue": sprintf("%s.https_only is undefined (defaults to false)",[modules[index]]),
+		"keyExpectedValue": sprintf("%s.https_only is defined", [modules[index]]),
+		"keyActualValue": sprintf("%s.https_only is undefined (defaults to false)", [modules[index]]),
 	}
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-	modules = {"azure.azcollection.azure_rm_storageaccount","azure_rm_storageaccount"}
+	task := ansLib.tasks[id][t]
+	modules = {"azure.azcollection.azure_rm_storageaccount", "azure_rm_storageaccount"}
 	storageAccount := task[modules[index]]
-	storageAccountName := task.name
-	not isAnsibleTrue(storageAccount.https_only)
+
+	not ansLib.isAnsibleTrue(storageAccount.https_only)
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("name={{%s}}.{{%s}}.https_only", [storageAccountName, modules[index]]),
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}.https_only", [task.name, modules[index]]),
 		"issueType": "WrongValue",
-		"keyExpectedValue": sprintf("%s should have https_only set to true",[modules[index]]),
-		"keyActualValue": sprintf("%s has https_only set to false",[modules[index]]),
+		"keyExpectedValue": sprintf("%s should have https_only set to true", [modules[index]]),
+		"keyActualValue": sprintf("%s has https_only set to false", [modules[index]]),
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
-}
-
-isAnsibleTrue(answer) {
-	lower(answer) == "yes"
-} else {
-	lower(answer) == "true"
-} else {
-	answer == true
 }

--- a/assets/queries/ansible/azure/storage_account_not_using_latest_tls_encryption_version/query.rego
+++ b/assets/queries/ansible/azure/storage_account_not_using_latest_tls_encryption_version/query.rego
@@ -1,16 +1,16 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-	modules = {"azure.azcollection.azure_rm_storageaccount","azure_rm_storageaccount"}
+	task := ansLib.tasks[id][t]
+	modules = {"azure.azcollection.azure_rm_storageaccount", "azure_rm_storageaccount"}
 	storage := task[modules[index]]
 
 	object.get(storage, "minimum_tls_version", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}", [task.name, modules[index]]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name=%s.{{%s}}.minimum_tls_version is defined", [task.name, modules[index]]),
@@ -19,27 +19,17 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
-
-	modules = {"azure.azcollection.azure_rm_storageaccount","azure_rm_storageaccount"}
+	task := ansLib.tasks[id][t]
+	modules = {"azure.azcollection.azure_rm_storageaccount", "azure_rm_storageaccount"}
 	tls_version := task[modules[index]].minimum_tls_version
-	not tls_version == "TLS1_2"
+
+	tls_version != "TLS1_2"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{%s}}.minimum_tls_version", [task.name, modules[index]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{%s}} is using the latest version of TLS encryption", [task.name, modules[index]]),
 		"keyActualValue": sprintf("name=%s.{{%s}} is using version %s of TLS encryption", [task.name, modules[index], tls_version]),
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/query.rego
+++ b/assets/queries/ansible/azure/trusted_microsoft_services_not_enabled/query.rego
@@ -1,28 +1,20 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 
 	task.azure_rm_storageaccount.network_acls.default_action == "Deny"
 	not containsAzureService(task.azure_rm_storageaccount.network_acls.bypass)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_storageaccount}}.network_acls.bypass", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_storageaccount.network_acls.bypass is not set or contains 'AzureServices'",
 		"keyActualValue": "azure_rm_storageaccount.network_acls.bypass does not contain 'AzureServices' ",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }
 
 containsAzureService(bypass) {

--- a/assets/queries/ansible/azure/vm_not_attached_to_network/query.rego
+++ b/assets/queries/ansible/azure/vm_not_attached_to_network/query.rego
@@ -1,25 +1,18 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	task := getTasks(document)[t].azure_rm_virtualmachine
+	task := ansLib.tasks[id][t].azure_rm_virtualmachine
 
 	object.get(task, "network_interface_names", "undefined") == "undefined"
 	object.get(task, "network_interfaces", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_virtualmachine}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'network_interface_names' is defined",
 		"keyActualValue": "'network_interface_names' is undefined",
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/waf_is_disabled_for_azure_application_gateway/query.rego
+++ b/assets/queries/ansible/azure/waf_is_disabled_for_azure_application_gateway/query.rego
@@ -1,27 +1,19 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	appGateway := task.azure_rm_appgateway
 	tier := appGateway.sku.tier
 
 	not startswith(tier, "waf")
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{azure_rm_appgateway}}.sku.tier", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "azure_rm_appgateway.sku.tier should be 'waf' or 'waf_v2'",
 		"keyActualValue": sprintf("azure_rm_appgateway.sku.tier is %s", [tier]),
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
 }

--- a/assets/queries/ansible/azure/web_app_accepts_not_only_https_traffic/query.rego
+++ b/assets/queries/ansible/azure/web_app_accepts_not_only_https_traffic/query.rego
@@ -1,15 +1,15 @@
 package Cx
 
+import data.generic.ansible as ansLib
+
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	https_value := task.azure_rm_webapp.https_only
 
-	not HasHttpsEnabled(https_value)
+	not ansLib.isAnsibleTrue(https_value)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_webapp}}.https_only", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{azure_rm_webapp}}.https_only is set to true or 'yes'",
@@ -18,34 +18,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	https := task.azure_rm_webapp
 
 	object.get(https, "https_only", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{azure_rm_webapp}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name=%s.{{azure_rm_webapp}}.https_only is defined", [task.name]),
 		"keyActualValue": sprintf("name=%s.{{azure_rm_webapp}}.https_only is undefined", [task.name]),
 	}
-}
-
-getTasks(document) = result {
-	result := [body | playbook := document.playbooks[0]; body := playbook.tasks]
-	count(result) != 0
-} else = result {
-	result := [body | playbook := document.playbooks[_]; body := playbook]
-	count(result) != 0
-}
-
-HasHttpsEnabled(value) {
-	lower(value) == "yes"
-} else {
-	lower(value) == "true"
-} else {
-	value == true
 }

--- a/assets/queries/ansible/gcp/bigquery_dataset_is_public/query.rego
+++ b/assets/queries/ansible/gcp/bigquery_dataset_is_public/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	bigquery_dataset := task["google.cloud.gcp_bigquery_dataset"]
 
 	ansLib.checkState(bigquery_dataset)
@@ -12,7 +11,7 @@ CxPolicy[result] {
 	lower(access[_].special_group) == "allauthenticatedusers"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_bigquery_dataset}}.access", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_bigquery_dataset}}.access.special_group is not equal to 'allAuthenticatedUsers'",

--- a/assets/queries/ansible/gcp/client_certificate_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/client_certificate_is_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster, "master_auth", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth is defined",
@@ -20,16 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster.master_auth, "client_certificate_config", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "google.cloud.gcp_container_cluster.master_auth.client_certificate_config is defined",
@@ -38,16 +35,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	tasks := ansLib.getTasks(document)
-	task := tasks[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	ansLib.isAnsibleFalse(cluster.master_auth.client_certificate_config.issue_client_certificate)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth.client_certificate_config.issue_client_certificate", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "google.cloud.gcp_container_cluster.master_auth.password is true",

--- a/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/query.rego
+++ b/assets/queries/ansible/gcp/cloud_dns_without_dnnsec/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	managed_zone := task["google.cloud.gcp_dns_managed_zone"]
 
 	ansLib.checkState(managed_zone)
 	object.get(managed_zone, "dnssec_config", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_dns_managed_zone}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_dns_managed_zone}}.dnssec_config is defined",
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	managed_zone := task["google.cloud.gcp_dns_managed_zone"]
 
 	ansLib.checkState(managed_zone)
 	object.get(managed_zone.dnssec_config, "state", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_dns_managed_zone}}.dnssec_config", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_dns_managed_zone}}.dnssec_config.state is defined",
@@ -37,15 +35,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	managed_zone := task["google.cloud.gcp_dns_managed_zone"]
 
 	ansLib.checkState(managed_zone)
 	managed_zone.dnssec_config.state != "on"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_dns_managed_zone}}.dnssec_config.state", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_dns_managed_zone}}.dnssec_config.state is equal to 'on'",

--- a/assets/queries/ansible/gcp/cloud_mysql_instance_with_local_infile_on/query.rego
+++ b/assets/queries/ansible/gcp/cloud_mysql_instance_with_local_infile_on/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(instance)
@@ -13,7 +12,7 @@ CxPolicy[result] {
 	ansLib.check_database_flags_content(database_flags, "local_infile", "off")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloud_gcp_sql_instance.settings.database_flags are correct",

--- a/assets/queries/ansible/gcp/cloud_sql_db_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/gcp/cloud_sql_db_is_publicly_accessible/query.rego
@@ -3,19 +3,18 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(instance)
 	ip_configuration := instance.settings.ip_configuration
 	count(ip_configuration.authorized_networks) > 0
-	authorized_network = ip_configuration.authorized_networks[id]
+	authorized_network := ip_configuration.authorized_networks[_]
 	authorized_network.value == "0.0.0.0"
 	network := authorized_network.name
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration.authorized_networks.name=%s.value", [task.name, network]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration.authorized_networks.name=%s.value address is trusted", [task.name, network]),
@@ -24,8 +23,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(instance)
@@ -34,7 +32,7 @@ CxPolicy[result] {
 	ansLib.isAnsibleTrue(ip_configuration.ipv4_enabled)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration.ipv4_enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration.ipv4_enabled is disabled when there are no authorized networks", [task.name]),
@@ -43,16 +41,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(instance)
-	settings := instance.settings
-	object.get(settings, "ip_configuration", "undefined") == "undefined"
+	object.get(instance.settings, "ip_configuration", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration is defined and allow only trusted networks", [task.name]),

--- a/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/query.rego
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_ssl_disabled/query.rego
@@ -3,19 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
-
 	ansLib.checkState(instance)
 
-	settings := instance.settings
-	ip_configuration := settings.ip_configuration
-
-	ansLib.isAnsibleFalse(ip_configuration.require_ssl)
+	ansLib.isAnsibleFalse(instance.settings.ip_configuration.require_ssl)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration.require_ssl", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{cloud_gcp_sql_instance}}.settings.ip_configuration.require_ssl is true",
@@ -24,19 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
-
 	ansLib.checkState(instance)
 
-	settings := instance.settings
-	ip_configuration := settings.ip_configuration
-
-	object.get(ip_configuration, "require_ssl", "undefined") == "undefined"
+	object.get(instance.settings.ip_configuration, "require_ssl", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{cloud_gcp_sql_instance}}.settings.ip_configuration.require_ssl is defined",

--- a/assets/queries/ansible/gcp/cloud_sql_instance_with_contained_database_authentication_on/query.rego
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_with_contained_database_authentication_on/query.rego
@@ -3,20 +3,18 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(instance)
 	contains(instance.database_version, "SQLSERVER")
 
-	settings := instance.settings
-	database_flags := settings.database_flags
+	database_flags := instance.settings.database_flags
 
 	ansLib.check_database_flags_content(database_flags, "contained database authentication", "off")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "cloud_gcp_sql_instance.settings.database_flags are correct",

--- a/assets/queries/ansible/gcp/cloud_sql_instance_with_cross_db_ownership_chaining_on/query.rego
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_with_cross_db_ownership_chaining_on/query.rego
@@ -3,20 +3,18 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(instance)
 	contains(instance.database_version, "SQLSERVER")
 
-	settings := instance.settings
-	database_flags := settings.database_flags
+	database_flags := instance.settings.database_flags
 
 	ansLib.check_database_flags_content(database_flags, "cross db ownership chaining", "off")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{cloud_gcp_sql_instance}}.settings.database_flags are correct",

--- a/assets/queries/ansible/gcp/cloud_sql_instance_with_public_ip/query.rego
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_with_public_ip/query.rego
@@ -3,20 +3,18 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(instance)
 	contains(instance.database_version, "SQLSERVER")
 
-	settings := instance.settings
-	ip_configuration := settings.ip_configuration
+	ip_configuration := instance.settings.ip_configuration
 
 	ansLib.isAnsibleTrue(ip_configuration.ipv4_enabled)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration.ipv4_enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{cloud_gcp_sql_instance}}.settings.ip_configuration.ipv4_enabled is disabled",

--- a/assets/queries/ansible/gcp/cloud_sql_instance_with_ssl_disabled/query.rego
+++ b/assets/queries/ansible/gcp/cloud_sql_instance_with_ssl_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	sql_instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(sql_instance)
 	path := getPathDefinitions(sql_instance)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}%s", [task.name, path.defined]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'%s' is defined", [path.undefined]),
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	sql_instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(sql_instance)
 	not ansLib.isAnsibleTrue(sql_instance.settings.ip_configuration.require_ssl)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.ip_configuration.require_ssl", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'settings.ip_configuration.require_ssl' is true",

--- a/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/query.rego
+++ b/assets/queries/ansible/gcp/cloud_storage_anonymous_or_publicly_accessible/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["google.cloud.gcp_storage_bucket"]
 
 	ansLib.checkState(bucket)
@@ -12,7 +11,7 @@ CxPolicy[result] {
 	object.get(bucket, "default_object_acl", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_storage_bucket}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_storage_bucke}}t.default_object_acl is defined",
@@ -21,16 +20,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["google.cloud.gcp_storage_bucket"]
 
 	ansLib.checkState(bucket)
-	bucket.acl
 	check(bucket.acl.entity)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_storage_bucket}}.acl.entity", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_storage_bucket}}.acl.entity isn't 'allUsers' or 'allAuthenticatedUsers'",
@@ -39,17 +36,15 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	bucket := task["google.cloud.gcp_storage_bucket"]
 
 	ansLib.checkState(bucket)
 	object.get(bucket, "acl", "undefined") == "undefined"
-	bucket.default_object_acl
 	check(bucket.default_object_acl.entity)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_storage_bucket}}.default_object_acl.entity", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_storage_bucket}}.default_object_acl.entity isn't 'allUsers' or 'allAuthenticatedUsers'",

--- a/assets/queries/ansible/gcp/cloud_storage_bucket_logging_not_enabled/query.rego
+++ b/assets/queries/ansible/gcp/cloud_storage_bucket_logging_not_enabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	storage_bucket := task["google.cloud.gcp_storage_bucket"]
 
 	ansLib.checkState(storage_bucket)
 	object.get(storage_bucket, "logging", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_storage_bucket}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_storage_bucket}}.logging is defined",

--- a/assets/queries/ansible/gcp/cluster_labels_are_disabled/query.rego
+++ b/assets/queries/ansible/gcp/cluster_labels_are_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster, "resource_labels", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("google.cloud.gcp_container_cluster[%s].resource_labels is defined", [task.name]),
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	cluster.resource_labels == null
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.resource_labels", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("google.cloud.gcp_container_cluster[%s].resource_labels is not null", [task.name]),
@@ -37,15 +35,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	count(cluster.resource_labels) == 0
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.resource_labels", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("google.cloud.gcp_container_cluster[%s].resource_labels is not empty", [task.name]),

--- a/assets/queries/ansible/gcp/compute_disk_is_not_encrypted/query.rego
+++ b/assets/queries/ansible/gcp/compute_disk_is_not_encrypted/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	disk := task["google.cloud.gcp_compute_disk"]
 
 	ansLib.checkState(disk)
 	object.get(disk, "disk_encryption_key", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_disk}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "google.cloud.gcp_compute_disk has a disk_encryption_key value",

--- a/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/query.rego
+++ b/assets/queries/ansible/gcp/compute_instance_is_publicly_accessible/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	compute_instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(compute_instance)
 	compute_instance.network_interfaces[_].access_configs
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_instance}}.network_interfaces.access_configs", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.network_interfaces.access_configs is not defined",

--- a/assets/queries/ansible/gcp/cos_node_image_not_used/query.rego
+++ b/assets/queries/ansible/gcp/cos_node_image_not_used/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	gcp_container := task["google.cloud.gcp_container_node_pool"]
 	image_type := gcp_container.config.image_type
 
@@ -12,7 +11,7 @@ CxPolicy[result] {
 	lower(image_type) != "cos"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_container_node_pool}}.config.image_type", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'config.image_type' is equal to 'COS'",

--- a/assets/queries/ansible/gcp/dnssec_using_rsasha1/query.rego
+++ b/assets/queries/ansible/gcp/dnssec_using_rsasha1/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	dns := task["google.cloud.gcp_dns_managed_zone"]
 
 	ansLib.checkState(dns)
 	lower(dns.dnssec_config.defaultKeySpecs.algorithm) == "rsasha1"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_dns_managed_zone}}.dnssec_config.defaultKeySpecs.algorithm", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'dnssec_config.defaultKeySpecs.algorithm' is not equal to 'rsasha1'",

--- a/assets/queries/ansible/gcp/gke_basic_authentication_is_enabled/query.rego
+++ b/assets/queries/ansible/gcp/gke_basic_authentication_is_enabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster, "master_auth", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth is defined",
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster.master_auth, "username", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth.username is defined",
@@ -37,15 +35,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster.master_auth, "password", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth.password is defined",
@@ -54,8 +51,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
@@ -63,7 +59,7 @@ CxPolicy[result] {
 	count(cluster.master_auth.username) > 0
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth.username", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth.username is empty",
@@ -72,8 +68,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
@@ -81,7 +76,7 @@ CxPolicy[result] {
 	count(cluster.master_auth.password) > 0
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth.password", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth.password is empty",

--- a/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/query.rego
+++ b/assets/queries/ansible/gcp/gke_master_authorized_networks_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	container_cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(container_cluster)
 	object.get(container_cluster, "master_authorized_networks_config", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'master_authorized_networks_config' is defined",
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	container_cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(container_cluster)
 	object.get(container_cluster.master_authorized_networks_config, "enabled", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_container_cluster}}.master_authorized_networks_config", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'master_authorized_networks_config.enabled' is defined",
@@ -37,15 +35,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	container_cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(container_cluster)
 	not ansLib.isAnsibleTrue(container_cluster.master_authorized_networks_config.enabled)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_container_cluster}}.master_authorized_networks_config.enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'master_authorized_networks_config.enabled' is true",

--- a/assets/queries/ansible/gcp/google_compute_ssl_policy_weak_cipher_suits_is_enabled/query.rego
+++ b/assets/queries/ansible/gcp/google_compute_ssl_policy_weak_cipher_suits_is_enabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	policy := task["google.cloud.gcp_compute_ssl_policy"]
 
 	ansLib.checkState(policy)
 	object.get(policy, "min_tls_version", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_ssl_policy}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_ssl_policy}} has min_tls_version set to 'TLS_1_2'",
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	policy := task["google.cloud.gcp_compute_ssl_policy"]
 
 	ansLib.checkState(policy)
 	policy.min_tls_version != "TLS_1_2"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_ssl_policy}}.min_tls_version", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_ssl_policy}}.min_tls_version has min_tls_version set to 'TLS_1_2'",

--- a/assets/queries/ansible/gcp/google_container_node_pool_auto_repair_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/google_container_node_pool_auto_repair_is_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	gcpContainer := task["google.cloud.gcp_container_node_pool"]
 
 	ansLib.checkState(gcpContainer)
 	object.get(gcpContainer, "management", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_node_pool}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_node_pool}}.gcpContainer.management is defined",
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	gcpContainer := task["google.cloud.gcp_container_node_pool"]
 
 	ansLib.checkState(gcpContainer)
 	not ansLib.isAnsibleTrue(gcpContainer.management.auto_repair)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_node_pool}}.management.auto_repair", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_container_node_pool}}.gcpContainer.management.auto_repair is set to true",

--- a/assets/queries/ansible/gcp/google_kms_crypto_key_rotation_period/query.rego
+++ b/assets/queries/ansible/gcp/google_kms_crypto_key_rotation_period/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	gcpTopic := task["google.cloud.gcp_kms_crypto_key"]
 
 	ansLib.checkState(gcpTopic)
 	object.get(gcpTopic, "rotation_period", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_kms_crypto_key}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_kms_key_ring}}.rotation_period is defined",
@@ -20,8 +19,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	gcpTopic := task["google.cloud.gcp_kms_crypto_key"]
 
 	ansLib.checkState(gcpTopic)
@@ -29,7 +27,7 @@ CxPolicy[result] {
 	to_number(rotationP) < 7776000
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_kms_crypto_key}}.rotation_period", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_kms_key_ring}}.rotation_period is >= 7776000",

--- a/assets/queries/ansible/gcp/ip_aliasing_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/ip_aliasing_is_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster, "ip_allocation_policy", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.ip_allocation_policy is defined",
@@ -20,8 +19,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 	cluster.ip_allocation_policy
 
@@ -29,7 +27,7 @@ CxPolicy[result] {
 	object.get(cluster.ip_allocation_policy, "use_ip_aliases", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.ip_allocation_policy", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.ip_allocation_policy.use_ip_aliases is set to true",
@@ -38,15 +36,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	not ansLib.isAnsibleTrue(cluster.ip_allocation_policy.use_ip_aliases)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.ip_allocation_policy.use_ip_aliases", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.ip_allocation_policy.use_ip_aliases is true",

--- a/assets/queries/ansible/gcp/ip_forwarding_is_enabled/query.rego
+++ b/assets/queries/ansible/gcp/ip_forwarding_is_enabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
 	ansLib.isAnsibleTrue(instance.can_ip_forward)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.can_ip_forward", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.can_ip_forward is false",

--- a/assets/queries/ansible/gcp/kms_rotation_period_higher_than_365_days/query.rego
+++ b/assets/queries/ansible/gcp/kms_rotation_period_higher_than_365_days/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_kms_crypto_key"]
 
 	ansLib.checkState(instance)
@@ -13,7 +12,7 @@ CxPolicy[result] {
 	to_number(rotation_period) > seconds_in_a_year
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_kms_crypto_key}}.rotation_period", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_kms_crypto_key}}.rotation_period is at most '315356000s'", [task.name]),
@@ -22,15 +21,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_kms_crypto_key"]
 
 	ansLib.checkState(instance)
 	object.get(instance, "rotation_period", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_kms_crypto_key}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_kms_crypto_key}}.rotation_period is set", [task.name]),

--- a/assets/queries/ansible/gcp/legacy_authorization_is_enabled/query.rego
+++ b/assets/queries/ansible/gcp/legacy_authorization_is_enabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	ansLib.isAnsibleTrue(cluster.legacy_abac.enabled)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.legacy_abac.enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "google.cloud.gcp_container_cluster.legacy_abac.enabled is false",

--- a/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/query.rego
+++ b/assets/queries/ansible/gcp/log_min_duration_statement_wrong_value/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(instance)
@@ -12,7 +11,7 @@ CxPolicy[result] {
 	ansLib.check_database_flags_content(database_flags, "log_min_duration_statement", -1)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags sets the log_min_duration_statement to -1", [task.name]),

--- a/assets/queries/ansible/gcp/log_min_messages_invalid_value/query.rego
+++ b/assets/queries/ansible/gcp/log_min_messages_invalid_value/query.rego
@@ -3,18 +3,16 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
-	settings := instance.settings
-	database_flags := settings.database_flags
-	database_flags[x].name == "log_min_messages"
+	database_flags := instance.settings.database_flags
 
 	ansLib.checkState(instance)
+	database_flags[x].name == "log_min_messages"
 	not check_database_flags_content(database_flags[x])
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags.log_min_messages", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags sets 'log_min_messages' to a valid value", [task.name]),

--- a/assets/queries/ansible/gcp/log_temp_files_wrong_value/query.rego
+++ b/assets/queries/ansible/gcp/log_temp_files_wrong_value/query.rego
@@ -3,17 +3,15 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
-	settings := instance.settings
-	database_flags := settings.database_flags
+	database_flags := instance.settings.database_flags
 
 	ansLib.checkState(instance)
 	ansLib.check_database_flags_content(database_flags, "log_temp_files", 0)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.database_flags sets the log_temp_files to 0", [task.name]),

--- a/assets/queries/ansible/gcp/master_authentication_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/master_authentication_is_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster, "master_auth", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth is defined",
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster.master_auth, "username", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth.username is defined",
@@ -37,15 +35,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster.master_auth, "password", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth.password is defined",
@@ -54,15 +51,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	ansLib.checkValue(cluster.master_auth.username)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth.username", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth.username is not empty",
@@ -71,15 +67,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	ansLib.checkValue(cluster.master_auth.password)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.master_auth.password", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.master_auth.password is not empty",

--- a/assets/queries/ansible/gcp/network_policy_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/network_policy_is_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster, "network_policy", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "google.cloud.gcp_container_cluster.network_policy is defined",
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster, "addons_config", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "google.cloud.gcp_container_cluster.addons_config is defined",
@@ -37,15 +35,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster.addons_config, "network_policy_config", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.addons_config", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "google.cloud.gcp_container_cluster.addons_config.network_policy_config is defined",
@@ -54,15 +51,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	ansLib.isAnsibleFalse(cluster.network_policy.enabled)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.network_policy.enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "google.cloud.gcp_container_cluster.network_policy.enabled is true",
@@ -71,8 +67,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
@@ -80,7 +75,7 @@ CxPolicy[result] {
 	ansLib.isAnsibleTrue(cluster.addons_config.network_policy_config.disabled)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.addons_config.network_policy_config.disabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "google.cloud.gcp_container_cluster.addons_config.network_policy_config.disabled is false",

--- a/assets/queries/ansible/gcp/node_auto_upgrade_not_enabled/query.rego
+++ b/assets/queries/ansible/gcp/node_auto_upgrade_not_enabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	container_task := task["google.cloud.gcp_container_node_pool"]
 
 	ansLib.checkState(container_task)
 	object.get(container_task, "management", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_container_node_pool}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_node_pool}}.management is defined",
@@ -20,8 +19,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	container_task := task["google.cloud.gcp_container_node_pool"]
 	management := container_task.management
 
@@ -29,7 +27,7 @@ CxPolicy[result] {
 	object.get(management, "auto_upgrade", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_container_node_pool}}.management", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_node_pool}}.management.auto_upgrade is defined",
@@ -38,8 +36,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	container_task := task["google.cloud.gcp_container_node_pool"]
 	auto_upgrade := container_task.management.auto_upgrade
 
@@ -47,7 +44,7 @@ CxPolicy[result] {
 	not ansLib.isAnsibleTrue(auto_upgrade)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_container_node_pool}}.management.auto_upgrade", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_container_node_pool}}.management.auto_upgrade is true",

--- a/assets/queries/ansible/gcp/object_versioning_not_enabled/query.rego
+++ b/assets/queries/ansible/gcp/object_versioning_not_enabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	storage_bucket := task["google.cloud.gcp_storage_bucket"]
 
 	ansLib.checkState(storage_bucket)
 	object.get(storage_bucket, "versioning", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_storage_bucket}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'versioning' is defined",
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	storage_bucket := task["google.cloud.gcp_storage_bucket"]
 
 	ansLib.checkState(storage_bucket)
-	not ansLib.isAnsibleTrue(task["google.cloud.gcp_storage_bucket"].versioning.enabled)
+	not ansLib.isAnsibleTrue(storage_bucket.versioning.enabled)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_storage_bucket}}.versioning.enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'versioning.enabled' is true",

--- a/assets/queries/ansible/gcp/oslogin_is_disabled_for_vm_instance/query.rego
+++ b/assets/queries/ansible/gcp/oslogin_is_disabled_for_vm_instance/query.rego
@@ -3,18 +3,17 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 	metadata := instance.metadata
 
 	ansLib.checkState(instance)
 	object.get(metadata, "enable-oslogin", "undefined") != "undefined"
 
-	not ansLib.isAnsibleTrue(object.get(metadata, "enable-oslogin", "undefined"))
+	not ansLib.isAnsibleTrue(metadata["enable-oslogin"])
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_instance}}.metadata.enable-oslogin", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'name=%s.{{google.cloud.gcp_compute_instance}}.metadata.enable-oslogin' is true", [task.name]),

--- a/assets/queries/ansible/gcp/postgresql_log_checkpoints_flag_not_set_to_on/query.rego
+++ b/assets/queries/ansible/gcp/postgresql_log_checkpoints_flag_not_set_to_on/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	gcp_task := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(gcp_task)
@@ -12,7 +11,7 @@ CxPolicy[result] {
 	IsMissingAttribute(gcp_task)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_sql_instance}}.settings.databaseFlags is defined",
@@ -21,8 +20,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	gcp_task := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(gcp_task)
@@ -30,7 +28,7 @@ CxPolicy[result] {
 	ansLib.check_database_flags_content(gcp_task.settings.databaseFlags, "log_checkpoints", "on")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.databaseFlags", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_sql_instance}}.settings.databaseFlags has 'log_checkpoints' flag set to 'on'",

--- a/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/query.rego
+++ b/assets/queries/ansible/gcp/postgresql_log_connections_flag_not_set_to_on/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	gcp_task := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(gcp_task)
@@ -12,7 +11,7 @@ CxPolicy[result] {
 	IsMissingAttribute(gcp_task)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_sql_instance}}.settings.databaseFlags is defined",
@@ -21,8 +20,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	gcp_task := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(gcp_task)
@@ -30,7 +28,7 @@ CxPolicy[result] {
 	ansLib.check_database_flags_content(gcp_task.settings.databaseFlags, "log_connections", "on")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.databaseFlags", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_sql_instance}}.settings.databaseFlags has 'log_connections' flag set to 'on'",

--- a/assets/queries/ansible/gcp/private_cluster_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/private_cluster_is_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster, "private_cluster_config", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("{{google.cloud.gcp_container_cluster}}[%s].private_cluster_config is defined", [task.name]),
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster.private_cluster_config, "enable_private_nodes", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.private_cluster_config", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("{{google.cloud.gcp_container_cluster}}[%s].private_cluster_config.enable_private_nodes is defined", [task.name]),
@@ -37,15 +35,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster.private_cluster_config, "enable_private_endpoint", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.private_cluster_config", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("{{google.cloud.gcp_container_cluster}}[%s].private_cluster_config.enable_private_endpoint is defined", [task.name]),
@@ -54,15 +51,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	not ansLib.isAnsibleTrue(cluster.private_cluster_config.enable_private_endpoint)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.private_cluster_config.enable_private_endpoint", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("{{google.cloud.gcp_container_cluster}}[%s].private_cluster_config.enable_private_endpoint is true", [task.name]),
@@ -71,15 +67,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	not ansLib.isAnsibleTrue(cluster.private_cluster_config.enable_private_nodes)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.private_cluster_config.enable_private_nodes", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("{{google.cloud.gcp_container_cluster}}[%s].private_cluster_config.enable_private_nodes is true", [task.name]),

--- a/assets/queries/ansible/gcp/project_wide_ssh_keys_are_enabled_in_vm_instances/query.rego
+++ b/assets/queries/ansible/gcp/project_wide_ssh_keys_are_enabled_in_vm_instances/query.rego
@@ -3,17 +3,16 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(input.document[i])[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 	metadata := instance.metadata
 
 	ansLib.checkState(instance)
 	object.get(metadata, "block-project-ssh-keys", "undefined") != "undefined"
-	not ansLib.isAnsibleTrue(object.get(metadata, "block-project-ssh-keys", "undefined"))
+	not ansLib.isAnsibleTrue(metadata["block-project-ssh-keys"])
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_instance}}.metadata.block-project-ssh-keys", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'name=%s.{{google.cloud.gcp_compute_instance}}.metadata.block-project-ssh-keys' is true", [task.name]),
@@ -22,16 +21,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(input.document[i])[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
-	metadata := instance.metadata
 
 	ansLib.checkState(instance)
-	object.get(metadata, "block-project-ssh-keys", "undefined") == "undefined"
+	object.get(instance.metadata, "block-project-ssh-keys", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_instance}}.metadata", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'name=%s.{{google.cloud.gcp_compute_instance}}.metadata.block-project-ssh-keys' is set and is true", [task.name]),
@@ -40,15 +37,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(input.document[i])[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
 	object.get(instance, "metadata", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_instance}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'name=%s.{{google.cloud.gcp_compute_instance}}.metadata' is set", [task.name]),

--- a/assets/queries/ansible/gcp/rdp_access_is_not_restricted/query.rego
+++ b/assets/queries/ansible/gcp/rdp_access_is_not_restricted/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_firewall"]
 
 	ansLib.checkState(instance)
@@ -14,7 +13,7 @@ CxPolicy[result] {
 	ansLib.allowsPort(allowed[k], "3389")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_firewall}}.allowed.ip_protocol=%s.ports", [task.name, allowed[k].ip_protocol]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_compute_firewall}}.allowed.ip_protocol=%s.ports don't contain RDP port (3389) with unrestricted ingress traffic", [task.name, allowed[k].ip_protocol]),

--- a/assets/queries/ansible/gcp/serial_ports_enabled_for_vm_instances/query.rego
+++ b/assets/queries/ansible/gcp/serial_ports_enabled_for_vm_instances/query.rego
@@ -3,16 +3,15 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 	metadata := instance.metadata
 
 	ansLib.checkState(instance)
-	ansLib.isAnsibleTrue(object.get(metadata, "serial-port-enable", "undefined"))
+	ansLib.isAnsibleTrue(metadata["serial-port-enable"])
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_instance}}.metadata.serial-port-enable", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'name=%s.{{google.cloud.gcp_compute_instance}}.metadata.serial-port-enable' is undefined or set to false", [task.name]),

--- a/assets/queries/ansible/gcp/shielded_vm_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/shielded_vm_is_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
 	object.get(instance, "shielded_instance_config", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.shielded_instance_config is defined",
@@ -20,16 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
-	instance.shielded_instance_config
 	object.get(instance.shielded_instance_config, "enable_integrity_monitoring", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_integrity_monitoring is defined",
@@ -38,16 +35,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
-	instance.shielded_instance_config
 	object.get(instance.shielded_instance_config, "enable_secure_boot", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_secure_boot is defined",
@@ -56,16 +51,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
-	instance.shielded_instance_config
 	object.get(instance.shielded_instance_config, "enable_vtpm", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_vtpm is defined",
@@ -74,15 +67,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
 	ansLib.isAnsibleFalse(instance.shielded_instance_config.enable_integrity_monitoring)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_integrity_monitoring", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_integrity_monitoring is true",
@@ -91,15 +83,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
 	ansLib.isAnsibleFalse(instance.shielded_instance_config.enable_secure_boot)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_secure_boot", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_secure_boot is true",
@@ -108,15 +99,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
 	ansLib.isAnsibleFalse(instance.shielded_instance_config.enable_vtpm)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_vtpm", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.shielded_instance_config.enable_vtpm is true",

--- a/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/query.rego
+++ b/assets/queries/ansible/gcp/sql_database_backup_configuration_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(instance)
 	path := getPathDefinitions(instance)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}%s", [task.name, path.defined]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'%s' is defined", [path.undefined]),
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_sql_instance"]
 
 	ansLib.checkState(instance)
 	not ansLib.isAnsibleTrue(instance.settings.backup_configuration.enabled)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_sql_instance}}.settings.backup_configuration.enabled", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'settings.backup_configuration.require_ssl' is true",

--- a/assets/queries/ansible/gcp/ssh_access_is_not_restricted_from_the_internet/query.rego
+++ b/assets/queries/ansible/gcp/ssh_access_is_not_restricted_from_the_internet/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_firewall"]
 
 	ansLib.checkState(instance)
@@ -17,7 +16,7 @@ CxPolicy[result] {
 	ansLib.allowsPort(allowed[k], "22")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_firewall}}.allowed.ip_protocol=%s.ports", [task.name, allowed[k].ip_protocol]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("name=%s.{{google.cloud.gcp_compute_firewall}}.allowed.ip_protocol=%s.ports don't contain SSH port (22) with unrestricted ingress traffic", [task.name, allowed[k].ip_protocol]),

--- a/assets/queries/ansible/gcp/stackdriver_logging_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/stackdriver_logging_is_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster, "logging_service", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.logging_service is defined",
@@ -20,8 +19,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
@@ -29,7 +27,7 @@ CxPolicy[result] {
 	lower(cluster.logging_service) == "none"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.logging_service", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.logging_service is different from 'none'",

--- a/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/stackdriver_monitoring_is_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
 	object.get(cluster, "monitoring_service", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.monitoring_service is defined",
@@ -20,8 +19,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	cluster := task["google.cloud.gcp_container_cluster"]
 
 	ansLib.checkState(cluster)
@@ -29,7 +27,7 @@ CxPolicy[result] {
 	lower(cluster.monitoring_service) == "none"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_container_cluster}}.monitoring_service", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_container_cluster}}.monitoring_service is different from 'none'",

--- a/assets/queries/ansible/gcp/using_default_service_account/query.rego
+++ b/assets/queries/ansible/gcp/using_default_service_account/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
@@ -12,7 +11,7 @@ CxPolicy[result] {
 	object.get(instance, "service_account_email", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.service_account_email is defined",
@@ -21,8 +20,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
@@ -32,7 +30,7 @@ CxPolicy[result] {
 	count(email) == 0
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.service_account_email", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.service_account_email is not empty",
@@ -41,8 +39,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
@@ -53,7 +50,7 @@ CxPolicy[result] {
 	not contains(email, "@")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.service_account_email", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.service_account_email is an email",
@@ -62,8 +59,7 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	instance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(instance)
@@ -72,7 +68,7 @@ CxPolicy[result] {
 	contains(email, "@developer.gserviceaccount.com")
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_instance}}.service_account_email", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_instance}}.service_account_email is not a default Google Compute Engine service account",

--- a/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/query.rego
+++ b/assets/queries/ansible/gcp/vm_csek_encryption_is_disabled/query.rego
@@ -3,15 +3,14 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	disk := task["google.cloud.gcp_compute_disk"]
 
 	ansLib.checkState(disk)
 	object.get(disk, "disk_encryption_key", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_disk}}", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_disk}}.disk_encryption_key is defined",
@@ -20,15 +19,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	disk := task["google.cloud.gcp_compute_disk"]
 
 	ansLib.checkState(disk)
 	object.get(disk.disk_encryption_key, "raw_key", "undefined") == "undefined"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_disk}}.disk_encryption_key", [task.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_disk}}.disk_encryption_key.raw_key is defined",
@@ -37,15 +35,14 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	disk := task["google.cloud.gcp_compute_disk"]
 
 	ansLib.checkState(disk)
 	ansLib.checkValue(disk.disk_encryption_key.raw_key)
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{google.cloud.gcp_compute_disk}}.disk_encryption_key.raw_key", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "{{google.cloud.gcp_compute_disk}}.disk_encryption_key.raw_key is not empty or null",

--- a/assets/queries/ansible/gcp/vm_with_full_cloud_access/query.rego
+++ b/assets/queries/ansible/gcp/vm_with_full_cloud_access/query.rego
@@ -3,8 +3,7 @@ package Cx
 import data.generic.ansible as ansLib
 
 CxPolicy[result] {
-	document := input.document[i]
-	task := ansLib.getTasks(document)[t]
+	task := ansLib.tasks[id][t]
 	taskComputeInstance := task["google.cloud.gcp_compute_instance"]
 
 	ansLib.checkState(taskComputeInstance)
@@ -14,7 +13,7 @@ CxPolicy[result] {
 	lower(scopes[_]) == "cloud-platform"
 
 	result := {
-		"documentId": document.id,
+		"documentId": id,
 		"searchKey": sprintf("name=%s.{{google.cloud.gcp_compute_instance}}.service_accounts", [task.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'service_accounts.scopes' does not contain 'cloud-platform'",


### PR DESCRIPTION
Closes #2112 

**Proposed Changes**

- The `getTasks` function now returns all tasks inside `block`, `always` and `rescue` blocks.

To achieve this, the new `getTasksFromBlocks` function checks if a task has a `block` field which means it's a block task. If it's true, the function will try to find all tasks by executing the built-in [`walk`](https://www.openpolicyagent.org/docs/latest/policy-reference/#graphs) function that will traverse all values nested under the block task (Rego doesn't support recursion). This is important because Ansible allows nested `blocks`. Let's check an example:

```
- hosts: all
  tasks:
    - name: "First block"
      block:
        - name: "Task 1" 
          task1: do_something

        - name: "Task 2" 
          task2: do_something

        - name: "Second block"
          block:
            - name: "Task 3"
              task3: do_something

            - name: "Third block"
              block:
              - name: "Task 4"
                task4: do_something
      always:
        - name: "Task 5"
          task5: do_something
```

By executing the `walk(block, [path, value])` function, we will iterate upon all values inside the "First block" task. We need to check that `value` is an object and doesn't have a `block` field (we don't want queries checking block tasks). We also need to validate the `path` by checking if its length is bigger than 1 and if the penultimate element is a valid group ("block", "always", "rescue"). This will assure that `value` is a valid task.

- Created the `TasksPerDocument` rule that returns an object where the fields represent the documents IDs and the values are the list of tasks of the respective document. This object will be saved on the `tasks` variable in the library that will be used by the queries to get the final results. With this, the `getTasks` function is executed only once for each document instead of being executed in each query for each document. This important because the `walk` function is expensive in terms of time.

I submit this contribution under Apache-2.0 license.