### PR TITLE
Add query to check if EFS doesn't have KMS. Closes #2330

### DIFF
--- a/assets/queries/ansible/aws/efs_without_kms/metadata.json
+++ b/assets/queries/ansible/aws/efs_without_kms/metadata.json
@@ -1,0 +1,9 @@
+{
+	"id": "bd77554e-f138-40c5-91b2-2a09f878608e",
+	"queryName": "EFS Without KMS",
+	"severity": "HIGH",
+	"category": "Secret Management",
+	"descriptionText": "Elastic File System (EFS) must have KMS Key ID",
+	"descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/efs_module.html#parameter-kms_key_id",
+	"platform": "Ansible"
+}

--- a/assets/queries/ansible/aws/efs_without_kms/query.rego
+++ b/assets/queries/ansible/aws/efs_without_kms/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.ansible as ansLib
+
+modules := {"community.aws.efs", "efs"}
+
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	efs := task[modules[m]]
+	ansLib.checkState(efs)
+
+	object.get(efs, "kms_key_id", "undefined") == "undefined"
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "efs.kms_key_id is set",
+		"keyActualValue": "efs.kms_key_id is undefined",
+	}
+}

--- a/assets/queries/ansible/aws/efs_without_kms/test/negative.yaml
+++ b/assets/queries/ansible/aws/efs_without_kms/test/negative.yaml
@@ -1,0 +1,12 @@
+- name: foo
+  community.aws.efs:
+    state: present
+    name: myTestEFS
+    encrypt: yes
+    tags:
+      Name: myTestNameTag
+      purpose: file-storage
+    targets:
+    - subnet_id: subnet-748c5d03
+      security_groups: [sg-1a2b3c4d]
+    kms_key_id: "some-key-id"

--- a/assets/queries/ansible/aws/efs_without_kms/test/positive.yaml
+++ b/assets/queries/ansible/aws/efs_without_kms/test/positive.yaml
@@ -1,0 +1,12 @@
+---
+- name: foo
+  community.aws.efs:
+    state: present
+    name: myTestEFS
+    encrypt: no
+    tags:
+      Name: myTestNameTag
+      purpose: file-storage
+    targets:
+      - subnet_id: subnet-748c5d03
+        security_groups: ["sg-1a2b3c4d"]

--- a/assets/queries/ansible/aws/efs_without_kms/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/efs_without_kms/test/positive_expected_result.json
@@ -2,6 +2,6 @@
 	{
 		"queryName": "EFS Without KMS",
 		"severity": "HIGH",
-		"line": 1
+		"line": 3
 	}
 ]

--- a/assets/queries/cloudFormation/efs_not_encrypted_with_kms_cmk/metadata.json
+++ b/assets/queries/cloudFormation/efs_not_encrypted_with_kms_cmk/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "6d087495-2a42-4735-abf7-02ef5660a7e6",
-  "queryName": "EFS Not Encrypted With KMS CMK",
+  "queryName": "EFS Without KMS",
   "severity": "HIGH",
   "category": "Encryption",
   "descriptionText": "Amazon Elastic Filesystem should have filesystem encryption enabled using KMS CMK customer-managed keys instead of AWS managed-keys",

--- a/assets/queries/cloudFormation/efs_not_encrypted_with_kms_cmk/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/efs_not_encrypted_with_kms_cmk/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
   {
-    "queryName": "EFS Not Encrypted With KMS CMK",
+    "queryName": "EFS Without KMS",
     "severity": "HIGH",
     "line": 82,
     "fileName": "positive1.yaml"
   },
   {
-    "queryName": "EFS Not Encrypted With KMS CMK",
+    "queryName": "EFS Without KMS",
     "severity": "HIGH",
     "line": 157,
     "fileName": "positive2.json"

--- a/assets/queries/terraform/aws/efs_without_kms_key_id/metadata.json
+++ b/assets/queries/terraform/aws/efs_without_kms_key_id/metadata.json
@@ -1,6 +1,6 @@
 {
 	"id": "25d251f3-f348-4f95-845c-1090e41a615c",
-	"queryName": "EFS Without KMS Key ID",
+	"queryName": "EFS Without KMS",
 	"severity": "HIGH",
 	"category": "Secret Management",
 	"descriptionText": "Elastic File System (EFS) must have KMS Key ID",


### PR DESCRIPTION
Closes #2330 

**Proposed Changes**
- Add a query to check if AWS EFS has KMS enabled through the key ID, in Ansible.
-Besides adding the query, updates the query name in Terraform and CloudFormation to the unified name.

I submit this contribution under Apache-2.0 license.
