### PR TITLE
Add "CPU Limits Not Set" query for Terraform Closes #2534

### DIFF
--- a/assets/queries/terraform/kubernetes/cpu_limits_not_set/metadata.json
+++ b/assets/queries/terraform/kubernetes/cpu_limits_not_set/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "5f4735ce-b9ba-4d95-a089-a37a767b716f",
+  "queryName": "CPU Limits Not Set",
+  "severity": "MEDIUM",
+  "category": "Resource Management",
+  "descriptionText": "CPU limits should be set because if the system has CPU time free, a container is guaranteed to be allocated as much CPU as it requests",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#limits",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/cpu_limits_not_set/query.rego
+++ b/assets/queries/terraform/kubernetes/cpu_limits_not_set/query.rego
@@ -1,0 +1,119 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	types := {"init_container", "container"}
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+
+	object.get(containers[y].resources.limits, "cpu", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].resources.limits.cpu is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].resources.limits.cpu is undefined", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	types := {"init_container", "container"}
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+
+	object.get(containers.resources.limits, "cpu", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s.resources.limits", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.resources.limits.cpu is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.resources.limits.cpu is undefined", [resourceType, name, types[x]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	types := {"init_container", "container"}
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+	object.get(containers[y], "resources", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].resources is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].resources is undefined", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	types := {"init_container", "container"}
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+	object.get(containers, "resources", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.resources is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.resources is undefined", [resourceType, name, types[x]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	types := {"init_container", "container"}
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+
+	object.get(containers[y].resources, "limits", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].resources.limits is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].resources.limits is undefined", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	types := {"init_container", "container"}
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+
+	object.get(containers.resources, "limits", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s.resources", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.resources.limits is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.resources.limits is undefined", [resourceType, name, types[x]]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/cpu_limits_not_set/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/cpu_limits_not_set/test/negative.tf
@@ -1,0 +1,174 @@
+
+resource "kubernetes_pod" "negative1" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+     {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      resources = {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+     ,
+     {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      resources = {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+   ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+
+resource "kubernetes_pod" "negative2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      resources  {
+            limits  {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/cpu_limits_not_set/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/cpu_limits_not_set/test/positive.tf
@@ -1,0 +1,154 @@
+
+resource "kubernetes_pod" "positive1" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+     {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+     ,
+     {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      resources = {
+            requests = {
+              memory = "50Mi"
+            }
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+   ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+
+resource "kubernetes_pod" "positive2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      resources {
+            limits {
+              memory = "512Mi"
+            }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+

--- a/assets/queries/terraform/kubernetes/cpu_limits_not_set/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/cpu_limits_not_set/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+  {
+    "queryName": "CPU Limits Not Set",
+    "severity": "MEDIUM",
+    "line": 8
+  },
+  {
+    "queryName": "CPU Limits Not Set",
+    "severity": "MEDIUM",
+    "line": 8
+  },
+  {
+    "queryName": "CPU Limits Not Set",
+    "severity": "MEDIUM",
+    "line": 106
+  }
+]


### PR DESCRIPTION
Closes #2534

**Proposed Changes**

- Support "CPU Limits Not Set" query for Terraform (same as "CPU Limits Not Set" for Kubernetes). It is necessary to check if the attribute `resources.limits.cpu` exists

I submit this contribution under Apache-2.0 license.
