### PR TITLE
Revert "Docs changes should not trigger CI #2677"

### DIFF
--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -3,10 +3,6 @@ name: go-ci-integration
 on:
   pull_request:
     branches: [master]
-    paths-ignore:
-    - 'docs/**'
-    - README.md
-    - mkdocs.yml
 
 jobs:
   integration-tests:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -4,12 +4,6 @@ name: go-ci
 on:
   pull_request:
     branches: [master]
-    paths-ignore:
-    - 'docs/**'
-    - README.md
-    - mkdocs.yml
-    - Dockerfile
-    - Dockerfile.integration
 
 jobs:
   lint:


### PR DESCRIPTION
Reverts Checkmarx/kics#2678

We cannot use `paths-ignore` feature because both workflows are "required" in our CI pipelines.

The issue is described here: https://github.community/t/feature-request-conditional-required-checks/16761

We might be able to workaround this issue by the using any of the suggestions in the thread above:
- https://github.com/marketplace/actions/skip-duplicate-actions#skip-ignored-paths
- https://github.com/technote-space/get-diff-action

cc: @joaoReigota1 @felipe-avelar @ruigomescx 