### PR TITLE
Add "Pod or Container Without Security Context" query for Terraform Closes #2513

### DIFF
--- a/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/metadata.json
+++ b/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "ad69e38a-d92e-4357-a8da-f2f29d545883",
+  "queryName": "Pod or Container Without Security Context",
+  "severity": "LOW",
+  "category": "Insecure Configurations",
+  "descriptionText": "A security context defines privilege and access control settings for a Pod or Container",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#security_context",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/query.rego
+++ b/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/query.rego
@@ -1,0 +1,55 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+
+	spec := resource.spec
+
+	object.get(spec, "security_context", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].spec", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_pod[%s].spec.security_context is set", [name]),
+		"keyActualValue": sprintf("kubernetes_pod[%s].spec.security_context is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+
+	spec := resource.spec
+	types := {"init_container", "container"}
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+	object.get(containers, "security_context", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].spec.%s", [name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_pod[%s].spec.%s.security_context is set", [name, types[x]]),
+		"keyActualValue": sprintf("kubernetes_pod[%s].spec.%s.security_context is undefined", [name, types[x]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+
+	spec := resource.spec
+	types := {"init_container", "container"}
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+	object.get(containers[y], "security_context", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].spec.%s", [name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_pod[%s].spec.%s[%d].security_context is set", [name, types[x], y]),
+		"keyActualValue": sprintf("kubernetes_pod[%s].spec.%s[%d].security_context is undefined", [name, types[x], y]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/query.rego
+++ b/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/query.rego
@@ -17,9 +17,9 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_pod[name]
+	resource := input.document[i].resource[resourceType]
 
-	spec := resource.spec
+	spec := resource[name].spec
 	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
@@ -28,17 +28,17 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_pod[%s].spec.%s", [name, types[x]]),
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("kubernetes_pod[%s].spec.%s.security_context is set", [name, types[x]]),
-		"keyActualValue": sprintf("kubernetes_pod[%s].spec.%s.security_context is undefined", [name, types[x]]),
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.security_context is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.security_context is undefined", [resourceType, name, types[x]]),
 	}
 }
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_pod[name]
+	resource := input.document[i].resource[resourceType]
 
-	spec := resource.spec
+	spec := resource[name].spec
 	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
@@ -47,9 +47,9 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_pod[%s].spec.%s", [name, types[x]]),
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("kubernetes_pod[%s].spec.%s[%d].security_context is set", [name, types[x], y]),
-		"keyActualValue": sprintf("kubernetes_pod[%s].spec.%s[%d].security_context is undefined", [name, types[x], y]),
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].security_context is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].security_context is undefined", [resourceType, name, types[x], y]),
 	}
 }

--- a/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/test/negative.tf
@@ -1,0 +1,161 @@
+
+resource "kubernetes_pod" "negative4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    security_context = {
+        allow_privilege_escalation = false
+    }
+
+    container = [
+     {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context = {
+        allow_privilege_escalation = false
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+     ,
+     {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context = {
+        allow_privilege_escalation = false
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+   ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+
+resource "kubernetes_pod" "negative5" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    security_context = {
+        allow_privilege_escalation = false
+    }
+
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      security_context = {
+        allow_privilege_escalation = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/test/positive.tf
@@ -1,5 +1,4 @@
-
-resource "kubernetes_pod" "negative4" {
+resource "kubernetes_pod" "positive1" {
   metadata {
     name = "terraform-example"
   }
@@ -86,7 +85,7 @@ resource "kubernetes_pod" "negative4" {
 
 
 
-resource "kubernetes_pod" "negative5" {
+resource "kubernetes_pod" "positive2" {
   metadata {
     name = "terraform-example"
   }

--- a/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/test/positive.tf
@@ -1,0 +1,145 @@
+
+resource "kubernetes_pod" "negative4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+     {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+     ,
+     {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+   ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+
+resource "kubernetes_pod" "negative5" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      security_context = {
+        allow_privilege_escalation = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/test/positive_expected_result.json
@@ -2,21 +2,21 @@
   {
     "queryName": "Pod or Container Without Security Context",
     "severity": "LOW",
+    "line": 6
+  },
+  {
+    "queryName": "Pod or Container Without Security Context",
+    "severity": "LOW",
     "line": 7
   },
   {
     "queryName": "Pod or Container Without Security Context",
     "severity": "LOW",
-    "line": 8
+    "line": 7
   },
   {
     "queryName": "Pod or Container Without Security Context",
     "severity": "LOW",
-    "line": 8
-  },
-  {
-    "queryName": "Pod or Container Without Security Context",
-    "severity": "LOW",
-    "line": 94
+    "line": 93
   }
 ]

--- a/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+  {
+    "queryName": "Pod or Container Without Security Context",
+    "severity": "LOW",
+    "line": 7
+  },
+  {
+    "queryName": "Pod or Container Without Security Context",
+    "severity": "LOW",
+    "line": 8
+  },
+  {
+    "queryName": "Pod or Container Without Security Context",
+    "severity": "LOW",
+    "line": 8
+  },
+  {
+    "queryName": "Pod or Container Without Security Context",
+    "severity": "LOW",
+    "line": 94
+  }
+]


### PR DESCRIPTION
Closes #2513

**Proposed Changes**

- Support "Pod or Container Without Security Context" query for Terraform (same as "Pod or Container Without Security Context" for Kubernetes). It is necessary to check if the attribute `security_context` exists

I submit this contribution under Apache-2.0 license.
