### PR TITLE
Add "Using Default Namespace" query for Terraform Closes #2502

### DIFF
--- a/assets/queries/k8s/using_default_namespace/query.rego
+++ b/assets/queries/k8s/using_default_namespace/query.rego
@@ -1,12 +1,13 @@
 package Cx
 
+listKinds := ["Pod", "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "ReplicationController", "Job", "CronJob", "Service", "Secret", "ServiceAccount", "Role", "RoleBinding", "ConfigMap", "Ingress"]
+
 import data.generic.k8s as k8sLib
 
 CxPolicy[result] {
 	document := input.document[i]
 
-    kind := document.kind
-    listKinds :=  ["Pod", "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "ReplicationController", "Job", "CronJob", "Service", "Secret", "ServiceAccount", "Role", "RoleBinding", "ConfigMap", "Ingress"]
+	kind := document.kind
 	k8sLib.checkKind(kind, listKinds)
 
 	metadata = document.metadata
@@ -25,8 +26,7 @@ CxPolicy[result] {
 CxPolicy[result] {
 	document := input.document[i]
 
-    kind := document.kind
-    listKinds :=  ["Pod", "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "ReplicationController", "Job", "CronJob", "Service", "Secret", "Role", "RoleBinding", "ConfigMap", "Ingress"]
+	kind := document.kind
 	k8sLib.checkKind(kind, listKinds)
 
 	metadata = document.metadata

--- a/assets/queries/terraform/kubernetes_pod/using_default_namespace/metadata.json
+++ b/assets/queries/terraform/kubernetes_pod/using_default_namespace/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "abcb818b-5af7-4d72-aba9-6dd84956b451",
+  "queryName": "Using Default Namespace",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "The default namespace should not be used",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#namespace",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes_pod/using_default_namespace/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/using_default_namespace/query.rego
@@ -34,6 +34,6 @@ CxPolicy[result] {
 		"searchKey": sprintf("%s[%s].metadata.namespace", [listKinds[x], name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].metadata.namespace is not set to 'default'", [listKinds[x], name]),
-		"keyActualValue": sprintf("%s[%s].metadata is set to 'default'", [listKinds[x], name]),
+		"keyActualValue": sprintf("%s[%s].metadata.namespace is set to 'default'", [listKinds[x], name]),
 	}
 }

--- a/assets/queries/terraform/kubernetes_pod/using_default_namespace/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/using_default_namespace/query.rego
@@ -1,9 +1,9 @@
 package Cx
 
+listKinds := {"kubernetes_ingress", "kubernetes_config_map", "kubernetes_secret", "kubernetes_service", "kubernetes_cron_job", "kubernetes_service_account", "kubernetes_role", "kubernetes_role_binding", "kubernetes_pod", "kubernetes_deployment", "kubernetes_daemonset", "kubernetes_job", "kubernetes_stateful_set", "kubernetes_replication_controller"}
+
 CxPolicy[result] {
 	resource := input.document[i].resource
-
-	listKinds := {"kubernetes_ingress", "kubernetes_config_map", "kubernetes_secret", "kubernetes_service", "kubernetes_cron_job", "kubernetes_service_account", "kubernetes_role", "kubernetes_role_binding", "kubernetes_pod", "kubernetes_deployment", "kubernetes_daemonset", "kubernetes_job", "kubernetes_stateful_set", "kubernetes_replication_controller"}
 
 	k8s := object.get(resource, listKinds[x], "undefined")
 	k8s != "undefined"
@@ -21,8 +21,6 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	resource := input.document[i].resource
-
-	listKinds := {"kubernetes_ingress", "kubernetes_config_map", "kubernetes_secret", "kubernetes_service", "kubernetes_cron_job", "kubernetes_service_account", "kubernetes_role", "kubernetes_role_binding", "kubernetes_pod", "kubernetes_deployment", "kubernetes_daemonset", "kubernetes_job", "kubernetes_stateful_set", "kubernetes_replication_controller"}
 
 	k8s := object.get(resource, listKinds[x], "undefined")
 	k8s != "undefined"

--- a/assets/queries/terraform/kubernetes_pod/using_default_namespace/query.rego
+++ b/assets/queries/terraform/kubernetes_pod/using_default_namespace/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource
+
+	listKinds := {"kubernetes_ingress", "kubernetes_config_map", "kubernetes_secret", "kubernetes_service", "kubernetes_cron_job", "kubernetes_service_account", "kubernetes_role", "kubernetes_role_binding", "kubernetes_pod", "kubernetes_deployment", "kubernetes_daemonset", "kubernetes_job", "kubernetes_stateful_set", "kubernetes_replication_controller"}
+
+	k8s := object.get(resource, listKinds[x], "undefined")
+	k8s != "undefined"
+
+	object.get(k8s[name].metadata, "namespace", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].metadata", [listKinds[x], name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].metadata is set", [listKinds[x], name]),
+		"keyActualValue": sprintf("%s[%s].metadata is undefined", [listKinds[x], name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource
+
+	listKinds := {"kubernetes_ingress", "kubernetes_config_map", "kubernetes_secret", "kubernetes_service", "kubernetes_cron_job", "kubernetes_service_account", "kubernetes_role", "kubernetes_role_binding", "kubernetes_pod", "kubernetes_deployment", "kubernetes_daemonset", "kubernetes_job", "kubernetes_stateful_set", "kubernetes_replication_controller"}
+
+	k8s := object.get(resource, listKinds[x], "undefined")
+	k8s != "undefined"
+
+	k8s[name].metadata.namespace == "default"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].metadata.namespace", [listKinds[x], name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].metadata.namespace is not set to 'default'", [listKinds[x], name]),
+		"keyActualValue": sprintf("%s[%s].metadata is set to 'default'", [listKinds[x], name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes_pod/using_default_namespace/test/negative.tf
+++ b/assets/queries/terraform/kubernetes_pod/using_default_namespace/test/negative.tf
@@ -1,0 +1,13 @@
+resource "kubernetes_pod" "test3" {
+  metadata {
+    name = "terraform-example"
+    namespace = "terraform-namespace"
+  }
+}
+
+resource "kubernetes_cron_job" "test4" {
+  metadata {
+    name = "terraform-example"
+    namespace = "terraform-namespace"
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/using_default_namespace/test/positive.tf
+++ b/assets/queries/terraform/kubernetes_pod/using_default_namespace/test/positive.tf
@@ -1,0 +1,12 @@
+resource "kubernetes_pod" "test" {
+  metadata {
+    name = "terraform-example"
+    namespace = "default"
+  }
+}
+
+resource "kubernetes_cron_job" "test2" {
+  metadata {
+    name = "terraform-example"
+  }
+}

--- a/assets/queries/terraform/kubernetes_pod/using_default_namespace/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes_pod/using_default_namespace/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "Using Default Namespace",
+    "severity": "MEDIUM",
+    "line": 4
+  },
+  {
+    "queryName": "Using Default Namespace",
+    "severity": "MEDIUM",
+    "line": 9
+  }
+]


### PR DESCRIPTION
Closes #2502

**Proposed Changes**

- Support "Using Default Namespace" query for Terraform (same as "Using Default Namespace" for Kubernetes). It is necessary to check if the attribute `metadata.namespace` is set to "default"

I submit this contribution under Apache-2.0 license.
