### PR TITLE
Add query to check is memcached is disabled in elasticache. Closes #2292

### DIFF
--- a/assets/queries/cloudFormation/memcached_disabled/metadata.json
+++ b/assets/queries/cloudFormation/memcached_disabled/metadata.json
@@ -1,0 +1,9 @@
+{
+	"id": "dd0971a6-09c3-4168-8474-a7ef8fbfd99d",
+	"queryName": "Memcached Disabled",
+	"severity": "HIGH",
+	"category": "Encryption",
+	"descriptionText": "Check if the Memcached is disabled on the ElastiCache",
+	"descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-engine",
+	"platform": "CloudFormation"
+}

--- a/assets/queries/cloudFormation/memcached_disabled/query.rego
+++ b/assets/queries/cloudFormation/memcached_disabled/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy[result] {
+	ecc := input.document[i].Resources[name]
+	ecc.Type == "AWS::ElastiCache::CacheCluster"
+	ecc.Properties.Engine == "redis"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.Engine", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.Engine is 'memcached'", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.Engine is 'redis'", [name]),
+	}
+}

--- a/assets/queries/cloudFormation/memcached_disabled/test/negative1.yaml
+++ b/assets/queries/cloudFormation/memcached_disabled/test/negative1.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: A sample template
+Resources:
+  ElasticacheCluster:
+    Type: 'AWS::ElastiCache::CacheCluster'
+    Properties:
+      Engine: memcached
+      CacheNodeType: cache.t2.micro
+      NumCacheNodes: '1'
+      VpcSecurityGroupIds:
+        - !GetAtt
+          - ElasticacheSecurityGroup
+          - GroupId

--- a/assets/queries/cloudFormation/memcached_disabled/test/negative2.json
+++ b/assets/queries/cloudFormation/memcached_disabled/test/negative2.json
@@ -1,0 +1,22 @@
+{
+  "Description": "A sample template",
+  "Resources": {
+    "ElasticacheCluster2": {
+        "Type": "AWS::ElastiCache::CacheCluster",
+        "Properties": {
+            "Engine": "memcached",
+            "CacheNodeType": "cache.t2.micro",
+            "NumCacheNodes": "1",
+            "VpcSecurityGroupIds": [
+                {
+                    "Fn::GetAtt": [
+                        "ElasticacheSecurityGroup",
+                        "GroupId"
+                    ]
+                }
+            ]
+        }
+    }
+  },
+  "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z"
+}

--- a/assets/queries/cloudFormation/memcached_disabled/test/positive1.yaml
+++ b/assets/queries/cloudFormation/memcached_disabled/test/positive1.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: A sample template
+Resources:
+  ElasticacheCluster3:
+    Type: 'AWS::ElastiCache::CacheCluster'
+    Properties:
+      Engine: redis
+      CacheNodeType: cache.t2.micro
+      NumCacheNodes: '1'
+      VpcSecurityGroupIds:
+        - !GetAtt
+          - ElasticacheSecurityGroup
+          - GroupId

--- a/assets/queries/cloudFormation/memcached_disabled/test/positive2.json
+++ b/assets/queries/cloudFormation/memcached_disabled/test/positive2.json
@@ -1,0 +1,22 @@
+{
+  "Description": "A sample template",
+  "Resources": {
+    "ElasticacheCluster4": {
+        "Type": "AWS::ElastiCache::CacheCluster",
+        "Properties": {
+            "Engine": "redis",
+            "CacheNodeType": "cache.t2.micro",
+            "NumCacheNodes": "1",
+            "VpcSecurityGroupIds": [
+                {
+                    "Fn::GetAtt": [
+                        "ElasticacheSecurityGroup",
+                        "GroupId"
+                    ]
+                }
+            ]
+        }
+    }
+  },
+  "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z"
+}

--- a/assets/queries/cloudFormation/memcached_disabled/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/memcached_disabled/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Memcached Disabled",
+    "severity": "HIGH",
+    "line": 7,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "Memcached Disabled",
+    "severity": "HIGH",
+    "line": 7,
+    "fileName": "positive2.json"
+  }
+]


### PR DESCRIPTION
Closes #2292

**Proposed Changes**

- Add support in CloudFormation for the query that checks if the engine used in ElastiCache clusters isn't memcached

I submit this contribution under Apache-2.0 license.
