### PR TITLE
Update ELB With Security Group Without Inbound Rules query for AWS CloudFormation

### DIFF
--- a/assets/queries/cloudFormation/elb_with_security_group_without_inbound_rules/query.rego
+++ b/assets/queries/cloudFormation/elb_with_security_group_without_inbound_rules/query.rego
@@ -38,3 +38,13 @@ withoutOutboundRules(securityGroupName) = result {
 	securityGroup.Properties.SecurityGroupIngress == []
 	result := {"expected": "not empty", "actual": "empty", "path": ".SecurityGroupIngress", "issue": "IncorrectValue"}
 }
+
+withoutOutboundRules(securityGroupName) = result {
+    some j
+        resource := input.document[i].Resources[j]
+        resource.Type == "AWS::EC2::SecurityGroupIngress"
+        groupId := resource.Properties.GroupId
+        id := replace(groupId, "!Ref ", "")
+        not id == securityGroupName
+    result := {"expected": "defined", "actual": "undefined", "path": "", "issue": "MissingAttribute"}
+}


### PR DESCRIPTION
Closes #2316

**Proposed Changes**

- Adding a verification for when the `SecurityGroupIngress` is defined out of the `SecurityGroup` resource.

I submit this contribution under Apache-2.0 license.
