### PR TITLE
Add Cluster Admin Rolebinding With Superuser Permissions query Closes #2391

### DIFF
--- a/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "1762af9e-6f52-45fc-a6f2-aa417a4d5b62",
+  "queryName": "Cluster Admin Rolebinding With Superuser Permissions",
+  "severity": "LOW",
+  "category": "Access Control",
+  "descriptionText": "Ensure that the cluster-admin role is only used where required (RBAC)",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding#name",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/metadata.json
@@ -1,5 +1,5 @@
 {
-  "id": "1762af9e-6f52-45fc-a6f2-aa417a4d5b62",
+  "id": "17172bc2-56fb-4f17-916f-a014147706cd",
   "queryName": "Cluster Admin Rolebinding With Superuser Permissions",
   "severity": "LOW",
   "category": "Access Control",

--- a/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role_binding[name]
+	resource.role_ref.name == "cluster-admin"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role_binding[%s].role_ref.name", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resource name '%s' isn't binding 'cluster-admin' role with superuser permissions", [name]),
+		"keyActualValue": sprintf("Resource name '%s' is binding 'cluster-admin' role with superuser permissions", [name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/test/negative.tf
@@ -1,0 +1,25 @@
+resource "kubernetes_cluster_role_binding" "example1" {
+  metadata {
+    name = "terraform-example1"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = "kube-system"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/test/positive.tf
@@ -1,0 +1,25 @@
+resource "kubernetes_cluster_role_binding" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = "kube-system"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/test/positive.tf
@@ -1,6 +1,6 @@
-resource "kubernetes_cluster_role_binding" "example" {
+resource "kubernetes_cluster_role_binding" "example2" {
   metadata {
-    name = "terraform-example"
+    name = "terraform-example2"
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"

--- a/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/cluster_admin_role_binding_with_super_user_permissions/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Cluster Admin Rolebinding With Superuser Permissions",
+    "severity": "LOW",
+    "line": 8
+  }
+]


### PR DESCRIPTION
Closes #2391 

**Proposed Changes**

- Support Cluster Admin Rolebinding With Superuser Permissions in Terraform (already exist in Kubernetes)

I submit this contribution under Apache-2.0 license.
