### PR TITLE
Add "Invalid Image" query for Terraform Closes #2643

### DIFF
--- a/assets/queries/k8s/invalid_image/query.rego
+++ b/assets/queries/k8s/invalid_image/query.rego
@@ -36,13 +36,7 @@ CxPolicy[result] {
 }
 
 check_content(images) {
-	images == ""
-}
+	options := {"", "latest", null}
 
-check_content(images) {
-	images == "latest"
-}
-
-check_content(images) {
-	images == null
+	images == options[j]
 }

--- a/assets/queries/k8s/invalid_image/test/positive.yaml
+++ b/assets/queries/k8s/invalid_image/test/positive.yaml
@@ -8,3 +8,24 @@ spec:
       image: ""
       imagePullPolicy: Always
       command: [ "echo", "SUCCESS" ]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: private-image-test-33
+spec:
+  containers:
+    - name: uses-private-image-container
+      image:
+      imagePullPolicy: Always
+      command: [ "echo", "SUCCESS" ]
+---
+kind: Pod
+metadata:
+  name: private-image-test-3344
+spec:
+  containers:
+    - name: uses-private-image-container
+      image: "latest"
+      imagePullPolicy: Always
+      command: [ "echo", "SUCCESS" ]

--- a/assets/queries/terraform/kubernetes/invalid_image/metadata.json
+++ b/assets/queries/terraform/kubernetes/invalid_image/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "e76cca7c-c3f9-4fc9-884c-b2831168ebd8",
+  "queryName": "Invalid Image",
+  "severity": "LOW",
+  "category": "Supply-Chain",
+  "descriptionText": "Image must be defined and not be empty or equal to latest.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#image",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/invalid_image/query.rego
+++ b/assets/queries/terraform/kubernetes/invalid_image/query.rego
@@ -1,0 +1,83 @@
+package Cx
+
+types := {"init_container", "container"}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+	object.get(containers[y], "image", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].image is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].image is undefined", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+	image := containers[y].image
+	check_content(image)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "IncorretValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].image is not empty or latest", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].image is empty or latest", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+	object.get(containers, "image", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.image is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.image is undefined", [resourceType, name, types[x]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+	image := containers.image
+	check_content(image)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s.image", [resourceType, name, types[x]]),
+		"issueType": "IncorretValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.image is not empty or latest", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.image is empty or latest", [resourceType, name, types[x]]),
+	}
+}
+
+check_content(image) {
+	options := {"", "latest"}
+
+	image == options[x]
+}

--- a/assets/queries/terraform/kubernetes/invalid_image/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/invalid_image/test/negative.tf
@@ -1,0 +1,52 @@
+resource "kubernetes_pod" "negative" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/invalid_image/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/invalid_image/test/positive.tf
@@ -1,0 +1,161 @@
+resource "kubernetes_pod" "positive1" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = ""
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod" "positive2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image =
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_pod" "positive3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+      {
+        image = "latest"
+        name  = "example"
+
+        env {
+          name  = "environment"
+          value = "test"
+        }
+
+        port {
+          container_port = 8080
+        }
+
+        liveness_probe {
+          http_get {
+            path = "/nginx_status"
+            port = 80
+
+            http_header {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ]
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/invalid_image/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/invalid_image/test/positive_expected_result.json
@@ -7,11 +7,11 @@
   {
     "queryName": "Invalid Image",
     "severity": "LOW",
-    "line": 19
+    "line": 60
   },
   {
     "queryName": "Invalid Image",
     "severity": "LOW",
-    "line": 29
+    "line": 114
   }
 ]


### PR DESCRIPTION
Closes #2643

**Proposed Changes**

- Support "Invalid Image" query for Terraform (same as "Invalid Image" for Kubernetes). It is necessary to check if the attribute image does not exist or is set to empty or "latest". Since `image =  `  in TF is not considered an attribute set to null, this case was not considered

I submit this contribution under Apache-2.0 license.
