### PR TITLE
Update docs after manual release publication

### DIFF
--- a/.github/workflows/update-docs-index.yaml
+++ b/.github/workflows/update-docs-index.yaml
@@ -1,0 +1,38 @@
+name: update-docs-index
+
+on:
+  workflow_dispatch:
+  release:
+    type: [published]
+
+jobs:
+  update-index:
+    name: Update index docs links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get current date
+        id: current-date
+        run: echo "::set-output name=date::$(date +'%Y.%m.%d')"
+      - name: Get release version
+        id: current-version
+        run: echo "::set-output name=version::$(git describe --tags --abbrev=0 | cut -c2-)"
+      - name: Replace lines
+        run: |
+          sed -E -i "s/<h4>Version [0-9]+\.[0-9]+\.[0-9]+<\/h4>/<h4>Version ${{ steps.current-version.version }}<\/h4>/" docs/index.md
+          sed -E -i "s/(<p.*>)[0-9]{4}\.[0-9]{2}\.[0-9]{2}<p>/\1${{ steps.current-date.date }}<p>/" docs/index.md
+          sed -E -i "s/(<a.*href=\"https:\/\/github.com\/Checkmarx\/kics\/releases\/download\/).*(\/kics_).*(_[a-z]+_.*>)/\1${{ steps.current-version.version }}\2${{ steps.current-version.version }}\3/g" docs/index.md
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Update documentation index page - ${{ steps.current-version.version }}
+          env:
+            GITHUB_TOKEN: ${{ secrets.KICS_BOT_PAT }}
+          body: |
+            **Automated changes**
+            Updating documentation index page.
+            Triggered by SHA: _${{ github.sha }}_
+          labels: documentation

--- a/.github/workflows/update-docs-queries.yaml
+++ b/.github/workflows/update-docs-queries.yaml
@@ -18,6 +18,17 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+      - name: Get commit changed files
+        uses: lots0logs/gh-action-get-changed-files@2.1.4
+        id: get-changed-files
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: DEBUG - print changed files
+        run: cat ${HOME}/files.json
+      - name: Filter queries metadata
+        id: get-changed-metadata
+        run: |
+          echo "::set-output name=files-list::$(cat ${HOME}/files.json | grep metadata.json)"
       - name: Update docs
         run: |
           pip3 install -r .github/generators/requirements.txt
@@ -33,5 +44,9 @@ jobs:
             **Automated changes**
             Updating queries' documentation.
             Triggered by SHA: _${{ github.sha }}_
+            Changed metadatas:
+            ```
+            ${{ steps.get-changed-metadata.files-list }}
+            ```
           labels: documentation
 

--- a/.github/workflows/update-docs-queries.yaml
+++ b/.github/workflows/update-docs-queries.yaml
@@ -1,4 +1,4 @@
-name: generate-queries-docs
+name: update-queries-docs
 
 on:
   workflow_dispatch:
@@ -8,8 +8,8 @@ on:
     - "assets/queries/**/metadata.json"
 
 jobs:
-  generate-docs:
-    name: generate-queries-docs
+  update-docs:
+    name: Update queries documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Generate docs
+      - name: Update docs
         run: |
           pip3 install -r .github/generators/requirements.txt
           python3 -u .github/generators/docs_generator.py -p ./assets/queries/ \
@@ -26,7 +26,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          title: Update queries docs - ${{ github.run_id }}
+          title: Update queries documentation - ${{ github.run_id }}
           env:
             GITHUB_TOKEN: ${{ secrets.KICS_BOT_PAT }}
           body: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,3 +23,5 @@ archives:
       - LICENSE
       - assets/queries
       - assets/libraries
+release:
+  prerelease: true


### PR DESCRIPTION
**Proposed Changes**

- Prerelease by default on pushed tags
- Automatically create PR to update documentation after the release was tested and has been manually published
- Renaming update queries docs workflow
- Update queries docs now displays changed metadata list in the PR's body

I submit this contribution under Apache-2.0 license.
