### PR TITLE
Increasing timeout for golangci-lint to 5min

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -21,7 +21,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2.5.1
       with:
         version: v1.37
-        args: --timeout 2m --skip-dirs assets,docs
+        args: --timeout 5m --skip-dirs assets,docs
         skip-go-installation: true
   go-generate:
     name: go-generate


### PR DESCRIPTION
**Proposed Changes**

- Increasing golangci-lint timeout to 5 minutes


I submit this contribution under Apache-2.0 license.
