### PR TITLE
Add "Memory Requests Not Defined" query for Terraform Closes #2615

### DIFF
--- a/assets/queries/k8s/container_cpu_requests_not_equal_limits/query.rego
+++ b/assets/queries/k8s/container_cpu_requests_not_equal_limits/query.rego
@@ -1,9 +1,10 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 	document.kind == "Pod"
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][c]
 	rec := {"requests", "limits"}
 
@@ -21,7 +22,6 @@ CxPolicy[result] {
 CxPolicy[result] {
 	document := input.document[i]
 	document.kind == "Pod"
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][c]
 
 	container.resources.requests.cpu != container.resources.limits.cpu

--- a/assets/queries/k8s/container_memory_requests_not_equal_limits/query.rego
+++ b/assets/queries/k8s/container_memory_requests_not_equal_limits/query.rego
@@ -1,9 +1,10 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 	document.kind == "Pod"
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][c]
 	rec := {"requests", "limits"}
 
@@ -21,7 +22,6 @@ CxPolicy[result] {
 CxPolicy[result] {
 	document := input.document[i]
 	document.kind == "Pod"
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][c]
 
 	container.resources.requests.memory != container.resources.limits.memory

--- a/assets/queries/k8s/container_requests_not_equal_limits/query.rego
+++ b/assets/queries/k8s/container_requests_not_equal_limits/query.rego
@@ -1,9 +1,10 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 	document.kind == "Pod"
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][c]
 	rec := {"requests", "limits"}
 
@@ -21,7 +22,6 @@ CxPolicy[result] {
 CxPolicy[result] {
 	document := input.document[i]
 	document.kind == "Pod"
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][c]
 	rec := {"requests", "limits"}
 
@@ -39,7 +39,6 @@ CxPolicy[result] {
 CxPolicy[result] {
 	document := input.document[i]
 	document.kind == "Pod"
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][c]
 	rec := {"cpu", "memory"}
 

--- a/assets/queries/k8s/containers_running_as_root/query.rego
+++ b/assets/queries/k8s/containers_running_as_root/query.rego
@@ -4,7 +4,7 @@ import data.generic.k8s as k8sLib
 
 CxPolicy[result] {
 	document := input.document[i]
-    document.kind == "Pod"
+	document.kind == "Pod"
 
 	spec := document.spec
 
@@ -14,7 +14,7 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	document := input.document[i]
-    document.kind == "CronJob"
+	document.kind == "CronJob"
 
 	spec := document.spec.jobTemplate.spec.template.spec
 
@@ -24,8 +24,8 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	document := input.document[i]
-    kind := document.kind
-    listKinds :=  ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "ReplicationController", "Job", "Service", "Secret", "ServiceAccount", "Role", "RoleBinding", "ConfigMap", "Ingress"]
+	kind := document.kind
+	listKinds := ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "ReplicationController", "Job", "Service", "Secret", "ServiceAccount", "Role", "RoleBinding", "ConfigMap", "Ingress"]
 	k8sLib.checkKind(kind, listKinds)
 
 	spec := document.spec.template.spec
@@ -64,9 +64,10 @@ checkRootParent(spec, path, metadata, id) = result {
 	result := checkRootContainer(spec, path, metadata, id)
 }
 
+types := {"initContainers", "containers"}
+
 checkRootContainer(spec, path, metadata, id) = result {
 	some j
-	types = {"initContainers", "containers"}
 	container := spec[types[x]][j]
 	not container.securityContext.runAsNonRoot
 	uid := container.securityContext.runAsUser
@@ -83,7 +84,6 @@ checkRootContainer(spec, path, metadata, id) = result {
 
 checkRootContainer(spec, path, metadata, id) = result {
 	some j
-	types = {"initContainers", "containers"}
 	container := spec[types[x]][j]
 	not container.securityContext.runAsNonRoot
 	object.get(container.securityContext, "runAsUser", "undefined") == "undefined"
@@ -99,7 +99,6 @@ checkRootContainer(spec, path, metadata, id) = result {
 
 checkUserContainer(spec, path, metadata, id) = result {
 	some j
-	types = {"initContainers", "containers"}
 	container := spec[types[x]][j]
 	uid := container.securityContext.runAsUser
 	to_number(uid) <= 0
@@ -115,7 +114,6 @@ checkUserContainer(spec, path, metadata, id) = result {
 
 checkUserContainer(spec, path, metadata, id) = result {
 	some j
-	types = {"initContainers", "containers"}
 	container := spec[types[x]][j]
 	not container.securityContext.runAsNonRoot
 	object.get(container.securityContext, "runAsUser", "undefined") == "undefined"
@@ -126,6 +124,5 @@ checkUserContainer(spec, path, metadata, id) = result {
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("'%s.%s[%d].securityContext.runAsUser' is defined", [path, types[x], j]),
 		"keyActualValue": sprintf("'%s.%s[%d].securityContext.runAsUser' is undefined", [path, types[x], j]),
-
 	}
 }

--- a/assets/queries/k8s/cpu_limits_not_set/query.rego
+++ b/assets/queries/k8s/cpu_limits_not_set/query.rego
@@ -2,12 +2,13 @@ package Cx
 
 import data.generic.k8s as k8sLib
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 	specInfo := k8sLib.getSpecInfo(document)
 	metadata := document.metadata
 
-	types := {"initContainers", "containers"}
 	containers := specInfo.spec[types[x]]
 
 	object.get(containers[index].resources.limits, "cpu", "undefined") == "undefined"
@@ -26,7 +27,6 @@ CxPolicy[result] {
 	specInfo := k8sLib.getSpecInfo(document)
 	metadata := document.metadata
 
-	types := {"initContainers", "containers"}
 	containers := specInfo.spec[types[x]]
 
 	object.get(containers[index].resources, "limits", "undefined") == "undefined"
@@ -45,7 +45,6 @@ CxPolicy[result] {
 	specInfo := k8sLib.getSpecInfo(document)
 	metadata := document.metadata
 
-	types := {"initContainers", "containers"}
 	containers := specInfo.spec[types[x]]
 
 	object.get(containers[index], "resources", "undefined") == "undefined"

--- a/assets/queries/k8s/cpu_requests_not_set/query.rego
+++ b/assets/queries/k8s/cpu_requests_not_set/query.rego
@@ -2,12 +2,13 @@ package Cx
 
 import data.generic.k8s as k8sLib
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 	specInfo := k8sLib.getSpecInfo(document)
 	metadata := document.metadata
 
-	types := {"initContainers", "containers"}
 	containers := specInfo.spec[types[x]]
 
 	object.get(containers[index].resources.requests, "cpu", "undefined") == "undefined"
@@ -26,7 +27,6 @@ CxPolicy[result] {
 	specInfo := k8sLib.getSpecInfo(document)
 	metadata := document.metadata
 
-	types := {"initContainers", "containers"}
 	containers := specInfo.spec[types[x]]
 
 	object.get(containers[index].resources, "requests", "undefined") == "undefined"
@@ -45,7 +45,6 @@ CxPolicy[result] {
 	specInfo := k8sLib.getSpecInfo(document)
 	metadata := document.metadata
 
-	types := {"initContainers", "containers"}
 	containers := specInfo.spec[types[x]]
 
 	object.get(containers[index], "resources", "undefined") == "undefined"

--- a/assets/queries/k8s/image_host_port_not_specified/query.rego
+++ b/assets/queries/k8s/image_host_port_not_specified/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 	metadata := document.metadata
 	spec := document.spec
-	types := {"initContainers", "containers"}
 	containers := spec[types[x]]
 	ports := containers[c].ports
 	object.get(ports[k], "hostPort", "undefined") != "undefined"
@@ -22,7 +23,6 @@ CxPolicy[result] {
 	document := input.document[i]
 	metadata := document.metadata
 	spec := document.spec.template.spec
-	types := {"initContainers", "containers"}
 	containers := spec[types[x]]
 	ports := containers[c].ports
 	object.get(ports[k], "hostPort", "undefined") != "undefined"

--- a/assets/queries/k8s/image_without_digest/query.rego
+++ b/assets/queries/k8s/image_without_digest/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 	metadata := document.metadata
 	spec := document.spec
-	types := {"initContainers", "containers"}
 	containers := spec[types[x]]
 	image := containers[c].image
 	not contains(image, "@")
@@ -22,7 +23,6 @@ CxPolicy[result] {
 	document := input.document[i]
 	metadata := document.metadata
 	spec := document.spec
-	types := {"initContainers", "containers"}
 	containers := spec[types[x]]
 	object.get(containers[k], "image", "undefined") == "undefined"
 

--- a/assets/queries/k8s/invalid_image/query.rego
+++ b/assets/queries/k8s/invalid_image/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document
 	metadata := document[i].metadata
 	spec := document[i].spec
-	types := {"initContainers", "containers"}
 	containers := spec[types[x]]
 	object.get(containers[c], "image", "undefined") == "undefined"
 
@@ -21,7 +22,6 @@ CxPolicy[result] {
 	document := input.document
 	metadata := document[i].metadata
 	spec := document[i].spec
-	types := {"initContainers", "containers"}
 	containers := spec[types[x]]
 	images = containers[c].image
 	check_content(images)

--- a/assets/queries/k8s/memory_limits_not_defined/query.rego
+++ b/assets/queries/k8s/memory_limits_not_defined/query.rego
@@ -1,13 +1,14 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 	spec := document.spec
 
-    types := {"initContainers", "containers"}
 	containers := spec[types[t]][c]
 
-    limits := containers.resources.limits
+	limits := containers.resources.limits
 	object.get(limits, "memory", "undefined") == "undefined"
 
 	metadata := document.metadata
@@ -25,7 +26,6 @@ CxPolicy[result] {
 	document := input.document[i]
 	spec := document.spec
 
-    types := {"initContainers", "containers"}
 	containers := spec[types[t]][c]
 
 	object.get(containers, "resources", "undefined") == "undefined"
@@ -35,16 +35,15 @@ CxPolicy[result] {
 		"documentId": document.id,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}", [metadata.name, types[t], containers.name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}.resources are defined", [metadata.name, types[t],containers.name]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}.resources are defined", [metadata.name, types[t], containers.name]),
 		"keyActualValue": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}.resources are undefined", [metadata.name, types[t], containers.name]),
 	}
 }
 
 CxPolicy[result] {
-    document := input.document[i]
+	document := input.document[i]
 	spec := document.spec
 
-	types := {"initContainers", "containers"}
 	containers := spec[types[t]][c]
 
 	resources := containers.resources
@@ -52,7 +51,7 @@ CxPolicy[result] {
 
 	metadata := document.metadata
 
-result := {
+	result := {
 		"documentId": document.id,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}.resources", [metadata.name, types[t], containers.name]),
 		"issueType": "MissingAttribute",

--- a/assets/queries/k8s/memory_requests_not_defined/query.rego
+++ b/assets/queries/k8s/memory_requests_not_defined/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
-    document := input.document[i]
+	document := input.document[i]
 	spec := document.spec
 
-    types := {"initContainers", "containers"}
 	containers := spec[types[t]][c]
 
 	requests := containers.resources.requests
@@ -25,7 +26,6 @@ CxPolicy[result] {
 	document := input.document[i]
 	spec := document.spec
 
-    types := {"initContainers", "containers"}
 	containers := spec[types[t]][c]
 
 	object.get(containers, "resources", "undefined") == "undefined"
@@ -35,7 +35,7 @@ CxPolicy[result] {
 		"documentId": document.id,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}", [metadata.name, types[t], containers.name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}.resources are defined", [metadata.name, types[t],containers.name]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}.resources are defined", [metadata.name, types[t], containers.name]),
 		"keyActualValue": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}.resources are undefined", [metadata.name, types[t], containers.name]),
 	}
 }
@@ -44,7 +44,6 @@ CxPolicy[result] {
 	document := input.document[i]
 	spec := document.spec
 
-	types := {"initContainers", "containers"}
 	containers := spec[types[t]][c]
 
 	resources := containers.resources

--- a/assets/queries/k8s/net_raw_capabilities_not_being_dropped/query.rego
+++ b/assets/queries/k8s/net_raw_capabilities_not_being_dropped/query.rego
@@ -2,17 +2,18 @@ package Cx
 
 import data.generic.common as commonLib
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 	document.kind == "Pod"
 	metadata := document.metadata
 	spec := document.spec
-	types := {"initContainers", "containers"}
 	containers := spec[types[x]]
 	capabilities := spec.containers[k].securityContext.capabilities
-    not commonLib.compareArrays(capabilities.drop, ["ALL", "NET_RAW"])
+	not commonLib.compareArrays(capabilities.drop, ["ALL", "NET_RAW"])
 
-    result := {
+	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}.securityContext.capabilities.drop", [metadata.name, types[x], containers[k].name]),
 		"issueType": "IncorrectValue",
@@ -26,7 +27,6 @@ CxPolicy[result] {
 	document.kind == "Pod"
 	metadata := document.metadata
 	spec := document.spec
-	types := {"initContainers", "containers"}
 	containers := spec[types[x]]
 
 	object.get(spec.containers[k].securityContext.capabilities, "drop", "undefined") == "undefined"
@@ -45,7 +45,6 @@ CxPolicy[result] {
 	document.kind == "Pod"
 	metadata := document.metadata
 	spec := document.spec
-	types := {"initContainers", "containers"}
 	containers := spec[types[x]]
 
 	object.get(spec.containers[k].securityContext, "capabilities", "undefined") == "undefined"
@@ -64,7 +63,6 @@ CxPolicy[result] {
 	document.kind == "Pod"
 	metadata := document.metadata
 	spec := document.spec
-	types := {"initContainers", "containers"}
 	containers := spec[types[x]]
 
 	object.get(spec.containers[k], "securityContext", "undefined") == "undefined"

--- a/assets/queries/k8s/privilege_escalation_allowed/query.rego
+++ b/assets/queries/k8s/privilege_escalation_allowed/query.rego
@@ -2,12 +2,13 @@ package Cx
 
 import data.generic.k8s as k8sLib
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 	specInfo := k8sLib.getSpecInfo(document)
 	metadata := document.metadata
 
-	types = {"initContainers", "containers"}
 	containers := specInfo.spec[types[x]]
 
 	object.get(containers[index].securityContext, "allowPrivilegeEscalation", "undefined") == "undefined"
@@ -26,7 +27,6 @@ CxPolicy[result] {
 	specInfo := k8sLib.getSpecInfo(document)
 	metadata := document.metadata
 
-	types = {"initContainers", "containers"}
 	containers := specInfo.spec[types[x]]
 	containers[index].securityContext.allowPrivilegeEscalation == true
 

--- a/assets/queries/k8s/root_container_not_mounted_as_read_only/query.rego
+++ b/assets/queries/k8s/root_container_not_mounted_as_read_only/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 
 	some j
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][j]
 	object.get(container, "securityContext", "undefined") == "undefined"
 
@@ -22,7 +23,6 @@ CxPolicy[result] {
 	document := input.document[i]
 
 	some j
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][j]
 	securityContext := container.securityContext
 	object.get(securityContext, "readOnlyRootFilesystem", "undefined") == "undefined"
@@ -41,7 +41,6 @@ CxPolicy[result] {
 	document := input.document[i]
 
 	some j
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][j]
 	container.securityContext.readOnlyRootFilesystem == false
 

--- a/assets/queries/k8s/secrets_as_environment_variables/query.rego
+++ b/assets/queries/k8s/secrets_as_environment_variables/query.rego
@@ -2,12 +2,12 @@ package Cx
 
 import data.generic.k8s as k8sLib
 
+containers := ["containers", "initContainers"]
+
 CxPolicy[result] {
 	document := input.document[i]
 	metadata := document.metadata
 	specInfo := k8sLib.getSpecInfo(document)
-
-	containers := ["containers", "initContainers"]
 
 	specInfo.spec[containers[c]][j].env[k].valueFrom.secretKeyRef
 
@@ -27,8 +27,6 @@ CxPolicy[result] {
 	document := input.document[i]
 	metadata := document.metadata
 	specInfo := k8sLib.getSpecInfo(document)
-
-	containers := ["containers", "initContainers"]
 
 	specInfo.spec[containers[c]][j].envFrom[k].secretRef
 

--- a/assets/queries/k8s/tiller_deployment_is_accessible_from_within_the_cluster/query.rego
+++ b/assets/queries/k8s/tiller_deployment_is_accessible_from_within_the_cluster/query.rego
@@ -1,11 +1,12 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 
 	isTiller(document)
 
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][j]
 	metadata := document.metadata
 
@@ -27,7 +28,6 @@ CxPolicy[result] {
 
 	isTiller(document)
 
-	types := {"initContainers", "containers"}
 	container := document.spec[types[x]][j]
 	metadata := document.metadata
 
@@ -52,7 +52,6 @@ CxPolicy[result] {
 
 	isTillerTemplate(document)
 
-	types := {"initContainers", "containers"}
 	container := document.spec.template.spec[types[x]][j]
 	metadata := document.metadata
 
@@ -72,7 +71,6 @@ CxPolicy[result] {
 
 	isTillerTemplate(document)
 
-	types := {"initContainers", "containers"}
 	container := document.spec.template.spec[types[x]][j]
 	metadata := document.metadata
 

--- a/assets/queries/k8s/tiller_is_deployed/query.rego
+++ b/assets/queries/k8s/tiller_is_deployed/query.rego
@@ -15,11 +15,12 @@ CxPolicy[result] {
 	}
 }
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	document := input.document[i]
 
 	some j
-	types := {"initContainers", "containers"}
 	contains(object.get(document.spec[types[x]][j], "image", "undefined"), "tiller")
 
 	metadata := document.metadata
@@ -53,7 +54,6 @@ CxPolicy[result] {
 	document := input.document[i]
 
 	some j
-	types := {"initContainers", "containers"}
 	contains(object.get(document.spec.template.spec[types[x]][j], "image", "undefined"), "tiller")
 
 	metadata := document.metadata

--- a/assets/queries/k8s/volume_mount_with_os_directory_write_permissions/query.rego
+++ b/assets/queries/k8s/volume_mount_with_os_directory_write_permissions/query.rego
@@ -1,8 +1,9 @@
 package Cx
 
+types := {"initContainers", "containers"}
+
 CxPolicy[result] {
 	resource := input.document[i]
-	types := {"initContainers", "containers"}
 	containers := resource.spec[types[x]]
 	volumeMounts := containers[_].volumeMounts
 	is_OS_Dir(volumeMounts[v].mountPath)
@@ -19,7 +20,6 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	resource := input.document[i]
-	types := {"initContainers", "containers"}
 	containers := resource.spec[types[x]]
 	volumeMounts := containers[_].volumeMounts
 	is_OS_Dir(volumeMounts[v].mountPath)

--- a/assets/queries/terraform/kubernetes/container_is_privileged/query.rego
+++ b/assets/queries/terraform/kubernetes/container_is_privileged/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"init_container", "container"}
+
 CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -23,7 +24,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true

--- a/assets/queries/terraform/kubernetes/container_resources_not_defined/query.rego
+++ b/assets/queries/terraform/kubernetes/container_resources_not_defined/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"init_container", "container"}
+
 CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -23,7 +24,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true
@@ -42,7 +42,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -64,7 +63,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true

--- a/assets/queries/terraform/kubernetes/container_with_added_capabilities/query.rego
+++ b/assets/queries/terraform/kubernetes/container_with_added_capabilities/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"init_container", "container"}
+
 CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -23,7 +24,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true

--- a/assets/queries/terraform/kubernetes/containers_with_sys_admin_capabilities/query.rego
+++ b/assets/queries/terraform/kubernetes/containers_with_sys_admin_capabilities/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"init_container", "container"}
+
 CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -23,7 +24,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true

--- a/assets/queries/terraform/kubernetes/cpu_requests_not_set/query.rego
+++ b/assets/queries/terraform/kubernetes/cpu_requests_not_set/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"init_container", "container"}
+
 CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -24,7 +25,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true
@@ -44,7 +44,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -63,7 +62,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true
@@ -82,7 +80,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -102,7 +99,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true

--- a/assets/queries/terraform/kubernetes/memory_requests_not_defined/metadata.json
+++ b/assets/queries/terraform/kubernetes/memory_requests_not_defined/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "21719347-d02b-497d-bda4-04a03c8e5b61",
+  "queryName": "Memory Requests Not Defined",
+  "severity": "MEDIUM",
+  "category": "Resource Management",
+  "descriptionText": "Memory requests should be specified",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#requests",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/memory_requests_not_defined/query.rego
+++ b/assets/queries/terraform/kubernetes/memory_requests_not_defined/query.rego
@@ -10,14 +10,14 @@ CxPolicy[result] {
 
 	is_array(containers) == true
 
-	object.get(containers[y].resources.limits, "cpu", "undefined") == "undefined"
+	object.get(containers[y].resources.requests, "memory", "undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].resources.limits.cpu is set", [resourceType, name, types[x], y]),
-		"keyActualValue": sprintf("%s[%s].spec.%s[%d].resources.limits.cpu is undefined", [resourceType, name, types[x], y]),
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].resources.requests.memory is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].resources.requests.memory is undefined", [resourceType, name, types[x], y]),
 	}
 }
 
@@ -29,14 +29,14 @@ CxPolicy[result] {
 
 	is_object(containers) == true
 
-	object.get(containers.resources.limits, "cpu", "undefined") == "undefined"
+	object.get(containers.resources.requests, "memory", "undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("%s[%s].spec.%s.resources.limits", [resourceType, name, types[x]]),
+		"searchKey": sprintf("%s[%s].spec.%s.resources.requests", [resourceType, name, types[x]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("%s[%s].spec.%s.resources.limits.cpu is set", [resourceType, name, types[x]]),
-		"keyActualValue": sprintf("%s[%s].spec.%s.resources.limits.cpu is undefined", [resourceType, name, types[x]]),
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.resources.requests.memory is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.resources.requests.memory is undefined", [resourceType, name, types[x]]),
 	}
 }
 
@@ -84,14 +84,14 @@ CxPolicy[result] {
 
 	is_array(containers) == true
 
-	object.get(containers[y].resources, "limits", "undefined") == "undefined"
+	object.get(containers[y].resources, "requests", "undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].resources.limits is set", [resourceType, name, types[x], y]),
-		"keyActualValue": sprintf("%s[%s].spec.%s[%d].resources.limits is undefined", [resourceType, name, types[x], y]),
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].resources.requests is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].resources.requests is undefined", [resourceType, name, types[x], y]),
 	}
 }
 
@@ -103,13 +103,13 @@ CxPolicy[result] {
 
 	is_object(containers) == true
 
-	object.get(containers.resources, "limits", "undefined") == "undefined"
+	object.get(containers.resources, "requests", "undefined") == "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("%s[%s].spec.%s.resources", [resourceType, name, types[x]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("%s[%s].spec.%s.resources.limits is set", [resourceType, name, types[x]]),
-		"keyActualValue": sprintf("%s[%s].spec.%s.resources.limits is undefined", [resourceType, name, types[x]]),
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.resources.requests is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.resources.requests is undefined", [resourceType, name, types[x]]),
 	}
 }

--- a/assets/queries/terraform/kubernetes/memory_requests_not_defined/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/memory_requests_not_defined/test/negative.tf
@@ -1,0 +1,174 @@
+
+resource "kubernetes_pod" "negative1" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+     {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      resources = {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+     ,
+     {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      resources = {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+   ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+
+resource "kubernetes_pod" "negative2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      resources  {
+            limits  {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/memory_requests_not_defined/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/memory_requests_not_defined/test/positive.tf
@@ -1,0 +1,155 @@
+
+resource "kubernetes_pod" "positive1" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+     {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+     ,
+     {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      resources = {
+            requests = {
+              cpu = "250m"
+            }
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+   ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+
+resource "kubernetes_pod" "positive2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      resources {
+            limits {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+

--- a/assets/queries/terraform/kubernetes/memory_requests_not_defined/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/memory_requests_not_defined/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+  {
+    "queryName": "Memory Requests Not Defined",
+    "severity": "MEDIUM",
+    "line": 8
+  },
+  {
+    "queryName": "Memory Requests Not Defined",
+    "severity": "MEDIUM",
+    "line": 8
+  },
+  {
+    "queryName": "Memory Requests Not Defined",
+    "severity": "MEDIUM",
+    "line": 105
+  }
+]

--- a/assets/queries/terraform/kubernetes/net_raw_capabilities_not_being_dropped/query.rego
+++ b/assets/queries/terraform/kubernetes/net_raw_capabilities_not_being_dropped/query.rego
@@ -6,7 +6,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -25,7 +24,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -47,7 +45,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -66,7 +63,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -85,7 +81,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true
@@ -104,7 +99,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true
@@ -125,7 +119,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true
@@ -144,7 +137,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true

--- a/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/query.rego
+++ b/assets/queries/terraform/kubernetes/pod_or_container_without_security_context/query.rego
@@ -16,11 +16,12 @@ CxPolicy[result] {
 	}
 }
 
+types := {"init_container", "container"}
+
 CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true
@@ -39,7 +40,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true

--- a/assets/queries/terraform/kubernetes/privilege_escalation_allowed/query.rego
+++ b/assets/queries/terraform/kubernetes/privilege_escalation_allowed/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"init_container", "container"}
+
 CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -23,7 +24,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true

--- a/assets/queries/terraform/kubernetes/root_container_not_mounted_as_read_only/query.rego
+++ b/assets/queries/terraform/kubernetes/root_container_not_mounted_as_read_only/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
+types := {"init_container", "container"}
+
 CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -24,7 +25,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -44,7 +44,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_array(containers) == true
@@ -63,7 +62,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true
@@ -82,7 +80,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true
@@ -101,7 +98,6 @@ CxPolicy[result] {
 	resource := input.document[i].resource[resourceType]
 
 	spec := resource[name].spec
-	types := {"init_container", "container"}
 	containers := spec[types[x]]
 
 	is_object(containers) == true


### PR DESCRIPTION
Closes #

**Proposed Changes**

- Support "Memory Requests Not Defined" query for Terraform (same as "Memory Requests Not Defined" for Kubernetes). It is necessary to check if the attribute `resources.requests.memory` is not set
- Pass types list to before the policies

I submit this contribution under Apache-2.0 license.
