### PR TITLE
Add 'API Gateway Method Does Not Contains An API Key' query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/api_gateway_method_does_not_contains_an_api_key/metadata.json
+++ b/assets/queries/terraform/aws/api_gateway_method_does_not_contains_an_api_key/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "671211c5-5d2a-4e97-8867-30fc28b02216",
+  "queryName": "API Gateway Method Does Not Contains An API Key",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "An API Key should be required on a method request.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_method",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/api_gateway_method_does_not_contains_an_api_key/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_method_does_not_contains_an_api_key/query.rego
@@ -1,0 +1,31 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document[i]
+	api = document.resource.aws_api_gateway_method[name]
+
+	object.get(api, "api_key_required", "undefined") == "undefined"
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("resource.aws_api_gateway_method[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("resource.aws_api_gateway_method[%s].api_key_required is defined", [name]),
+		"keyActualValue": sprintf("resource.aws_api_gateway_method[%s].api_key_required is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	document := input.document[i]
+	api = document.resource.aws_api_gateway_method[name]
+
+	api.api_key_required != true
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("resource.aws_api_gateway_method[%s].api_key_required", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("resource.aws_api_gateway_method[%s].api_key_required is 'true'", [name]),
+		"keyActualValue": sprintf("resource.aws_api_gateway_method[%s].api_key_required is 'false'", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/api_gateway_method_does_not_contains_an_api_key/test/negative.tf
+++ b/assets/queries/terraform/aws/api_gateway_method_does_not_contains_an_api_key/test/negative.tf
@@ -1,0 +1,8 @@
+resource "aws_api_gateway_method" "negative1" {
+  rest_api_id       = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id       = aws_api_gateway_resource.MyDemoResource.id
+  http_method       = "GET"
+  authorization     = "NONE"
+  api_key_required  = true
+}
+

--- a/assets/queries/terraform/aws/api_gateway_method_does_not_contains_an_api_key/test/positive.tf
+++ b/assets/queries/terraform/aws/api_gateway_method_does_not_contains_an_api_key/test/positive.tf
@@ -1,0 +1,15 @@
+resource "aws_api_gateway_method" "positive1" {
+  rest_api_id       = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id       = aws_api_gateway_resource.MyDemoResource.id
+  http_method       = "GET"
+  authorization     = "NONE"
+}
+
+resource "aws_api_gateway_method" "positive2" {
+  rest_api_id       = aws_api_gateway_rest_api.MyDemoAPI.id
+  resource_id       = aws_api_gateway_resource.MyDemoResource.id
+  http_method       = "GET"
+  authorization     = "NONE"
+  api_key_required  = false
+}
+

--- a/assets/queries/terraform/aws/api_gateway_method_does_not_contains_an_api_key/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_method_does_not_contains_an_api_key/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "line": 1,
+    "queryName": "API Gateway Method Does Not Contains An API Key",
+    "severity": "MEDIUM"
+  },
+  {
+    "line": 13,
+    "queryName": "API Gateway Method Does Not Contains An API Key",
+    "severity": "MEDIUM"
+  }
+]


### PR DESCRIPTION
Closes #2570

**Proposed Changes**

- Added a new query that checks if an API Gateway Method resource has `api_key_required` set to `true`, which enforces an API Key to be required on a method request.

I submit this contribution under Apache-2.0 license.
