### PR TITLE
Update CloudFront Without Minimum Protocol TLS 1.2 query for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/cloudfront_without_minimum_protocol_tls_1.2/query.rego
+++ b/assets/queries/cloudFormation/cloudfront_without_minimum_protocol_tls_1.2/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::CloudFront::Distribution"
 	properties := resource.Properties
 	protocolVer := properties.DistributionConfig.ViewerCertificate.MinimumProtocolVersion
-	not containsProtocolVersion(["TLSv1.2_2018", "TLSv1.2_2019"], protocolVer)
+	not containsProtocolVersion(["TLSv1.2_2018", "TLSv1.2_2019","TLSv1.2-2018", "TLSv1.2-2019"], protocolVer)
 
 	result := {
 		"documentId": input.document[i].id,


### PR DESCRIPTION
Closes #2263

**Proposed Changes**

- Adding a different format for the CloudFront Minimum Protocol Version, using "-" instead of "_".

I submit this contribution under Apache-2.0 license.
