### PR TITLE
Add Workload Mounting With Sensitive OS Directory query Closes #2388

### DIFF
--- a/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "5308a7a8-06f8-45ac-bf10-791fe21de46e",
+  "queryName": "Workload Mounting With Sensitive OS Directory",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "Workload is mounting a volume with sensitive OS Directory",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/",
+  "platform": "Kubernetes"
+}

--- a/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/metadata.json
@@ -1,9 +1,9 @@
 {
-  "id": "5308a7a8-06f8-45ac-bf10-791fe21de46e",
+  "id": "a737be28-37d8-4bff-aa6d-1be8aa0a0015",
   "queryName": "Workload Mounting With Sensitive OS Directory",
   "severity": "MEDIUM",
   "category": "Insecure Configurations",
   "descriptionText": "Workload is mounting a volume with sensitive OS Directory",
-  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/",
-  "platform": "Kubernetes"
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#host_path",
+  "platform": "Terraform"
 }

--- a/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/query.rego
@@ -1,0 +1,58 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+	metadata := resource.metadata
+	volumes := resource.spec.volume
+	isOSDir(volumes[j].path)
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].spec.volume.host_path.path", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Workload name '%s' should not mount a host sensitive OS directory '%s' with host_path", [
+			metadata.name,
+			volumes[j].path,
+		]),
+		"keyActualValue": sprintf("Workload name '%s' is mounting a host sensitive OS directory '%s' with host_path", [
+			resource.metadata.name,
+			volumes[j].path,
+		]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_persistent_volume[name]
+	metadata := resource.metadata
+	volumes := resource.spec.volume
+	isOSDir(volumes[j].path)
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_persistent_volume[%s].spec.volume.host_path.path", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Workload name '%s' should not mount a host sensitive OS directory '%s' with host_path", [
+			metadata.name,
+			volumes[j].path,
+		]),
+		"keyActualValue": sprintf("Workload name '%s' is mounting a host sensitive OS directory '%s' with host_path", [
+			resource.metadata.name,
+			volumes[j].path,
+		]),
+	}
+}
+
+isOSDir(mountPath) = result {
+	hostSensitiveDir = {
+		"/bin", "/sbin", "/boot", "/cdrom",
+		"/dev", "/etc", "/home", "/lib",
+		"/media", "/proc", "/root", "/run",
+		"/seLinux", "/srv", "/usr", "/var",
+	}
+
+	result = listcontains(hostSensitiveDir, mountPath)
+} else = result {
+	result = mountPath == "/"
+}
+
+listcontains(dirs, elem) {
+	startswith(elem, dirs[_])
+}

--- a/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/test/negative.tf
@@ -1,0 +1,106 @@
+resource "kubernetes_pod" "test3" {
+  metadata {
+    name = "terraform-example3"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_persistent_volume" "test4" {
+  metadata {
+    name = "terraform-example4"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/test/positive.tf
@@ -1,0 +1,118 @@
+resource "kubernetes_pod" "test1" {
+  metadata {
+    name = "terraform-example1"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    volume {
+      host_path {
+        path = "/var/log"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_persistent_volume" "test2" {
+  metadata {
+    name = "terraform-example2"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    volume {
+      host_path {
+        path = "/var/log"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/workload_mounting_with_sensitive_os_directory/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "Workload Mounting With Sensitive OS Directory",
+    "severity": "MEDIUM",
+    "line": 53
+  },
+  {
+    "queryName": "Workload Mounting With Sensitive OS Directory",
+    "severity": "MEDIUM",
+    "line": 112
+  }
+]


### PR DESCRIPTION
Closes #2388 

**Proposed Changes**

- Support Workload Mounting With Sensitive OS Directory in Terraform (already exist in Kubernetes)

I submit this contribution under Apache-2.0 license.