### PR TITLE
Added PSP Allows Sharing Host IPC terraform query

### DIFF
--- a/assets/queries/terraform/kubernetes/psp_allows_sharing_host_ipc/metadata.json
+++ b/assets/queries/terraform/kubernetes/psp_allows_sharing_host_ipc/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "51bed0ac-a8ae-407a-895e-90c6cb0610ce",
+  "queryName": "PSP Allows Sharing Host IPC",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "Pod Security Policy allows containers to share the host IPC namespace",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod_security_policy#host_ipc",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/psp_allows_sharing_host_ipc/query.rego
+++ b/assets/queries/terraform/kubernetes/psp_allows_sharing_host_ipc/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod_security_policy[name]
+
+	resource.spec.host_ipc == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec.host_ipc", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Attribute 'host_ipc' is undefined or false",
+		"keyActualValue": "Attribute 'host_ipc' is true",
+	}
+}

--- a/assets/queries/terraform/kubernetes/psp_allows_sharing_host_ipc/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/psp_allows_sharing_host_ipc/test/negative.tf
@@ -1,0 +1,45 @@
+resource "kubernetes_pod_security_policy" "example2" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+    allow_privilege_escalation = false
+    host_ipc = false
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}

--- a/assets/queries/terraform/kubernetes/psp_allows_sharing_host_ipc/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/psp_allows_sharing_host_ipc/test/positive.tf
@@ -1,0 +1,45 @@
+resource "kubernetes_pod_security_policy" "example2" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+    allow_privilege_escalation = false
+    host_ipc                   = true
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}

--- a/assets/queries/terraform/kubernetes/psp_allows_sharing_host_ipc/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/psp_allows_sharing_host_ipc/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "PSP Allows Sharing Host IPC",
+    "severity": "MEDIUM",
+    "line": 8
+  }
+]


### PR DESCRIPTION
Closes #2574

**Proposed Changes**

-Pod Security Policy allows containers to share the host IPC namespace


I submit this contribution under Apache-2.0 license.
