### PR TITLE
Add "Batch Job Definition With Privileged Container Properties" query for Terraform and Ansible

### DIFF
--- a/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/metadata.json
+++ b/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "defe5b18-978d-4722-9325-4d1975d3699f",
+  "queryName": "Batch Job Definition With Privileged Container Properties",
+  "severity": "HIGH",
+  "category": "Insecure Configurations",
+  "descriptionText": "Batch Job Definition should not have Privileged Container Properties",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/aws_batch_job_definition_module.html",
+  "platform": "Ansible"
+}

--- a/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/query.rego
+++ b/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+import data.generic.ansible as ansLib
+
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	modules := {"community.aws.aws_batch_job_definition", "aws_batch_job_definition"}
+	batch_job_definition := task[modules[m]]
+
+	ansLib.checkState(batch_job_definition)
+	batch_job_definition.privileged == true
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}.privileged", [task.name, modules[m]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.privileged is 'false' or not set", [task.name, modules[m]]),
+		"keyActualValue": sprintf("name={{%s}}.{{%s}}.privileged is 'true'", [task.name, modules[m]]),
+	}
+}

--- a/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/test/negative.yaml
+++ b/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/test/negative.yaml
@@ -1,0 +1,37 @@
+- name: My Batch Job Definition
+  community.aws.aws_batch_job_definition:
+    job_definition_name: My Batch Job Definition without privilege
+    state: present
+    type: container
+    parameters:
+      Param1: Val1
+      Param2: Val2
+    privileged: false
+    image: <Docker Image URL>
+    vcpus: 1
+    memory: 512
+    command:
+      - python
+      - run_my_script.py
+      - arg1
+    job_role_arn: <Job Role ARN>
+    attempts: 3
+  register: job_definition_create_result
+- name: My Batch Job Definition without explicit privilege
+  community.aws.aws_batch_job_definition:
+    job_definition_name: My Batch Job Definition
+    state: present
+    type: container
+    parameters:
+      Param1: Val1
+      Param2: Val2
+    image: <Docker Image URL>
+    vcpus: 1
+    memory: 512
+    command:
+      - python
+      - run_my_script.py
+      - arg1
+    job_role_arn: <Job Role ARN>
+    attempts: 3
+  register: job_definition_create_result

--- a/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/test/positive.yaml
+++ b/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/test/positive.yaml
@@ -1,0 +1,19 @@
+- name: My Batch Job Definition
+  community.aws.aws_batch_job_definition:
+    job_definition_name: My Batch Job Definition
+    state: present
+    type: container
+    parameters:
+      Param1: Val1
+      Param2: Val2
+    privileged: true
+    image: <Docker Image URL>
+    vcpus: 1
+    memory: 512
+    command:
+      - python
+      - run_my_script.py
+      - arg1
+    job_role_arn: <Job Role ARN>
+    attempts: 3
+  register: job_definition_create_result

--- a/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/batch_job_definition_with_privileged_container_properties/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "line": 9,
+    "queryName": "Batch Job Definition With Privileged Container Properties",
+    "severity": "HIGH"
+  }
+]

--- a/assets/queries/terraform/aws/batch_job_definition_with_privileged_container_properties/metadata.json
+++ b/assets/queries/terraform/aws/batch_job_definition_with_privileged_container_properties/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "66cd88ac-9ddf-424a-b77e-e55e17630bee",
+  "queryName": "Batch Job Definition With Privileged Container Properties",
+  "severity": "HIGH",
+  "category": "Insecure Configurations",
+  "descriptionText": "Batch Job Definition should not have Privileged Container Properties",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/batch_job_definition",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/batch_job_definition_with_privileged_container_properties/query.rego
+++ b/assets/queries/terraform/aws/batch_job_definition_with_privileged_container_properties/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document[i]
+	properties_json = document.resource.aws_batch_job_definition[name].container_properties
+	properties := json.unmarshal(properties_json)
+	properties.privileged == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_batch_job_definition[%s].container_properties.privileged", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_batch_job_definition[%s].container_properties.privileged is 'false' or not set", [name]),
+		"keyActualValue": sprintf("aws_batch_job_definition[%s].container_properties.privileged is 'true'", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/batch_job_definition_with_privileged_container_properties/test/negative.tf
+++ b/assets/queries/terraform/aws/batch_job_definition_with_privileged_container_properties/test/negative.tf
@@ -1,0 +1,78 @@
+resource "aws_batch_job_definition" "negative1" {
+  name = "tf_test_batch_job_definition"
+  type = "container"
+
+  container_properties = <<CONTAINER_PROPERTIES
+{
+    "command": ["ls", "-la"],
+    "image": "busybox",
+    "memory": 1024,
+    "vcpus": 1,
+    "privileged": false,
+    "volumes": [
+      {
+        "host": {
+          "sourcePath": "/tmp"
+        },
+        "name": "tmp"
+      }
+    ],
+    "environment": [
+        {"name": "VARNAME", "value": "VARVAL"}
+    ],
+    "mountPoints": [
+        {
+          "sourceVolume": "tmp",
+          "containerPath": "/tmp",
+          "readOnly": false
+        }
+    ],
+    "ulimits": [
+      {
+        "hardLimit": 1024,
+        "name": "nofile",
+        "softLimit": 1024
+      }
+    ]
+}
+CONTAINER_PROPERTIES
+}
+
+resource "aws_batch_job_definition" "negative2" {
+  name = "tf_test_batch_job_definition2"
+  type = "container"
+
+  container_properties = <<CONTAINER_PROPERTIES
+{
+    "command": ["ls", "-la"],
+    "image": "busybox",
+    "memory": 1024,
+    "vcpus": 1,
+    "volumes": [
+      {
+        "host": {
+          "sourcePath": "/tmp"
+        },
+        "name": "tmp"
+      }
+    ],
+    "environment": [
+        {"name": "VARNAME", "value": "VARVAL"}
+    ],
+    "mountPoints": [
+        {
+          "sourceVolume": "tmp",
+          "containerPath": "/tmp",
+          "readOnly": false
+        }
+    ],
+    "ulimits": [
+      {
+        "hardLimit": 1024,
+        "name": "nofile",
+        "softLimit": 1024
+      }
+    ]
+}
+CONTAINER_PROPERTIES
+}

--- a/assets/queries/terraform/aws/batch_job_definition_with_privileged_container_properties/test/positive.tf
+++ b/assets/queries/terraform/aws/batch_job_definition_with_privileged_container_properties/test/positive.tf
@@ -1,0 +1,39 @@
+resource "aws_batch_job_definition" "positive1" {
+  name = "tf_test_batch_job_definition"
+  type = "container"
+
+  container_properties = <<CONTAINER_PROPERTIES
+{
+    "command": ["ls", "-la"],
+    "image": "busybox",
+    "memory": 1024,
+    "vcpus": 1,
+    "privileged": true,
+    "volumes": [
+      {
+        "host": {
+          "sourcePath": "/tmp"
+        },
+        "name": "tmp"
+      }
+    ],
+    "environment": [
+        {"name": "VARNAME", "value": "VARVAL"}
+    ],
+    "mountPoints": [
+        {
+          "sourceVolume": "tmp",
+          "containerPath": "/tmp",
+          "readOnly": false
+        }
+    ],
+    "ulimits": [
+      {
+        "hardLimit": 1024,
+        "name": "nofile",
+        "softLimit": 1024
+      }
+    ]
+}
+CONTAINER_PROPERTIES
+}

--- a/assets/queries/terraform/aws/batch_job_definition_with_privileged_container_properties/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/batch_job_definition_with_privileged_container_properties/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "line": 11,
+    "queryName": "Batch Job Definition With Privileged Container Properties",
+    "severity": "HIGH"
+  }
+]


### PR DESCRIPTION
Closes #2419

**Proposed Changes**

- Added support for query "Batch Job Definition With Privileged Container Properties" in Terraform and Ansible.
- The query checks if the attribute `privileged` is set to `true`.


I submit this contribution under Apache-2.0 license.
