### PR TITLE
Fix automatic PR in generate-queries-docs not triggering checks

### DIFF
--- a/.github/workflows/generate-queries-docs.yaml
+++ b/.github/workflows/generate-queries-docs.yaml
@@ -26,9 +26,11 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          title: Update queries docs ${{ github.ref }} - ${{ github.run_id }}
+          title: Update queries docs - ${{ github.run_id }}
+          env:
+            GITHUB_TOKEN: ${{ secrets.KICS_BOT_PAT }}
           body: |
-            **Automated changes** 
+            **Automated changes**
             Updating queries' documentation.
             Triggered by SHA: _${{ github.sha }}_
           labels: documentation


### PR DESCRIPTION
Fixes #2214

**Proposed Changes**

- Use KICS BOT Personal Access Token as recommended in this thread https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
- Removing irrelevant ref parameter from PR title.

I submit this contribution under Apache-2.0 license.
