### PR TITLE
Add Container Runs Unmasked query #2482

### DIFF
--- a/assets/queries/k8s/container_runs_unmasked/query.rego
+++ b/assets/queries/k8s/container_runs_unmasked/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": document.id,
-		"searchKey": sprintf("metadata.name=%s.spec.allowedProcMountTypes", [document.metadata.name]),
+		"searchKey": sprintf("metadata.name={{%s}}.spec.allowedProcMountTypes", [document.metadata.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "AllowedProcMountTypes contains the value Default",
 		"keyActualValue": "AllowedProcMountTypes contains the value Unmasked",

--- a/assets/queries/terraform/kubernetes_pod/container_runs_unmasked/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/container_runs_unmasked/metadata.json
@@ -1,0 +1,9 @@
+{
+	"id": "0ad60203-c050-4115-83b6-b94bde92541d",
+	"queryName": "Container Runs Unmasked",
+	"severity": "MEDIUM",
+	"category": "Insecure Configurations",
+	"descriptionText": "Check if a container has full access (unmasked) to the host’s /proc command, which would allow to retrieve sensitive information and possibly change the kernel parameters in runtime.",
+	"descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod_security_policy#allowed_proc_mount_types",
+	"platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes_pod/container_runs_unmasked/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/container_runs_unmasked/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod_security_policy[name]
+
+	allowed_proc_mount_types := resource.spec.allowed_proc_mount_types
+	allowed_proc_mount_types[_] == "Unmasked"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec.allowed_proc_mount_types", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "allowed_proc_mount_types contains the value Default",
+		"keyActualValue": "allowed_proc_mount_types contains the value Unmasked",
+	}
+}

--- a/assets/queries/terraform/kubernetes_pod/container_runs_unmasked/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/container_runs_unmasked/test/negative.tf
@@ -1,0 +1,45 @@
+resource "kubernetes_pod_security_policy" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+    allow_privilege_escalation = false
+    allowed_proc_mount_types   = ["Default"]
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/container_runs_unmasked/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/container_runs_unmasked/test/positive.tf
@@ -1,0 +1,45 @@
+resource "kubernetes_pod_security_policy" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+    allow_privilege_escalation = false
+    allowed_proc_mount_types   = ["Unmasked"]
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/container_runs_unmasked/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/container_runs_unmasked/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+	{
+		"queryName": "Container Runs Unmasked",
+		"severity": "MEDIUM",
+		"line": 8
+	}
+]


### PR DESCRIPTION
Closes #2482

**Proposed Changes**

Check if a container has full access (unmasked) to the host’s /proc command, which would allow to retrieve sensitive information and possibly change the kernel parameters in runtime.

I submit this contribution under Apache-2.0 license.
