### PR TITLE
Archive integration tests logs and results 

### DIFF
--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -44,10 +44,21 @@ jobs:
       run: echo ${{ steps.docker_build.outputs.digest }}
     - name: Run docker image and generate results.json
       run: |
-        docker run -v ${PWD}/assets/queries:/path -e SENTRY_DSN=${{secrets.SENTRY_DSN}} kics:${{ github.sha }} --no-progress -p "/path" -o "/path/results.json"
+        docker run -v ${PWD}/assets/queries:/path -e SENTRY_DSN=${{secrets.SENTRY_DSN}} kics:${{ github.sha }} --silent --log-file -p "/path" -o "/path/results.json"
+    - name: Archive test logs
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: integration-logs-${{ github.event.pull_request.head.sha }}
+        path: info.log
     - name: Display results
       run: |
         cat  ${PWD}/assets/queries/results.json
+    - name: Archive test results
+      uses: actions/upload-artifact@v2
+      with:
+        name: integration-results-${{ github.event.pull_request.head.sha }}
+        path: ${PWD}/assets/queries/results.json
     - name: Assert results.json
       run: |
         set -eo pipefail


### PR DESCRIPTION
Closes #2616

**Proposed Changes**

- Run kics in silent mode during integration tests to keep stdout clean
- archive info.log and results.json to be analised locally in case of failure

I submit this contribution under Apache-2.0 license.
