### PR TITLE
Bump go version to 1.16

### DIFF
--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -9,7 +9,7 @@ jobs:
     name: integration-tests
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.16.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         go-version: [1.16.x]
         os: [ubuntu-latest]
+        exclude:
+        - os: ubuntu-latest
+          go-version: 1.15.x
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out code into the Go module directory

--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -7,11 +7,7 @@ on:
 jobs:
   integration-tests:
     name: integration-tests
-    strategy:
-      matrix:
-        go-version: [1.16.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -11,9 +11,6 @@ jobs:
       matrix:
         go-version: [1.16.x]
         os: [ubuntu-latest]
-        exclude:
-        - os: ubuntu-latest
-          go-version: 1.15.x
     runs-on: ${{ matrix.os }}
     steps:
     - name: Check out code into the Go module directory

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: unit-tests
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.15.x, 1.16.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -10,7 +10,7 @@ jobs:
     name: unit-tests
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.15.x, 1.16.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Checkmarx/kics
 
-go 1.15
+go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
Closes #2142

**Proposed Changes**

- Bump go version to 1.16

I submit this contribution under Apache-2.0 license.
