### PR TITLE
Add "HPA Targets Invalid Object" query for Terraform Closes #2608

### DIFF
--- a/assets/queries/terraform/kubernetes/hpa_targets_invalid_object/metadata.json
+++ b/assets/queries/terraform/kubernetes/hpa_targets_invalid_object/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "17e52ca3-ddd0-4610-9d56-ce107442e110",
+  "queryName": "HPA Targets Invalid Object",
+  "severity": "LOW",
+  "category": "Availability",
+  "descriptionText": "The Horizontal Pod Autoscale must target a valid object",
+  "descriptionUrl": "hhttps://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/horizontal_pod_autoscaler#metric",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/hpa_targets_invalid_object/query.rego
+++ b/assets/queries/terraform/kubernetes/hpa_targets_invalid_object/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_horizontal_pod_autoscaler[name]
+
+	metric := resource.spec.metric
+
+	not checkIsValidObject(metric)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_horizontal_pod_autoscaler[%s].spec.metric", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_horizontal_pod_autoscaler[%s].spec.metric is a valid object", [name]),
+		"keyActualValue": sprintf("kubernetes_horizontal_pod_autoscaler[%s].spec.metric is a invalid object", [name]),
+	}
+}
+
+checkIsValidObject(resource) {
+	resource.type == "Object"
+	resource.object != null
+	resource.object.metric != null
+	resource.object.target != null
+	resource.object.described_object.name != null
+	resource.object.described_object.api_version != null
+	resource.object.described_object.kind != null
+}

--- a/assets/queries/terraform/kubernetes/hpa_targets_invalid_object/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/hpa_targets_invalid_object/test/negative.tf
@@ -1,0 +1,33 @@
+resource "kubernetes_horizontal_pod_autoscaler" "example5" {
+  metadata {
+    name = "test"
+  }
+
+  spec {
+    min_replicas = 50
+    max_replicas = 100
+
+    scale_target_ref {
+      kind = "Deployment"
+      name = "MyApp"
+    }
+
+    metric {
+      type = "Object"
+      object {
+        metric {
+          name = "latency"
+        }
+        described_object {
+          name = "main-route"
+          api_version = "networking.k8s.io/v1beta1"
+          kind = "Ingress"
+        }
+        target {
+          type  = "Value"
+          value = "100"
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes/hpa_targets_invalid_object/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/hpa_targets_invalid_object/test/positive.tf
@@ -1,0 +1,59 @@
+resource "kubernetes_horizontal_pod_autoscaler" "example" {
+  metadata {
+    name = "test"
+  }
+
+  spec {
+    min_replicas = 50
+    max_replicas = 100
+
+    scale_target_ref {
+      kind = "Deployment"
+      name = "MyApp"
+    }
+
+    metric {
+      type = "External"
+      external {
+        metric {
+          name = "latency"
+          selector {
+            match_labels = {
+              lb_name = "test"
+            }
+          }
+        }
+        target {
+          type  = "Value"
+          value = "100"
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_horizontal_pod_autoscaler" "example2" {
+  metadata {
+    name = "test"
+  }
+
+  spec {
+    min_replicas = 50
+    max_replicas = 100
+
+    scale_target_ref {
+      kind = "Deployment"
+      name = "MyApp"
+    }
+
+    metric {
+      type = "Object"
+      object {
+        target {
+          type  = "Value"
+          value = "100"
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes/hpa_targets_invalid_object/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/hpa_targets_invalid_object/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "HPA Targets Invalid Object",
+    "severity": "LOW",
+    "line": 15
+  },
+  {
+    "queryName": "HPA Targets Invalid Object",
+    "severity": "LOW",
+    "line": 49
+  }
+]


### PR DESCRIPTION
Closes #2608

**Proposed Changes**

- Support "HPA Targets Invalid Object" query for Terraform (same as "HPA Targets Invalid Object" for Kubernetes). It is necessary to check if the attribute `spec.metric` is not  properly configured

I submit this contribution under Apache-2.0 license.
