### PR TITLE
Add "SNS Topic Publicity Has Allow and NotAction Simultaneously" query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/metadata.json
+++ b/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "5ea624e4-c8b1-4bb3-87a4-4235a776adcc",
+  "queryName": "SNS Topic Publicity Has Allow and NotAction Simultaneously",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "SNS topic Publicity should not have 'Effect: Allow' and argument 'NotAction' at the same time. If it has 'Effect: Allow', the argument stated should be 'Action'.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/query.rego
+++ b/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document[i]
+	resources := {"aws_sns_topic", "aws_sns_topic_policy"}
+	policy := document.resource[resources[r]][name].policy
+
+	validate_json(policy)
+
+	pol := json.unmarshal(policy)
+	statement := pol.Statement[s]
+
+	statement.Effect = "Allow"
+	statement.NotAction
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("%s[%s].policy.Sid", [resources[r], name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].policy.Sid doesn't have 'Effect: Allow' and 'NotAction' simultaneously", [resources[r], name]),
+		"keyActualValue": sprintf("%s[%s].policy.Sid has 'Effect: Allow' and 'NotAction' simultaneously", [resources[r], name]),
+	}
+}
+
+validate_json(string) {
+	not startswith(string, "$")
+}

--- a/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/negative.tf
+++ b/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/negative.tf
@@ -1,0 +1,22 @@
+resource "aws_sns_topic" "negative1" {
+  name = "my-topic-with-policy"
+}
+
+resource "aws_sns_topic_policy" "negative2" {
+  arn = aws_sns_topic.test.arn
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "MYPOLICYTEST",
+  "Statement": [
+    {
+      "Action": "s3:DeleteBucket",
+      "Resource": "arn:aws:s3:::*",
+      "Sid": "MyStatementId",
+      "Effect": "Allow"
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/positive.tf
+++ b/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/positive.tf
@@ -1,0 +1,22 @@
+resource "aws_sns_topic" "positive1" {
+  name = "my-topic-with-policy"
+}
+
+resource "aws_sns_topic_policy" "positive2" {
+  arn = aws_sns_topic.test.arn
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "MYPOLICYTEST",
+  "Statement": [
+    {
+      "NotAction": "s3:DeleteBucket",
+      "Resource": "arn:aws:s3:::*",
+      "Sid": "MyStatementId",
+      "Effect": "Allow"
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sns_topic_publicity_has_allow_and_not_action_simultaneously/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "SNS Topic Publicity Has Allow and NotAction Simultaneously",
+    "severity": "MEDIUM",
+    "line": 16
+  }
+]


### PR DESCRIPTION
Closes #2288

**Proposed Changes**

- Add support in Terraform for a query with the same name already implemented in CloudFormation.
- The query checks if a SNS Topic policy has statements `Effect: Allow` and `NotAction` simultaneously.

I submit this contribution under Apache-2.0 license.
