### PR TITLE
Update "IAM Password Without" queries for AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/iam_password_without_lowercase_letter/query.rego
+++ b/assets/queries/cloudFormation/iam_password_without_lowercase_letter/query.rego
@@ -4,6 +4,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	password := resource.Properties.LoginProfile.Password
 	is_string(password)
+    not contains(lower(password), "secretsmanager")
 	not regex.match(".*[a-z]", password)
 
 	result := {

--- a/assets/queries/cloudFormation/iam_password_without_minimum_length/query.rego
+++ b/assets/queries/cloudFormation/iam_password_without_minimum_length/query.rego
@@ -4,6 +4,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	password := resource.Properties.LoginProfile.Password
 	is_string(password)
+    not contains(lower(password), "secretsmanager")
 	count(password) < 14
 
 	result := {

--- a/assets/queries/cloudFormation/iam_password_without_number/query.rego
+++ b/assets/queries/cloudFormation/iam_password_without_number/query.rego
@@ -4,6 +4,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	password := resource.Properties.LoginProfile.Password
 	is_string(password)
+    not contains(lower(password), "secretsmanager")
 	not regex.match(".*\\d", password)
 
 	result := {

--- a/assets/queries/cloudFormation/iam_password_without_symbol/query.rego
+++ b/assets/queries/cloudFormation/iam_password_without_symbol/query.rego
@@ -4,6 +4,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	password := resource.Properties.LoginProfile.Password
 	is_string(password)
+    not contains(lower(password), "secretsmanager")
 	not regex.match(".*[-+_!@#$%^&*.,?]", password)
 
 	result := {

--- a/assets/queries/cloudFormation/iam_password_without_uppercase_letter/query.rego
+++ b/assets/queries/cloudFormation/iam_password_without_uppercase_letter/query.rego
@@ -4,6 +4,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	password := resource.Properties.LoginProfile.Password
 	is_string(password)
+    not contains(lower(password), "secretsmanager")
 	not regex.match(".*[A-Z]", password)
 
 	result := {


### PR DESCRIPTION
Closes #2334

**Proposed Changes**

- Adding a check, as to ignore if value references SecretsManager.

I submit this contribution under Apache-2.0 license.
