### PR TITLE
Use short SHA for nightly builds

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -17,6 +17,9 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
+      - name: Set short hash
+        id: set-short-hash
+        run: echo "::set-output name=short-sha::${GITHUB_SHA::8}"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -38,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: nightly
-          release_name: nightly-${{ github.sha }}
+          release_name: nightly-${{ steps.set-short-hash.short-sha }}
           draft: false
           prerelease: true
       - name: Display assets
@@ -104,7 +107,7 @@ jobs:
           push: true
           tags: checkmarx/kics:nightly
           build-args: |
-            VERSION=nightly-${{ github.sha }}
+            VERSION=nightly-${{ steps.set-short-hash.short-sha }}
       - name: Push alpine to Docker Hub
         uses: docker/build-push-action@v2
         with:
@@ -113,4 +116,4 @@ jobs:
           push: true
           tags: checkmarx/kics:nightly-alpine
           build-args: |
-            VERSION=nightly-${{ github.sha }}
+            VERSION=nightly-${{ steps.set-short-hash.short-sha }}


### PR DESCRIPTION
Closes  #2222

**Proposed Changes**

-  use short (8 chars) IDs to make those easier to read.

I submit this contribution under Apache-2.0 license.
