### PR TITLE
Add "Not Limited Capabilities For Pod Security Policy" query for Terraform  Closes #2541

### DIFF
--- a/assets/queries/terraform/kubernetes/not_limited_capabilities_for_pod_security_policy/metadata.json
+++ b/assets/queries/terraform/kubernetes/not_limited_capabilities_for_pod_security_policy/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "2acb555f-f4ad-4b1b-b984-84e6588f4b05",
+  "queryName": "Not Limited Capabilities For Pod Security Policy",
+  "severity": "HIGH",
+  "category": "Insecure Configurations",
+  "descriptionText": "Limit capabilities for a Pod Security Policy",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod_security_policy#required_drop_capabilities",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/not_limited_capabilities_for_pod_security_policy/query.rego
+++ b/assets/queries/terraform/kubernetes/not_limited_capabilities_for_pod_security_policy/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod_security_policy[name]
+
+	object.get(resource.spec, "required_drop_capabilities", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_pod_security_policy[%s].spec.required_drop_capabilities is set", [name]),
+		"keyActualValue": sprintf("kubernetes_pod_security_policy[%s].spec.required_drop_capabilities is undefined", [name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/not_limited_capabilities_for_pod_security_policy/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/not_limited_capabilities_for_pod_security_policy/test/negative.tf
@@ -1,0 +1,45 @@
+resource "kubernetes_pod_security_policy" "example2" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+    allow_privilege_escalation = false
+    required_drop_capabilities = ["ALL"]
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}

--- a/assets/queries/terraform/kubernetes/not_limited_capabilities_for_pod_security_policy/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/not_limited_capabilities_for_pod_security_policy/test/positive.tf
@@ -1,0 +1,44 @@
+resource "kubernetes_pod_security_policy" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+    allow_privilege_escalation = false
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}

--- a/assets/queries/terraform/kubernetes/not_limited_capabilities_for_pod_security_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/not_limited_capabilities_for_pod_security_policy/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Not Limited Capabilities For Pod Security Policy",
+    "severity": "HIGH",
+    "line": 5
+  }
+]


### PR DESCRIPTION
Closes #2541

**Proposed Changes**

- Support "Not Limited Capabilities For Pod Security Policy" query for Terraform (same as "Not Limited Capabilities For Pod Security Policy" for Kubernetes). It is necessary to check if the attribute `spec.required_drop_capabilities` is set

I submit this contribution under Apache-2.0 license.
