### PR TITLE
Add "Memory Limits Not Defined" query for Terraform Closes #2622

### DIFF
--- a/assets/queries/terraform/kubernetes/memory_limits_not_defined/metadata.json
+++ b/assets/queries/terraform/kubernetes/memory_limits_not_defined/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "fd097ed0-7fe6-4f58-8b71-fef9f0820a21",
+  "queryName": "Memory Limits Not Defined",
+  "severity": "MEDIUM",
+  "category": "Resource Management",
+  "descriptionText": "Memory limits should be specified",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#limits",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/memory_limits_not_defined/query.rego
+++ b/assets/queries/terraform/kubernetes/memory_limits_not_defined/query.rego
@@ -1,0 +1,115 @@
+package Cx
+
+types := {"init_container", "container"}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+
+	object.get(containers[y].resources.limits, "memory", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].resources.limits.memory is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].resources.limits.memory is undefined", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+
+	object.get(containers.resources.limits, "memory", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s.resources.limits", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.resources.limits.memory is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.resources.limits.memory is undefined", [resourceType, name, types[x]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+	object.get(containers[y], "resources", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].resources is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].resources is undefined", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+	object.get(containers, "resources", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.resources is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.resources is undefined", [resourceType, name, types[x]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+
+	object.get(containers[y].resources, "limits", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].resources.limits is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].resources.limits is undefined", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+
+	object.get(containers.resources, "limits", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s.resources", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.resources.limits is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.resources.limits is undefined", [resourceType, name, types[x]]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/memory_limits_not_defined/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/memory_limits_not_defined/test/negative.tf
@@ -1,0 +1,174 @@
+
+resource "kubernetes_pod" "negative1" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+     {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      resources = {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+     ,
+     {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      resources = {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+   ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+
+resource "kubernetes_pod" "negative2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      resources  {
+            limits  {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/memory_limits_not_defined/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/memory_limits_not_defined/test/positive.tf
@@ -1,0 +1,154 @@
+
+resource "kubernetes_pod" "positive1" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+     {
+      image = "nginx:1.7.9"
+      name  = "example22"
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+     ,
+     {
+      image = "nginx:1.7.9"
+      name  = "example22222"
+
+      resources = {
+            requests = {
+              memory = "50Mi"
+            }
+      }
+
+      env = {
+        name  = "environment"
+        value = "test"
+      }
+
+      port = {
+        container_port = 8080
+      }
+
+      liveness_probe = {
+        http_get = {
+          path = "/nginx_status"
+          port = 80
+
+          http_header = {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+     }
+   ]
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+
+resource "kubernetes_pod" "positive2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      resources {
+            limits {
+              cpu = "0.5"
+            }
+      }
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+

--- a/assets/queries/terraform/kubernetes/memory_limits_not_defined/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/memory_limits_not_defined/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+  {
+    "queryName": "Memory Limits Not Defined",
+    "severity": "MEDIUM",
+    "line": 8
+  },
+  {
+    "queryName": "Memory Limits Not Defined",
+    "severity": "MEDIUM",
+    "line": 8
+  },
+  {
+    "queryName": "Memory Limits Not Defined",
+    "severity": "MEDIUM",
+    "line": 106
+  }
+]


### PR DESCRIPTION
Closes #2622

**Proposed Changes**

- Support "Memory Limits Not Defined" query for Terraform (same as "Memory Limits Not Defined" for Kubernetes). It is necessary to check if the attribute `resources.limits.memory` is not set

I submit this contribution under Apache-2.0 license.
