### PR TITLE
Adding .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ bin
 *.so
 *.dylib
 
+# MacOS finder files
+.DS_Store
+**/.DS_Store
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
**Proposed Changes**

- Add `.DS_Store` MacOS finder file to gitignore

I submit this contribution under Apache-2.0 license.
