### PR TITLE
Add "Container Is Privileged" for Terraform Closes #2536

### DIFF
--- a/assets/queries/terraform/kubernetes/container_is_privileged/metadata.json
+++ b/assets/queries/terraform/kubernetes/container_is_privileged/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "87065ef8-de9b-40d8-9753-f4a4303e27a4",
+  "queryName": "Container Is Privileged",
+  "severity": "HIGH",
+  "category": "Insecure Configurations",
+  "descriptionText": "Do not allow container to be privileged.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#privileged",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/container_is_privileged/query.rego
+++ b/assets/queries/terraform/kubernetes/container_is_privileged/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	types := {"init_container", "container"}
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+	containers[y].security_context.privileged == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].security_context.privileged is set to false", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].security_context.privileged is set to true", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	types := {"init_container", "container"}
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+	containers.security_context.privileged == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s.security_context.privileged", [resourceType, name, types[x]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.security_context.privileged is not set to true", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.security_context.privileged is set to true", [resourceType, name, types[x]]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/container_is_privileged/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/container_is_privileged/test/negative.tf
@@ -1,0 +1,153 @@
+
+resource "kubernetes_pod" "negative4" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+     {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context = {
+        privileged = false
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+     ,
+     {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context = {
+        privileged = false
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+   ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+
+resource "kubernetes_pod" "negative5" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      security_context = {
+        privileged = false
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/container_is_privileged/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/container_is_privileged/test/positive.tf
@@ -1,0 +1,153 @@
+
+resource "kubernetes_pod" "positive1" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+     {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      security_context = {
+        privileged = true
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+     ,
+     {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      security_context = {
+        privileged = true
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+   ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+
+resource "kubernetes_pod" "positive2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      security_context = {
+        privileged = true
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/container_is_privileged/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/container_is_privileged/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+  {
+    "queryName": "Container Is Privileged",
+    "severity": "HIGH",
+    "line": 8
+  },
+  {
+    "queryName": "Container Is Privileged",
+    "severity": "HIGH",
+    "line": 8
+  },
+  {
+    "queryName": "Container Is Privileged",
+    "severity": "HIGH",
+    "line": 108
+  }
+]


### PR DESCRIPTION
Closes #2536

**Proposed Changes**

- Support "Container Is Privileged" query for Terraform (same as "Container Is Privileged" for Kubernetes). It is necessary to check if the attribute `security_context.privileged `is set to true

I submit this contribution under Apache-2.0 license.
