### PR TITLE
Add "API Gateway V2 Stage Access Logging Settings Not Defined" query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/metadata.json
+++ b/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "9111f9a5-6b80-40f9-bc82-c05f970779c3",
+  "queryName": "API Gateway V2 Stage Access Logging Settings Not Defined",
+  "severity": "MEDIUM",
+  "category": "Observability",
+  "descriptionText": "API Gateway V2 Stage should have Access Logging Settings defined.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_stage",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document[i]
+	resource = document.resource.aws_apigatewayv2_stage[name]
+
+	not resource.access_log_settings
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("aws_apigatewayv2_stage[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_apigatewayv2_stage[%s].access_log_settings is defined", [name]),
+		"keyActualValue": sprintf("aws_apigatewayv2_stage[%s].access_log_settings is not defined", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/query.rego
@@ -4,7 +4,7 @@ CxPolicy[result] {
 	document := input.document[i]
 	resource = document.resource.aws_apigatewayv2_stage[name]
 
-	not resource.access_log_settings
+	object.get(resource, "access_log_settings", "undefined") == "undefined"
 
 	result := {
 		"documentId": document.id,

--- a/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/test/negative.tf
+++ b/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/test/negative.tf
@@ -1,0 +1,21 @@
+resource "aws_apigatewayv2_stage" "negative1" {
+  api_id = aws_apigatewayv2_api.example.id
+  name   = "example-stage"
+  description = "example description"
+  auto_deploy = true
+  access_log_settings = {
+    destination_arn = aws_cloudwatch_log_group.api_logs.arn
+    format = jsonencode(
+      {
+        httpMethod     = "$context.httpMethod"
+        ip             = "$context.identity.sourceIp"
+        protocol       = "$context.protocol"
+        requestId      = "$context.requestId"
+        requestTime    = "$context.requestTime"
+        responseLength = "$context.responseLength"
+        routeKey       = "$context.routeKey"
+        status         = "$context.status"
+      }
+    )
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/test/positive.tf
+++ b/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/test/positive.tf
@@ -1,0 +1,6 @@
+resource "aws_apigatewayv2_stage" "positive1" {
+  api_id = aws_apigatewayv2_api.example.id
+  name   = "example-stage-positive"
+  description = "example description"
+  auto_deploy = true
+}

--- a/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_v2_stage_access_logging_settings_not_defined/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "API Gateway V2 Stage Access Logging Settings Not Defined",
+    "severity": "MEDIUM",
+    "line": 1
+  }
+]


### PR DESCRIPTION
Closes #2318
**Proposed Changes**

- Add support for query  "API Gateway V2 Stage Access Logging Settings Not Defined"
- The query checks if the object `access_log_settings` is defined

I submit this contribution under Apache-2.0 license.
