### PR TITLE
Add ECR Image Tag Not Immutable query for Terraform and AWS CloudFormation 

### DIFF
--- a/assets/queries/cloudFormation/ecr_image_tag_not_immutable/metadata.json
+++ b/assets/queries/cloudFormation/ecr_image_tag_not_immutable/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "33f41d31-86b1-46a4-81f7-9c9a671f59ac",
+  "queryName": "ECR Image Tag Not Immutable",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "ECR should have an image tag be immutable",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html",
+  "platform": "CloudFormation"
+}

--- a/assets/queries/cloudFormation/ecr_image_tag_not_immutable/query.rego
+++ b/assets/queries/cloudFormation/ecr_image_tag_not_immutable/query.rego
@@ -1,0 +1,31 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::ECR::Repository"
+
+	object.get(resource.Properties, "ImageTagMutability", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.ImageTagMutability is defined", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.ImageTagMutability is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::ECR::Repository"
+
+	resource.Properties.ImageTagMutability == "MUTABLE"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.ImageTagMutability", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.ImageTagMutability is 'IMMUTABLE'", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.ImageTagMutability is 'MUTABLE'", [name]),
+	}
+}

--- a/assets/queries/cloudFormation/ecr_image_tag_not_immutable/test/negative1.yaml
+++ b/assets/queries/cloudFormation/ecr_image_tag_not_immutable/test/negative1.yaml
@@ -1,0 +1,24 @@
+Resources:
+  MyRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      ImageTagMutability: "IMMUTABLE"
+      RepositoryName: "test-repository"
+      RepositoryPolicyText:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: AllowPushPull
+            Effect: Allow
+            Principal:
+              AWS:
+                - "arn:aws:iam::123456789012:user/Bob"
+                - "arn:aws:iam::123456789012:user/Alice"
+            Action:
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:BatchGetImage"
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:PutImage"
+              - "ecr:InitiateLayerUpload"
+              - "ecr:UploadLayerPart"
+              - "ecr:CompleteLayerUpload"

--- a/assets/queries/cloudFormation/ecr_image_tag_not_immutable/test/negative2.json
+++ b/assets/queries/cloudFormation/ecr_image_tag_not_immutable/test/negative2.json
@@ -1,0 +1,35 @@
+{
+  "Resources": {
+    "MyRepository2": {
+      "Type": "AWS::ECR::Repository",
+      "Properties": {
+        "ImageTagMutability": "IMMUTABLE",
+        "RepositoryName": "test-repository",
+        "RepositoryPolicyText": {
+          "Version": "2008-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowPushPull",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": [
+                  "arn:aws:iam::123456789012:user/Bob",
+                  "arn:aws:iam::123456789012:user/Alice"
+                ]
+              },
+              "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/ecr_image_tag_not_immutable/test/positive1.yaml
+++ b/assets/queries/cloudFormation/ecr_image_tag_not_immutable/test/positive1.yaml
@@ -1,0 +1,46 @@
+Resources:
+  MyRepository3:
+    Type: AWS::ECR::Repository
+    Properties:
+      ImageTagMutability: "MUTABLE"
+      RepositoryName: "test-repository"
+      RepositoryPolicyText:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: AllowPushPull
+            Effect: Allow
+            Principal:
+              AWS:
+                - "arn:aws:iam::123456789012:user/Bob"
+                - "arn:aws:iam::123456789012:user/Alice"
+            Action:
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:BatchGetImage"
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:PutImage"
+              - "ecr:InitiateLayerUpload"
+              - "ecr:UploadLayerPart"
+              - "ecr:CompleteLayerUpload"
+  MyRepository4:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: "test-repository"
+      RepositoryPolicyText:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: AllowPushPull
+            Effect: Allow
+            Principal:
+              AWS:
+                - "arn:aws:iam::123456789012:user/Bob"
+                - "arn:aws:iam::123456789012:user/Alice"
+            Action:
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:BatchGetImage"
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:PutImage"
+              - "ecr:InitiateLayerUpload"
+              - "ecr:UploadLayerPart"
+              - "ecr:CompleteLayerUpload"

--- a/assets/queries/cloudFormation/ecr_image_tag_not_immutable/test/positive2.json
+++ b/assets/queries/cloudFormation/ecr_image_tag_not_immutable/test/positive2.json
@@ -1,0 +1,65 @@
+{
+  "Resources": {
+    "MyRepository5": {
+      "Type": "AWS::ECR::Repository",
+      "Properties": {
+        "ImageTagMutability": "MUTABLE",
+        "RepositoryName": "test-repository",
+        "RepositoryPolicyText": {
+          "Version": "2008-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowPushPull",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": [
+                  "arn:aws:iam::123456789012:user/Bob",
+                  "arn:aws:iam::123456789012:user/Alice"
+                ]
+              },
+              "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "MyRepository6": {
+      "Type": "AWS::ECR::Repository",
+      "Properties": {
+        "RepositoryName": "test-repository",
+        "RepositoryPolicyText": {
+          "Version": "2008-10-17",
+          "Statement": [
+            {
+              "Sid": "AllowPushPull",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": [
+                  "arn:aws:iam::123456789012:user/Bob",
+                  "arn:aws:iam::123456789012:user/Alice"
+                ]
+              },
+              "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/ecr_image_tag_not_immutable/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ecr_image_tag_not_immutable/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "ECR Image Tag Not Immutable",
+    "severity": "MEDIUM",
+    "line": 5,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "ECR Image Tag Not Immutable",
+    "severity": "MEDIUM",
+    "line": 27,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "ECR Image Tag Not Immutable",
+    "severity": "MEDIUM",
+    "line": 6,
+    "fileName": "positive2.json"
+  },
+  {
+    "queryName": "ECR Image Tag Not Immutable",
+    "severity": "MEDIUM",
+    "line": 36,
+    "fileName": "positive2.json"
+  }
+]

--- a/assets/queries/terraform/aws/ecr_image_tag_not_immutable/metadata.json
+++ b/assets/queries/terraform/aws/ecr_image_tag_not_immutable/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "d1846b12-20c5-4d45-8798-fc35b79268eb",
+  "queryName": "ECR Image Tag Not Immutable",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "ECR should have an image tag be immutable",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/ecr_image_tag_not_immutable/query.rego
+++ b/assets/queries/terraform/aws/ecr_image_tag_not_immutable/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_ecr_repository[name]
+
+	object.get(resource, "image_tag_mutability", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ecr_repository.%s", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_ecr_repository.%s.image_tag_mutability is defined", [name]),
+		"keyActualValue": sprintf("aws_ecr_repository.%s.image_tag_mutability is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_ecr_repository[name]
+
+	resource.image_tag_mutability == "MUTABLE"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ecr_repository.%s.image_tag_mutability", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_ecr_repository.%s.image_tag_mutability is 'IMMUTABLE'", [name]),
+		"keyActualValue": sprintf("aws_ecr_repository.%s.image_tag_mutability is 'MUTABLE'", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/ecr_image_tag_not_immutable/test/negative.tf
+++ b/assets/queries/terraform/aws/ecr_image_tag_not_immutable/test/negative.tf
@@ -1,0 +1,8 @@
+resource "aws_ecr_repository" "foo" {
+  name                 = "bar"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/assets/queries/terraform/aws/ecr_image_tag_not_immutable/test/positive.tf
+++ b/assets/queries/terraform/aws/ecr_image_tag_not_immutable/test/positive.tf
@@ -1,0 +1,16 @@
+resource "aws_ecr_repository" "foo2" {
+  name                 = "bar"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_repository" "foo3" {
+  name                 = "bar"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/assets/queries/terraform/aws/ecr_image_tag_not_immutable/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ecr_image_tag_not_immutable/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "ECR Image Tag Not Immutable",
+    "severity": "MEDIUM",
+    "line": 3,
+    "fileName": "positive.tf"
+  },
+  {
+    "queryName": "ECR Image Tag Not Immutable",
+    "severity": "MEDIUM",
+    "line": 10,
+    "fileName": "positive.tf"
+  }
+]


### PR DESCRIPTION
Closes #2397

**Proposed Changes**

- Adding ECR Imag Tag Not Immutable queries for Terraform and AWS CloudFormation.

I submit this contribution under Apache-2.0 license.
