### PR TITLE
Add "API Gateway With Open Access" query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/api_gateway_with_open_access/metadata.json
+++ b/assets/queries/terraform/aws/api_gateway_with_open_access/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "15ccec05-5476-4890-ad19-53991eba1db8",
+  "queryName": "API Gateway With Open Access",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "API Gateway Method should restrict the authorization type, except for the HTTP OPTIONS method.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_method",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/api_gateway_with_open_access/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_with_open_access/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document[i]
+	resource = document.resource.aws_api_gateway_method[name]
+
+	resource.authorization == "NONE"
+	resource.http_method != "OPTIONS"
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("aws_api_gateway_method[%s].authorization", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "aws_api_gateway_method.authorization is only 'NONE' if http_method is 'OPTIONS'",
+		"keyActualValue": sprintf("aws_api_gateway_method[%s].authorization type is 'NONE' and http_method is not ''OPTIONS'", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/api_gateway_with_open_access/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_with_open_access/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": document.id,
-		"searchKey": sprintf("aws_api_gateway_method[%s].authorization", [name]),
+		"searchKey": sprintf("aws_api_gateway_method[%s].http_method", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_api_gateway_method.authorization is only 'NONE' if http_method is 'OPTIONS'",
 		"keyActualValue": sprintf("aws_api_gateway_method[%s].authorization type is 'NONE' and http_method is not ''OPTIONS'", [name]),

--- a/assets/queries/terraform/aws/api_gateway_with_open_access/test/negative.tf
+++ b/assets/queries/terraform/aws/api_gateway_with_open_access/test/negative.tf
@@ -1,0 +1,11 @@
+resource "aws_api_gateway_method" "positive1" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.this.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+  authorizer_id = aws_api_gateway_authorizer.this.id
+
+  request_parameters = {
+    "method.request.path.proxy" = true
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_with_open_access/test/negative.tf
+++ b/assets/queries/terraform/aws/api_gateway_with_open_access/test/negative.tf
@@ -1,4 +1,4 @@
-resource "aws_api_gateway_method" "positive1" {
+resource "aws_api_gateway_method" "negative1" {
   rest_api_id   = aws_api_gateway_rest_api.this.id
   resource_id   = aws_api_gateway_resource.this.id
   http_method   = "OPTIONS"

--- a/assets/queries/terraform/aws/api_gateway_with_open_access/test/positive.tf
+++ b/assets/queries/terraform/aws/api_gateway_with_open_access/test/positive.tf
@@ -1,0 +1,11 @@
+resource "aws_api_gateway_method" "positive1" {
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.this.id
+  http_method   = "GET"
+  authorization = "NONE"
+  authorizer_id = aws_api_gateway_authorizer.this.id
+
+  request_parameters = {
+    "method.request.path.proxy" = true
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_with_open_access/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_with_open_access/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "API Gateway With Open Access",
+    "severity": "MEDIUM",
+    "line": 5
+  }
+]

--- a/assets/queries/terraform/aws/api_gateway_with_open_access/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_with_open_access/test/positive_expected_result.json
@@ -2,6 +2,6 @@
   {
     "queryName": "API Gateway With Open Access",
     "severity": "MEDIUM",
-    "line": 5
+    "line": 4
   }
 ]


### PR DESCRIPTION
Closes #2307

**Proposed Changes**

- Add support in Terraform for a query with the same name already implemented in CloudFormation.
- The query checks if the authorization type is restricted in API Gateway Method resource (therefore being different from `NONE`). The authorization type can only be `NONE` when the http method is `OPTIONS`.
