### PR TITLE
Update "Yum Install Allows Manual Input" and "APT-GET Missing '-y' To Avoid Manual Input" queries for Docker Closes #2169

### DIFF
--- a/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
+++ b/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
@@ -63,5 +63,9 @@ avoidManualInput(command) {
 }
 
 avoidManualInput(command) {
-	regex.match("apt-get (-(-)?[a-zA-Z]+ *)*install (-(-)?[a-zA-Z]+ *)*(-y|-yes|--assumeyes) (-(-)?[a-zA-Z]+ *)*", command)
+	regex.match("apt-get (-(-)?[a-zA-Z]+ *)*install (-(-)?[a-zA-Z]+ *)*(-y|-yes|--assumeyes)", command)
+}
+
+avoidManualInput(command) {
+	regex.match("apt-get (-(-)?[a-zA-Z]+ *)*install ([A-Za-z0-9-:=.$_]+ *)*(-y|-yes|--assumeyes)", command)
 }

--- a/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/test/positive.dockerfile
+++ b/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/test/positive.dockerfile
@@ -1,3 +1,4 @@
 FROM node:12
+RUN apt-get install python=2.7
 RUN apt-get install apt-utils
 RUN ["apt-get", "install", "apt-utils"]

--- a/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/test/positive_expected_result.json
@@ -1,12 +1,17 @@
 [
-	{
-		"queryName": "APT-GET Missing '-y' To Avoid Manual Input",
-		"severity": "MEDIUM",
-		"line": 2
-	},
-	{
-		"queryName": "APT-GET Missing '-y' To Avoid Manual Input",
-		"severity": "MEDIUM",
-		"line": 3
-	}
+  {
+    "queryName": "APT-GET Missing '-y' To Avoid Manual Input",
+    "severity": "MEDIUM",
+    "line": 2
+  },
+  {
+    "queryName": "APT-GET Missing '-y' To Avoid Manual Input",
+    "severity": "MEDIUM",
+    "line": 3
+  },
+  {
+    "queryName": "APT-GET Missing '-y' To Avoid Manual Input",
+    "severity": "MEDIUM",
+    "line": 4
+  }
 ]

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
@@ -46,7 +46,11 @@ avoidManualInput(command) {
 }
 
 avoidManualInput(command) {
-	regex.match("yum (-(-)?[a-zA-Z]+ *)*(group|local)?install (-(-)?[a-zA-Z]+ *)*(-y|-yes|--assumeyes) (-(-)?[a-zA-Z]+ *)*", command)
+	regex.match("yum (-(-)?[a-zA-Z]+ *)*(group|local)?install (-(-)?[a-zA-Z]+ *)*(-y|-yes|--assumeyes)", command)
+}
+
+avoidManualInput(command) {
+	regex.match("yum (-(-)?[a-zA-Z]+ *)*(group|local)?install ([A-Za-z0-9-:=.$_]+ *)*(-y|-yes|--assumeyes)", command)
 }
 
 isYumInstallInList(command) {


### PR DESCRIPTION
Closes #2169

**Proposed Changes**

- Additional regex to include cases when the yes flag is after the packages

I submit this contribution under Apache-2.0 license.

