### PR TITLE
Add "API Gateway Without SSL Certificate" query for CloudFormation #2358

### DIFF
--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/metadata.json
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "ed4c48b8-eccc-4881-95c1-09fdae23db25",
+  "queryName": "API Gateway Without SSL Certificate",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "SSL Client Certificate should be enabled.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html",
+  "platform": "CloudFormation"
+}

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/metadata.json
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "API Gateway Without SSL Certificate",
   "severity": "MEDIUM",
   "category": "Networking and Firewall",
-  "descriptionText": "SSL Client Certificate should be enabled.",
+  "descriptionText": "SSL Client Certificate should be enabled",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html",
   "platform": "CloudFormation"
 }

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document
+	resource = document[i].Resources[name]
+	resource.Type == "AWS::ApiGateway::Stage"
+
+	properties := resource.Properties
+	object.get(properties, "ClientCertificateId", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("Resources.%s.Properties has ClientCertificateId defined", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties doesn't have ClientCertificateId defined", [name]),
+	}
+}

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/negative1.yaml
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/negative1.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  ProdApiGatewayStage:
+  ProdApiGatewayStageNeg:
     Type: AWS::ApiGateway::Stage
     Properties:
       StageName: Prod

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/negative1.yaml
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/negative1.yaml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ProdApiGatewayStage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      StageName: Prod
+      Description: Prod Stage
+      RestApiId: !Ref MyRestApi
+      DeploymentId: !Ref TestDeployment
+      DocumentationVersion: !Ref MyDocumentationVersion
+      ClientCertificateId: !Ref ClientCertificate
+      Variables:
+        Stack: Prod
+      MethodSettings:
+        - ResourcePath: /
+          HttpMethod: GET
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+        - ResourcePath: /stack
+          HttpMethod: POST
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+          ThrottlingBurstLimit: '999'
+        - ResourcePath: /stack
+          HttpMethod: GET
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+          ThrottlingBurstLimit: '555'
+

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/negative2.json
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/negative2.json
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Resources": {
-    "ProdApiGatewayStage": {
+    "ProdApiGatewayStageNeg": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "StageName": "Prod",

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/negative2.json
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/negative2.json
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Resources": {
-    "ProdApiGatewayStageNeg": {
+    "ProdApiGatewayStageNeg2": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "StageName": "Prod",

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/negative2.json
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/negative2.json
@@ -1,0 +1,48 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "ProdApiGatewayStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "StageName": "Prod",
+        "RestApiId": {
+          "Ref": "MyRestApi"
+        },
+        "DeploymentId": {
+          "Ref": "TestDeployment"
+        },
+        "DocumentationVersion": {
+          "Ref": "MyDocumentationVersion"
+        },
+        "ClientCertificateId": {
+          "Ref": "ClientCertificate"
+        },
+        "Variables": {
+          "Stack": "Prod"
+        },
+        "MethodSettings": [
+          {
+            "ResourcePath": "/",
+            "HttpMethod": "GET",
+            "MetricsEnabled": "true",
+            "DataTraceEnabled": "false"
+          },
+          {
+            "ResourcePath": "/stack",
+            "HttpMethod": "POST",
+            "MetricsEnabled": "true",
+            "DataTraceEnabled": "false",
+            "ThrottlingBurstLimit": "999"
+          },
+          {
+            "ResourcePath": "/stack",
+            "HttpMethod": "GET",
+            "MetricsEnabled": "true",
+            "DataTraceEnabled": "false",
+            "ThrottlingBurstLimit": "555"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive1.yaml
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive1.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  ProdApiGatewayStage:
+  ProdApiGatewayStagePos:
     Type: AWS::ApiGateway::Stage
     Properties:
       StageName: Prod

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive1.yaml
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive1.yaml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  ProdApiGatewayStage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      StageName: Prod
+      Description: Prod Stage
+      RestApiId: !Ref MyRestApi
+      DeploymentId: !Ref TestDeployment
+      DocumentationVersion: !Ref MyDocumentationVersion
+      Variables:
+        Stack: Prod
+      MethodSettings:
+        - ResourcePath: /
+          HttpMethod: GET
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+        - ResourcePath: /stack
+          HttpMethod: POST
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+          ThrottlingBurstLimit: '999'
+        - ResourcePath: /stack
+          HttpMethod: GET
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+          ThrottlingBurstLimit: '555'
+

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive2.json
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive2.json
@@ -1,0 +1,39 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "ProdApiGatewayStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "MethodSettings": [
+          {
+            "DataTraceEnabled": "false",
+            "ResourcePath": "/",
+            "HttpMethod": "GET",
+            "MetricsEnabled": "true"
+          },
+          {
+            "ResourcePath": "/stack",
+            "HttpMethod": "POST",
+            "MetricsEnabled": "true",
+            "DataTraceEnabled": "false",
+            "ThrottlingBurstLimit": "999"
+          },
+          {
+            "MetricsEnabled": "true",
+            "DataTraceEnabled": "false",
+            "ThrottlingBurstLimit": "555",
+            "ResourcePath": "/stack",
+            "HttpMethod": "GET"
+          }
+        ],
+        "StageName": "Prod",
+        "RestApiId": "MyRestApi",
+        "DeploymentId": "TestDeployment",
+        "DocumentationVersion": "MyDocumentationVersion",
+        "Variables": {
+          "Stack": "Prod"
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive2.json
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive2.json
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Resources": {
-    "ProdApiGatewayStage": {
+    "ProdApiGatewayStagePos": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "MethodSettings": [

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive2.json
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive2.json
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Resources": {
-    "ProdApiGatewayStagePos": {
+    "ProdApiGatewayStagePos2": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "MethodSettings": [

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "API Gateway Without SSL Certificate",
+    "severity": "MEDIUM",
+    "line": 5,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "API Gateway Without SSL Certificate",
+    "severity": "MEDIUM",
+    "line": 6,
+    "fileName": "positive2.json"
+  }
+]


### PR DESCRIPTION
Closes #2358 

Add query API Gateway Without SSL Certificate, that checks if SSL Client Certificate exists.

I submit this contribution under Apache-2.0 license.
