### PR TITLE
Add 'AmazonMQ Broker Encryption Disabled' query for Terraform

### DIFF
--- a/assets/queries/cloudFormation/amazon_mq_broker_encryption_disabled/metadata.json
+++ b/assets/queries/cloudFormation/amazon_mq_broker_encryption_disabled/metadata.json
@@ -1,9 +1,9 @@
 {
-	"id": "316278b3-87ac-444c-8f8f-a733a28da60f",
-	"queryName": "AmazonMQ Broker Encryption Disabled",
-	"severity": "MEDIUM",
-	"category": "Encryption",
-	"descriptionText": "AmazonMQ Broker should be Encryption Options defined",
-	"descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-encryptionoptions",
-	"platform": "CloudFormation"
+  "id": "316278b3-87ac-444c-8f8f-a733a28da60f",
+  "queryName": "AmazonMQ Broker Encryption Disabled",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "AmazonMQ Broker should have Encryption Options defined",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-encryptionoptions",
+  "platform": "CloudFormation"
 }

--- a/assets/queries/terraform/aws/amazon_mq_broker_encryption_disabled/metadata.json
+++ b/assets/queries/terraform/aws/amazon_mq_broker_encryption_disabled/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "3db3f534-e3a3-487f-88c7-0a9fbf64b702",
+  "queryName": "AmazonMQ Broker Encryption Disabled",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "AmazonMQ Broker should have Encryption Options defined",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mq_broker",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/amazon_mq_broker_encryption_disabled/query.rego
+++ b/assets/queries/terraform/aws/amazon_mq_broker_encryption_disabled/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document[i]
+	resource = document.resource.aws_mq_broker[name]
+
+	object.get(resource, "encryption_options", "undefined") == "undefined"
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("resource.aws_mq_broker[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("resource.aws_mq_broker[%s].encryption_options is defined", [name]),
+		"keyActualValue": sprintf("resource.aws_mq_broker[%s].encryption_options is not defined", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/amazon_mq_broker_encryption_disabled/test/negative.tf
+++ b/assets/queries/terraform/aws/amazon_mq_broker_encryption_disabled/test/negative.tf
@@ -1,0 +1,45 @@
+resource "aws_mq_broker" "negative1" {
+  broker_name = "example"
+
+  configuration {
+    id       = aws_mq_configuration.test.id
+    revision = aws_mq_configuration.test.latest_revision
+  }
+
+  engine_type        = "ActiveMQ"
+  engine_version     = "5.15.9"
+  host_instance_type = "mq.t2.micro"
+  security_groups    = [aws_security_group.test.id]
+
+  user {
+    username = "ExampleUser"
+    password = "MindTheGap"
+  }
+
+  encryption_options {
+    kms_key_id = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+    use_aws_owned_key = false
+  }
+}
+
+resource "aws_mq_broker" "negative2" {
+  broker_name = "example"
+
+  configuration {
+    id       = aws_mq_configuration.test.id
+    revision = aws_mq_configuration.test.latest_revision
+  }
+
+  engine_type        = "ActiveMQ"
+  engine_version     = "5.15.9"
+  host_instance_type = "mq.t2.micro"
+  security_groups    = [aws_security_group.test.id]
+
+  user {
+    username = "ExampleUser"
+    password = "MindTheGap"
+  }
+
+  encryption_options {
+  }
+}

--- a/assets/queries/terraform/aws/amazon_mq_broker_encryption_disabled/test/positive.tf
+++ b/assets/queries/terraform/aws/amazon_mq_broker_encryption_disabled/test/positive.tf
@@ -1,0 +1,18 @@
+resource "aws_mq_broker" "positive1" {
+  broker_name = "example"
+
+  configuration {
+    id       = aws_mq_configuration.test.id
+    revision = aws_mq_configuration.test.latest_revision
+  }
+
+  engine_type        = "ActiveMQ"
+  engine_version     = "5.15.9"
+  host_instance_type = "mq.t2.micro"
+  security_groups    = [aws_security_group.test.id]
+
+  user {
+    username = "ExampleUser"
+    password = "MindTheGap"
+  }
+}

--- a/assets/queries/terraform/aws/amazon_mq_broker_encryption_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/amazon_mq_broker_encryption_disabled/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "AmazonMQ Broker Encryption Disabled",
+    "severity": "MEDIUM",
+    "line": 1
+  }
+]


### PR DESCRIPTION
Closes #2591

**Proposed Changes**

- Added a query that checks if a 'AmazonMQ Broker' resource has encryption options configured for the broker. A `encryption_options` block must be defined, although it can be empty 

I submit this contribution under Apache-2.0 license.
