### PR TITLE
Add RBAC Roles with Read Secrets Permissions query Closes #2383

### DIFF
--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "826abb30-3cd5-4e0b-a93b-67729b4f7e63",
+  "queryName": "RBAC Roles with Read Secrets Permissions",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Minimize access to secrets (RBAC)",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role#rule",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/query.rego
@@ -1,61 +1,31 @@
 package Cx
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_role[name]
+	resource := input.document[i].resource[resourceType]
 	readVerbs := ["get", "watch", "list"]
-	resource.rule[ru].resources[r] == "secrets"
-	resource.rule[ru].verbs[j] == readVerbs[k]
+	resource[name].rule[ru].resources[r] == "secrets"
+	resource[name].rule[ru].verbs[j] == readVerbs[k]
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_role.%s.rule", [name]),
+		"searchKey": sprintf("%s[%s].rule", [resourceType, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Roles should not be allowed to send read verbs to 'secrets' resources",
-		"keyActualValue": sprintf("Roles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rule[ru].verbs)]),
+		"keyActualValue": sprintf("Roles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource[name].rule[ru].verbs)]),
 	}
 }
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_role[name]
+	resource := input.document[i].resource[resourceType]
 	readVerbs := ["get", "watch", "list"]
-	resource.rule.resources[r] == "secrets"
-	resource.rule.verbs[j] == readVerbs[k]
+	resource[name].rule.resources[r] == "secrets"
+	resource[name].rule.verbs[j] == readVerbs[k]
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_role.%s.rule", [name]),
+		"searchKey": sprintf("%s[%s].rule", [resourceType, name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Roles should not be allowed to send read verbs to 'secrets' resources",
-		"keyActualValue": sprintf("Roles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rule.verbs)]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_cluster_role[name]
-	readVerbs := ["get", "watch", "list"]
-	resource.rule[ru].resources[r] == "secrets"
-	resource.rule[ru].verbs[j] == readVerbs[k]
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_cluster_role.%s.rule", [name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "ClusterRoles should not be allowed to send read verbs to 'secrets' resources",
-		"keyActualValue": sprintf("ClusterRoles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rule[ru].verbs)]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_cluster_role[name]
-	readVerbs := ["get", "watch", "list"]
-	resource.rule.resources[r] == "secrets"
-	resource.rule.verbs[j] == readVerbs[k]
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_cluster_role.%s.rule", [name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "ClusterRoles should not be allowed to send read verbs to 'secrets' resources",
-		"keyActualValue": sprintf("ClusterRoles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rule.verbs)]),
+		"keyActualValue": sprintf("Roles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource[name].rule.verbs)]),
 	}
 }

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/query.rego
@@ -1,11 +1,11 @@
 package Cx
 
+readVerbs := ["get", "watch", "list"]
+
 CxPolicy[result] {
 	resourceTypes := ["kubernetes_role", "kubernetes_cluster_role"]
 	resource := input.document[i].resource[resourceTypes[t]][name]
-	readVerbs := ["get", "watch", "list"]
-	resource.rule[ru].resources[r] == "secrets"
-	resource.rule[ru].verbs[j] == readVerbs[k]
+	allowsSecrets(resource.rule)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -14,4 +14,17 @@ CxPolicy[result] {
 		"keyExpectedValue": "Rules don't give access to 'secrets' resources",
 		"keyActualValue": "Some rule is giving access to 'secrets' resources",
 	}
+}
+
+allowsSecrets(rules) {
+	is_array(rules)
+	some r
+	rules[r].resources[_] == "secrets"
+	rules[r].verbs[_] == readVerbs[_]
+}
+
+allowsSecrets(rule) {
+	is_object(rule)
+	rule.resources[_] == "secrets"
+	rule.verbs[_] == readVerbs[_]
 }

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/query.rego
@@ -1,0 +1,61 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_role[name]
+	readVerbs := ["get", "watch", "list"]
+	resource.rule[ru].resources[r] == "secrets"
+	resource.rule[ru].verbs[j] == readVerbs[k]
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_role.%s.rule", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Roles should not be allowed to send read verbs to 'secrets' resources",
+		"keyActualValue": sprintf("Roles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rule[ru].verbs)]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_role[name]
+	readVerbs := ["get", "watch", "list"]
+	resource.rule.resources[r] == "secrets"
+	resource.rule.verbs[j] == readVerbs[k]
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_role.%s.rule", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Roles should not be allowed to send read verbs to 'secrets' resources",
+		"keyActualValue": sprintf("Roles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rule.verbs)]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role[name]
+	readVerbs := ["get", "watch", "list"]
+	resource.rule[ru].resources[r] == "secrets"
+	resource.rule[ru].verbs[j] == readVerbs[k]
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role.%s.rule", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "ClusterRoles should not be allowed to send read verbs to 'secrets' resources",
+		"keyActualValue": sprintf("ClusterRoles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rule[ru].verbs)]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role[name]
+	readVerbs := ["get", "watch", "list"]
+	resource.rule.resources[r] == "secrets"
+	resource.rule.verbs[j] == readVerbs[k]
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role.%s.rule", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "ClusterRoles should not be allowed to send read verbs to 'secrets' resources",
+		"keyActualValue": sprintf("ClusterRoles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource.rule.verbs)]),
+	}
+}

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/query.rego
@@ -1,31 +1,17 @@
 package Cx
 
 CxPolicy[result] {
-	resource := input.document[i].resource[resourceType]
+	resourceTypes := ["kubernetes_role", "kubernetes_cluster_role"]
+	resource := input.document[i].resource[resourceTypes[t]][name]
 	readVerbs := ["get", "watch", "list"]
-	resource[name].rule[ru].resources[r] == "secrets"
-	resource[name].rule[ru].verbs[j] == readVerbs[k]
+	resource.rule[ru].resources[r] == "secrets"
+	resource.rule[ru].verbs[j] == readVerbs[k]
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("%s[%s].rule", [resourceType, name]),
+		"searchKey": sprintf("%s[%s].rule", [resourceTypes[t], name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Roles should not be allowed to send read verbs to 'secrets' resources",
-		"keyActualValue": sprintf("Roles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource[name].rule[ru].verbs)]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource[resourceType]
-	readVerbs := ["get", "watch", "list"]
-	resource[name].rule.resources[r] == "secrets"
-	resource[name].rule.verbs[j] == readVerbs[k]
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("%s[%s].rule", [resourceType, name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Roles should not be allowed to send read verbs to 'secrets' resources",
-		"keyActualValue": sprintf("Roles should not be allowed to send read verbs to 'secrets' resources, verbs found: [%v]", [concat(", ", resource[name].rule.verbs)]),
+		"keyExpectedValue": "Rules don't give access to 'secrets' resources",
+		"keyActualValue": "Some rule is giving access to 'secrets' resources",
 	}
 }

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/negative.tf
@@ -1,0 +1,32 @@
+resource "kubernetes_role" "example1" {
+  metadata {
+    name = "terraform-example1"
+    labels = {
+      test = "MyRole"
+    }
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["pods"]
+    resource_names = ["foo"]
+    verbs          = ["get", "list", "watch"]
+  }
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_cluster_role" "example2" {
+  metadata {
+    name = "terraform-example2"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "pods"]
+    verbs      = ["get", "list", "watch"]
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive.tf
@@ -1,0 +1,65 @@
+resource "kubernetes_role" "example1" {
+  metadata {
+    name = "terraform-example1"
+    labels = {
+      test = "MyRole"
+    }
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["secrets", "namespaces"]
+    resource_names = ["foo"]
+    verbs          = ["get", "list", "watch"]
+  }
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_cluster_role" "example2" {
+  metadata {
+    name = "terraform-example2"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "secrets"]
+    verbs      = ["get", "list", "watch"]
+  }
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_role" "example3" {
+  metadata {
+    name = "terraform-example3"
+    labels = {
+      test = "MyRole"
+    }
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["secrets", "namespaces"]
+    resource_names = ["foo"]
+    verbs          = ["get", "list", "watch"]
+  }
+}
+
+resource "kubernetes_cluster_role" "example4" {
+  metadata {
+    name = "terraform-example4"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "secrets"]
+    verbs      = ["get", "list", "watch"]
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive.tf
@@ -35,3 +35,34 @@ resource "kubernetes_cluster_role" "example2" {
     verbs      = ["get", "list"]
   }
 }
+
+
+resource "kubernetes_role" "example3" {
+  metadata {
+    name = "terraform-example3"
+    labels = {
+      test = "MyRole"
+    }
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["secrets", "namespaces"]
+    resource_names = ["foo"]
+    verbs          = ["get", "list", "watch"]
+  }
+
+}
+
+resource "kubernetes_cluster_role" "example4" {
+  metadata {
+    name = "terraform-example4"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "secrets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+}

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive.tf
@@ -35,31 +35,3 @@ resource "kubernetes_cluster_role" "example2" {
     verbs      = ["get", "list"]
   }
 }
-
-resource "kubernetes_role" "example3" {
-  metadata {
-    name = "terraform-example3"
-    labels = {
-      test = "MyRole"
-    }
-  }
-
-  rule {
-    api_groups     = [""]
-    resources      = ["secrets", "namespaces"]
-    resource_names = ["foo"]
-    verbs          = ["get", "list", "watch"]
-  }
-}
-
-resource "kubernetes_cluster_role" "example4" {
-  metadata {
-    name = "terraform-example4"
-  }
-
-  rule {
-    api_groups = [""]
-    resources  = ["namespaces", "secrets"]
-    verbs      = ["get", "list", "watch"]
-  }
-}

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+  {
+    "queryName": "RBAC Roles with Read Secrets Permissions",
+    "severity": "MEDIUM",
+    "line": 9
+  },
+  {
+    "queryName": "RBAC Roles with Read Secrets Permissions",
+    "severity": "MEDIUM",
+    "line": 27
+  },
+  {
+    "queryName": "RBAC Roles with Read Secrets Permissions",
+    "severity": "MEDIUM",
+    "line": 47
+  },
+  {
+    "queryName": "RBAC Roles with Read Secrets Permissions",
+    "severity": "MEDIUM",
+    "line": 60
+  }
+]

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive_expected_result.json
@@ -8,5 +8,15 @@
     "queryName": "RBAC Roles with Read Secrets Permissions",
     "severity": "MEDIUM",
     "line": 27
+  },
+  {
+    "queryName": "RBAC Roles with Read Secrets Permissions",
+    "severity": "MEDIUM",
+    "line": 48
+  },
+  {
+    "queryName": "RBAC Roles with Read Secrets Permissions",
+    "severity": "MEDIUM",
+    "line": 62
   }
 ]

--- a/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/rbac_roles_with_read_secrets_permissions/test/positive_expected_result.json
@@ -8,15 +8,5 @@
     "queryName": "RBAC Roles with Read Secrets Permissions",
     "severity": "MEDIUM",
     "line": 27
-  },
-  {
-    "queryName": "RBAC Roles with Read Secrets Permissions",
-    "severity": "MEDIUM",
-    "line": 47
-  },
-  {
-    "queryName": "RBAC Roles with Read Secrets Permissions",
-    "severity": "MEDIUM",
-    "line": 60
   }
 ]


### PR DESCRIPTION
Closes #2383

**Proposed Changes**

- Support RBAC Roles with Read Secrets Permissions in Terraform (already exist in Kubernetes)

I submit this contribution under Apache-2.0 license.
