### PR TITLE
Add "CloudFront Without Minimum Protocol TLS 1.2" query for Terraform and Ansible

### DIFF
--- a/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/metadata.json
+++ b/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "d0c13053-d2c8-44a6-95da-d592996e9e67",
+  "queryName": "CloudFront Without Minimum Protocol TLS 1.2",
+  "severity": "HIGH",
+  "category": "Insecure Configurations",
+  "descriptionText": "CloudFront Minimum Protocol version should be at least TLS 1.2",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/cloudfront_distribution_module.html#parameter-viewer_certificate/minimum_protocol_version",
+  "platform": "Ansible"
+}

--- a/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/query.rego
+++ b/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/query.rego
@@ -1,0 +1,45 @@
+package Cx
+
+import data.generic.ansible as ansLib
+
+modules := {"community.aws.cloudfront_distribution", "cloudfront_distribution"}
+
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	cloudfront := task[modules[m]]
+
+	ansLib.checkState(cloudfront)
+	object.get(cloudfront, "viewer_certificate", "undefined") == "undefined"
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "cloudfront_distribution.viewer_certificate is defined",
+		"keyActualValue": "cloudfront_distribution.viewer_certificate is undefined",
+	}
+}
+
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	cloudfront := task[modules[m]]
+
+	ansLib.checkState(cloudfront)
+	protocol_version := cloudfront.viewer_certificate.minimum_protocol_version
+
+	not containsProtocolVersion(["TLSv1.2_2018", "TLSv1.2_2019"], protocol_version)
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}.viewer_certificate.minimum_protocol_version", [task.name, modules[m]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.viewer_certificate.minimum_protocol_version' is TLSv1.2_x", [task.name, modules[m]]),
+		"keyActualValue": sprintf("name={{%s}}.{{%s}}.viewer_certificate.minimum_protocol_version' is %s", [task.name, modules[m], protocol_version]),
+	}
+}
+
+containsProtocolVersion(array, elem) {
+	array[_] == elem
+} else = false {
+	true
+}

--- a/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/test/negative.yaml
@@ -3,12 +3,12 @@
     state: present
     caller_reference: unique test distribution ID
     origins:
-        - id: 'my test origin-000111'
-          domain_name: www.example.com
-          origin_path: /production
-          custom_headers:
-            - header_name: MyCustomHeaderName
-              header_value: MyCustomHeaderValue
+      - id: 'my test origin-000111'
+        domain_name: www.example.com
+        origin_path: /production
+        custom_headers:
+          - header_name: MyCustomHeaderName
+            header_value: MyCustomHeaderValue
     logging:
       enabled: true
       include_cookies: false

--- a/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/test/negative.yaml
@@ -1,0 +1,19 @@
+- name: create a distribution with an origin and logging
+  community.aws.cloudfront_distribution:
+    state: present
+    caller_reference: unique test distribution ID
+    origins:
+        - id: 'my test origin-000111'
+          domain_name: www.example.com
+          origin_path: /production
+          custom_headers:
+            - header_name: MyCustomHeaderName
+              header_value: MyCustomHeaderValue
+    logging:
+      enabled: true
+      include_cookies: false
+      bucket: mylogbucket.s3.amazonaws.com
+      prefix: myprefix/
+    viewer_certificate:
+      minimum_protocol_version: TLSv1.2_2018
+    comment: this is a CloudFront distribution with logging

--- a/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/test/positive.yaml
@@ -1,0 +1,55 @@
+- name: create a distribution with an origin and logging
+  community.aws.cloudfront_distribution:
+    state: present
+    caller_reference: unique test distribution ID
+    origins:
+        - id: 'my test origin-000111'
+          domain_name: www.example.com
+          origin_path: /production
+          custom_headers:
+            - header_name: MyCustomHeaderName
+              header_value: MyCustomHeaderValue
+    logging:
+      enabled: true
+      include_cookies: false
+      bucket: mylogbucket.s3.amazonaws.com
+      prefix: myprefix/
+    viewer_certificate:
+      minimum_protocol_version: TLSv1
+    comment: this is a CloudFront distribution with logging
+- name: create another distribution with an origin and logging
+  community.aws.cloudfront_distribution:
+    state: present
+    caller_reference: unique test distribution ID
+    origins:
+        - id: 'my test origin-000111'
+          domain_name: www.example.com
+          origin_path: /production
+          custom_headers:
+            - header_name: MyCustomHeaderName
+              header_value: MyCustomHeaderValue
+    logging:
+      enabled: true
+      include_cookies: false
+      bucket: mylogbucket.s3.amazonaws.com
+      prefix: myprefix/
+    viewer_certificate:
+      minimum_protocol_version: TLSv1.1_2016
+    comment: this is a CloudFront distribution with logging
+- name: create a third distribution
+  community.aws.cloudfront_distribution:
+    state: present
+    caller_reference: unique test distribution ID
+    origins:
+        - id: 'my test origin-000111'
+          domain_name: www.example.com
+          origin_path: /production
+          custom_headers:
+            - header_name: MyCustomHeaderName
+              header_value: MyCustomHeaderValue
+    logging:
+      enabled: true
+      include_cookies: false
+      bucket: mylogbucket.s3.amazonaws.com
+      prefix: myprefix/
+    comment: this is a CloudFront distribution with logging

--- a/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/test/positive.yaml
@@ -3,12 +3,12 @@
     state: present
     caller_reference: unique test distribution ID
     origins:
-        - id: 'my test origin-000111'
-          domain_name: www.example.com
-          origin_path: /production
-          custom_headers:
-            - header_name: MyCustomHeaderName
-              header_value: MyCustomHeaderValue
+      - id: 'my test origin-000111'
+        domain_name: www.example.com
+        origin_path: /production
+        custom_headers:
+          - header_name: MyCustomHeaderName
+            header_value: MyCustomHeaderValue
     logging:
       enabled: true
       include_cookies: false
@@ -22,12 +22,12 @@
     state: present
     caller_reference: unique test distribution ID
     origins:
-        - id: 'my test origin-000111'
-          domain_name: www.example.com
-          origin_path: /production
-          custom_headers:
-            - header_name: MyCustomHeaderName
-              header_value: MyCustomHeaderValue
+      - id: 'my test origin-000111'
+        domain_name: www.example.com
+        origin_path: /production
+        custom_headers:
+          - header_name: MyCustomHeaderName
+            header_value: MyCustomHeaderValue
     logging:
       enabled: true
       include_cookies: false
@@ -41,12 +41,12 @@
     state: present
     caller_reference: unique test distribution ID
     origins:
-        - id: 'my test origin-000111'
-          domain_name: www.example.com
-          origin_path: /production
-          custom_headers:
-            - header_name: MyCustomHeaderName
-              header_value: MyCustomHeaderValue
+      - id: 'my test origin-000111'
+        domain_name: www.example.com
+        origin_path: /production
+        custom_headers:
+          - header_name: MyCustomHeaderName
+            header_value: MyCustomHeaderValue
     logging:
       enabled: true
       include_cookies: false

--- a/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudfront_without_minimum_protocol_tls_1.2/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+  {
+    "queryName": "CloudFront Without Minimum Protocol TLS 1.2",
+    "severity": "HIGH",
+    "line": 18
+  },
+  {
+    "queryName": "CloudFront Without Minimum Protocol TLS 1.2",
+    "severity": "HIGH",
+    "line": 37
+  },
+  {
+    "line": 40,
+    "queryName": "CloudFront Without Minimum Protocol TLS 1.2",
+    "severity": "HIGH"
+  }
+]

--- a/assets/queries/cloudFormation/cloudfront_without_minimum_protocol_tls_1.2/metadata.json
+++ b/assets/queries/cloudFormation/cloudfront_without_minimum_protocol_tls_1.2/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "CloudFront Without Minimum Protocol TLS 1.2",
   "severity": "HIGH",
   "category": "Insecure Configurations",
-  "descriptionText": "CloudFront Minimum Protocol version should be higher than TLS 1.2",
+  "descriptionText": "CloudFront Minimum Protocol version should be at least TLS 1.2",
   "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-distribution.html",
   "platform": "CloudFormation"
 }

--- a/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/metadata.json
+++ b/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "CloudFront Without Minimum Protocol TLS 1.2",
   "severity": "HIGH",
   "category": "Insecure Configurations",
-  "descriptionText": "CloudFront Minimum Protocol version should be higher than TLS 1.2",
+  "descriptionText": "CloudFront Minimum Protocol version should be at least TLS 1.2",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution",
   "platform": "Terraform"
 }

--- a/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/metadata.json
+++ b/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "00e5e55e-c2ff-46b3-a757-a7a1cd802456",
+  "queryName": "CloudFront Without Minimum Protocol TLS 1.2",
+  "severity": "HIGH",
+  "category": "Insecure Configurations",
+  "descriptionText": "CloudFront Minimum Protocol version should be higher than TLS 1.2",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/query.rego
+++ b/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/query.rego
@@ -1,0 +1,55 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document[i]
+	resource := document.resource.aws_cloudfront_distribution[name]
+
+	object.get(resource, "viewer_certificate", "undefined") == "undefined"
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("resource.aws_cloudfront_distribution[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("resource.aws_cloudfront_distribution[%s].viewer_certificate' is defined", [name]),
+		"keyActualValue": sprintf("resource.aws_cloudfront_distribution[%s].viewer_certificate' is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	document := input.document[i]
+	resource := document.resource.aws_cloudfront_distribution[name]
+
+	resource.viewer_certificate.cloudfront_default_certificate == true
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("resource.aws_cloudfront_distribution[%s].viewer_certificate.cloudfront_default_certificate", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("resource.aws_cloudfront_distribution[%s].viewer_certificate.cloudfront_default_certificate' is 'false'", [name]),
+		"keyActualValue": sprintf("resource.aws_cloudfront_distribution[%s].viewer_certificate.cloudfront_default_certificate' is 'true'", [name]),
+	}
+}
+
+CxPolicy[result] {
+	document := input.document[i]
+	resource := document.resource.aws_cloudfront_distribution[name]
+
+	resource.viewer_certificate.cloudfront_default_certificate == false
+	protocol_version := resource.viewer_certificate.minimum_protocol_version
+
+	not containsProtocolVersion(["TLSv1.2_2018", "TLSv1.2_2019"], protocol_version)
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("resource.aws_cloudfront_distribution[%s].viewer_certificate.minimum_protocol_version", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("resource.aws_cloudfront_distribution[%s].viewer_certificate.minimum_protocol_version' is TLSv1.2_x", [name]),
+		"keyActualValue": sprintf("resource.aws_cloudfront_distribution[%s].viewer_certificate.minimum_protocol_version' is %s", [name, protocol_version]),
+	}
+}
+
+containsProtocolVersion(array, elem) {
+	array[_] == elem
+} else = false {
+	true
+}

--- a/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/test/negative.tf
+++ b/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/test/negative.tf
@@ -1,0 +1,91 @@
+resource "aws_cloudfront_distribution" "negative1" {
+  origin {
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
+    }
+  }
+
+  enabled             = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    minimum_protocol_version = "TLSv1.2_2018"
+  }
+}
+
+resource "aws_cloudfront_distribution" "negative2" {
+  origin {
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
+    }
+  }
+
+  enabled             = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["US", "CA", "GB", "DE"]
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    minimum_protocol_version = "TLSv1.2_2019"
+  }
+}

--- a/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/test/positive.tf
+++ b/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/test/positive.tf
@@ -1,0 +1,133 @@
+resource "aws_cloudfront_distribution" "positive1" {
+  origin {
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
+    }
+  }
+
+  enabled             = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    #settings
+  }
+
+  restrictions {
+    #restrictions
+  }
+}
+
+resource "aws_cloudfront_distribution" "positive2" {
+  origin {
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
+    }
+  }
+
+  enabled             = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    #settings
+  }
+
+  restrictions {
+    #restrictions
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    minimum_protocol_version = "TLSv1_2016"
+  }
+}
+
+resource "aws_cloudfront_distribution" "positive3" {
+  origin {
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
+    }
+  }
+
+  enabled             = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    #settings
+  }
+
+  restrictions {
+    #restrictions
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    minimum_protocol_version = "SSLv3"
+  }
+}
+
+resource "aws_cloudfront_distribution" "positive4" {
+  origin {
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
+    }
+  }
+
+  enabled             = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    #settings
+  }
+
+  restrictions {
+    #restrictions
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    minimum_protocol_version = "TLSv1.1_2016"
+  }
+}
+
+resource "aws_cloudfront_distribution" "positive5" {
+  origin {
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+
+    s3_origin_config {
+      origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
+    }
+  }
+
+  enabled             = true
+  comment             = "Some comment"
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    #settings
+  }
+
+  restrictions {
+    #restrictions
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudfront_without_minimum_protocol_tls_1.2/test/positive_expected_result.json
@@ -1,0 +1,27 @@
+[
+  {
+    "queryName": "CloudFront Without Minimum Protocol TLS 1.2",
+    "severity": "HIGH",
+    "line": 1
+  },
+  {
+    "queryName": "CloudFront Without Minimum Protocol TLS 1.2",
+    "severity": "HIGH",
+    "line": 48
+  },
+  {
+    "line": 76,
+    "queryName": "CloudFront Without Minimum Protocol TLS 1.2",
+    "severity": "HIGH"
+  },
+  {
+    "severity": "HIGH",
+    "line": 104,
+    "queryName": "CloudFront Without Minimum Protocol TLS 1.2"
+  },
+  {
+    "severity": "HIGH",
+    "line": 131,
+    "queryName": "CloudFront Without Minimum Protocol TLS 1.2"
+  }
+]


### PR DESCRIPTION
Closes #2427

**Proposed Changes**

- Added support for query "CloudFront Without Minimum Protocol TLS 1.2" in Terraform and Ansible.
- The query checks if the attribute `minimum_protocol_version` is set to one of `{TLSv1.2_2018, TLSv1.2_2019}`

I submit this contribution under Apache-2.0 license.
