### PR TITLE
Add "Role Binding To Default Service Account" query for Terraform Closes #2491

### DIFF
--- a/assets/queries/k8s/role_binding_to_default_service_account/query.rego
+++ b/assets/queries/k8s/role_binding_to_default_service_account/query.rego
@@ -2,6 +2,7 @@ package Cx
 
 CxPolicy[result] {
 	document := input.document[i]
+	document.kind == "RoleBinding"
 	subjects := document.subjects
 	subjects[c].kind == "ServiceAccount"
 	subjects[c].name == "default"

--- a/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/metadata.json
@@ -4,6 +4,6 @@
   "severity": "HIGH",
   "category": "Insecure Defaults",
   "descriptionText": "No role nor cluster role should bind to a default service account",
-  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account#name",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding#subject",
   "platform": "Terraform"
 }

--- a/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "3360c01e-c8c0-4812-96a2-a6329b9b7f9f",
+  "queryName": "Role Binding To Default Service Account",
+  "severity": "HIGH",
+  "category": "Insecure Defaults",
+  "descriptionText": "No role nor cluster role should bind to a default service account",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account#name",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_service_account[name]
+
+	resource.metadata.name == "default"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_service_account[%s].metadata.name", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_service_account[%s].metadata.name is not default", [name]),
+		"keyActualValue": sprintf("kubernetes_service_account[%s].metadata.name is default", [name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/query.rego
@@ -1,15 +1,17 @@
 package Cx
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_service_account[name]
+	resource := input.document[i].resource.kubernetes_role_binding[name]
 
-	resource.metadata.name == "default"
+	resource.subject[k].kind == "ServiceAccount"
+
+	resource.subject[k].name == "default"
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_service_account[%s].metadata.name", [name]),
+		"searchKey": sprintf("resource.kubernetes_role_binding[%s]", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_service_account[%s].metadata.name is not default", [name]),
-		"keyActualValue": sprintf("kubernetes_service_account[%s].metadata.name is default", [name]),
+		"keyExpectedValue": sprintf("resource.kubernetes_role_binding[%s].subject[%d].name is not default", [name, k]),
+		"keyActualValue": sprintf("resource.kubernetes_role_binding[%s].subject[%d].name is default", [name, k]),
 	}
 }

--- a/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/negative.tf
@@ -1,0 +1,5 @@
+resource "kubernetes_service_account" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/negative.tf
@@ -1,5 +1,26 @@
-resource "kubernetes_service_account" "example" {
+resource "kubernetes_role_binding" "example2" {
   metadata {
-    name = "terraform-example"
+    name      = "terraform-example"
+    namespace = "default"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "serviceExample"
+    namespace = "kube-system"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
   }
 }

--- a/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/positive.tf
@@ -1,0 +1,5 @@
+resource "kubernetes_service_account" "example" {
+  metadata {
+    name = "default"
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/positive.tf
@@ -1,5 +1,26 @@
-resource "kubernetes_service_account" "example" {
+resource "kubernetes_role_binding" "example" {
   metadata {
-    name = "default"
+    name      = "terraform-example"
+    namespace = "default"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "admin"
+  }
+  subject {
+    kind      = "User"
+    name      = "admin"
+    api_group = "rbac.authorization.k8s.io"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = "kube-system"
+  }
+  subject {
+    kind      = "Group"
+    name      = "system:masters"
+    api_group = "rbac.authorization.k8s.io"
   }
 }

--- a/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/positive_expected_result.json
@@ -2,6 +2,6 @@
   {
     "queryName": "Role Binding To Default Service Account",
     "severity": "HIGH",
-    "line": 3
+    "line": 1
   }
 ]

--- a/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/role_binding_to_default_service_account/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Role Binding To Default Service Account",
+    "severity": "HIGH",
+    "line": 3
+  }
+]


### PR DESCRIPTION
Closes #2491

**Proposed Changes**

- Support "Role Binding To Default Service Account" query for Terraform (same as "Role Binding To Default Service Account" for Kubernetes). It is necessary to check if the attribute `subject[k].kind` is equal to "ServiceAccount" and `subject[k].name` is equal to "default"

I submit this contribution under Apache-2.0 license.
