### PR TITLE
Add "API Gateway Stage Without API Gateway UsagePlan Associated" query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/metadata.json
+++ b/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "c999cf62-0920-40f8-8dda-0caccd66ed7e",
+  "queryName": "API Gateway Stage Without API Gateway UsagePlan Associated",
+  "severity": "LOW",
+  "category": "Resource Management",
+  "descriptionText": "API Gateway Stage should have API Gateway UsagePlan defined and associated.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_stage",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/query.rego
@@ -1,0 +1,26 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document[i]
+	stage = document.resource.aws_api_gateway_stage[name]
+
+	not settings_are_equal(document.resource, stage.rest_api_id, stage.stage_name)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_api_gateway_stage[%s]", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_api_gateway_stage[%s] has a 'aws_api_gateway_usage_plan' resource associated. ", [name]),
+		"keyActualValue": sprintf("aws_api_gateway_stage[%s] doesn't have a 'aws_api_gateway_usage_plan' resource associated.", [name]),
+	}
+}
+
+check_resources(resource) {
+	resource.aws_api_gateway_usage_plan[_]
+}
+
+settings_are_equal(resource, rest_api_id, stage_name) {
+	usage_plan := resource.aws_api_gateway_usage_plan[_]
+	usage_plan.api_stages.api_id == rest_api_id
+	usage_plan.api_stages.stage == stage_name
+}

--- a/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/negative.tf
+++ b/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/negative.tf
@@ -1,0 +1,16 @@
+resource "aws_api_gateway_stage" "negative1" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "development"
+}
+
+resource "aws_api_gateway_usage_plan" "negative2" {
+  name         = "my-usage-plan"
+  description  = "my description"
+  product_code = "MYCODE"
+
+  api_stages {
+    api_id = aws_api_gateway_rest_api.example.id
+    stage  = "development"
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/negative.tf
+++ b/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/negative.tf
@@ -1,6 +1,6 @@
 resource "aws_api_gateway_stage" "negative1" {
-  deployment_id = aws_api_gateway_deployment.example.id
-  rest_api_id   = aws_api_gateway_rest_api.example.id
+  deployment_id = "some deployment id"
+  rest_api_id   = "rest_api_1"
   stage_name    = "development"
 }
 
@@ -10,7 +10,7 @@ resource "aws_api_gateway_usage_plan" "negative2" {
   product_code = "MYCODE"
 
   api_stages {
-    api_id = aws_api_gateway_rest_api.example.id
+    api_id = "rest_api_1"
     stage  = "development"
   }
 }

--- a/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/positive.tf
+++ b/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/positive.tf
@@ -1,0 +1,25 @@
+resource "aws_api_gateway_stage" "positive1" {
+  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
+  deployment_id = "${aws_api_gateway_deployment.test.id}"
+  stage_name = "some name"
+  tags {
+    project = "ProjectName"
+  }
+}
+
+resource "aws_api_gateway_stage" "positive2" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "development"
+}
+
+resource "aws_api_gateway_usage_plan" "positive3" {
+  name         = "my-usage-plan"
+  description  = "my description"
+  product_code = "MYCODE"
+
+  api_stages {
+    api_id = aws_api_gateway_rest_api.somename.id
+    stage  = "development"
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/positive.tf
+++ b/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/positive.tf
@@ -1,6 +1,6 @@
 resource "aws_api_gateway_stage" "positive1" {
-  rest_api_id   = "${aws_api_gateway_rest_api.test.id}"
-  deployment_id = "${aws_api_gateway_deployment.test.id}"
+  rest_api_id   = "some deployment id"
+  deployment_id = "some rest api id"
   stage_name = "some name"
   tags {
     project = "ProjectName"

--- a/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/positive.tf
+++ b/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/positive.tf
@@ -8,8 +8,8 @@ resource "aws_api_gateway_stage" "positive1" {
 }
 
 resource "aws_api_gateway_stage" "positive2" {
-  deployment_id = aws_api_gateway_deployment.example.id
-  rest_api_id   = aws_api_gateway_rest_api.example.id
+  deployment_id = "some deployment id"
+  rest_api_id   = "some rest api id"
   stage_name    = "development"
 }
 
@@ -19,7 +19,7 @@ resource "aws_api_gateway_usage_plan" "positive3" {
   product_code = "MYCODE"
 
   api_stages {
-    api_id = aws_api_gateway_rest_api.somename.id
+    api_id = "another id"
     stage  = "development"
   }
 }

--- a/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_stage_without_api_gateway_usage_plan_associated/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "API Gateway Stage Without API Gateway UsagePlan Associated",
+    "severity": "LOW",
+    "line": 1
+  },
+  {
+    "queryName": "API Gateway Stage Without API Gateway UsagePlan Associated",
+    "severity": "LOW",
+    "line": 10
+  }
+]


### PR DESCRIPTION
Closes #2340

**Proposed Changes**

- Add support for query "API Gateway Stage Without API Gateway UsagePlan Associated".
- The query checks if there's an API Gateway UsagePlan resource that references an API Gateway Stage, through attributes `stage` and `api_id`, that should be same as `stage_name` and `rest_api_id`.

I submit this contribution under Apache-2.0 license.
