### PR TITLE
Cancel previous runs on new push for automated PR's workflows

### DIFF
--- a/.github/workflows/update-docs-index.yaml
+++ b/.github/workflows/update-docs-index.yaml
@@ -10,6 +10,10 @@ jobs:
     name: Update index docs links
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout project
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/update-docs-queries.yaml
+++ b/.github/workflows/update-docs-queries.yaml
@@ -12,6 +12,10 @@ jobs:
     name: Update queries documentation
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/update-godownloader-script.yaml
+++ b/.github/workflows/update-godownloader-script.yaml
@@ -10,6 +10,10 @@ jobs:
     name: Update install script
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
       - name: Checkout project
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION

**Proposed Changes**

- Small change to avoid a long queue of executions in the automated PR's workflows
- The workflow should cancel previous executions to only have the latest one completed


I submit this contribution under Apache-2.0 license.
