### PR TITLE
Update queries to be more explicit for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/query.rego
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/query.rego
@@ -11,8 +11,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'Resources.Type=AWS::WAFRegional::WebACLAssociation.ResourceArn.Ref=%s' is defined", [name]),
-		"keyActualValue": sprintf("'Resources.Type=AWS::WAFRegional::WebACLAssociation.ResourceArn.Ref=%s' is undefined", [name]),
+		"keyExpectedValue": sprintf("'Resources.%s' has an 'internal' scheme and a 'WebACLAssociation' associated", [name]),
+		"keyActualValue": sprintf("'Resources.%s' doesn't have an 'internal' scheme or a 'WebACLAssociation' associated", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/cloudfront_distribution_access_log_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudfront_distribution_access_log_disabled/query.rego
@@ -11,8 +11,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties should have logging enabled", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties has logging disabled", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.DistributionConfig.Logging is defined", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.DistributionConfig.Logging is undefined", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/cloudfront_distribution_without_waf/query.rego
+++ b/assets/queries/cloudFormation/cloudfront_distribution_without_waf/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.DistributionConfig", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "'Resources.Properties.DistributionConfig.WebACLId' is defined",
-		"keyActualValue": "'Resources.Properties.DistributionConfig.WebACLId' is undefined",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.DistributionConfig.WebACLId is defined", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.DistributionConfig.WebACLId is undefined", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/ec2_network_acl_ineffective_denied_traffic/query.rego
+++ b/assets/queries/cloudFormation/ec2_network_acl_ineffective_denied_traffic/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.CidrBlock", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.CidrBlock should not be denied to traffic once RuleAction should be configured with allow.' ", [name]),
-		"keyActualValue": sprintf("'Resources.%s.Properties.CidrBlock will be denied to traffic since RuleAction is configured with deny.' ", [name]),
+		"keyExpectedValue": sprintf("Traffic denial is effective (Action is 'Deny' when CidrBlock is '0.0.0.0/0')", [name]),
+		"keyActualValue": sprintf("Traffic denial is ineffective (Action is 'Deny' when CidrBlock is different from '0.0.0.0/0'", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/efs_without_tags/query.rego
+++ b/assets/queries/cloudFormation/efs_without_tags/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 		"documentId": document.id,
 		"searchKey": sprintf("Resources.%s", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("EFS resource '%s' should have file system tags associated", [name]),
-		"keyActualValue": sprintf("EFS resource '%s' doesn't have any file system tags associated", [name]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.FileSystemTags' is defined", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.FileSystemTags' is undefined", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/elb_without_ssl/query.rego
+++ b/assets/queries/cloudFormation/elb_without_ssl/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Listeners", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Listeners is setup with SSL", [name]),
-		"keyActualValue": sprintf("Resources.%s.Listeners isn't setup with SSL", [name]),
+		"keyExpectedValue": sprintf("'Resources.%s.Listeners.InstanceProtocol' and 'Resources.%s.Listeners.Protocol' is set to 'HTTPS'", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Listeners.InstanceProtocol' or 'Resources.%s.Listeners.Protocol' isn't set to 'HTTPS'", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/lambda_function_without_tags/query.rego
+++ b/assets/queries/cloudFormation/lambda_function_without_tags/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 		"documentId": document.id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "All Lambda Functions have associated tags",
-		"keyActualValue": "A Lambda Function is missing associated tags",
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.Tags' is defined", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.Tags' is undefined", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/query.rego
@@ -11,8 +11,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.BucketName", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.BucketName' or 'Resources.[%s]' should be the same as 'AWS::S3::BucketPolicy' Bucket Ref", [name, name]),
-		"keyActualValue": sprintf("'Resources.%s.Properties.BucketName' or 'Resources.[%s]' is not the same as 'AWS::S3::BucketPolicy' Bucket Ref", [name, name]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.BucketName' or 'Resources.[%s]' is the same as an 'AWS::S3::BucketPolicy' Bucket Ref", [name, name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.BucketName' or 'Resources.[%s]' is not the same as an 'AWS::S3::BucketPolicy' Bucket Ref", [name, name]),
 	}
 }
 
@@ -25,8 +25,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.BucketName' should be defined in 'AWS::S3::Bucket'", [name]),
-		"keyActualValue": sprintf("'Resources.%s.Properties.BucketName' is not defined in 'AWS::S3::Bucket'", [name]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.BucketName' is defined", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.BucketName' is not defined", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/s3_bucket_versioning_not_enabled/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_versioning_not_enabled/query.rego
@@ -10,8 +10,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "S3 bucket versioning is configured",
-		"keyActualValue": "S3 bucket versioning is missing",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.VersioningConfiguration is defined", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.VersioningConfiguration is undefined", [name]),
 	}
 }
 
@@ -24,7 +24,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.VersioningConfiguration.Status", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "S3 bucket versioning is set to Enabled",
-		"keyActualValue": "S3 bucket versioning is set to Suspended",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.VersioningConfiguration.Status is set to Enabled", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.VersioningConfiguration.Status is set to Suspended", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/s3_bucket_website_host_is_disabled/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_website_host_is_disabled/query.rego
@@ -9,8 +9,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.PublicAccessBlockConfiguration", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'Resources.Properties.PublicAccessBlockConfiguration' is set and configuration has value true",
-		"keyActualValue": "'Resources.Properties.PublicAccessBlockConfiguration' is not set or configuration has value false ",
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.PublicAccessBlockConfiguration' is set and configuration has value true", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.PublicAccessBlockConfiguration' is not set or configuration has value false", [name]),
 	}
 }
 
@@ -24,8 +24,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'Resources.Properties.PublicAccessBlockConfiguration' is set and configuration has value true ",
-		"keyActualValue": "'Resources.Properties.WebsiteConfiguration' is configured",
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.WebsiteConfiguration' and 'Resources.%s.Properties.AcessControl' are undefined", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.WebsiteConfiguration' or 'Resources.%s.Properties.AccessControl' are defined", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/s3_bucket_without_server_side_encryption/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_without_server_side_encryption/query.rego
@@ -15,8 +15,8 @@ CxPolicy[result] {
 		"documentId": document.id,
 		"searchKey": sprintf("Resources.%s", [bucketName]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s bucket should server-side encryption enabled", [bucketName]),
-		"keyActualValue": sprintf("Resources.%s bucket doesn't have any server-side encryption configuration", [bucketName]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.BucketEncryption.ServerSideEncryptionConfiguration is defined and not empty", [bucketName]),
+		"keyActualValue": sprintf("Resources.%s.Properties.BucketEncryption.ServerSideEncryptionConfiguration is undefined or empty", [bucketName]),
 	}
 }
 

--- a/assets/queries/cloudFormation/security_group_ingress_cidr_open_to_world/query.rego
+++ b/assets/queries/cloudFormation/security_group_ingress_cidr_open_to_world/query.rego
@@ -12,8 +12,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.CidrIp", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.CidrIp is not open to the world", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.CidrIp is open to the world", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.CidrIp is not open to the world (0.0.0.0/0)", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.CidrIp is open to the world (0.0.0.0/0)", [name]),
 	}
 }
 
@@ -29,8 +29,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.CidrIpv6", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.CidrIpv6 is not open to the world", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.CidrIpv6 is open to the world", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.CidrIpv6 is not open to the world (::/0)", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.CidrIpv6 is open to the world (::/0)", [name]),
 	}
 }
 
@@ -46,8 +46,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.SecurityGroupIngress.CidrIp", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIp is not open to the world", [name, index]),
-		"keyActualValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIp is open to the world", [name, index]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIp is not open to the world (0.0.0.0/0)", [name, index]),
+		"keyActualValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIp is open to the world (0.0.0.0/0)", [name, index]),
 	}
 }
 
@@ -63,7 +63,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.SecurityGroupIngress.CidrIpv6", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIpv6 is not open to the world", [name, index]),
-		"keyActualValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIpv6 is open to the world", [name, index]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIpv6 is not open to the world (::/0)", [name, index]),
+		"keyActualValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d].CidrIpv6 is open to the world (::/0)", [name, index]),
 	}
 }

--- a/assets/queries/cloudFormation/security_groups_with_exhibited_admin_ports/query.rego
+++ b/assets/queries/cloudFormation/security_groups_with_exhibited_admin_ports/query.rego
@@ -11,8 +11,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.SecurityGroupIngress", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("None of the Resources.%s.Properties.SecurityGroupIngress has a correct port", [name]),
-		"keyActualValue": sprintf("One of the Resources.%s.Properties.SecurityGroupIngress has a too exposed port", [name]),
+		"keyExpectedValue": sprintf("None of the Resources.%s.Properties.SecurityGroupIngress has an exposed port", [name]),
+		"keyActualValue": sprintf("One of the Resources.%s.Properties.SecurityGroupIngress has a too exposed port (20,21,22,23,115,137,138,2049,3389)", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/vpc_has_flowlog_disabled/query.rego
+++ b/assets/queries/cloudFormation/vpc_has_flowlog_disabled/query.rego
@@ -10,8 +10,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s has FlowLogs enabled", [name]),
-		"keyActualValue": sprintf("Resources.%s has FlowLogs disabled", [name]),
+		"keyExpectedValue": sprintf("Resources.%s has a FlowLogs resource associated", [name]),
+		"keyActualValue": sprintf("Resources.%s doesn't have a FlowLogs resource associated", [name]),
 	}
 }
 


### PR DESCRIPTION
Closes #2259

**Proposed Changes**

Changing keyExpectedValue and/or keyActualValue to be more explicit, in queries:

- 105ba098-1e34-48cd-b0f2-a8a43a51bf9b
- 0f139403-303f-467c-96bd-e717e6cfd62d
- de77cd9f-0e8b-46cc-b4a4-b6b436838642
- cdbb0467-2957-4a77-9992-7b55b29df7b7
- 90501b1b-cded-4cc1-9e8b-206b85cda317
- a227ec01-f97a-4084-91a4-47b350c1db54
- f6d299d2-21eb-41cc-b1e1-fe12d857500b
- 80908a75-586b-4c61-ab04-490f4f4525b8
- b2e8752c-3497-4255-98d2-e4ae5b46bbf5
- 08e39832-5e42-4304-98a0-aa5b43393162
- 8df8e857-bd59-44fa-9f4c-d77594b95b46
- 4a1e6b34-1008-4e61-a5f2-1f7c276f8d14
- 37fa8188-738b-42c8-bf82-6334ea567738
- 2623d682-dccb-44cd-99d0-54d9fd62f8f2

I submit this contribution under Apache-2.0 license.
