### PR TITLE
Add StatefulSets Without Service Name query Closes #2582

### DIFF
--- a/assets/queries/terraform/kubernetes/statefulsets_without_service_name/metadata.json
+++ b/assets/queries/terraform/kubernetes/statefulsets_without_service_name/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "2a7fef84-b3a2-4077-8aeb-16f039245df7",
+  "queryName": "StatefulSets Without Service Name",
+  "severity": "LOW",
+  "category": "Availability",
+  "descriptionText": "Check if the StatefulSets have a headless 'serviceName'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/stateful_set",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/statefulsets_without_service_name/query.rego
+++ b/assets/queries/terraform/kubernetes/statefulsets_without_service_name/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+CxPolicy[result] {
+	document1 := input.document[i].resource.kubernetes_service[name]
+	metadata := document1.metadata
+	specs := document1.spec
+	specs.cluster_ip != "None"
+
+	document2 := input.document[j].resource.kubernetes_stateful_set[x]
+	document2.spec.selector.match_labels == document2.spec.template.metadata.labels
+	metadata.name == document2.spec.service_name
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_stateful_set[%s].spec.service_name", [x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_stateful_set[%s].spec.service_name refers to a Headless Service", [x]),
+		"keyActualValue": sprintf("kubernetes_stateful_set[%s].spec.service_name doesn't refers to a Headless Service", [x]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/statefulsets_without_service_name/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/statefulsets_without_service_name/test/negative.tf
@@ -1,0 +1,203 @@
+resource "kubernetes_stateful_set" "prometheus" {
+  metadata {
+    annotations = {
+      SomeAnnotation = "foobar"
+    }
+
+    labels = {
+      k8s-app                           = "prometheus"
+      "kubernetes.io/cluster-service"   = "true"
+      "addonmanager.kubernetes.io/mode" = "Reconcile"
+      version                           = "v2.2.1"
+    }
+
+    name = "prometheus"
+  }
+
+  spec {
+    pod_management_policy  = "Parallel"
+    replicas               = 1
+    revision_history_limit = 5
+
+
+    selector {
+      match_labels = {
+        k8s-app = "prometheus"
+      }
+    }
+
+    service_name = "prometheus"
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "prometheus"
+        }
+
+        annotations = {}
+      }
+
+      spec {
+        service_account_name = "prometheus"
+
+        init_container {
+          name              = "init-chown-data"
+          image             = "busybox:latest"
+          image_pull_policy = "IfNotPresent"
+          command           = ["chown", "-R", "65534:65534", "/data"]
+
+          volume_mount {
+            name       = "prometheus-data"
+            mount_path = "/data"
+            sub_path   = ""
+          }
+        }
+
+        container {
+          name              = "prometheus-server-configmap-reload"
+          image             = "jimmidyson/configmap-reload:v0.1"
+          image_pull_policy = "IfNotPresent"
+
+          args = [
+            "--volume-dir=/etc/config",
+            "--webhook-url=http://localhost:9090/-/reload",
+          ]
+
+          volume_mount {
+            name       = "config-volume"
+            mount_path = "/etc/config"
+            read_only  = true
+          }
+
+          resources {
+            limits = {
+              cpu    = "10m"
+              memory = "10Mi"
+            }
+
+            requests = {
+              cpu    = "10m"
+              memory = "10Mi"
+            }
+          }
+        }
+
+        container {
+          name              = "prometheus-server"
+          image             = "prom/prometheus:v2.2.1"
+          image_pull_policy = "IfNotPresent"
+
+          args = [
+            "--config.file=/etc/config/prometheus.yml",
+            "--storage.tsdb.path=/data",
+            "--web.console.libraries=/etc/prometheus/console_libraries",
+            "--web.console.templates=/etc/prometheus/consoles",
+            "--web.enable-lifecycle",
+          ]
+
+          port {
+            container_port = 9090
+          }
+
+          resources {
+            limits = {
+              cpu    = "200m"
+              memory = "1000Mi"
+            }
+
+            requests = {
+              cpu    = "200m"
+              memory = "1000Mi"
+            }
+          }
+
+          volume_mount {
+            name       = "config-volume"
+            mount_path = "/etc/config"
+          }
+
+          volume_mount {
+            name       = "prometheus-data"
+            mount_path = "/data"
+            sub_path   = ""
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/-/ready"
+              port = 9090
+            }
+
+            initial_delay_seconds = 30
+            timeout_seconds       = 30
+          }
+
+          liveness_probe {
+            http_get {
+              path   = "/-/healthy"
+              port   = 9090
+              scheme = "HTTPS"
+            }
+
+            initial_delay_seconds = 30
+            timeout_seconds       = 30
+          }
+        }
+
+        termination_grace_period_seconds = 300
+
+        volume {
+          name = "config-volume"
+
+          config_map {
+            name = "prometheus-config"
+          }
+        }
+      }
+    }
+
+    update_strategy {
+      type = "RollingUpdate"
+
+      rolling_update {
+        partition = 1
+      }
+    }
+
+    volume_claim_template {
+      metadata {
+        name = "prometheus-data"
+      }
+
+      spec {
+        access_modes       = ["ReadWriteOnce"]
+        storage_class_name = "standard"
+
+        resources {
+          requests = {
+            storage = "16Gi"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "example" {
+  metadata {
+    name = "prometheus"
+  }
+  spec {
+    cluster_ip = "None"
+    selector = {
+      app = kubernetes_pod.example.metadata.0.labels.app
+    }
+    session_affinity = "ClientIP"
+    port {
+      port        = 8080
+      target_port = 80
+    }
+
+    type = "LoadBalancer"
+  }
+}

--- a/assets/queries/terraform/kubernetes/statefulsets_without_service_name/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/statefulsets_without_service_name/test/positive.tf
@@ -1,0 +1,203 @@
+resource "kubernetes_stateful_set" "prometheus" {
+  metadata {
+    annotations = {
+      SomeAnnotation = "foobar"
+    }
+
+    labels = {
+      k8s-app                           = "prometheus"
+      "kubernetes.io/cluster-service"   = "true"
+      "addonmanager.kubernetes.io/mode" = "Reconcile"
+      version                           = "v2.2.1"
+    }
+
+    name = "prometheus"
+  }
+
+  spec {
+    pod_management_policy  = "Parallel"
+    replicas               = 1
+    revision_history_limit = 5
+
+
+    selector {
+      match_labels = {
+        k8s-app = "prometheus"
+      }
+    }
+
+    service_name = "prometheus"
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "prometheus"
+        }
+
+        annotations = {}
+      }
+
+      spec {
+        service_account_name = "prometheus"
+
+        init_container {
+          name              = "init-chown-data"
+          image             = "busybox:latest"
+          image_pull_policy = "IfNotPresent"
+          command           = ["chown", "-R", "65534:65534", "/data"]
+
+          volume_mount {
+            name       = "prometheus-data"
+            mount_path = "/data"
+            sub_path   = ""
+          }
+        }
+
+        container {
+          name              = "prometheus-server-configmap-reload"
+          image             = "jimmidyson/configmap-reload:v0.1"
+          image_pull_policy = "IfNotPresent"
+
+          args = [
+            "--volume-dir=/etc/config",
+            "--webhook-url=http://localhost:9090/-/reload",
+          ]
+
+          volume_mount {
+            name       = "config-volume"
+            mount_path = "/etc/config"
+            read_only  = true
+          }
+
+          resources {
+            limits = {
+              cpu    = "10m"
+              memory = "10Mi"
+            }
+
+            requests = {
+              cpu    = "10m"
+              memory = "10Mi"
+            }
+          }
+        }
+
+        container {
+          name              = "prometheus-server"
+          image             = "prom/prometheus:v2.2.1"
+          image_pull_policy = "IfNotPresent"
+
+          args = [
+            "--config.file=/etc/config/prometheus.yml",
+            "--storage.tsdb.path=/data",
+            "--web.console.libraries=/etc/prometheus/console_libraries",
+            "--web.console.templates=/etc/prometheus/consoles",
+            "--web.enable-lifecycle",
+          ]
+
+          port {
+            container_port = 9090
+          }
+
+          resources {
+            limits = {
+              cpu    = "200m"
+              memory = "1000Mi"
+            }
+
+            requests = {
+              cpu    = "200m"
+              memory = "1000Mi"
+            }
+          }
+
+          volume_mount {
+            name       = "config-volume"
+            mount_path = "/etc/config"
+          }
+
+          volume_mount {
+            name       = "prometheus-data"
+            mount_path = "/data"
+            sub_path   = ""
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/-/ready"
+              port = 9090
+            }
+
+            initial_delay_seconds = 30
+            timeout_seconds       = 30
+          }
+
+          liveness_probe {
+            http_get {
+              path   = "/-/healthy"
+              port   = 9090
+              scheme = "HTTPS"
+            }
+
+            initial_delay_seconds = 30
+            timeout_seconds       = 30
+          }
+        }
+
+        termination_grace_period_seconds = 300
+
+        volume {
+          name = "config-volume"
+
+          config_map {
+            name = "prometheus-config"
+          }
+        }
+      }
+    }
+
+    update_strategy {
+      type = "RollingUpdate"
+
+      rolling_update {
+        partition = 1
+      }
+    }
+
+    volume_claim_template {
+      metadata {
+        name = "prometheus-data"
+      }
+
+      spec {
+        access_modes       = ["ReadWriteOnce"]
+        storage_class_name = "standard"
+
+        resources {
+          requests = {
+            storage = "16Gi"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "example" {
+  metadata {
+    name = "prometheus"
+  }
+  spec {
+    cluster_ip = "All"
+    selector = {
+      app = kubernetes_pod.example.metadata.0.labels.app
+    }
+    session_affinity = "ClientIP"
+    port {
+      port        = 8080
+      target_port = 80
+    }
+
+    type = "LoadBalancer"
+  }
+}

--- a/assets/queries/terraform/kubernetes/statefulsets_without_service_name/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/statefulsets_without_service_name/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "StatefulSets Without Service Name",
+    "severity": "LOW",
+    "line": 29
+  }
+]


### PR DESCRIPTION
Closes #2582 

**Proposed Changes**

- Support StatefulSets Without Service Name in Terraform (already exist in Kubernetes)

I submit this contribution under Apache-2.0 license.
