### PR TITLE
Update IAM User LoginProfile Password Is In Plaintext query for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/iam_user_login_profile_password_is_in_plaintext/query.rego
+++ b/assets/queries/cloudFormation/iam_user_login_profile_password_is_in_plaintext/query.rego
@@ -16,4 +16,5 @@ CxPolicy[result] {
 
 checkPass(pass) {
 	is_string(pass)
+    not contains(pass, "secretsmanager")
 }


### PR DESCRIPTION
Closes #2314

**Proposed Changes**

- Adding additional verification to confirm that value being looked at isn't a SecretsManager reference.

I submit this contribution under Apache-2.0 license.
