### PR TITLE
Add "PSP With Added Capabilities" query for Terraform Closes #2355

### DIFF
--- a/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "48388bd2-7201-4dcc-b56d-e8a9efa58fad",
+  "queryName": "PSP With Added Capabilities",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "PodSecurityPolicy should not have added capabilities",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod_security_policy#allowed_capabilities",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod_security_policy[name]
+
+	resource.spec.allowed_capabilities
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec.allowed_capabilities", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Pod Security Policy %s does not have allowed capabilities", [name]),
+		"keyActualValue": sprintf("Pod Security Policy %s has allowed capabilities", [name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/test/negative.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_pod_security_policy" "example" {
+resource "kubernetes_pod_security_policy" "example2" {
   metadata {
     name = "terraform-example"
   }

--- a/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/test/negative.tf
@@ -1,0 +1,44 @@
+resource "kubernetes_pod_security_policy" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+    allow_privilege_escalation = false
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/test/positive.tf
@@ -1,0 +1,45 @@
+resource "kubernetes_pod_security_policy" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    allowed_capabilities = ["NET_BIND_SERVICE"]
+    privileged                 = false
+    allow_privilege_escalation = false
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/psp_with_added_capabilities/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "PSP With Added Capabilities",
+    "severity": "MEDIUM",
+    "line": 6
+  }
+]


### PR DESCRIPTION
Closes #2355

**Proposed Changes**

- Support "PSP With Added Capabilities" query for Terraform (same as "PSP With Added Capabilities" for Kubernetes). It is necessary to check if the attribute `allowed_capabilities` is set 

I submit this contribution under Apache-2.0 license.
