### PR TITLE
Add Permissive Access to Create Pods query Closes #2392

### DIFF
--- a/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/metadata.json
+++ b/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "522d4a64-4dc9-44bd-9240-7d8a0d5cb5ba",
+  "queryName": "Permissive Access to Create Pods",
+  "severity": "LOW",
+  "category": "Access Control",
+  "descriptionText": "The permission to create pods in a cluster should be restricted because it allows privilege escalation.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role#rule",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/query.rego
+++ b/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/query.rego
@@ -5,13 +5,13 @@ create := "create"
 pods := "pods"
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_role[name]
-	resource.rule[ru].verbs[l] == create
-	resource.rule[ru].resources[r] == pods
+	resource := input.document[i].resource[resourceType]
+	resource[name].rule[ru].verbs[l] == create
+	resource[name].rule[ru].resources[r] == pods
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, create]),
+		"searchKey": sprintf("%s[%s].rule.verbs.%s", [resourceType, name, create]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain the value 'create' when kubernetes_role[%s].rule.resources contains the value 'pods'", [name, name]),
 		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains the value 'create' and kubernetes_role[%s].rule.resources contains the value 'pods'", [name, name]),
@@ -19,13 +19,13 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_role[name]
-	resource.rule[ru].verbs[l] == create
-	isWildCardValue(resource.rule[ru].resources[r])
+	resource := input.document[i].resource[resourceType]
+	resource[name].rule[ru].verbs[l] == create
+	isWildCardValue(resource[name].rule[ru].resources[r])
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, create]),
+		"searchKey": sprintf("%s[%s].rule.verbs.%s", [resourceType, name, create]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain the value 'create' when kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
 		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains the value 'create' and kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
@@ -33,27 +33,27 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_role[name]
-	isWildCardValue(resource.rule[ru].verbs[l])
-	resource.rule[ru].resources[r] == pods
+	resource := input.document[i].resource[resourceType]
+	isWildCardValue(resource[name].rule[ru].verbs[l])
+	resource[name].rule[ru].resources[r] == pods
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, resource.rule[ru].verbs[l]]),
+		"searchKey": sprintf("%s[%s].rule.verbs.%s", [resourceType, resourceType.metadata.name, resource.rule[ru].verbs[l]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains the value 'pods'", [name, name]),
-		"keyActualValue": sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains the value 'pods'", [name, name]),
+		"keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains the value 'pods'", [resourceType.metadata.name, resourceType.metadata.name]),
+		"keyActualValue": sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains the value 'pods'", [resourceType.metadata.name, resourceType.metadata.name]),
 	}
 }
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_role[name]
-	isWildCardValue(resource.rule[ru].verbs[l])
-	isWildCardValue(resource.rule[ru].resources[r])
+	resource := input.document[i].resource[resourceType]
+	isWildCardValue(resource[name].rule[ru].verbs[l])
+	isWildCardValue(resource[name].rule[ru].resources[r])
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, resource.rule[ru].verbs[l]]),
+		"searchKey": sprintf("%s[%s].rule.verbs.%s", [resourceType, name, resource.rule[ru].verbs[l]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain a wildcard value when kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
 		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains a wildcard value and kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
@@ -61,14 +61,13 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_role[name]
-
-	resource.rule.verbs[l] == create
-	resource.rule.resources[r] == pods
+	resource := input.document[i].resource[resourceType]
+	resource[name].rule.verbs[l] == create
+	resource[name].rule.resources[r] == pods
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, create]),
+		"searchKey": sprintf("%s[%s].rule.verbs.%s", [resourceType, name, create]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain the value 'create' when kubernetes_role[%s].rule.resources contains the value 'pods'", [name, name]),
 		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains the value 'create' and kubernetes_role[%s].rule.resources contains the value 'pods'", [name, name]),
@@ -76,13 +75,13 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_role[name]
-	resource.rule.verbs[l] == create
-	isWildCardValue(resource.rule.resources[r])
+	resource := input.document[i].resource[resourceType]
+	resource[name].rule.verbs[l] == create
+	isWildCardValue(resource[name].rule.resources[r])
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, create]),
+		"searchKey": sprintf("%s[%s].rule.verbs.%s", [resourceType, name, create]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain the value 'create' when kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
 		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains the value 'create' and kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
@@ -90,13 +89,13 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_role[name]
-	isWildCardValue(resource.rule.verbs[l])
-	resource.rule.resources[r] == pods
+	resource := input.document[i].resource[resourceType]
+	isWildCardValue(resource[name].rule.verbs[l])
+	resource[name].rule.resources[r] == pods
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, resource.rule.verbs[l]]),
+		"searchKey": sprintf("%s[%s].rule.verbs.%s", [resourceType, name, resource[name].rule.verbs[l]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains the value 'pods'", [name, name]),
 		"keyActualValue": sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains the value 'pods'", [name, name]),
@@ -104,128 +103,16 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_role[name]
-	isWildCardValue(resource.rule.verbs[l])
-	isWildCardValue(resource.rule.resources[r])
+	resource := input.document[i].resource[resourceType]
+	isWildCardValue(resource[name].rule.verbs[l])
+	isWildCardValue(resource[name].rule.resources[r])
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, resource.rule.verbs[l]]),
+		"searchKey": sprintf("%s[%s].rule.verbs.%s", [resourceType, name, resource[name].rule.verbs[l]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain a wildcard value when kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
 		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains a wildcard value and kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_cluster_role[name]
-	resource.rule[ru].verbs[l] == create
-	resource.rule[ru].resources[r] == pods
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, create]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain the value 'create' when kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
-		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains the value 'create' and kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_cluster_role[name]
-	resource.rule[ru].verbs[l] == create
-	isWildCardValue(resource.rule[ru].resources[r])
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, create]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain the value 'create' when kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
-		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains the value 'create' and kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_cluster_role[name]
-	isWildCardValue(resource.rule[ru].verbs[l])
-	resource.rule[ru].resources[r] == pods
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, resource.rule[ru].verbs[l]]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain a wildcard value when kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
-		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains a wildcard value and kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_cluster_role[name]
-	isWildCardValue(resource.rule[ru].verbs[l])
-	isWildCardValue(resource.rule[ru].resources[r])
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, resource.rule[ru].verbs[l]]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain a wildcard value when kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
-		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains a wildcard value and kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_cluster_role[name]
-	resource.rule.verbs[l] == create
-	resource.rule.resources[r] == pods
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, create]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain the value 'create' when kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
-		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains the value 'create' and kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_cluster_role[name]
-	resource.rule.verbs[l] == create
-	isWildCardValue(resource.rule.resources[r])
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, create]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain the value 'create' when kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
-		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains the value 'create' and kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_cluster_role[name]
-	isWildCardValue(resource.rule.verbs[l])
-	resource.rule.resources[r] == pods
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, resource.rule.verbs[l]]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain a wildcard value when kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
-		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains a wildcard value and kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.kubernetes_cluster_role[name]
-	isWildCardValue(resource.rule.verbs[l])
-	isWildCardValue(resource.rule.resources[r])
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, resource.rule.verbs[l]]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain a wildcard value when kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
-		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains a wildcard value and kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
 	}
 }
 

--- a/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/query.rego
+++ b/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/query.rego
@@ -1,0 +1,234 @@
+package Cx
+
+create := "create"
+
+pods := "pods"
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_role[name]
+	resource.rule[ru].verbs[l] == create
+	resource.rule[ru].resources[r] == pods
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, create]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain the value 'create' when kubernetes_role[%s].rule.resources contains the value 'pods'", [name, name]),
+		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains the value 'create' and kubernetes_role[%s].rule.resources contains the value 'pods'", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_role[name]
+	resource.rule[ru].verbs[l] == create
+	isWildCardValue(resource.rule[ru].resources[r])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, create]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain the value 'create' when kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
+		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains the value 'create' and kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_role[name]
+	isWildCardValue(resource.rule[ru].verbs[l])
+	resource.rule[ru].resources[r] == pods
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, resource.rule[ru].verbs[l]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains the value 'pods'", [name, name]),
+		"keyActualValue": sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains the value 'pods'", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_role[name]
+	isWildCardValue(resource.rule[ru].verbs[l])
+	isWildCardValue(resource.rule[ru].resources[r])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, resource.rule[ru].verbs[l]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain a wildcard value when kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
+		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains a wildcard value and kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_role[name]
+
+	resource.rule.verbs[l] == create
+	resource.rule.resources[r] == pods
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, create]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain the value 'create' when kubernetes_role[%s].rule.resources contains the value 'pods'", [name, name]),
+		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains the value 'create' and kubernetes_role[%s].rule.resources contains the value 'pods'", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_role[name]
+	resource.rule.verbs[l] == create
+	isWildCardValue(resource.rule.resources[r])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, create]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain the value 'create' when kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
+		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains the value 'create' and kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_role[name]
+	isWildCardValue(resource.rule.verbs[l])
+	resource.rule.resources[r] == pods
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, resource.rule.verbs[l]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name=%s.rules.verbs should not contain a wildcard value when metadata.name=%s.rules.resources contains the value 'pods'", [name, name]),
+		"keyActualValue": sprintf("metadata.name=%s.rules.verbs contains a wildcard value and metadata.name=%s.rules.resources contains the value 'pods'", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_role[name]
+	isWildCardValue(resource.rule.verbs[l])
+	isWildCardValue(resource.rule.resources[r])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_role[%s].rule.verbs.%s", [name, resource.rule.verbs[l]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_role[%s].rule.verbs should not contain a wildcard value when kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
+		"keyActualValue": sprintf("kubernetes_role[%s].rule.verbs contains a wildcard value and kubernetes_role[%s].rule.resources contains a wildcard value", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role[name]
+	resource.rule[ru].verbs[l] == create
+	resource.rule[ru].resources[r] == pods
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, create]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain the value 'create' when kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
+		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains the value 'create' and kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role[name]
+	resource.rule[ru].verbs[l] == create
+	isWildCardValue(resource.rule[ru].resources[r])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, create]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain the value 'create' when kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
+		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains the value 'create' and kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role[name]
+	isWildCardValue(resource.rule[ru].verbs[l])
+	resource.rule[ru].resources[r] == pods
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, resource.rule[ru].verbs[l]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain a wildcard value when kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
+		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains a wildcard value and kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role[name]
+	isWildCardValue(resource.rule[ru].verbs[l])
+	isWildCardValue(resource.rule[ru].resources[r])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, resource.rule[ru].verbs[l]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain a wildcard value when kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
+		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains a wildcard value and kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role[name]
+	resource.rule.verbs[l] == create
+	resource.rule.resources[r] == pods
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, create]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain the value 'create' when kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
+		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains the value 'create' and kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role[name]
+	resource.rule.verbs[l] == create
+	isWildCardValue(resource.rule.resources[r])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, create]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain the value 'create' when kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
+		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains the value 'create' and kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role[name]
+	isWildCardValue(resource.rule.verbs[l])
+	resource.rule.resources[r] == pods
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, resource.rule.verbs[l]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain a wildcard value when kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
+		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains a wildcard value and kubernetes_cluster_role[%s].rule.resources contains the value 'pods'", [name, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cluster_role[name]
+	isWildCardValue(resource.rule.verbs[l])
+	isWildCardValue(resource.rule.resources[r])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cluster_role[%s].rule.verbs.%s", [name, resource.rule.verbs[l]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_cluster_role[%s].rule.verbs should not contain a wildcard value when kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
+		"keyActualValue": sprintf("kubernetes_cluster_role[%s].rule.verbs contains a wildcard value and kubernetes_cluster_role[%s].rule.resources contains a wildcard value", [name, name]),
+	}
+}
+
+isWildCardValue(val) {
+	regex.match(".*\\*.*", val)
+}

--- a/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/negative1.tf
+++ b/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/negative1.tf
@@ -1,0 +1,20 @@
+resource "kubernetes_role" "example" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyRole"
+    }
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["pods"]
+    resource_names = ["foo"]
+    verbs          = ["get", "list", "watch"]
+  }
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments"]
+    verbs      = ["get", "list"]
+  }
+}

--- a/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/negative2.tf
+++ b/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/negative2.tf
@@ -1,0 +1,11 @@
+resource "kubernetes_cluster_role" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "pods"]
+    verbs      = ["get", "list", "watch"]
+  }
+}

--- a/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/positive1.tf
+++ b/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/positive1.tf
@@ -12,6 +12,12 @@ resource "kubernetes_role" "example1" {
     resource_names = ["foo"]
     verbs          = ["create", "list", "watch"]
   }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments"]
+    verbs      = ["get", "list"]
+  }
 }
 
 resource "kubernetes_role" "example2" {

--- a/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/positive1.tf
+++ b/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/positive1.tf
@@ -1,0 +1,63 @@
+resource "kubernetes_role" "example1" {
+  metadata {
+    name = "terraform-example1"
+    labels = {
+      test = "MyRole"
+    }
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["pods"]
+    resource_names = ["foo"]
+    verbs          = ["create", "list", "watch"]
+  }
+}
+
+resource "kubernetes_role" "example2" {
+  metadata {
+    name = "terraform-example2"
+    labels = {
+      test = "MyRole"
+    }
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["*"]
+    resource_names = ["foo"]
+    verbs          = ["create", "list", "watch"]
+  }
+}
+
+resource "kubernetes_role" "example3" {
+  metadata {
+    name = "terraform-example3"
+    labels = {
+      test = "MyRole"
+    }
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["pods"]
+    resource_names = ["foo"]
+    verbs          = ["*", "list", "watch"]
+  }
+}
+
+resource "kubernetes_role" "example4" {
+  metadata {
+    name = "terraform-example4"
+    labels = {
+      test = "MyRole"
+    }
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["*"]
+    resource_names = ["foo"]
+    verbs          = ["*", "list", "watch"]
+  }
+}

--- a/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/positive2.tf
+++ b/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/positive2.tf
@@ -1,0 +1,47 @@
+resource "kubernetes_cluster_role" "example1" {
+  metadata {
+    name = "terraform-example1"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "pods"]
+    verbs      = ["create", "list", "watch"]
+  }
+}
+
+resource "kubernetes_cluster_role" "example2" {
+  metadata {
+    name = "terraform-example2"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "*"]
+    verbs      = ["create", "list", "watch"]
+  }
+}
+
+resource "kubernetes_cluster_role" "example3" {
+  metadata {
+    name = "terraform-example3"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "*"]
+    verbs      = ["*", "list", "watch"]
+  }
+}
+
+resource "kubernetes_cluster_role" "example4" {
+  metadata {
+    name = "terraform-example4"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "pods"]
+    verbs      = ["*", "list", "watch"]
+  }
+}

--- a/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/positive_expected_result.json
@@ -8,19 +8,19 @@
   {
     "queryName": "Permissive Access to Create Pods",
     "severity": "LOW",
-    "line": 29,
+    "line": 35,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "Permissive Access to Create Pods",
     "severity": "LOW",
-    "line": 45,
+    "line": 51,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "Permissive Access to Create Pods",
     "severity": "LOW",
-    "line": 61,
+    "line": 67,
     "fileName": "positive1.tf"
   },
   {

--- a/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/permissive_access_to_create_pods/test/positive_expected_result.json
@@ -1,0 +1,50 @@
+[
+  {
+    "queryName": "Permissive Access to Create Pods",
+    "severity": "LOW",
+    "line": 13,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "Permissive Access to Create Pods",
+    "severity": "LOW",
+    "line": 29,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "Permissive Access to Create Pods",
+    "severity": "LOW",
+    "line": 45,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "Permissive Access to Create Pods",
+    "severity": "LOW",
+    "line": 61,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "Permissive Access to Create Pods",
+    "severity": "LOW",
+    "line": 9,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Permissive Access to Create Pods",
+    "severity": "LOW",
+    "line": 21,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Permissive Access to Create Pods",
+    "severity": "LOW",
+    "line": 33,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Permissive Access to Create Pods",
+    "severity": "LOW",
+    "line": 45,
+    "fileName": "positive2.tf"
+  }
+]


### PR DESCRIPTION
Closes #2392 

**Proposed Changes**

- Support Permissive Access to Create Pods in Terraform (already exist in Kubernetes)

I submit this contribution under Apache-2.0 license.
