### PR TITLE
Add "Seccomp Profile Is Not Configured" query for Terraform Closes #2548

### DIFF
--- a/assets/queries/terraform/kubernetes/secoomp_profile_is_not_configured/metadata.json
+++ b/assets/queries/terraform/kubernetes/secoomp_profile_is_not_configured/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "455f2e0c-686d-4fcb-8b5f-3f953f12c43c",
+  "queryName": "Seccomp Profile Is Not Configured",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "Check if any resource does not configure Seccomp default profile properly",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#annotations",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/secoomp_profile_is_not_configured/query.rego
+++ b/assets/queries/terraform/kubernetes/secoomp_profile_is_not_configured/query.rego
@@ -1,0 +1,176 @@
+package Cx
+
+#pod
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+
+	metadata := resource.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
+
+	annotations := metadata.annotations
+	object.get(annotations, "${seccomp.security.alpha.kubernetes.io/defaultProfileName}", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].metadata.annotations", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_pod[%s].metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is set", [name]),
+		"keyActualValue": sprintf("kubernetes_pod[%s].metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+
+	metadata := resource.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
+
+	annotations := metadata.annotations
+	object.get(annotations, "${seccomp.security.alpha.kubernetes.io/defaultProfileName}", "undefined") != "undefined"
+
+	seccomp := annotations["${seccomp.security.alpha.kubernetes.io/defaultProfileName}"]
+
+	seccomp != "runtime/default"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].metadata.annotations", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_pod[%s].metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is 'runtime/default'", [name]),
+		"keyActualValue": sprintf("kubernetes_pod[%s].metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is '%s'", [name, seccomp]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+
+	metadata := resource.metadata
+	object.get(metadata, "annotations", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].metadata", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_pod[%s].metadata.annotations is set", [name]),
+		"keyActualValue": sprintf("kubernetes_pod[%s].metadata.annotations is undefined", [name]),
+	}
+}
+
+# cron_job
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cron_job[name]
+
+	metadata := resource.spec.job_template.spec.template.metadata
+	object.get(metadata, "annotations", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.metadata", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.metadata.annotations is set", [name]),
+		"keyActualValue": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.metadata.annotations is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cron_job[name]
+
+	metadata := resource.spec.job_template.spec.template.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
+
+	annotations := metadata.annotations
+	object.get(annotations, "${seccomp.security.alpha.kubernetes.io/defaultProfileName}", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.metadata.annotations", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is set", [name]),
+		"keyActualValue": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cron_job[name]
+
+	metadata := resource.spec.job_template.spec.template.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
+
+	annotations := metadata.annotations
+	object.get(annotations, "${seccomp.security.alpha.kubernetes.io/defaultProfileName}", "undefined") != "undefined"
+
+	seccomp := annotations["${seccomp.security.alpha.kubernetes.io/defaultProfileName}"]
+	seccomp != "runtime/default"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.metadata.annotations", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is 'runtime/default'", [name]),
+		"keyActualValue": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is '%s'", [name, seccomp]),
+	}
+}
+
+#general
+resources := {"kubernetes_cron_job", "kubernetes_pod"}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	resourceType != resources[x]
+
+	metadata := resource[name].spec.template.metadata
+	object.get(metadata, "annotations", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.template.metadata", [resourceType, name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.template.metadata.annotations is set", [resourceType, name]),
+		"keyActualValue": sprintf("%s[%s].spec.template.metadata.annotations is undefined", [resourceType, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	resourceType != resources[x]
+
+	metadata := resource[name].spec.template.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
+
+	annotations := metadata.annotations
+	object.get(annotations, "${seccomp.security.alpha.kubernetes.io/defaultProfileName}", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.template.metadata.annotations", [resourceType, name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is set", [resourceType, name]),
+		"keyActualValue": sprintf("%s[%s].spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is undefined", [resourceType, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	resourceType != resources[x]
+
+	metadata := resource[name].spec.template.metadata
+	object.get(metadata, "annotations", "undefined") != "undefined"
+
+	annotations := metadata.annotations
+	object.get(annotations, "${seccomp.security.alpha.kubernetes.io/defaultProfileName}", "undefined") != "undefined"
+
+	seccomp := annotations["${seccomp.security.alpha.kubernetes.io/defaultProfileName}"]
+
+	seccomp != "runtime/default"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.template.metadata.annotations", [resourceType, name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is 'runtime/default'", [resourceType, name]),
+		"keyActualValue": sprintf("%s[%s].spec.template.metadata.annotations.seccomp.security.alpha.kubernetes.io/defaultProfileName is '%s'", [resourceType, name, seccomp]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/secoomp_profile_is_not_configured/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/secoomp_profile_is_not_configured/test/negative.tf
@@ -1,0 +1,153 @@
+resource "kubernetes_pod" "pod" {
+  metadata {
+    name = "terraform-example"
+
+    annotations = {
+      seccomp.security.alpha.kubernetes.io/defaultProfileName = "runtime/default"
+    }
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_cron_job" "cron" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {
+            annotations = {
+              seccomp.security.alpha.kubernetes.io/defaultProfileName = "runtime/default"
+            }
+          }
+          spec {
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment" "deployment" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+        annotations = {
+          seccomp.security.alpha.kubernetes.io/defaultProfileName = "runtime/default"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes/secoomp_profile_is_not_configured/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/secoomp_profile_is_not_configured/test/positive.tf
@@ -1,0 +1,450 @@
+resource "kubernetes_pod" "pod1" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod" "pod2" {
+  metadata {
+    name = "terraform-example"
+
+    annotations = {
+      SomeAnnotation = "foobar"
+    }
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod" "pod3" {
+  metadata {
+    name = "terraform-example"
+
+    annotations = {
+      seccomp.security.alpha.kubernetes.io/defaultProfileName = "rntim/dfl"
+    }
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_cron_job" "cron1" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_cron_job" "cron2" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {
+            annotations = {
+              SomeAnnotation = "foobar"
+            }
+          }
+          spec {
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_cron_job" "cron3" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {
+            annotations = {
+              seccomp.security.alpha.kubernetes.io/defaultProfileName = "rntim/dfl"
+            }
+          }
+          spec {
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment" "deployment1" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment" "deployment2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+        annotations = {
+          SomeAnnotation = "foobar"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment" "deployment3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+        annotations = {
+          seccomp.security.alpha.kubernetes.io/defaultProfileName = "rntim/dfl"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes/secoomp_profile_is_not_configured/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/secoomp_profile_is_not_configured/test/positive_expected_result.json
@@ -1,0 +1,47 @@
+[
+  {
+    "queryName": "Seccomp Profile Is Not Configured",
+    "severity": "MEDIUM",
+    "line": 2
+  },
+  {
+    "queryName": "Seccomp Profile Is Not Configured",
+    "severity": "MEDIUM",
+    "line": 58
+  },
+  {
+    "queryName": "Seccomp Profile Is Not Configured",
+    "severity": "MEDIUM",
+    "line": 115
+  },
+  {
+    "queryName": "Seccomp Profile Is Not Configured",
+    "severity": "MEDIUM",
+    "line": 184
+  },
+  {
+    "queryName": "Seccomp Profile Is Not Configured",
+    "severity": "MEDIUM",
+    "line": 215
+  },
+  {
+    "queryName": "Seccomp Profile Is Not Configured",
+    "severity": "MEDIUM",
+    "line": 249
+  },
+  {
+    "queryName": "Seccomp Profile Is Not Configured",
+    "severity": "MEDIUM",
+    "line": 284
+  },
+  {
+    "queryName": "Seccomp Profile Is Not Configured",
+    "severity": "MEDIUM",
+    "line": 348
+  },
+  {
+    "queryName": "Seccomp Profile Is Not Configured",
+    "severity": "MEDIUM",
+    "line": 411
+  }
+]


### PR DESCRIPTION
Closes #2548

**Proposed Changes**

- Support "Seccomp Profile Is Not Configured" query for Terraform (same as "Seccomp Profile Is Not Configured" for Kubernetes). It is necessary to check if `object.get(metadata, "annotations", "undefined") == "undefined"`, `object.get(annotations, "${seccomp.security.alpha.kubernetes.io/defaultProfileName}", "undefined") == "undefined"` or `annotations["${seccomp.security.alpha.kubernetes.io/defaultProfileName}"] != "runtime/default"`

I submit this contribution under Apache-2.0 license.
