### PR TITLE
Add "Elasticsearch Without Slow Logs" query for CloudFormation #2312

### DIFF
--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/metadata.json
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "086ea2eb-14a6-4fd4-914b-38e0bc8703e8",
+  "queryName": "ElasticSearch Without Slow Logs",
+  "severity": "MEDIUM",
+  "category": "Observability",
+  "descriptionText": "Ensure that AWS Elasticsearch enables support for slow logs",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html#cfn-elasticsearch-domain-logpublishingoptions",
+  "platform": "CloudFormation"
+}

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/query.rego
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/query.rego
@@ -32,17 +32,18 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	resource := input.document[i].Resources[name]
+	document := input.document[i]
+	resource := document.Resources[name]
 	resource.Type == "AWS::Elasticsearch::Domain"
 	properties := resource.Properties
 	object.get(properties, "LogPublishingOptions", "undefined") == "undefined"
 
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("Resources.%s.Properties.LogPublishingOptions", [name]),
+		"documentId": document.id,
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("Resources.%s.Properties.LogPublishingOptions exists", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions doe snot exist", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions does not exist", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/query.rego
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/query.rego
@@ -1,0 +1,53 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::Elasticsearch::Domain"
+	logs := resource.Properties.LogPublishingOptions[log]
+	not contains(["INDEX_SLOW_LOGS", "SEARCH_SLOW_LOGS"], log)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.LogPublishingOptions.%s", [name, log]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.LogPublishingOptions.%s is slow logs", [name, log]),
+		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions.%s is not not slow logs", [name, log]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::Elasticsearch::Domain"
+	logs := resource.Properties.LogPublishingOptions[log]
+	contains(["INDEX_SLOW_LOGS", "SEARCH_SLOW_LOGS"], log)
+	logs.Enabled == "false"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.LogPublishingOptions.%s.Enabled", [name, log]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.LogPublishingOptions.%s is slow logs but is not enabled", [name, log]),
+		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions.%s is slow logs as is enabled", [name, log]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::Elasticsearch::Domain"
+	properties := resource.Properties
+	object.get(properties, "LogPublishingOptions", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.LogPublishingOptions", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.LogPublishingOptions exists", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions doe snot exist", [name]),
+	}
+}
+
+contains(array, elem) {
+	array[_] == elem
+} else = false {
+	true
+}

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/query.rego
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/query.rego
@@ -26,8 +26,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.LogPublishingOptions.%s.Enabled", [name, log]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.LogPublishingOptions.%s is slow logs but is not enabled", [name, log]),
-		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions.%s is slow logs as is enabled", [name, log]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.LogPublishingOptions.%s is a slow log and is enabled", [name, logs]),
+		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions.%s is a slow log but isn't enabled", [name, logs]),
 	}
 }
 
@@ -42,8 +42,8 @@ CxPolicy[result] {
 		"documentId": document.id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.LogPublishingOptions exists", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions does not exist", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.LogPublishingOptions is defined", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions is undefined", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/negative1.yaml
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/negative1.yaml
@@ -1,0 +1,57 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ElasticsearchDomain resource
+Parameters:
+  DomainName:
+    Description: User defined Elasticsearch Domain name
+    Type: String
+  ElasticsearchVersion:
+    Description: User defined Elasticsearch Version
+    Type: String
+  InstanceType:
+    Type: String
+  AvailabilityZone:
+    Type: String
+  CidrBlock:
+    Type: String
+  GroupDescription:
+    Type: String
+  SGName:
+    Type: String
+Resources:
+  ElasticsearchDomain:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      DomainName:
+        Ref: DomainName
+      ElasticsearchVersion:
+        Ref: ElasticsearchVersion
+      ElasticsearchClusterConfig:
+        InstanceCount: '1'
+        InstanceType:
+          Ref: InstanceType
+      EBSOptions:
+        EBSEnabled: 'true'
+        Iops: 0
+        VolumeSize: 10
+        VolumeType: standard
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: '0'
+      AccessPolicies:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Deny
+            Principal:
+              AWS: '*'
+            Action: 'es:*'
+            Resource: '*'
+      LogPublishingOptions:
+        SEARCH_SLOW_LOGS:
+          CloudWatchLogsLogGroupArn: >-
+            arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs
+          Enabled: 'true'
+        INDEX_SLOW_LOGS:
+          CloudWatchLogsLogGroupArn: >-
+            arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs
+          Enabled: 'true'
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: 'true'

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/negative2.json
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/negative2.json
@@ -1,0 +1,89 @@
+{
+  "document": [
+    {
+      "AWSTemplateFormatVersion": "2010-09-09",
+      "Description": "ElasticsearchDomain resource",
+      "Parameters": {
+        "GroupDescription": {
+          "Type": "String"
+        },
+        "SGName": {
+          "Type": "String"
+        },
+        "DomainName": {
+          "Description": "User defined Elasticsearch Domain name",
+          "Type": "String"
+        },
+        "ElasticsearchVersion": {
+          "Description": "User defined Elasticsearch Version",
+          "Type": "String"
+        },
+        "InstanceType": {
+          "Type": "String"
+        },
+        "AvailabilityZone": {
+          "Type": "String"
+        },
+        "CidrBlock": {
+          "Type": "String"
+        }
+      },
+      "Resources": {
+        "ElasticsearchDomain": {
+          "Type": "AWS::Elasticsearch::Domain",
+          "Properties": {
+            "AdvancedOptions": {
+              "rest.action.multi.allow_explicit_index": "true"
+            },
+            "DomainName": {
+              "Ref": "DomainName"
+            },
+            "ElasticsearchVersion": {
+              "Ref": "ElasticsearchVersion"
+            },
+            "ElasticsearchClusterConfig": {
+              "InstanceCount": "1",
+              "InstanceType": {
+                "Ref": "InstanceType"
+              }
+            },
+            "EBSOptions": {
+              "Iops": 0,
+              "VolumeSize": 10,
+              "VolumeType": "standard",
+              "EBSEnabled": "true"
+            },
+            "SnapshotOptions": {
+              "AutomatedSnapshotStartHour": "0"
+            },
+            "AccessPolicies": {
+              "Statement": [
+                {
+                  "Effect": "Deny",
+                  "Principal": {
+                    "AWS": "*"
+                  },
+                  "Action": "es:*",
+                  "Resource": "*"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "LogPublishingOptions": {
+              "SEARCH_SLOW_LOGS": {
+                "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs",
+                "Enabled": "true"
+              },
+              "INDEX_SLOW_LOGS": {
+                "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs",
+                "Enabled": "true"
+              }
+            }
+          }
+        }
+      },
+      "id": "c886b8d1-8c44-4f23-ba01-6e30a2f5be7b",
+      "file": "C:\\Users\\pedrom\\Desktop\\Data\\yaml\\yaml.yaml"
+    }
+  ]
+}

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive1.yaml
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive1.yaml
@@ -1,0 +1,57 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ElasticsearchDomain resource
+Parameters:
+  DomainName:
+    Description: User defined Elasticsearch Domain name
+    Type: String
+  ElasticsearchVersion:
+    Description: User defined Elasticsearch Version
+    Type: String
+  InstanceType:
+    Type: String
+  AvailabilityZone:
+    Type: String
+  CidrBlock:
+    Type: String
+  GroupDescription:
+    Type: String
+  SGName:
+    Type: String
+Resources:
+  ElasticsearchDomain:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      DomainName:
+        Ref: DomainName
+      ElasticsearchVersion:
+        Ref: ElasticsearchVersion
+      ElasticsearchClusterConfig:
+        InstanceCount: '1'
+        InstanceType:
+          Ref: InstanceType
+      EBSOptions:
+        EBSEnabled: 'true'
+        Iops: 0
+        VolumeSize: 10
+        VolumeType: standard
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: '0'
+      AccessPolicies:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Deny
+            Principal:
+              AWS: '*'
+            Action: 'es:*'
+            Resource: '*'
+      LogPublishingOptions:
+        SEARCH_SLOW_LOGS:
+          CloudWatchLogsLogGroupArn: >-
+            arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs
+          Enabled: 'false'
+        INDEX_SLOW_LOGS:
+          CloudWatchLogsLogGroupArn: >-
+            arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs
+          Enabled: 'true'
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: 'true'

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive2.yaml
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive2.yaml
@@ -1,0 +1,53 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ElasticsearchDomain resource
+Parameters:
+  DomainName:
+    Description: User defined Elasticsearch Domain name
+    Type: String
+  ElasticsearchVersion:
+    Description: User defined Elasticsearch Version
+    Type: String
+  InstanceType:
+    Type: String
+  AvailabilityZone:
+    Type: String
+  CidrBlock:
+    Type: String
+  GroupDescription:
+    Type: String
+  SGName:
+    Type: String
+Resources:
+  ElasticsearchDomain:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      DomainName:
+        Ref: DomainName
+      ElasticsearchVersion:
+        Ref: ElasticsearchVersion
+      ElasticsearchClusterConfig:
+        InstanceCount: '1'
+        InstanceType:
+          Ref: InstanceType
+      EBSOptions:
+        EBSEnabled: 'true'
+        Iops: 0
+        VolumeSize: 10
+        VolumeType: standard
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: '0'
+      AccessPolicies:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Deny
+            Principal:
+              AWS: '*'
+            Action: 'es:*'
+            Resource: '*'
+      LogPublishingOptions:
+        ES_APPLICATION_LOGS:
+          CloudWatchLogsLogGroupArn: >-
+            arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs
+          Enabled: 'true'
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: 'true'

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive3.yaml
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive3.yaml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ElasticsearchDomain resource
+Parameters:
+  DomainName:
+    Description: User defined Elasticsearch Domain name
+    Type: String
+  ElasticsearchVersion:
+    Description: User defined Elasticsearch Version
+    Type: String
+  InstanceType:
+    Type: String
+  AvailabilityZone:
+    Type: String
+  CidrBlock:
+    Type: String
+  GroupDescription:
+    Type: String
+  SGName:
+    Type: String
+Resources:
+  ElasticsearchDomain:
+    Type: 'AWS::Elasticsearch::Domain'
+    Properties:
+      DomainName:
+        Ref: DomainName
+      ElasticsearchVersion:
+        Ref: ElasticsearchVersion
+      ElasticsearchClusterConfig:
+        InstanceCount: '1'
+        InstanceType:
+          Ref: InstanceType
+      EBSOptions:
+        EBSEnabled: 'true'
+        Iops: 0
+        VolumeSize: 10
+        VolumeType: standard
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: '0'
+      AccessPolicies:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Deny
+            Principal:
+              AWS: '*'
+            Action: 'es:*'
+            Resource: '*'
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: 'true'

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive4.json
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive4.json
@@ -1,89 +1,54 @@
 {
-  "document": [
-    {
-      "Resources": {
-        "ElasticsearchDomain": {
-          "Type": "AWS::Elasticsearch::Domain",
-          "Properties": {
-            "DomainName": {
-              "Ref": "DomainName"
-            },
-            "ElasticsearchVersion": {
-              "Ref": "ElasticsearchVersion"
-            },
-            "ElasticsearchClusterConfig": {
-              "InstanceCount": "1",
-              "InstanceType": {
-                "Ref": "InstanceType"
-              }
-            },
-            "EBSOptions": {
-              "Iops": 0,
-              "VolumeSize": 10,
-              "VolumeType": "standard",
-              "EBSEnabled": "true"
-            },
-            "SnapshotOptions": {
-              "AutomatedSnapshotStartHour": "0"
-            },
-            "AccessPolicies": {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Action": "es:*",
-                  "Resource": "*",
-                  "Effect": "Deny",
-                  "Principal": {
-                    "AWS": "*"
-                  }
-                }
-              ]
-            },
-            "LogPublishingOptions": {
-              "SEARCH_SLOW_LOGS": {
-                "Enabled": "false",
-                "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs"
-              },
-              "INDEX_SLOW_LOGS": {
-                "Enabled": "true",
-                "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs"
-              }
-            },
-            "AdvancedOptions": {
-              "rest.action.multi.allow_explicit_index": "true"
-            }
-          }
-        }
-      },
-      "id": "f4c9db60-7a5d-4fb4-8da0-a9b72768c288",
-      "file": "C:\\Users\\pedrom\\Desktop\\Data\\yaml\\yaml.yaml",
-      "AWSTemplateFormatVersion": "2010-09-09",
-      "Description": "ElasticsearchDomain resource",
-      "Parameters": {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "ElasticsearchDomain resource",
+  "Resources": {
+    "ElasticsearchDomain": {
+      "Type": "AWS::Elasticsearch::Domain",
+      "Properties": {
         "DomainName": {
-          "Description": "User defined Elasticsearch Domain name",
-          "Type": "String"
+          "Ref": "DomainName"
         },
         "ElasticsearchVersion": {
-          "Description": "User defined Elasticsearch Version",
-          "Type": "String"
+          "Ref": "ElasticsearchVersion"
         },
-        "InstanceType": {
-          "Type": "String"
+        "ElasticsearchClusterConfig": {
+          "InstanceCount": "1",
+          "InstanceType": {
+            "Ref": "InstanceType"
+          }
         },
-        "AvailabilityZone": {
-          "Type": "String"
+        "EBSOptions": {
+          "Iops": 0,
+          "VolumeSize": 10,
+          "VolumeType": "standard",
+          "EBSEnabled": "true"
         },
-        "CidrBlock": {
-          "Type": "String"
+        "SnapshotOptions": {
+          "AutomatedSnapshotStartHour": "0"
         },
-        "GroupDescription": {
-          "Type": "String"
+        "AccessPolicies": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "es:*",
+              "Resource": "*",
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              }
+            }
+          ]
         },
-        "SGName": {
-          "Type": "String"
+        "LogPublishingOptions": {
+          "SEARCH_SLOW_LOGS": {
+            "Enabled": "false",
+            "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs"
+          }
+        },
+        "AdvancedOptions": {
+          "rest.action.multi.allow_explicit_index": "true"
         }
       }
     }
-  ]
+  }
 }

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive4.json
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive4.json
@@ -1,0 +1,89 @@
+{
+  "document": [
+    {
+      "Resources": {
+        "ElasticsearchDomain": {
+          "Type": "AWS::Elasticsearch::Domain",
+          "Properties": {
+            "DomainName": {
+              "Ref": "DomainName"
+            },
+            "ElasticsearchVersion": {
+              "Ref": "ElasticsearchVersion"
+            },
+            "ElasticsearchClusterConfig": {
+              "InstanceCount": "1",
+              "InstanceType": {
+                "Ref": "InstanceType"
+              }
+            },
+            "EBSOptions": {
+              "Iops": 0,
+              "VolumeSize": 10,
+              "VolumeType": "standard",
+              "EBSEnabled": "true"
+            },
+            "SnapshotOptions": {
+              "AutomatedSnapshotStartHour": "0"
+            },
+            "AccessPolicies": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": "es:*",
+                  "Resource": "*",
+                  "Effect": "Deny",
+                  "Principal": {
+                    "AWS": "*"
+                  }
+                }
+              ]
+            },
+            "LogPublishingOptions": {
+              "SEARCH_SLOW_LOGS": {
+                "Enabled": "false",
+                "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs"
+              },
+              "INDEX_SLOW_LOGS": {
+                "Enabled": "true",
+                "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs"
+              }
+            },
+            "AdvancedOptions": {
+              "rest.action.multi.allow_explicit_index": "true"
+            }
+          }
+        }
+      },
+      "id": "f4c9db60-7a5d-4fb4-8da0-a9b72768c288",
+      "file": "C:\\Users\\pedrom\\Desktop\\Data\\yaml\\yaml.yaml",
+      "AWSTemplateFormatVersion": "2010-09-09",
+      "Description": "ElasticsearchDomain resource",
+      "Parameters": {
+        "DomainName": {
+          "Description": "User defined Elasticsearch Domain name",
+          "Type": "String"
+        },
+        "ElasticsearchVersion": {
+          "Description": "User defined Elasticsearch Version",
+          "Type": "String"
+        },
+        "InstanceType": {
+          "Type": "String"
+        },
+        "AvailabilityZone": {
+          "Type": "String"
+        },
+        "CidrBlock": {
+          "Type": "String"
+        },
+        "GroupDescription": {
+          "Type": "String"
+        },
+        "SGName": {
+          "Type": "String"
+        }
+      }
+    }
+  ]
+}

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive5.json
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive5.json
@@ -1,0 +1,85 @@
+{
+  "document": [
+    {
+      "AWSTemplateFormatVersion": "2010-09-09",
+      "Description": "ElasticsearchDomain resource",
+      "Parameters": {
+        "DomainName": {
+          "Description": "User defined Elasticsearch Domain name",
+          "Type": "String"
+        },
+        "ElasticsearchVersion": {
+          "Description": "User defined Elasticsearch Version",
+          "Type": "String"
+        },
+        "InstanceType": {
+          "Type": "String"
+        },
+        "AvailabilityZone": {
+          "Type": "String"
+        },
+        "CidrBlock": {
+          "Type": "String"
+        },
+        "GroupDescription": {
+          "Type": "String"
+        },
+        "SGName": {
+          "Type": "String"
+        }
+      },
+      "Resources": {
+        "ElasticsearchDomain": {
+          "Type": "AWS::Elasticsearch::Domain",
+          "Properties": {
+            "EBSOptions": {
+              "EBSEnabled": "true",
+              "Iops": 0,
+              "VolumeSize": 10,
+              "VolumeType": "standard"
+            },
+            "SnapshotOptions": {
+              "AutomatedSnapshotStartHour": "0"
+            },
+            "AccessPolicies": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Deny",
+                  "Principal": {
+                    "AWS": "*"
+                  },
+                  "Action": "es:*",
+                  "Resource": "*"
+                }
+              ]
+            },
+            "LogPublishingOptions": {
+              "ES_APPLICATION_LOGS": {
+                "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs",
+                "Enabled": "true"
+              }
+            },
+            "AdvancedOptions": {
+              "rest.action.multi.allow_explicit_index": "true"
+            },
+            "DomainName": {
+              "Ref": "DomainName"
+            },
+            "ElasticsearchVersion": {
+              "Ref": "ElasticsearchVersion"
+            },
+            "ElasticsearchClusterConfig": {
+              "InstanceCount": "1",
+              "InstanceType": {
+                "Ref": "InstanceType"
+              }
+            }
+          }
+        }
+      },
+      "id": "30a2951c-f239-4686-a915-94d5085b6b08",
+      "file": "C:\\Users\\pedrom\\Desktop\\Data\\yaml\\yaml.yaml"
+    }
+  ]
+}

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive5.json
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive5.json
@@ -1,85 +1,79 @@
 {
-  "document": [
-    {
-      "AWSTemplateFormatVersion": "2010-09-09",
-      "Description": "ElasticsearchDomain resource",
-      "Parameters": {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "ElasticsearchDomain resource",
+  "Parameters": {
+    "DomainName": {
+      "Description": "User defined Elasticsearch Domain name",
+      "Type": "String"
+    },
+    "ElasticsearchVersion": {
+      "Description": "User defined Elasticsearch Version",
+      "Type": "String"
+    },
+    "InstanceType": {
+      "Type": "String"
+    },
+    "AvailabilityZone": {
+      "Type": "String"
+    },
+    "CidrBlock": {
+      "Type": "String"
+    },
+    "GroupDescription": {
+      "Type": "String"
+    },
+    "SGName": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "ElasticsearchDomain": {
+      "Type": "AWS::Elasticsearch::Domain",
+      "Properties": {
         "DomainName": {
-          "Description": "User defined Elasticsearch Domain name",
-          "Type": "String"
+          "Ref": "DomainName"
         },
         "ElasticsearchVersion": {
-          "Description": "User defined Elasticsearch Version",
-          "Type": "String"
+          "Ref": "ElasticsearchVersion"
         },
-        "InstanceType": {
-          "Type": "String"
+        "ElasticsearchClusterConfig": {
+          "InstanceCount": "1",
+          "InstanceType": {
+            "Ref": "InstanceType"
+          }
         },
-        "AvailabilityZone": {
-          "Type": "String"
+        "EBSOptions": {
+          "Iops": 0,
+          "VolumeSize": 10,
+          "VolumeType": "standard",
+          "EBSEnabled": "true"
         },
-        "CidrBlock": {
-          "Type": "String"
+        "SnapshotOptions": {
+          "AutomatedSnapshotStartHour": "0"
         },
-        "GroupDescription": {
-          "Type": "String"
-        },
-        "SGName": {
-          "Type": "String"
-        }
-      },
-      "Resources": {
-        "ElasticsearchDomain": {
-          "Type": "AWS::Elasticsearch::Domain",
-          "Properties": {
-            "EBSOptions": {
-              "EBSEnabled": "true",
-              "Iops": 0,
-              "VolumeSize": 10,
-              "VolumeType": "standard"
-            },
-            "SnapshotOptions": {
-              "AutomatedSnapshotStartHour": "0"
-            },
-            "AccessPolicies": {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Effect": "Deny",
-                  "Principal": {
-                    "AWS": "*"
-                  },
-                  "Action": "es:*",
-                  "Resource": "*"
-                }
-              ]
-            },
-            "LogPublishingOptions": {
-              "ES_APPLICATION_LOGS": {
-                "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs",
-                "Enabled": "true"
-              }
-            },
-            "AdvancedOptions": {
-              "rest.action.multi.allow_explicit_index": "true"
-            },
-            "DomainName": {
-              "Ref": "DomainName"
-            },
-            "ElasticsearchVersion": {
-              "Ref": "ElasticsearchVersion"
-            },
-            "ElasticsearchClusterConfig": {
-              "InstanceCount": "1",
-              "InstanceType": {
-                "Ref": "InstanceType"
+        "AccessPolicies": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "es:*",
+              "Resource": "*",
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
               }
             }
+          ]
+        },
+        "LogPublishingOptions": {
+          "ES_APPLICATION_LOGS": {
+            "Enabled": "true",
+            "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs"
           }
+        },
+        "AdvancedOptions": {
+          "rest.action.multi.allow_explicit_index": "true"
         }
-      },
-      "id": "30a2951c-f239-4686-a915-94d5085b6b08",
-      "file": "C:\\Users\\pedrom\\Desktop\\Data\\yaml\\yaml.yaml"
+      }
     }
-  ]
+  }
 }

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive6.json
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive6.json
@@ -1,79 +1,73 @@
 {
-  "document": [
-    {
-      "Resources": {
-        "ElasticsearchDomain": {
-          "Type": "AWS::Elasticsearch::Domain",
-          "Properties": {
-            "ElasticsearchVersion": {
-              "Ref": "ElasticsearchVersion"
-            },
-            "ElasticsearchClusterConfig": {
-              "InstanceCount": "1",
-              "InstanceType": {
-                "Ref": "InstanceType"
-              }
-            },
-            "EBSOptions": {
-              "VolumeSize": 10,
-              "VolumeType": "standard",
-              "EBSEnabled": "true",
-              "Iops": 0
-            },
-            "SnapshotOptions": {
-              "AutomatedSnapshotStartHour": "0"
-            },
-            "AccessPolicies": {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Effect": "Deny",
-                  "Principal": {
-                    "AWS": "*"
-                  },
-                  "Action": "es:*",
-                  "Resource": "*"
-                }
-              ]
-            },
-            "AdvancedOptions": {
-              "rest.action.multi.allow_explicit_index": "true"
-            },
-            "DomainName": {
-              "Ref": "DomainName"
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "ElasticsearchDomain resource",
+  "Parameters": {
+    "DomainName": {
+      "Description": "User defined Elasticsearch Domain name",
+      "Type": "String"
+    },
+    "ElasticsearchVersion": {
+      "Description": "User defined Elasticsearch Version",
+      "Type": "String"
+    },
+    "InstanceType": {
+      "Type": "String"
+    },
+    "AvailabilityZone": {
+      "Type": "String"
+    },
+    "CidrBlock": {
+      "Type": "String"
+    },
+    "GroupDescription": {
+      "Type": "String"
+    },
+    "SGName": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "ElasticsearchDomain": {
+      "Type": "AWS::Elasticsearch::Domain",
+      "Properties": {
+        "EBSOptions": {
+          "EBSEnabled": "true",
+          "Iops": 0,
+          "VolumeSize": 10,
+          "VolumeType": "standard"
+        },
+        "SnapshotOptions": {
+          "AutomatedSnapshotStartHour": "0"
+        },
+        "AccessPolicies": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Action": "es:*",
+              "Resource": "*"
             }
-          }
-        }
-      },
-      "id": "7db6a2f8-2f3a-40d1-b150-eb6b5faccabf",
-      "file": "C:\\Users\\pedrom\\Desktop\\Data\\yaml\\yaml.yaml",
-      "AWSTemplateFormatVersion": "2010-09-09",
-      "Description": "ElasticsearchDomain resource",
-      "Parameters": {
-        "AvailabilityZone": {
-          "Type": "String"
+          ]
         },
-        "CidrBlock": {
-          "Type": "String"
-        },
-        "GroupDescription": {
-          "Type": "String"
-        },
-        "SGName": {
-          "Type": "String"
+        "AdvancedOptions": {
+          "rest.action.multi.allow_explicit_index": "true"
         },
         "DomainName": {
-          "Description": "User defined Elasticsearch Domain name",
-          "Type": "String"
+          "Ref": "DomainName"
         },
         "ElasticsearchVersion": {
-          "Description": "User defined Elasticsearch Version",
-          "Type": "String"
+          "Ref": "ElasticsearchVersion"
         },
-        "InstanceType": {
-          "Type": "String"
+        "ElasticsearchClusterConfig": {
+          "InstanceCount": "1",
+          "InstanceType": {
+            "Ref": "InstanceType"
+          }
         }
       }
     }
-  ]
+  }
 }

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive6.json
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive6.json
@@ -1,0 +1,79 @@
+{
+  "document": [
+    {
+      "Resources": {
+        "ElasticsearchDomain": {
+          "Type": "AWS::Elasticsearch::Domain",
+          "Properties": {
+            "ElasticsearchVersion": {
+              "Ref": "ElasticsearchVersion"
+            },
+            "ElasticsearchClusterConfig": {
+              "InstanceCount": "1",
+              "InstanceType": {
+                "Ref": "InstanceType"
+              }
+            },
+            "EBSOptions": {
+              "VolumeSize": 10,
+              "VolumeType": "standard",
+              "EBSEnabled": "true",
+              "Iops": 0
+            },
+            "SnapshotOptions": {
+              "AutomatedSnapshotStartHour": "0"
+            },
+            "AccessPolicies": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Deny",
+                  "Principal": {
+                    "AWS": "*"
+                  },
+                  "Action": "es:*",
+                  "Resource": "*"
+                }
+              ]
+            },
+            "AdvancedOptions": {
+              "rest.action.multi.allow_explicit_index": "true"
+            },
+            "DomainName": {
+              "Ref": "DomainName"
+            }
+          }
+        }
+      },
+      "id": "7db6a2f8-2f3a-40d1-b150-eb6b5faccabf",
+      "file": "C:\\Users\\pedrom\\Desktop\\Data\\yaml\\yaml.yaml",
+      "AWSTemplateFormatVersion": "2010-09-09",
+      "Description": "ElasticsearchDomain resource",
+      "Parameters": {
+        "AvailabilityZone": {
+          "Type": "String"
+        },
+        "CidrBlock": {
+          "Type": "String"
+        },
+        "GroupDescription": {
+          "Type": "String"
+        },
+        "SGName": {
+          "Type": "String"
+        },
+        "DomainName": {
+          "Description": "User defined Elasticsearch Domain name",
+          "Type": "String"
+        },
+        "ElasticsearchVersion": {
+          "Description": "User defined Elasticsearch Version",
+          "Type": "String"
+        },
+        "InstanceType": {
+          "Type": "String"
+        }
+      }
+    }
+  ]
+}

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+  {
+    "queryName": "ElasticSearch Without Slow Logs",
+    "severity": "MEDIUM",
+    "line": 48,
+    "fileName": "positive2.yaml"
+  },
+  {
+    "queryName": "ElasticSearch Without Slow Logs",
+    "severity": "MEDIUM",
+    "line": 51,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "ElasticSearch Without Slow Logs",
+    "severity": "MEDIUM",
+    "line": 23,
+    "fileName": "positive3.yaml"
+  }
+]

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/test/positive_expected_result.json
@@ -16,5 +16,23 @@
     "severity": "MEDIUM",
     "line": 23,
     "fileName": "positive3.yaml"
+  },
+  {
+    "line": 32,
+    "fileName": "positive6.json",
+    "queryName": "ElasticSearch Without Slow Logs",
+    "severity": "MEDIUM"
+  },
+  {
+    "line": 68,
+    "fileName": "positive5.json",
+    "queryName": "ElasticSearch Without Slow Logs",
+    "severity": "MEDIUM"
+  },
+  {
+    "line": 44,
+    "fileName": "positive4.json",
+    "queryName": "ElasticSearch Without Slow Logs",
+    "severity": "MEDIUM"
   }
 ]


### PR DESCRIPTION
Closes #2312

Ensure that AWS Elasticsearch enables support for slow logs.
