### PR TITLE
Add "Image Without Digest" query for Terraform Closes #2648

### DIFF
--- a/assets/queries/terraform/kubernetes/image_without_digest/metadata.json
+++ b/assets/queries/terraform/kubernetes/image_without_digest/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "228c4c19-feeb-4c18-848c-800ac70fdfb7",
+  "queryName": "Image Without Digest",
+  "severity": "LOW",
+  "category": "Insecure Configurations",
+  "descriptionText": "Sees if Kubernetes image has digest on",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#image",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/image_without_digest/query.rego
+++ b/assets/queries/terraform/kubernetes/image_without_digest/query.rego
@@ -1,0 +1,77 @@
+package Cx
+
+types := {"init_container", "container"}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+	object.get(containers[y], "image", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].image is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].image is undefined", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_array(containers) == true
+	image := containers[y].image
+	not contains(image, "@")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].image has '@'", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].image does not have '@'", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+	object.get(containers, "image", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.image is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.image is undefined", [resourceType, name, types[x]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	spec := resource[name].spec
+	containers := spec[types[x]]
+
+	is_object(containers) == true
+	image := containers.image
+	not contains(image, "@")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s.image", [resourceType, name, types[x]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.image has '@'", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.image does not have '@'", [resourceType, name, types[x]]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/image_without_digest/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/image_without_digest/test/negative.tf
@@ -1,0 +1,52 @@
+resource "kubernetes_pod" "negative" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/image_without_digest/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/image_without_digest/test/positive.tf
@@ -1,0 +1,160 @@
+resource "kubernetes_pod" "positive1" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "uses-private-image"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+resource "kubernetes_pod" "positive2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}
+
+
+resource "kubernetes_pod" "positive3" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container = [
+      {
+        image = "uses-private-image"
+        name  = "example"
+
+        env = {
+          name  = "environment"
+          value = "test"
+        }
+
+        port =  {
+          container_port = 8080
+        }
+
+        liveness_probe = {
+          http_get = {
+            path = "/nginx_status"
+            port = 80
+
+            http_header = {
+              name  = "X-Custom-Header"
+              value = "Awesome"
+            }
+          }
+
+          initial_delay_seconds = 3
+          period_seconds        = 3
+        }
+      }
+    ]
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/image_without_digest/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/image_without_digest/test/positive_expected_result.json
@@ -1,0 +1,17 @@
+[
+  {
+    "queryName": "Image Without Digest",
+    "severity": "LOW",
+    "line": 8
+  },
+  {
+    "queryName": "Image Without Digest",
+    "severity": "LOW",
+    "line": 60
+  },
+  {
+    "queryName": "Image Without Digest",
+    "severity": "LOW",
+    "line": 113
+  }
+]


### PR DESCRIPTION
Closes #2648

**Proposed Changes**

- Support "Image Without Digest" query for Terraform (same as "Image Without Digest" for Kubernetes). It is necessary to check if the attribute image does not have '@'

I submit this contribution under Apache-2.0 license.
