### PR TITLE
Print help when provided with configuration file that contains invalid keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 
 # ci/cd binaries
 .bin
+
+# kics configuration file
+kics.config

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -85,7 +85,9 @@ func initializeConfig(cmd *cobra.Command) error {
 }
 
 func bindFlags(cmd *cobra.Command, v *viper.Viper) {
+	settingsMap := v.AllSettings()
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		settingsMap[f.Name] = true
 		if strings.Contains(f.Name, "-") {
 			envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 			if err := v.BindEnv(f.Name, fmt.Sprintf("%s_%s", "VIPER_", envVarSuffix)); err != nil {
@@ -99,6 +101,18 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 			}
 		}
 	})
+	for key, val := range settingsMap {
+		if val == true {
+			continue
+		} else {
+			fmt.Printf("Unknown configuration key: '%s'\nShowing help for '%s' command:\n\n", key, cmd.Name())
+			err := cmd.Help()
+			if err != nil {
+				log.Err(err).Msg("Unable to show help message")
+			}
+			os.Exit(1)
+		}
+	}
 }
 
 func initScanCmd() {


### PR DESCRIPTION
Closes #2136

**Proposed Changes**

- print help and exit with status code 1 when provided with an invalid key in the configuration file


I submit this contribution under Apache-2.0 license.
