### PR TITLE
Add "Service Type is NodePort" for Terraform Closes #2587

### DIFF
--- a/assets/queries/terraform/kubernetes/service_type_is_nodeport/metadata.json
+++ b/assets/queries/terraform/kubernetes/service_type_is_nodeport/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "5c281bf8-d9bb-47f2-b909-3f6bb11874ad",
+  "queryName": "Service Type is NodePort",
+  "severity": "LOW",
+  "category": "Networking and Firewall",
+  "descriptionText": "Service type should not be NodePort",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service#type",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/service_type_is_nodeport/query.rego
+++ b/assets/queries/terraform/kubernetes/service_type_is_nodeport/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_service[name]
+
+	resource.spec.type == "NodePort"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_service[%s].spec.type", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_service[name].spec.type is not 'NodePort'", [name]),
+		"keyActualValue": sprintf("kubernetes_service[name].spec.type is 'NodePort'", [name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/service_type_is_nodeport/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/service_type_is_nodeport/test/negative.tf
@@ -1,0 +1,17 @@
+resource "kubernetes_service" "example2" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    selector = {
+      app = kubernetes_pod.example.metadata.0.labels.app
+    }
+    session_affinity = "ClientIP"
+    port {
+      port        = 8080
+      target_port = 80
+    }
+
+    type = "LoadBalancer"
+  }
+}

--- a/assets/queries/terraform/kubernetes/service_type_is_nodeport/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/service_type_is_nodeport/test/positive.tf
@@ -1,0 +1,17 @@
+resource "kubernetes_service" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    selector = {
+      app = kubernetes_pod.example.metadata.0.labels.app
+    }
+    session_affinity = "ClientIP"
+    port {
+      port        = 8080
+      target_port = 80
+    }
+
+    type = "NodePort"
+  }
+}

--- a/assets/queries/terraform/kubernetes/service_type_is_nodeport/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/service_type_is_nodeport/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Service Type is NodePort",
+    "severity": "LOW",
+    "line": 15
+  }
+]


### PR DESCRIPTION
Closes #2587

**Proposed Changes**

- Support "Service Type is NodePort" query for Terraform (same as "Service Type is NodePort" for Kubernetes). It is necessary to check if the attribute `spec.type` is equal "NodePort"

I submit this contribution under Apache-2.0 license.
