### PR TITLE
Add "Network Policy Is Not Targeting Any Pod" query for Terraform Closes #2631

### DIFF
--- a/assets/queries/k8s/network_policy_is_not_targeting_any_pod/query.rego
+++ b/assets/queries/k8s/network_policy_is_not_targeting_any_pod/query.rego
@@ -6,7 +6,7 @@ CxPolicy[result] {
 
 	object.get(document, "kind", "undefined") == "NetworkPolicy"
 
-	object.get(document.spec, "podSelector", "undefined") != null
+	object.get(document.spec.podSelector, "matchLabels", "undefined") != "undefined"
 
 	targetLabels := document.spec.podSelector.matchLabels
 	findTargettedPod(targetLabels[key], key) == false

--- a/assets/queries/terraform/kubernetes/network_policy_is_not_targeting_any_pod/metadata.json
+++ b/assets/queries/terraform/kubernetes/network_policy_is_not_targeting_any_pod/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b80b14c6-aaa2-4876-b651-8a48b6c32fbf",
+  "queryName": "Network Policy Is Not Targeting Any Pod",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Check if any network policy is not targeting any pod.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy#match_labels",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/network_policy_is_not_targeting_any_pod/query.rego
+++ b/assets/queries/terraform/kubernetes/network_policy_is_not_targeting_any_pod/query.rego
@@ -1,0 +1,38 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_network_policy[name]
+
+	object.get(resource.spec.pod_selector, "match_labels", "undefined") != "undefined"
+
+	targetLabels := resource.spec.pod_selector.match_labels
+	labelValue := targetLabels[key]
+
+	not hasReference(labelValue)
+
+	not findTargettedPod(labelValue, key)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_network_policy[%s].spec.pod_selector.match_labels", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_network_policy[%s].spec.pod_selector.match_labels is targeting at least a pod", [name]),
+		"keyActualValue": sprintf("kubernetes_network_policy[%s].spec.pod_selector.match_labels is not targeting any pod", [name]),
+	}
+}
+
+findTargettedPod(lValue, lKey) {
+	pod := input.document[_].resource[resourceType]
+	resourceType != "kubernetes_network_policy"
+	labels := pod[podName].metadata.labels
+
+	some key
+	key == lKey
+	labels[key] == lValue
+} else = false {
+	true
+}
+
+hasReference(label) {
+	regex.match("kubernetes_[_a-zA-Z]+.[a-zA-Z-_0-9]+", label)
+}

--- a/assets/queries/terraform/kubernetes/network_policy_is_not_targeting_any_pod/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/network_policy_is_not_targeting_any_pod/test/negative.tf
@@ -1,0 +1,165 @@
+resource "kubernetes_network_policy" "example2" {
+  metadata {
+    name      = "terraform-example-network-policy"
+    namespace = "default"
+  }
+
+  spec {
+    pod_selector {
+      match_expressions {
+        key      = "name"
+        operator = "In"
+        values   = ["webfront", "api"]
+      }
+      match_labels = {
+            app = "ngnix2"
+      }
+
+    }
+
+    ingress {
+      ports {
+        port     = "http"
+        protocol = "TCP"
+      }
+      ports {
+        port     = "8125"
+        protocol = "UDP"
+      }
+
+      from {
+        namespace_selector {
+          match_labels = {
+            name = "default"
+          }
+        }
+      }
+
+      from {
+        ip_block {
+          cidr = "10.0.0.0/8"
+          except = [
+            "10.0.0.0/24",
+            "10.0.1.0/24",
+          ]
+        }
+      }
+    }
+
+    egress {} # single empty rule to allow all egress traffic
+
+    policy_types = ["Ingress", "Egress"]
+  }
+}
+
+resource "kubernetes_pod" "test2" {
+  metadata {
+    name = "terraform-example"
+
+    labels = {
+      app = "ngnix2"
+    }
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_network_policy" "example222" {
+  metadata {
+    name      = "terraform-example-network-policy"
+    namespace = "default"
+  }
+
+  spec {
+    pod_selector {
+      match_expressions {
+        key      = "name"
+        operator = "In"
+        values   = ["webfront", "api"]
+      }
+      match_labels = {
+            app = "${kubernetes_pod.test2.metadata.0.labels.app}"
+      }
+
+    }
+
+    ingress {
+      ports {
+        port     = "http"
+        protocol = "TCP"
+      }
+      ports {
+        port     = "8125"
+        protocol = "UDP"
+      }
+
+      from {
+        namespace_selector {
+          match_labels = {
+            name = "default"
+          }
+        }
+      }
+
+      from {
+        ip_block {
+          cidr = "10.0.0.0/8"
+          except = [
+            "10.0.0.0/24",
+            "10.0.1.0/24",
+          ]
+        }
+      }
+    }
+
+    egress {} # single empty rule to allow all egress traffic
+
+    policy_types = ["Ingress", "Egress"]
+  }
+}

--- a/assets/queries/terraform/kubernetes/network_policy_is_not_targeting_any_pod/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/network_policy_is_not_targeting_any_pod/test/positive.tf
@@ -1,0 +1,53 @@
+resource "kubernetes_network_policy" "example" {
+  metadata {
+    name      = "terraform-example-network-policy"
+    namespace = "default"
+  }
+
+  spec {
+    pod_selector {
+      match_expressions {
+        key      = "name"
+        operator = "In"
+        values   = ["webfront", "api"]
+      }
+      match_labels = {
+            app = "ngnix"
+      }
+
+    }
+
+    ingress {
+      ports {
+        port     = "http"
+        protocol = "TCP"
+      }
+      ports {
+        port     = "8125"
+        protocol = "UDP"
+      }
+
+      from {
+        namespace_selector {
+          match_labels = {
+            name = "default"
+          }
+        }
+      }
+
+      from {
+        ip_block {
+          cidr = "10.0.0.0/8"
+          except = [
+            "10.0.0.0/24",
+            "10.0.1.0/24",
+          ]
+        }
+      }
+    }
+
+    egress {} # single empty rule to allow all egress traffic
+
+    policy_types = ["Ingress", "Egress"]
+  }
+}

--- a/assets/queries/terraform/kubernetes/network_policy_is_not_targeting_any_pod/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/network_policy_is_not_targeting_any_pod/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Network Policy Is Not Targeting Any Pod",
+    "severity": "MEDIUM",
+    "line": 14
+  }
+]


### PR DESCRIPTION
Closes #2631

**Proposed Changes**

- Support "Network Policy Is Not Targeting Any Pod" query for Terraform (same as "Network Policy Is Not Targeting Any Pod" for Kubernetes). It is necessary to check if the attribute `spec.pod_selector.match_labels` is not targeting any pod. We need to exclude cases like `app = "${kubernetes_pod.test2.metadata.0.labels.app}"` in TF (this is a direct reference)
- Since "Each NetworkPolicy includes a podSelector which selects the grouping of pods to which the policy applies. The example policy selects pods with the label "role=db". An empty podSelector selects all pods in the namespace.", I changed `object.get(document.spec, "podSelector", "undefined") != null` to `object.get(document.spec.podSelector, "matchLabels", "undefined") != null` in `\assets\queries\k8s\network_policy_is_not_targeting_any_pod\query.rego`

I submit this contribution under Apache-2.0 license.
