### PR TITLE
Add query to check if database auth is enabled. Closes #2376

### DIFF
--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/metadata.json
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/metadata.json
@@ -1,0 +1,9 @@
+{
+	"id": "9fcd0a0a-9b6f-4670-a215-d94e6bf3f184",
+	"queryName": "IAM Database Auth Not Enabled",
+	"severity": "HIGH",
+	"category": "Encryption",
+	"descriptionText": "IAM Database Auth Enabled must be configured to true",
+	"descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-enableiamdatabaseauthentication",
+	"platform": "CloudFormation"
+}

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/query.rego
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/query.rego
@@ -1,0 +1,34 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document
+	resource = document[i].Resources[name]
+	resource.Type == "AWS::RDS::DBInstance"
+	properties := resource.Properties
+    object.get(properties, "EnableIAMDatabaseAuthentication", "undefined") != "undefined"
+	not properties.EnableIAMDatabaseAuthentication
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.EnableIAMDatabaseAuthentication", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.EnableIAMDatabaseAuthentication is true", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.EnableIAMDatabaseAuthentication is false", [name]),
+	}
+}
+
+CxPolicy[result] {
+	document := input.document
+	resource = document[i].Resources[name]
+	resource.Type == "AWS::RDS::DBInstance"
+	properties := resource.Properties
+	object.get(properties, "EnableIAMDatabaseAuthentication", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.EnableIAMDatabaseAuthentication is defined", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.EnableIAMDatabaseAuthentication is undefined", [name]),
+	}
+}

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/negative1.yaml
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/negative1.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: RDS Storage Encrypted
+Parameters:
+  SourceDBInstanceIdentifier:
+    Type: String
+  DBInstanceType:
+    Type: String
+  SourceRegion:
+    Type: String
+Resources:
+  MyDBSmall:
+    Type: "AWS::RDS::DBInstance"
+    Properties:
+      DBInstanceClass: !Ref DBInstanceType
+      SourceDBInstanceIdentifier: !Ref SourceDBInstanceIdentifier
+      SourceRegion: !Ref SourceRegion
+      DeletionProtection: false
+      KmsKeyId: !Ref MyKey
+      EnableIAMDatabaseAuthentication: true

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/negative2.json
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/negative2.json
@@ -1,0 +1,35 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "RDS Storage Encrypted",
+  "Parameters": {
+      "SourceDBInstanceIdentifier": {
+          "Type": "String"
+      },
+      "DBInstanceType": {
+          "Type": "String"
+      },
+      "SourceRegion": {
+          "Type": "String"
+      }
+  },
+  "Resources": {
+      "MyDBSmall": {
+          "Type": "AWS::RDS::DBInstance",
+          "Properties": {
+              "DBInstanceClass": {
+                  "Ref": "DBInstanceType"
+              },
+              "SourceDBInstanceIdentifier": {
+                  "Ref": "SourceDBInstanceIdentifier"
+              },
+              "SourceRegion": {
+                  "Ref": "SourceRegion"
+              },
+              "KmsKeyId": {
+                  "Ref": "MyKey"
+              },
+              "EnableIAMDatabaseAuthentication" : true
+          }
+      }
+  }
+}

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/positive1.yaml
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/positive1.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: RDS Storage Encrypted
+Parameters:
+  SourceDBInstanceIdentifier:
+    Type: String
+  DBInstanceType:
+    Type: String
+  SourceRegion:
+    Type: String
+Resources:
+  MyDBSmall:
+    Type: "AWS::RDS::DBInstance"
+    Properties:
+      DBInstanceClass: !Ref DBInstanceType
+      SourceDBInstanceIdentifier: !Ref SourceDBInstanceIdentifier
+      SourceRegion: !Ref SourceRegion
+      DeletionProtection: false
+      KmsKeyId: !Ref MyKey
+      EnableIAMDatabaseAuthentication: false

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/positive2.json
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/positive2.json
@@ -1,0 +1,35 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "RDS Storage Encrypted",
+  "Parameters": {
+      "SourceDBInstanceIdentifier": {
+          "Type": "String"
+      },
+      "DBInstanceType": {
+          "Type": "String"
+      },
+      "SourceRegion": {
+          "Type": "String"
+      }
+  },
+  "Resources": {
+      "MyDBSmall": {
+          "Type": "AWS::RDS::DBInstance",
+          "Properties": {
+              "DBInstanceClass": {
+                  "Ref": "DBInstanceType"
+              },
+              "SourceDBInstanceIdentifier": {
+                  "Ref": "SourceDBInstanceIdentifier"
+              },
+              "SourceRegion": {
+                  "Ref": "SourceRegion"
+              },
+              "KmsKeyId": {
+                  "Ref": "MyKey"
+              },
+              "EnableIAMDatabaseAuthentication" : false
+          }
+      }
+  }
+}

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/positive3.yaml
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/positive3.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: RDS Storage Encrypted
+Parameters:
+  SourceDBInstanceIdentifier:
+    Type: String
+  DBInstanceType:
+    Type: String
+  SourceRegion:
+    Type: String
+Resources:
+  MyDBSmall:
+    Type: "AWS::RDS::DBInstance"
+    Properties:
+      DBInstanceClass: !Ref DBInstanceType
+      SourceDBInstanceIdentifier: !Ref SourceDBInstanceIdentifier
+      SourceRegion: !Ref SourceRegion
+      DeletionProtection: false
+      KmsKeyId: !Ref MyKey

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/positive4.json
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/positive4.json
@@ -1,0 +1,34 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "RDS Storage Encrypted",
+  "Parameters": {
+      "SourceDBInstanceIdentifier": {
+          "Type": "String"
+      },
+      "DBInstanceType": {
+          "Type": "String"
+      },
+      "SourceRegion": {
+          "Type": "String"
+      }
+  },
+  "Resources": {
+      "MyDBSmall": {
+          "Type": "AWS::RDS::DBInstance",
+          "Properties": {
+              "DBInstanceClass": {
+                  "Ref": "DBInstanceType"
+              },
+              "SourceDBInstanceIdentifier": {
+                  "Ref": "SourceDBInstanceIdentifier"
+              },
+              "SourceRegion": {
+                  "Ref": "SourceRegion"
+              },
+              "KmsKeyId": {
+                  "Ref": "MyKey"
+              }
+          }
+      }
+  }
+}

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "IAM Database Auth Not Enabled",
+    "severity": "HIGH",
+    "line": 19,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "IAM Database Auth Not Enabled",
+    "severity": "HIGH",
+    "line": 31,
+    "fileName": "positive2.json"
+  },
+  {
+    "queryName": "IAM Database Auth Not Enabled",
+    "severity": "HIGH",
+    "line": 13,
+    "fileName": "positive3.yaml"
+  },
+  {
+    "fileName": "positive4.json",
+    "queryName": "IAM Database Auth Not Enabled",
+    "severity": "HIGH",
+    "line": 18
+  }
+]


### PR DESCRIPTION
Closes #2376 

**Proposed Changes**

- Add query support in CloudFormation to check if DB instances are not enabling database authentication

I submit this contribution under Apache-2.0 license.
