### PR TITLE
Add Missing App Armor Config query Closes #2404

### DIFF
--- a/assets/queries/terraform/kubernetes/missing_app_armor_config/metadata.json
+++ b/assets/queries/terraform/kubernetes/missing_app_armor_config/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "bd6bd46c-57db-4887-956d-d372f21291b6",
+  "queryName": "Missing App Armor Config",
+  "severity": "LOW",
+  "category": "Access Control",
+  "descriptionText": "Containers should be configured with AppArmor for any application to reduce its potential attack",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#annotations",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/missing_app_armor_config/query.rego
+++ b/assets/queries/terraform/kubernetes/missing_app_armor_config/query.rego
@@ -1,0 +1,31 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+	metadata := resource[name].metadata
+	metadata.annotations[key]
+	expectedKey := "container.apparmor.security.beta.kubernetes.io"
+	not startswith(key, expectedKey)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].metadata.annotations", [resourceType, name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].metadata.annotations should contain AppArmor profile config: '%s'", [resourceType, name, expectedKey]),
+		"keyActualValue": sprintf("%s[%s].metadata.annotations doesn't contain AppArmor profile config: '%s'", [resourceType, name, expectedKey]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+	metadata := resource[name].metadata
+	not metadata.annotations
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].metadata", [resourceType, name]),
+		"issueType": "MissingValue",
+		"keyExpectedValue": sprintf("%s[%s].metadata should include annotations for AppArmor profile config", [resourceType, name]),
+		"keyActualValue": sprintf("%s[%s].metadata doesn't contain AppArmor profile config in annotations", [resourceType, name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/missing_app_armor_config/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/missing_app_armor_config/test/negative.tf
@@ -1,0 +1,55 @@
+resource "kubernetes_pod" "test" {
+  metadata {
+    name = "terraform-example"
+    annotations = {
+      "container.apparmor.security.beta.kubernetes.io" = "localhost/k8s-apparmor-example-allow-write"
+    }
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/missing_app_armor_config/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/missing_app_armor_config/test/positive.tf
@@ -1,0 +1,108 @@
+resource "kubernetes_pod" "example1" {
+  metadata {
+    name = "terraform-example1"
+    annotations = {
+      "container.apparmor" = "localhost"
+    }
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod" "example2" {
+  metadata {
+    name = "terraform-example2"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/missing_app_armor_config/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/missing_app_armor_config/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "Missing App Armor Config",
+    "severity": "LOW",
+    "line": 4
+  },
+  {
+    "queryName": "Missing App Armor Config",
+    "severity": "LOW",
+    "line": 58
+  }
+]


### PR DESCRIPTION
Closes #2404 

**Proposed Changes**

- Support Missing App Armor Config in Terraform (already exist in Kubernetes)

I submit this contribution under Apache-2.0 license.
