### PR TITLE
Fixing release workflow GH actions interpolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,4 @@ jobs:
           push: true
           tags: checkmarx/kics:latest,checkmarx/kics:${{ outputs.get-version.version }}
           build-args: |
-            VERSION=${{ outputs.get-version.version }}
+            VERSION=${{ steps.get-version.outputs.version }}


### PR DESCRIPTION
Fixing release workflow GH actions string interpolation issue. Invalid previous context "outputs"


I submit this contribution under Apache-2.0 license.
