### PR TITLE
Optimize golangci-lint

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -21,7 +21,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2.5.1
       with:
         version: v1.37
-        args: --timeout 5m --skip-dirs assets,docs
+        args: -c .golangci.yml
         skip-go-installation: true
   go-generate:
     name: go-generate

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -105,15 +105,16 @@ issues:
         - scopelint
 
 run:
+  timeout: 5m
   skip-dirs:
-    - test/testdata_etc
-    - internal/cache
-    - internal/renameio
-    - internal/robustio
+    - assets
+    - docs
+    - vendor
+    - tools
 
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.28.1 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.37 # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,6 +106,7 @@ issues:
 
 run:
   timeout: 5m
+  allow-parallel-runners: true
   skip-dirs:
     - assets
     - docs

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,7 +106,6 @@ issues:
 
 run:
   timeout: 5m
-  allow-parallel-runners: true
   skip-dirs:
     - assets
     - docs


### PR DESCRIPTION

**Proposed Changes**

- `golangci-lint` is taking longer than usual, we should try different configurations to optimize its executions.


I submit this contribution under Apache-2.0 license.
