### PR TITLE
Add Host Aliases Undefined Or Empty query #2441

### DIFF
--- a/assets/queries/terraform/kubernetes_pod/host_aliases_undefined_or_empty/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/host_aliases_undefined_or_empty/metadata.json
@@ -1,0 +1,9 @@
+{
+	"id": "5d05ea11-ae3e-470e-9864-97e55fb2b2e0",
+	"queryName": "Host Aliases Undefined Or Empty",
+	"severity": "HIGH",
+	"category": "Insecure Configurations",
+	"descriptionText": "A Kubernetes Pod should have Host Aliases defined as to prevent the container from modifying the file after a pod's containers have already been started. This means the attribute 'spec.host_aliases' must be defined and not empty or null.",
+	"descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#host_aliases",
+	"platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes_pod/host_aliases_undefined_or_empty/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/host_aliases_undefined_or_empty/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+
+	spec := resource.spec
+    object.get(spec, "host_aliases", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].spec", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_pod[%s].spec.host_aliases is defined", [name]),
+		"keyActualValue": sprintf("kubernetes_pod[%s].spec.host_aliases is undefined", [name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes_pod/host_aliases_undefined_or_empty/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/host_aliases_undefined_or_empty/test/negative.tf
@@ -1,0 +1,33 @@
+resource "kubernetes_pod" "name1" {
+  metadata {
+    name = "with-pod-affinity"
+  }
+
+  spec {
+    affinity {
+      pod_affinity {
+        required_during_scheduling_ignored_during_execution {
+          label_selector {
+            match_expressions {
+              key      = "security"
+              operator = "In"
+              values   = ["S1"]
+            }
+          }
+
+          topology_key = "failure-domain.beta.kubernetes.io/zone"
+        }
+      }
+    }
+
+    container {
+      name  = "with-pod-affinity"
+      image = "k8s.gcr.io/pause:2.0"
+    }
+
+    host_aliases {
+      id  = "127.0.0.1"
+      hostnames = ["localhost"]
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/host_aliases_undefined_or_empty/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/host_aliases_undefined_or_empty/test/positive.tf
@@ -1,0 +1,28 @@
+resource "kubernetes_pod" "name1" {
+  metadata {
+    name = "with-pod-affinity"
+  }
+
+  spec {
+    affinity {
+      pod_affinity {
+        required_during_scheduling_ignored_during_execution {
+          label_selector {
+            match_expressions {
+              key      = "security"
+              operator = "In"
+              values   = ["S1"]
+            }
+          }
+
+          topology_key = "failure-domain.beta.kubernetes.io/zone"
+        }
+      }
+    }
+
+    container {
+      name  = "with-pod-affinity"
+      image = "k8s.gcr.io/pause:2.0"
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/host_aliases_undefined_or_empty/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/host_aliases_undefined_or_empty/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Host Aliases Undefined Or Empty",
+		"severity": "HIGH",
+		"line": 6
+	}
+]


### PR DESCRIPTION
Closes #2441 

**Proposed Changes**

A Kubernetes Pod should have Host Aliases defined as to prevent the container from modifying the file after a pod's containers have already been started. This means the attribute 'spec.host_aliases' must be defined and not empty or null.

I submit this contribution under Apache-2.0 license.
