### PR TITLE
Considering global var in some queries for Docker Closes #2188

### DIFF
--- a/assets/libraries/dockerfile/library.rego
+++ b/assets/libraries/dockerfile/library.rego
@@ -14,7 +14,7 @@ getPackages(commands, command) = output {
 }
 
 withVersion(pack) {
-	regex.match("[A-Za-z0-9_-]+-[$](.+)", pack)
+	regex.match("[A-Za-z0-9_-]+[-:][$](.+)", pack)
 }
 
 withVersion(pack) {

--- a/assets/queries/dockerfile/apt_get_install_pin_version_not_defined/query.rego
+++ b/assets/queries/dockerfile/apt_get_install_pin_version_not_defined/query.rego
@@ -13,9 +13,10 @@ CxPolicy[result] {
 	aptGet != null
 
 	packages = dockerLib.getPackages(commands, aptGet)
-	regex.match("^[a-zA-Z]", packages[j]) == true
+	length := count(packages)
 
-	not dockerLib.withVersion(packages[j])
+	some j
+	analyzePackages(j, packages[j], packages, length)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -51,4 +52,17 @@ CxPolicy[result] {
 isAptGet(command) {
 	contains(command[x], "apt-get")
 	contains(command[j], "install")
+}
+
+analyzePackages(j, currentPackage, packages, length) {
+	j == length - 1
+	regex.match("^[a-zA-Z]", currentPackage) == true
+	not dockerLib.withVersion(currentPackage)
+}
+
+analyzePackages(j, currentPackage, packages, length) {
+	j != length - 1
+	regex.match("^[a-zA-Z]", currentPackage) == true
+	packages[plus(j, 1)] != "-v"
+	not dockerLib.withVersion(currentPackage)
 }

--- a/assets/queries/dockerfile/gem_install_without_version/test/negative.dockerfile
+++ b/assets/queries/dockerfile/gem_install_without_version/test/negative.dockerfile
@@ -8,5 +8,6 @@ COPY app.py /usr/src/app/
 COPY templates/index.html /usr/src/app/templates/
 EXPOSE 5000
 CMD ["python", "/usr/src/app/app.py"]
+ENV GRPC_VERSION 1.0.0
 RUN gem install grpc -v ${GRPC_RUBY_VERSION}
 RUN gem install grpc:${GRPC_VERSION} grpc-tools:${GRPC_VERSION}

--- a/assets/queries/dockerfile/gem_install_without_version/test/negative.dockerfile
+++ b/assets/queries/dockerfile/gem_install_without_version/test/negative.dockerfile
@@ -8,3 +8,5 @@ COPY app.py /usr/src/app/
 COPY templates/index.html /usr/src/app/templates/
 EXPOSE 5000
 CMD ["python", "/usr/src/app/app.py"]
+RUN gem install grpc -v ${GRPC_RUBY_VERSION}
+RUN gem install grpc:${GRPC_VERSION} grpc-tools:${GRPC_VERSION}

--- a/assets/queries/dockerfile/gem_install_without_version/test/positive.dockerfile
+++ b/assets/queries/dockerfile/gem_install_without_version/test/positive.dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.5
 RUN apk add --update py2-pip
 RUN gem install bundler
 RUN ["gem", "install", "blunder"]
+RUN gem install grpc -v ${GRPC_RUBY_VERSION} blunder
 RUN bundle install
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt

--- a/assets/queries/dockerfile/gem_install_without_version/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/gem_install_without_version/test/positive_expected_result.json
@@ -8,5 +8,10 @@
     "queryName": "Gem Install Without Version",
     "severity": "MEDIUM",
     "line": 4
+  },
+  {
+    "queryName": "Gem Install Without Version",
+    "severity": "MEDIUM",
+    "line": 5
   }
 ]

--- a/assets/queries/dockerfile/image_version_not_explicit/query.rego
+++ b/assets/queries/dockerfile/image_version_not_explicit/query.rego
@@ -4,13 +4,55 @@ CxPolicy[result] {
 	resource := input.document[i].command[name][_]
 	resource.Cmd == "from"
 	not resource.Value[0] == "scratch"
-	not contains(resource.Value[0], ":")
+
+	versionNotExplicit(resource.Value)
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}", [name]),
-		"issueType": "MissingAttribute", #"MissingAttribute" / "RedundantAttribute"
+		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("FROM %s:'version'", [resource.Value[0]]),
 		"keyActualValue": sprintf("FROM %s'", [resource.Value[0]]),
 	}
+}
+
+versionNotExplicit(cmd) {
+	count(cmd) == 1
+	regex.match("^\\$[{}A-z0-9-_+].*", cmd[0]) == false
+	not contains(cmd[0], ":")
+}
+
+versionNotExplicit(cmd) {
+	count(cmd) == 1
+	regex.match("^\\$[{}A-z0-9-_+].*", cmd[0]) == true
+
+	resource := input.document[i].command[name][_]
+	not resource.Value[0] == "scratch"
+
+	possibilities := {"arg", "env"}
+	resource.Cmd == possibilities[j]
+
+	cmdClean := trim_prefix(cmd[0], "$")
+
+	startswith(resource.Value[0], cmdClean)
+
+	not contains(resource.Value[0], ":")
+}
+
+versionNotExplicit(cmd) {
+	count(cmd) > 1
+
+	not contains(cmd[0], ":")
+
+	resource := input.document[i].command[name][_]
+	not resource.Value[0] == "scratch"
+	resource.Cmd == "from"
+
+	count(resource.Value) > 1
+
+	resource.Value[1] == "as"
+
+	resource.Value[2] == cmd[0]
+
+	not contains(resource.Value[0], ":")
 }

--- a/assets/queries/dockerfile/image_version_not_explicit/test/negative.dockerfile
+++ b/assets/queries/dockerfile/image_version_not_explicit/test/negative.dockerfile
@@ -6,4 +6,6 @@ RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt
 COPY app.py /usr/src/app/
 COPY templates/index.html /usr/src/app/templates/
 EXPOSE 5000
-CMD ["python", "/usr/src/app/app.py"] 
+ARG IMAGE=alpine:3.12
+FROM $IMAGE
+CMD ["python", "/usr/src/app/app.py"]

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/negative.dockerfile
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/negative.dockerfile
@@ -1,5 +1,6 @@
 FROM fedora:latest
 RUN dnf -y update && dnf -y install httpd-2.24.2 && dnf clean all
+RUN ["dnf", "install", "httpd-2.24.2"]
 COPY index.html /var/www/html/index.html
 EXPOSE 80
 ENTRYPOINT /usr/sbin/httpd -DFOREGROUND

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive.dockerfile
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive.dockerfile
@@ -1,5 +1,6 @@
 FROM fedora:latest
 RUN dnf -y update && dnf -y install httpd && dnf clean all
+RUN ["dnf", "install", "httpd"]
 COPY index.html /var/www/html/index.html
 EXPOSE 80
 ENTRYPOINT /usr/sbin/httpd -DFOREGROUND

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive_expected_result.json
@@ -1,7 +1,12 @@
 [
-	{
-		"queryName": "Missing Version Specification In dnf install",
-		"severity": "MEDIUM",
-		"line": 2
-	}
+  {
+    "queryName": "Missing Version Specification In dnf install",
+    "severity": "MEDIUM",
+    "line": 2
+  },
+  {
+    "queryName": "Missing Version Specification In dnf install",
+    "severity": "MEDIUM",
+    "line": 3
+  }
 ]

--- a/assets/queries/dockerfile/unpinned_package_version_in_apk_add/test/negative.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_apk_add/test/negative.dockerfile
@@ -10,6 +10,7 @@ CMD ["python", "/usr/src/app/app.py"]
 
 FROM alpine:3.1
 RUN apk add py-pip=7.1.2-r0
+RUN ["apk", "add", "py-pip=7.1.2-r0"]
 RUN sudo pip install --upgrade pip
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt

--- a/assets/queries/dockerfile/unpinned_package_version_in_apk_add/test/positive.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_apk_add/test/positive.dockerfile
@@ -15,6 +15,7 @@ RUN apk add py-pip \
     && rm -rf /tmp/*
 RUN apk add --dir /dir libimagequant \
     && minidlna
+RUN ["apk", "add", "py-pip"]
 RUN sudo pip install --upgrade pip
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt

--- a/assets/queries/dockerfile/unpinned_package_version_in_apk_add/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/unpinned_package_version_in_apk_add/test/positive_expected_result.json
@@ -1,22 +1,27 @@
 [
-	{
-		"queryName": "Unpinned Package Version in Apk Add",
-		"severity": "MEDIUM",
-		"line": 2
-	},
-	{
-		"queryName": "Unpinned Package Version in Apk Add",
-		"severity": "MEDIUM",
-		"line": 13
-	},
-	{
-		"queryName": "Unpinned Package Version in Apk Add",
-		"severity": "MEDIUM",
-		"line": 14
-	},
-	{
-		"queryName": "Unpinned Package Version in Apk Add",
-		"severity": "MEDIUM",
-		"line": 16
-	}
+  {
+    "queryName": "Unpinned Package Version in Apk Add",
+    "severity": "MEDIUM",
+    "line": 2
+  },
+  {
+    "queryName": "Unpinned Package Version in Apk Add",
+    "severity": "MEDIUM",
+    "line": 13
+  },
+  {
+    "queryName": "Unpinned Package Version in Apk Add",
+    "severity": "MEDIUM",
+    "line": 14
+  },
+  {
+    "queryName": "Unpinned Package Version in Apk Add",
+    "severity": "MEDIUM",
+    "line": 16
+  },
+  {
+    "queryName": "Unpinned Package Version in Apk Add",
+    "severity": "MEDIUM",
+    "line": 18
+  }
 ]

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/query.rego
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/query.rego
@@ -13,13 +13,14 @@ CxPolicy[result] {
 	yum != null
 
 	packages = dockerLib.getPackages(commands, yum)
-	regex.match("^[a-zA-Z]", packages[j]) == true
+	length := count(packages)
 
-	not dockerLib.withVersion(packages[j])
+	some j
+	analyzePackages(j, packages[j], packages, length)
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, commands]),
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "RUN instruction with 'pip install <package>' should use package pinning form 'pip install <package>=<version>'",
 		"keyActualValue": sprintf("RUN instruction %s does not use package pinning form", [commands]),
@@ -51,4 +52,17 @@ CxPolicy[result] {
 isPip(command) {
 	contains(command[x], "pip")
 	contains(command[j], "install")
+}
+
+analyzePackages(j, currentPackage, packages, length) {
+	j == length - 1
+	regex.match("^[a-zA-Z]", currentPackage) == true
+	not dockerLib.withVersion(currentPackage)
+}
+
+analyzePackages(j, currentPackage, packages, length) {
+	j != length - 1
+	regex.match("^[a-zA-Z]", currentPackage) == true
+	packages[plus(j, 1)] != "-v"
+	not dockerLib.withVersion(currentPackage)
 }

--- a/assets/queries/dockerfile/workdir_path_not_absolute/query.rego
+++ b/assets/queries/dockerfile/workdir_path_not_absolute/query.rego
@@ -3,7 +3,7 @@ package Cx
 CxPolicy[result] {
 	resource := input.document[i].command[name][_]
 	resource.Cmd == "workdir"
-	not regex.match("(^/[A-z0-9-_+].*)|(^[A-z0-9-_+]:\\\\.*)|(^\\$[A-z0-9-_+].*)", resource.Value[0])
+	not regex.match("(^/[A-z0-9-_+].*)|(^[A-z0-9-_+]:\\\\.*)|(^\\$[{}A-z0-9-_+].*)", resource.Value[0])
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/dockerfile/workdir_path_not_absolute/test/negative.dockerfile
+++ b/assets/queries/dockerfile/workdir_path_not_absolute/test/negative.dockerfile
@@ -5,6 +5,7 @@ WORKDIR /path/to/workdir
 WORKDIR c:\\windows
 ENV DIRPATH=/path
 WORKDIR $DIRPATH/$DIRNAME
+WORKDIR ${GLASSFISH_HOME}/bin
 COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r /usr/src/app/requirements.txt
 COPY app.py /usr/src/app/

--- a/assets/queries/dockerfile/workdir_path_not_absolute/test/negative.dockerfile
+++ b/assets/queries/dockerfile/workdir_path_not_absolute/test/negative.dockerfile
@@ -4,6 +4,7 @@ RUN pip install --upgrade pip
 WORKDIR /path/to/workdir
 WORKDIR c:\\windows
 ENV DIRPATH=/path
+ENV GLASSFISH_ARCHIVE glassfish5
 WORKDIR $DIRPATH/$DIRNAME
 WORKDIR ${GLASSFISH_HOME}/bin
 COPY requirements.txt /usr/src/app/

--- a/assets/queries/dockerfile/yum_install_without_version/query.rego
+++ b/assets/queries/dockerfile/yum_install_without_version/query.rego
@@ -13,13 +13,14 @@ CxPolicy[result] {
 	yum != null
 
 	packages = dockerLib.getPackages(commands, yum)
-	regex.match("^[a-zA-Z]", packages[j]) == true
+	length := count(packages)
 
-	not dockerLib.withVersion(packages[j])
+	some j
+	analyzePackages(j, packages[j], packages, length)
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, commands]),
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "The package version should always be specified when using yum install",
 		"keyActualValue": sprintf("No version is specified in package '%s'", [packages[j]]),
@@ -51,4 +52,17 @@ CxPolicy[result] {
 isYum(command) {
 	contains(command[x], "yum")
 	contains(command[j], "install")
+}
+
+analyzePackages(j, currentPackage, packages, length) {
+	j == length - 1
+	regex.match("^[a-zA-Z]", currentPackage) == true
+	not dockerLib.withVersion(currentPackage)
+}
+
+analyzePackages(j, currentPackage, packages, length) {
+	j != length - 1
+	regex.match("^[a-zA-Z]", currentPackage) == true
+	packages[plus(j, 1)] != "-v"
+	not dockerLib.withVersion(currentPackage)
 }

--- a/assets/queries/dockerfile/zypper_install_without_version/query.rego
+++ b/assets/queries/dockerfile/zypper_install_without_version/query.rego
@@ -13,13 +13,14 @@ CxPolicy[result] {
 	zypper != null
 
 	packages = dockerLib.getPackages(commands, zypper)
-	regex.match("^[a-zA-Z]", packages[j]) == true
+	length := count(packages)
 
-	not dockerLib.withVersion(packages[j])
+	some j
+	analyzePackages(j, packages[j], packages, length)
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, commands]),
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "The package version should always be specified when using zypper install",
 		"keyActualValue": sprintf("No version is specified in package '%s'", [packages[j]]),
@@ -51,4 +52,17 @@ CxPolicy[result] {
 isZypper(command) {
 	contains(command[x], "zypper")
 	contains(command[j], "install")
+}
+
+analyzePackages(j, currentPackage, packages, length) {
+	j == length - 1
+	regex.match("^[a-zA-Z]", currentPackage) == true
+	not dockerLib.withVersion(currentPackage)
+}
+
+analyzePackages(j, currentPackage, packages, length) {
+	j != length - 1
+	regex.match("^[a-zA-Z]", currentPackage) == true
+	packages[plus(j, 1)] != "-v"
+	not dockerLib.withVersion(currentPackage)
 }


### PR DESCRIPTION
Closes #2188

**Proposed Changes**

- **"WORKDIR Path Not Absolute"**: considering global var in WORKDIR path. For example, "WORKDIR ${GLASSFISH_HOME}/bin"
- **"Image Version Not Explicit"**: considering global var and alias in version. For example, "ARG IMAGE=alpine:3.12
FROM $IMAGE"; "FROM python:3.7-alpine as base".
- **"Apt Get Install Pin Version Not Defined"**, **"Gem Install Without Version"**, **"Yum install Without Version"**, **"Zypper Install Without Version"**: considering another version case (grpc-tools:${GRPC_VERSION}}) and excluding cases like "RUN gem install grpc -v ${GRPC_RUBY_VERSION}"

I submit this contribution under Apache-2.0 license.
