### PR TITLE
Add "Metadata Label Is Invalid" query for Terraform Closes #2593

### DIFF
--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/metadata.json
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "bc3dabb6-fd50-40f8-b9ba-7429c9f1fb0e",
+  "queryName": "Metadata Label Is Invalid",
+  "severity": "LOW",
+  "category": "Best Practices",
+  "descriptionText": "Check if any label in the metadata is invalid.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#labels",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/query.rego
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	labels := resource[name].metadata.labels
+
+	regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", labels[key]) == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].metadata.labels", [resourceType, name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].metada.labels[%s] has valid label", [resourceType, name, key]),
+		"keyActualValue": sprintf("%s[%s].metada.labels[%s] has invalid label", [resourceType, name, key]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/query.rego
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/query.rego
@@ -10,7 +10,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("%s[%s].metadata.labels", [resourceType, name]),
-		"issueType": "MissingAttribute",
+		"issueType": "IncorretValue",
 		"keyExpectedValue": sprintf("%s[%s].metada.labels[%s] has valid label", [resourceType, name, key]),
 		"keyActualValue": sprintf("%s[%s].metada.labels[%s] has invalid label", [resourceType, name, key]),
 	}

--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/negative.tf
@@ -1,0 +1,56 @@
+resource "kubernetes_pod" "test2" {
+  metadata {
+    name = "terraform-example"
+
+    labels = {
+      app = "MyApp"
+    }
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/positive.tf
@@ -1,0 +1,56 @@
+resource "kubernetes_pod" "test" {
+  metadata {
+    name = "terraform-example"
+
+    labels = {
+      app = "g**dy.l+bel"
+    }
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Metadata Label Is Invalid",
+    "severity": "LOW",
+    "line": 5
+  }
+]


### PR DESCRIPTION
Closes #2593

**Proposed Changes**

- Support "Metadata Label Is Invalid" query for Terraform (same as "Metadata Label Is Invalid" for Kubernetes). It is necessary to check if `regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", labels[key]) == false`

I submit this contribution under Apache-2.0 license.
