### PR TITLE
Added Chown Flag Exists query

### DIFF
--- a/assets/queries/dockerfile/chown_flag_exists/metadata.json
+++ b/assets/queries/dockerfile/chown_flag_exists/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "aa93e17f-b6db-4162-9334-c70334e7ac28",
+  "queryName": "Chown Flag Exists",
+  "severity": "LOW",
+  "category": "Best Practices",
+  "descriptionText": "You can just drop the --chown option, the user only needs execution permissions on the file, not ownership",
+  "descriptionUrl": "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/",
+  "platform": "Dockerfile"
+}

--- a/assets/queries/dockerfile/chown_flag_exists/metadata.json
+++ b/assets/queries/dockerfile/chown_flag_exists/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Chown Flag Exists",
   "severity": "LOW",
   "category": "Best Practices",
-  "descriptionText": "You can just drop the --chown option, the user only needs execution permissions on the file, not ownership",
+  "descriptionText": "If the user only needs execution permissions on the file and not ownership, don't use --chown option",
   "descriptionUrl": "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/",
   "platform": "Dockerfile"
 }

--- a/assets/queries/dockerfile/chown_flag_exists/query.rego
+++ b/assets/queries/dockerfile/chown_flag_exists/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].command[name]
+
+	contains(resource[j].Flags[f], "--chown")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource[j].Original]),
+		"category": "Best Practices",
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The 'Dockerfile' shouldn´t contains the 'chown' flag",
+		"keyActualValue": "The 'Dockerfile' contains the 'chown' flag",
+	}
+}

--- a/assets/queries/dockerfile/chown_flag_exists/query.rego
+++ b/assets/queries/dockerfile/chown_flag_exists/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource[j].Original]),
 		"category": "Best Practices",
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "The 'Dockerfile' shouldn´t contains the 'chown' flag",
+		"keyExpectedValue": "The 'Dockerfile' shouldn´t contain the 'chown' flag",
 		"keyActualValue": "The 'Dockerfile' contains the 'chown' flag",
 	}
 }

--- a/assets/queries/dockerfile/chown_flag_exists/test/negative.dockerfile
+++ b/assets/queries/dockerfile/chown_flag_exists/test/negative.dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7
+RUN pip install Flask==0.11.1
+RUN useradd -ms /bin/bash patrick
+COPY app /app
+WORKDIR /app
+USER patrick
+CMD ["python", "app.py"]

--- a/assets/queries/dockerfile/chown_flag_exists/test/positive.dockerfile
+++ b/assets/queries/dockerfile/chown_flag_exists/test/positive.dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7
+RUN pip install Flask==0.11.1
+RUN useradd -ms /bin/bash patrick
+COPY --chown=patrick:patrick app /app
+WORKDIR /app
+USER patrick
+CMD ["python", "app.py"]

--- a/assets/queries/dockerfile/chown_flag_exists/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/chown_flag_exists/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Chown Flag Exists",
+    "severity": "LOW",
+    "line": 4
+  }
+]


### PR DESCRIPTION
Closes # 2257
**Proposed Changes**

-Query to check the --chown flag, because we can just drop the --chown option, the user only needs execution permissions on the file, not ownership


I submit this contribution under Apache-2.0 license.
