### PR TITLE
Close metadata file handlers #2367

### DIFF
--- a/pkg/engine/source/filesystem.go
+++ b/pkg/engine/source/filesystem.go
@@ -213,6 +213,7 @@ func ReadMetadata(queryDir string) map[string]interface{} {
 
 		return nil
 	}
+	defer f.Close()
 
 	var metadata map[string]interface{}
 	if err := json.NewDecoder(f).Decode(&metadata); err != nil {


### PR DESCRIPTION
Closes #2367

**Proposed Changes**

- Closing file handlers after reading metadata to avoid resource exaustion


I submit this contribution under Apache-2.0 license.
