### PR TITLE
Add 'API Gateway Deployment Without API Gateway UsagePlan Associated' query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/metadata.json
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b3a59b8e-94a3-403e-b6e2-527abaf12034",
+  "queryName": "API Gateway Deployment Without API Gateway UsagePlan Associated",
+  "severity": "LOW",
+  "category": "Observability",
+  "descriptionText": "API Gateway Deployment should have API Gateway UsagePlan defined and associated.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/query.rego
@@ -7,7 +7,7 @@ CxPolicy[result] {
 	not settings_are_equal(document.resource, deployment.rest_api_id, deployment.stage_name)
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": document.id,
 		"searchKey": sprintf("aws_api_gateway_deployment[%s]", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_api_gateway_deployment[%s] has a 'aws_api_gateway_usage_plan' resource associated. ", [name]),

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/query.rego
@@ -1,0 +1,22 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document[i]
+	deployment = document.resource.aws_api_gateway_deployment[name]
+
+	not settings_are_equal(document.resource, deployment.rest_api_id, deployment.stage_name)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_api_gateway_deployment[%s]", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_api_gateway_deployment[%s] has a 'aws_api_gateway_usage_plan' resource associated. ", [name]),
+		"keyActualValue": sprintf("aws_api_gateway_deployment[%s] doesn't have a 'aws_api_gateway_usage_plan' resource associated.", [name]),
+	}
+}
+
+settings_are_equal(resource, rest_api_id, stage_name) {
+	usage_plan := resource.aws_api_gateway_usage_plan[_]
+	usage_plan.api_stages.api_id == rest_api_id
+	usage_plan.api_stages.stage == stage_name
+}

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/test/negative.tf
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/test/negative.tf
@@ -1,0 +1,15 @@
+resource "aws_api_gateway_deployment" "negative1" {
+  rest_api_id   = "rest_api_1"
+  stage_name    = "development"
+}
+
+resource "aws_api_gateway_usage_plan" "negative2" {
+  name         = "my-usage-plan"
+  description  = "my description"
+  product_code = "MYCODE"
+
+  api_stages {
+    api_id = "rest_api_1"
+    stage  = "development"
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/test/positive.tf
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/test/positive.tf
@@ -1,0 +1,23 @@
+resource "aws_api_gateway_deployment" "positive1" {
+  rest_api_id   = "some rest api id"
+  stage_name = "some name"
+  tags {
+    project = "ProjectName"
+  }
+}
+
+resource "aws_api_gateway_deployment" "positive2" {
+  rest_api_id   = "some rest api id"
+  stage_name    = "development"
+}
+
+resource "aws_api_gateway_usage_plan" "positive3" {
+  name         = "my-usage-plan"
+  description  = "my description"
+  product_code = "MYCODE"
+
+  api_stages {
+    api_id = "another id"
+    stage  = "development"
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_api_gateway_usage_plan_associated/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "API Gateway Deployment Without API Gateway UsagePlan Associated",
+    "severity": "LOW",
+    "line": 1
+  },
+  {
+    "queryName": "API Gateway Deployment Without API Gateway UsagePlan Associated",
+    "severity": "LOW",
+    "line": 9
+  }
+]


### PR DESCRIPTION
Closes #2551

**Proposed Changes**

- Add support for query "API Gateway Deployment Without API Gateway UsagePlan Associated".
- The query checks if there's an API Gateway UsagePlan resource that references an API Gateway Deployment, through attributes `stage` and `api_id`, that should be same as `stage_name` and `rest_api_id`.

I submit this contribution under Apache-2.0 license.
