### PR TITLE
Add EC2 Instance Has Public IP query for Terraform 

### DIFF
--- a/assets/queries/cloudFormation/ec2_subnet_mapping_public_ip_on_launch/metadata.json
+++ b/assets/queries/cloudFormation/ec2_subnet_mapping_public_ip_on_launch/metadata.json
@@ -1,9 +1,9 @@
 {
-	"id": "b3de4e4c-14be-4159-b99d-9ad194365e4c",
-	"queryName": "EC2 Subnet Mapping Public IP On Launch",
-	"severity": "MEDIUM",
-	"category": "Insecure Configurations",
-	"descriptionText": "EC2 Subnet should not have MapPublicIpOnLaunch set to true",
-	"descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet.html#cfn-ec2-subnet-mappubliciponlaunch",
-	"platform": "CloudFormation"
+  "id": "b3de4e4c-14be-4159-b99d-9ad194365e4c",
+  "queryName": "EC2 Instance Has Public IP",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "EC2 Subnet should not have MapPublicIpOnLaunch set to true",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet.html#cfn-ec2-subnet-mappubliciponlaunch",
+  "platform": "CloudFormation"
 }

--- a/assets/queries/cloudFormation/ec2_subnet_mapping_public_ip_on_launch/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/ec2_subnet_mapping_public_ip_on_launch/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
   {
-    "queryName": "EC2 Subnet Mapping Public IP On Launch",
+    "queryName": "EC2 Instance Has Public IP",
     "severity": "MEDIUM",
     "line": 7,
     "fileName": "positive1.yaml"
   },
   {
-    "queryName": "EC2 Subnet Mapping Public IP On Launch",
+    "queryName": "EC2 Instance Has Public IP",
     "severity": "MEDIUM",
     "line": 8,
     "fileName": "positive2.json"

--- a/assets/queries/terraform/aws/ec2_instance_has_public_ip/metadata.json
+++ b/assets/queries/terraform/aws/ec2_instance_has_public_ip/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "5a2486aa-facf-477d-a5c1-b010789459ce",
+  "queryName": "EC2 Instance Has Public IP",
+  "severity": "HIGH",
+  "category": "Networking and Firewall",
+  "descriptionText": "EC2 Instance should not have a public IP address.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#associate_public_ip_address",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/ec2_instance_has_public_ip/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_has_public_ip/query.rego
@@ -1,0 +1,37 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_instance[name]
+
+	object.get(resource, "associate_public_ip_address", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_instance.%s", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_instance.%s.associate_public_ip_address is defined", [name]),
+		"keyActualValue": sprintf("aws_instance.%s.associate_public_ip_address is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_instance[name]
+
+	isTrue(resource.associate_public_ip_address)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_instance.%s.associate_public_ip_address", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_instance.%s.associate_public_ip_address is false", [name]),
+		"keyActualValue": sprintf("aws_instance.%s.associate_public_ip_address is true", [name]),
+	}
+}
+
+isTrue(answer) {
+	lower(answer) == "yes"
+} else {
+	lower(answer) == "true"
+} else {
+	answer == true
+}

--- a/assets/queries/terraform/aws/ec2_instance_has_public_ip/test/negative.tf
+++ b/assets/queries/terraform/aws/ec2_instance_has_public_ip/test/negative.tf
@@ -1,0 +1,25 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  associate_public_ip_address = false
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}

--- a/assets/queries/terraform/aws/ec2_instance_has_public_ip/test/positive.tf
+++ b/assets/queries/terraform/aws/ec2_instance_has_public_ip/test/positive.tf
@@ -1,0 +1,34 @@
+data "aws_ami" "ubuntu1" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "web2" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}
+
+resource "aws_instance" "web3" {
+  ami           = data.aws_ami.ubuntu.id
+  associate_public_ip_address = true
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}

--- a/assets/queries/terraform/aws/ec2_instance_has_public_ip/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ec2_instance_has_public_ip/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "EC2 Instance Has Public IP",
+    "severity": "HIGH",
+    "line": 17
+  },
+  {
+    "queryName": "EC2 Instance Has Public IP",
+    "severity": "HIGH",
+    "line": 28
+  }
+]


### PR DESCRIPTION
Closes #2529

**Proposed Changes**

- Adding EC2 Instance Has Public IP query for Terraform;
- Updating the name of the query in CloudFormation.

I submit this contribution under Apache-2.0 license.
