### PR TITLE
Update EC2 Permissive Network ACL Protocols query for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/ec2_permissive_network_acl_protocols/query.rego
+++ b/assets/queries/cloudFormation/ec2_permissive_network_acl_protocols/query.rego
@@ -15,21 +15,21 @@ CxPolicy[result] {
 }
 
 checkValue(protocol) {
-	to_number(protocol)
-	protocol == 6
+	prt := to_number(protocol)
+	prt == 6
 }
 
 checkValue(protocol) {
-	to_number(protocol)
-	protocol == 17
+	prt := to_number(protocol)
+	prt == 17
 }
 
 checkValue(protocol) {
-	to_number(protocol)
-	protocol == 1
+	prt := to_number(protocol)
+	prt == 1
 }
 
 checkValue(protocol) {
-	to_number(protocol)
-	protocol == 58
+	prt := to_number(protocol)
+	prt == 58
 }


### PR DESCRIPTION
Closes #2265

**Proposed Changes**

- Correcting a mistake in which the value before a conversion was being used to compare, instead of the value after the conversion.

I submit this contribution under Apache-2.0 license.
