### PR TITLE
Add "Default Service Account In Use" query for Terraform Closes #2499

### DIFF
--- a/assets/queries/terraform/kubernetes_pod/default_service_account_in_use/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/default_service_account_in_use/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "737a0dd9-0aaa-4145-8118-f01778262b8a",
+  "queryName": "Default Service Account In Use",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "Default service accounts should not be actively used",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account#automount_service_account_token",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes_pod/default_service_account_in_use/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/default_service_account_in_use/query.rego
@@ -1,0 +1,33 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_service_account[name]
+
+	resource.metadata.name == "default"
+
+	object.get(resource, "automount_service_account_token", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_service_account[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_service_account[%s].automount_service_account_token is set", [name]),
+		"keyActualValue": sprintf("kubernetes_service_account[%s].automount_service_account_token is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_service_account[name]
+
+	resource.metadata.name == "default"
+
+	resource.automount_service_account_token == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_service_account[%s].automount_service_account_token", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_service_account[%s].automount_service_account_token is set to false", [name]),
+		"keyActualValue": sprintf("kubernetes_service_account[%s].automount_service_account_token is not set to false", [name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes_pod/default_service_account_in_use/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/default_service_account_in_use/test/negative.tf
@@ -1,0 +1,7 @@
+resource "kubernetes_service_account" "example3" {
+  metadata {
+    name = "default"
+  }
+
+  automount_service_account_token = false
+}

--- a/assets/queries/terraform/kubernetes_pod/default_service_account_in_use/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/default_service_account_in_use/test/positive.tf
@@ -1,0 +1,13 @@
+resource "kubernetes_service_account" "example" {
+  metadata {
+    name = "default"
+  }
+}
+
+resource "kubernetes_service_account" "example2" {
+  metadata {
+    name = "default"
+  }
+
+  automount_service_account_token = true
+}

--- a/assets/queries/terraform/kubernetes_pod/default_service_account_in_use/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/default_service_account_in_use/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "Default Service Account In Use",
+    "severity": "MEDIUM",
+    "line": 1
+  },
+  {
+    "queryName": "Default Service Account In Use",
+    "severity": "MEDIUM",
+    "line": 12
+  }
+]


### PR DESCRIPTION
Closes #2499

**Proposed Changes**

- Support "Default Service Account In Use" query for Terraform (same as "Default Service Account In Use" for Kubernetes). It is necessary to check if the attribute `automount_service_account_token` is undefined or set to true when `metadata.name` is equal to "default"

I submit this contribution under Apache-2.0 license.
