### PR TITLE
Add "IAM Role Allows All Principals To Assume" query for CloudFormation Closes #2351

### DIFF
--- a/assets/libraries/common/library.rego
+++ b/assets/libraries/common/library.rego
@@ -241,3 +241,17 @@ isCommonKey(p) {
 	black := bl[_]
 	contains(lower(p), black)
 }
+
+allowsAllPrincipalsToAssume(resource, statement) {
+	is_string(resource) == true
+	contains(resource, "arn:aws:iam::")
+	contains(resource, ":root")
+	not contains(statement.Effect, "Deny")
+}
+
+allowsAllPrincipalsToAssume(resource, statement) {
+	is_array(resource) == true
+	contains(resource[x], "arn:aws:iam::")
+	contains(resource[x], ":root")
+	not contains(statement.Effect, "Deny")
+}

--- a/assets/libraries/common/library.rego
+++ b/assets/libraries/common/library.rego
@@ -242,6 +242,7 @@ isCommonKey(p) {
 	contains(lower(p), black)
 }
 
+# verifies if the resource(statement.Principal.AWS) contains an ARN that points to a specific IAM user
 allowsAllPrincipalsToAssume(resource, statement) {
 	is_string(resource) == true
 	contains(resource, "arn:aws:iam::")

--- a/assets/queries/ansible/aws/iam_role_allows_all_principals_to_assume/query.rego
+++ b/assets/queries/ansible/aws/iam_role_allows_all_principals_to_assume/query.rego
@@ -12,10 +12,9 @@ CxPolicy[result] {
 
 	policy := commonLib.json_unmarshal(awsApiGateway.policy)
 	statement := policy.Statement[_]
-	resource := statement.Principal.AWS
-	contains(resource, "arn:aws:iam::")
-	contains(resource, ":root")
-	not contains(statement.Effect, "Deny")
+	aws := statement.Principal.AWS
+
+	commonLib.allowsAllPrincipalsToAssume(aws, statement)
 
 	result := {
 		"documentId": id,
@@ -32,10 +31,9 @@ CxPolicy[result] {
 	ansLib.checkState(awsApiGateway)
 
 	statement := awsApiGateway.policy.Statement[_]
-	resource := statement.Principal[j].AWS
-	contains(resource, "arn:aws:iam::")
-	contains(resource, ":root")
-	not contains(statement.Effect, "Deny")
+	aws := statement.Principal[j].AWS
+
+	commonLib.allowsAllPrincipalsToAssume(aws, statement)
 
 	result := {
 		"documentId": id,

--- a/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/metadata.json
+++ b/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "f80e3aa7-7b34-4185-954e-440a6894dde6",
+  "queryName": "IAM Role Allows All Principals To Assume",
+  "severity": "LOW",
+  "category": "Access Control",
+  "descriptionText": "IAM role allows all services or principals to assume it",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-assumerolepolicydocument",
+  "platform": "CloudFormation"
+}

--- a/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/query.rego
+++ b/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+import data.generic.common as commonLib
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[Name]
+	resource.Type == "AWS::IAM::Role"
+
+	out := commonLib.json_unmarshal(resource.Properties.AssumeRolePolicyDocument)
+	aws := out.Statement[_].Principal.AWS
+
+	commonLib.allowsAllPrincipalsToAssume(aws, out.Statement[_])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement.Principal.AWS", [Name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement.Principal.AWS does not contain ':root'", [Name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement.Principal.AWS contains ':root'", [Name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[Name]
+	resource.Type == "AWS::IAM::Role"
+
+	statement := resource.Properties.AssumeRolePolicyDocument.Statement[_]
+	aws := statement.Principal.AWS
+
+	commonLib.allowsAllPrincipalsToAssume(aws, statement)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement.Principal.AWS", [Name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement.Principal.AWS does not contain ':root'", [Name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.AssumeRolePolicyDocument.Statement.Principal.AWS contains ':root'", [Name]),
+	}
+}

--- a/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/negative1.yaml
+++ b/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/negative1.yaml
@@ -3,18 +3,17 @@ Resources:
   RootRole:
     Type: "AWS::IAM::Role"
     Properties:
-      AssumeRolePolicyDocument: <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
+      AssumeRolePolicyDocument: >
         {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "AWS": "arn:aws:iam::root"
-            },
-            "Effect": "Deny",
-            "Sid": ""
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "AWS": "arn:aws:iam::root"
+                    },
+                    "Effect": "Deny",
+                    "Sid": ""
+                }
+            ]
         }
-    ]
-}
-EOF

--- a/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/negative1.yaml
+++ b/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/negative1.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  RootRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument: <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "AWS": "arn:aws:iam::root"
+            },
+            "Effect": "Deny",
+            "Sid": ""
+        }
+    ]
+}
+EOF

--- a/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/negative2.json
+++ b/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/negative2.json
@@ -1,0 +1,27 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "RootRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Deny",
+              "Principal": {
+                "AWS": [
+                  "arn:aws:iam::root"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Path": "/"
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/positive1.yaml
+++ b/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/positive1.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  RootRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument: >
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "AWS": "arn:aws:iam::root"
+                    },
+                    "Effect": "Allow",
+                    "Sid": ""
+                }
+            ]
+        }

--- a/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/positive2.json
+++ b/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/positive2.json
@@ -1,0 +1,27 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "RootRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": [
+                  "arn:aws:iam::root"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Path": "/"
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/iam_role_allows_all_principals_to_assume/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "IAM Role Allows All Principals To Assume",
+    "severity": "LOW",
+    "line": 13,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "IAM Role Allows All Principals To Assume",
+    "severity": "LOW",
+    "line": 13,
+    "fileName": "positive2.json"
+  }
+]

--- a/assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/query.rego
+++ b/assets/queries/terraform/aws/iam_role_allows_all_principals_to_assume/query.rego
@@ -1,18 +1,20 @@
 package Cx
 
+import data.generic.common as commonLib
+
 CxPolicy[result] {
 	policy := input.document[i].resource.aws_iam_role[name].assume_role_policy
-	re_match("arn:aws:iam::", policy)
-	out := json.unmarshal(policy)
+
+	out := commonLib.json_unmarshal(policy)
 	aws := out.Statement[idx].Principal.AWS
-	contains(aws, "arn:aws:iam::")
-	contains(aws, ":root")
+
+	commonLib.allowsAllPrincipalsToAssume(aws, out.Statement[idx])
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_iam_role[%s].assume_role_policy.Principal.AWS", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'assume_role_policy.Statement.Principal.AWS' contain ':root'",
+		"keyExpectedValue": "'assume_role_policy.Statement.Principal.AWS' does not contain ':root'",
 		"keyActualValue": "'assume_role_policy.Statement.Principal.AWS' contains ':root'",
 	}
 }


### PR DESCRIPTION
Closes #2351

**Proposed Changes**

- Support "IAM Role Allows All Principals To Assume" query for CloudFormation (same as "IAM Role Allows All Principals To Assume" for Terraform and Ansible). It is necessary to check if IAM role denies "arn:aws:iam::root" principal.
- Add "allowsAllPrincipalsToAssume" to common library

I submit this contribution under Apache-2.0 license.
