### PR TITLE
Add "Docker Daemon Socket is Exposed to Containers" query for Terraform Closes #2415

### DIFF
--- a/assets/queries/terraform/kubernetes_pod/docker_daemon_socket_is_exposed_to_containers/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/docker_daemon_socket_is_exposed_to_containers/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "4e203a65-c8d8-49a2-b749-b124d43c9dc1",
+  "queryName": "Docker Daemon Socket is Exposed to Containers",
+  "severity": "LOW",
+  "category": "Access Control",
+  "descriptionText": "Sees if Docker Daemon Socket is not exposed to Containers",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#host_path",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes_pod/docker_daemon_socket_is_exposed_to_containers/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/docker_daemon_socket_is_exposed_to_containers/query.rego
@@ -1,0 +1,54 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+
+	volumes := resource.spec.volume
+
+	volumes[c].host_path.path == "/var/run/docker.sock"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].spec.volume", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.volume[%d].host_path.path is not '/var/run/docker.sock'", [c]),
+		"keyActualValue": sprintf("spec.volume[%d].host_path.path is '/var/run/docker.sock'", [c]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource
+
+	listKinds := {"kubernetes_deployment", "kubernetes_daemonset", "kubernetes_job", "kubernetes_stateful_set", "kubernetes_replication_controller"}
+
+	k8s := object.get(resource, listKinds[x], "undefined")
+	k8s != "undefined"
+
+	spec := k8s[name].spec.template.spec
+	volumes := spec.volume
+	volumes[c].host_path.path == "/var/run/docker.sock"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.template.spec.volume", [listKinds[x], name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.template.spec.volume[%d].host_path.path is not '/var/run/docker.sock'", [c]),
+		"keyActualValue": sprintf("spec.template.spec.volume[%d].host_path.path is '/var/run/docker.sock'", [c]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cron_job[name]
+
+	spec := resource.spec.job_template.spec.template.spec
+	volumes := spec.volume
+	volumes[c].host_path.path == "/var/run/docker.sock"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.spec.volume", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("spec.job_template.spec.template.spec.volume[%d].host_path.path is not '/var/run/docker.sock'", [c]),
+		"keyActualValue": sprintf("spec.job_template.spec.template.spec.volume[%d].host_path.path is '/var/run/docker.sock'", [c]),
+	}
+}

--- a/assets/queries/terraform/kubernetes_pod/docker_daemon_socket_is_exposed_to_containers/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/docker_daemon_socket_is_exposed_to_containers/test/negative.tf
@@ -1,0 +1,195 @@
+resource "kubernetes_pod" "test2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    volume = [
+     {
+       host_path = {
+         path = "/data"
+         type = "Directory"
+       }
+     }
+     ,
+     {
+       host_path = {
+         path = "/data"
+         type = "Directory"
+       }
+     }
+    ]
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_deployment" "example2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+
+        volume = [
+          {
+            host_path = {
+              path = "/data"
+              type = "Directory"
+            }
+          }
+          ,
+          {
+            host_path = {
+              path = "/data"
+              type = "Directory"
+            }
+          }
+        ]
+
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+
+resource "kubernetes_cron_job" "demo22" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+
+            volume = [
+              {
+                host_path = {
+                  path = "/data"
+                  type = "Directory"
+                }
+              }
+              ,
+              {
+                host_path = {
+                  path = "/data"
+                  type = "Directory"
+                }
+              }
+            ]
+
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/docker_daemon_socket_is_exposed_to_containers/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/docker_daemon_socket_is_exposed_to_containers/test/positive.tf
@@ -1,0 +1,195 @@
+resource "kubernetes_pod" "test" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+
+    volume = [
+     {
+       host_path = {
+         path = "/var/run/docker.sock"
+         type = "Directory"
+       }
+     }
+     ,
+     {
+       host_path = {
+         path = "/var/run/docker.sock"
+         type = "Directory"
+       }
+     }
+    ]
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_deployment" "example" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+
+        volume = [
+          {
+            host_path = {
+              path = "/var/run/docker.sock"
+              type = "Directory"
+            }
+          }
+          ,
+          {
+            host_path = {
+              path = "/var/run/docker.sock"
+              type = "Directory"
+            }
+          }
+        ]
+
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+
+resource "kubernetes_cron_job" "demo2" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+
+            volume = [
+              {
+                host_path = {
+                  path = "/var/run/docker.sock"
+                  type = "Directory"
+                }
+              }
+              ,
+              {
+                host_path = {
+                  path = "/var/run/docker.sock"
+                  type = "Directory"
+                }
+              }
+            ]
+
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/docker_daemon_socket_is_exposed_to_containers/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/docker_daemon_socket_is_exposed_to_containers/test/positive_expected_result.json
@@ -1,0 +1,32 @@
+[
+  {
+    "queryName": "Docker Daemon Socket is Exposed to Containers",
+    "severity": "LOW",
+    "line": 8
+  },
+  {
+    "queryName": "Docker Daemon Socket is Exposed to Containers",
+    "severity": "LOW",
+    "line": 8
+  },
+  {
+    "queryName": "Docker Daemon Socket is Exposed to Containers",
+    "severity": "LOW",
+    "line": 98
+  },
+  {
+    "queryName": "Docker Daemon Socket is Exposed to Containers",
+    "severity": "LOW",
+    "line": 98
+  },
+  {
+    "queryName": "Docker Daemon Socket is Exposed to Containers",
+    "severity": "LOW",
+    "line": 169
+  },
+  {
+    "queryName": "Docker Daemon Socket is Exposed to Containers",
+    "severity": "LOW",
+    "line": 169
+  }
+]


### PR DESCRIPTION
Closes #2415

**Proposed Changes**

- Support "Docker Daemon Socket is Exposed to Containers" query for Terraform (same as "Docker Daemon Socket is Exposed to Containers" for Kubernetes). It is necessary to check if the attribute `volumes[c].host_path.path` is equal `"/var/run/docker.sock"`

I submit this contribution under Apache-2.0 license.
