### PR TITLE
Update AWS RDS Configuration Automatic Backup Disabled query for AWS CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/rds_configuration_automatic_backup_disabled/query.rego
+++ b/assets/queries/cloudFormation/rds_configuration_automatic_backup_disabled/query.rego
@@ -3,7 +3,8 @@ package Cx
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
-	resource.Properties.BackupRetentionPeriod == 0
+    backupRetentionPeriod = to_number(resource.Properties.BackupRetentionPeriod)
+	backupRetentionPeriod == 0
 
 	result := {
 		"documentId": input.document[i].id,


### PR DESCRIPTION
Closes #2249

**Proposed Changes**

- Added a use of the method `to_number` in the query, to handle when the value comes as a string.

I submit this contribution under Apache-2.0 license.
