### PR TITLE
Getting short commit hash from git instead of env vars

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -19,7 +19,7 @@ jobs:
           go-version: 1.16
       - name: Set short hash
         id: set-short-hash
-        run: echo "::set-output name=short-sha::${GITHUB_SHA::8}"
+        run: echo "::set-output name=short-sha::$(git rev-parse --short HEAD)"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
Attempting to fix nightly builds naming

I submit this contribution under Apache-2.0 license.
