### PR TITLE
Enable JSON parser to unmarshal []map[string]inteface{} 

### DIFF
--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -15,6 +15,11 @@ type Parser struct {
 func (p *Parser) Parse(_ string, fileContent []byte) ([]model.Document, error) {
 	r := model.Document{}
 	err := json.Unmarshal(fileContent, &r)
+	if err != nil {
+		r := []model.Document{}
+		err = json.Unmarshal(fileContent, &r)
+		return r, err
+	}
 
 	return []model.Document{r}, errors.Wrap(err, "failed to unmarshall json content")
 }


### PR DESCRIPTION
Closes #2408

**Proposed Changes**

- try to unmarshal with `map[string]interface{}`
- if an error is found unmarshal with `[]map[string]inteface{}`

I submit this contribution under Apache-2.0 license.
