### PR TITLE
Add "PSP Allows Privilege Escalation" query for Terraform Closes #2360

### DIFF
--- a/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "2bff9906-4e9b-4f71-9346-8ebedfdf43ef",
+  "queryName": "PSP Allows Privilege Escalation",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "PodSecurityPolicy should not allow privilege escalation",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod_security_policy#allow_privilege_escalation",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod_security_policy[name]
+
+	object.get(resource.spec, "allow_privilege_escalation", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_pod_security_policy[%s].spec.allow_privilege_escalation is set", [name]),
+		"keyActualValue": sprintf("kubernetes_pod_security_policy[%s].spec.allow_privilege_escalation is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod_security_policy[name]
+
+	resource.spec.allow_privilege_escalation != false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec.allow_privilege_escalation", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_pod_security_policy[%s].spec.allow_privilege_escalation is set to false", [name]),
+		"keyActualValue": sprintf("kubernetes_pod_security_policy[%s].spec.allow_privilege_escalation is set to true", [name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/test/negative.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_pod_security_policy" "example" {
+resource "kubernetes_pod_security_policy" "example2" {
   metadata {
     name = "terraform-example"
   }

--- a/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/test/negative.tf
@@ -1,0 +1,44 @@
+resource "kubernetes_pod_security_policy" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+    allow_privilege_escalation = false
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/test/positive.tf
@@ -1,0 +1,89 @@
+resource "kubernetes_pod_security_policy" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+    allow_privilege_escalation = true
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}
+
+resource "kubernetes_pod_security_policy" "example2" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}
+

--- a/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/psp_allows_privilege_escalation/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "PSP Allows Privilege Escalation",
+    "severity": "MEDIUM",
+    "line": 7
+  },
+  {
+    "queryName": "PSP Allows Privilege Escalation",
+    "severity": "MEDIUM",
+    "line": 50
+  }
+]


### PR DESCRIPTION
Closes #2360

**Proposed Changes**

- Support "PSP Allows Privilege Escalation" query for Terraform (same as "PSP With Added Capabilities" for Kubernetes). It is necessary to check if the attribute `allow_privilege_escalation` is set to false. By default, is set to true

I submit this contribution under Apache-2.0 license.
