### PR TITLE
Add 'EFS Without Tags' query for Ansible

### DIFF
--- a/assets/queries/ansible/aws/efs_without_tags/metadata.json
+++ b/assets/queries/ansible/aws/efs_without_tags/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b8a9852c-9943-4973-b8d5-77dae9352851",
+  "queryName": "EFS Without Tags",
+  "severity": "LOW",
+  "category": "Build Process",
+  "descriptionText": "Amazon Elastic Filesystem should have filesystem tags associated",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/efs_module.html",
+  "platform": "Ansible"
+}

--- a/assets/queries/ansible/aws/efs_without_tags/query.rego
+++ b/assets/queries/ansible/aws/efs_without_tags/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.ansible as ansLib
+
+modules := {"community.aws.efs", "efs"}
+
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	efs := task[modules[m]]
+
+	ansLib.checkState(efs)
+	object.get(efs, "tags", "undefined") == "undefined"
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("name={{%s}}.{{%s}}.tags is set", [task.name, modules[m]]),
+		"keyActualValue": sprintf("name={{%s}}.{{%s}}.tags is not defined", [task.name, modules[m]]),
+	}
+}

--- a/assets/queries/ansible/aws/efs_without_tags/test/negative.yaml
+++ b/assets/queries/ansible/aws/efs_without_tags/test/negative.yaml
@@ -1,0 +1,10 @@
+- name: EFS provisioning
+  community.aws.efs:
+    state: present
+    name: myTestEFS
+    tags:
+      Name: myTestNameTag
+      purpose: file-storage
+    targets:
+      - subnet_id: subnet-748c5d03
+        security_groups: [ "sg-1a2b3c4d" ]

--- a/assets/queries/ansible/aws/efs_without_tags/test/positive.yaml
+++ b/assets/queries/ansible/aws/efs_without_tags/test/positive.yaml
@@ -1,0 +1,7 @@
+- name: EFS provisioning without tags
+  community.aws.efs:
+    state: present
+    name: myTestEFS
+    targets:
+      - subnet_id: subnet-748c5d03
+        security_groups: [ "sg-1a2b3c4d" ]

--- a/assets/queries/ansible/aws/efs_without_tags/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/efs_without_tags/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "EFS Without Tags",
+    "severity": "LOW",
+    "line": 2
+  }
+]


### PR DESCRIPTION
Closes #2655

**Proposed Changes**

- The query checks if there are any tags associated with the Elastic Filesystem.

I submit this contribution under Apache-2.0 license.
