### PR TITLE
Fixing typo in github actions integrations docs #2466

### DIFF
--- a/docs/integrations_ghactions.md
+++ b/docs/integrations_ghactions.md
@@ -41,7 +41,7 @@ steps:
     uses: checkmarx/kics-action@v1.0
     with:
       path: 'terraform'
-      output-path: 'results.sarif'
+      output_path: 'results.sarif'
   - name: Upload SARIF file
     uses: github/codeql-action/upload-sarif@v1
     with:


### PR DESCRIPTION
Closes #2466

**Proposed Changes**

- fixing typo `output-path` to `output_path`

I submit this contribution under Apache-2.0 license.
