### PR TITLE
Add "Deployment Without PodDisruptionBudget" query for Terraform Closes #2637

### DIFF
--- a/assets/queries/terraform/kubernetes/deployment_without_pod_disruption_budget/metadata.json
+++ b/assets/queries/terraform/kubernetes/deployment_without_pod_disruption_budget/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a05331ee-1653-45cb-91e6-13637a76e4f0",
+  "queryName": "Deployment Without PodDisruptionBudget",
+  "severity": "LOW",
+  "category": "Availability",
+  "descriptionText": "Deployments should be assigned with a PodDisruptionBudget to ensure high availability",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment#selector",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/deployment_without_pod_disruption_budget/query.rego
+++ b/assets/queries/terraform/kubernetes/deployment_without_pod_disruption_budget/query.rego
@@ -1,0 +1,41 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_deployment[name]
+
+	resource.spec.replicas > 1
+
+	object.get(resource.spec.selector, "match_labels", "undefined") != "undefined"
+
+	targetLabels := resource.spec.selector.match_labels
+	labelValue := targetLabels[key]
+
+	not hasReference(labelValue)
+
+	not hasPodDisruptionBudget(labelValue, key)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_deployment[%s].spec.selector.match_labels", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_deployment[%s].spec.selector.match_labels is targeted by a PodDisruptionBudget", [name]),
+		"keyActualValue": sprintf("kubernetes_deployment[%s].spec.selector.match_labels is not targeted by a PodDisruptionBudget", [name]),
+	}
+}
+
+hasPodDisruptionBudget(lValue, lKey) {
+	pod := input.document[_].resource[resourceType]
+	resourceType == "kubernetes_pod_disruption_budget"
+
+	labels := pod[podName].spec.selector.match_labels
+
+	some key
+	key == lKey
+	labels[key] == lValue
+} else = false {
+	true
+}
+
+hasReference(label) {
+	regex.match("kubernetes_pod_disruption_budget.[a-zA-Z-_0-9]+", label)
+}

--- a/assets/queries/terraform/kubernetes/deployment_without_pod_disruption_budget/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/deployment_without_pod_disruption_budget/test/negative.tf
@@ -1,0 +1,136 @@
+resource "kubernetes_deployment" "example2" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app2 = "prometheus2"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app2 = "prometheus2"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app2 = "prometheus2"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+
+resource "kubernetes_pod_disruption_budget" "demo2" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    max_unavailable = "20%"
+    selector {
+      match_labels = {
+        k8s-app2 = "prometheus2"
+      }
+    }
+  }
+}
+
+
+
+resource "kubernetes_deployment" "example3" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app2 = "prometheus2"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app2 = "${kubernetes_pod_disruption_budget.demo2.spec.selector.0.match_labels.k8s-app2}"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app2 = "prometheus2"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes/deployment_without_pod_disruption_budget/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/deployment_without_pod_disruption_budget/test/positive.tf
@@ -1,0 +1,74 @@
+resource "kubernetes_deployment" "example" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      k8s-app = "prometheus"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        k8s-app = "prometheus"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          k8s-app = "prometheus"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+
+resource "kubernetes_pod_disruption_budget" "demo" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    max_unavailable = "20%"
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes/deployment_without_pod_disruption_budget/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/deployment_without_pod_disruption_budget/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Deployment Without PodDisruptionBudget",
+    "severity": "LOW",
+    "line": 13
+  }
+]


### PR DESCRIPTION
Closes #2637

**Proposed Changes**

- Support "Deployment Without PodDisruptionBudget" query for Terraform (same as "Deployment Without PodDisruptionBudget" for Kubernetes). It is necessary to check if the attribute `spec.selector.match_labels` is not targeted by a PodDisruptionBudget. We need to exclude cases like `k8s-app2 = "${kubernetes_pod_disruption_budget.demo2.spec.selector.0.match_labels.k8s-app2}"` in TF (this is a direct reference)

I submit this contribution under Apache-2.0 license.
