### PR TITLE
Add "CronJob Deadline Not Configured" query for Terraform Closes #2611

### DIFF
--- a/assets/queries/terraform/kubernetes/cronjob_deadline_not_configured/metadata.json
+++ b/assets/queries/terraform/kubernetes/cronjob_deadline_not_configured/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "58876b44-a690-4e9f-9214-7735fa0dd15d",
+  "queryName": "CronJob Deadline Not Configured",
+  "severity": "LOW",
+  "category": "Resource Management",
+  "descriptionText": "Cronjobs must have a configured deadline, which means the attribute 'starting_deadline_seconds' must be defined",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cron_job#starting_deadline_seconds",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/cronjob_deadline_not_configured/query.rego
+++ b/assets/queries/terraform/kubernetes/cronjob_deadline_not_configured/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cron_job[name]
+
+	object.get(resource.spec, "starting_deadline_seconds", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cron_job[%s].spec", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_cron_job[%s].spec.starting_deadline_seconds is set", [name]),
+		"keyActualValue": sprintf("kubernetes_cron_job[%s].spec.starting_deadline_seconds is undefined", [name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/cronjob_deadline_not_configured/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/cronjob_deadline_not_configured/test/negative.tf
@@ -1,0 +1,29 @@
+resource "kubernetes_cron_job" "demo2" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes/cronjob_deadline_not_configured/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/cronjob_deadline_not_configured/test/positive.tf
@@ -1,0 +1,28 @@
+resource "kubernetes_cron_job" "demo" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes/cronjob_deadline_not_configured/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/cronjob_deadline_not_configured/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "CronJob Deadline Not Configured",
+    "severity": "LOW",
+    "line": 5
+  }
+]


### PR DESCRIPTION
Closes #2611

**Proposed Changes**

- Support "CronJob Deadline Not Configured" query for Terraform (same as "CronJob Deadline Not Configured" for Kubernetes). It is necessary to check if the attribute `spec.starting_deadline_seconds` is undefined

I submit this contribution under Apache-2.0 license.
