### PR TITLE
Add "Service Account Token Automount Not Disabled" query for Terraform Closes#2684

### DIFF
--- a/assets/queries/k8s/service_account_token_automount_not_disabled/query.rego
+++ b/assets/queries/k8s/service_account_token_automount_not_disabled/query.rego
@@ -2,11 +2,12 @@ package Cx
 
 import data.generic.k8s as k8sLib
 
+listKinds := ["Pod", "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "ReplicationController", "Job", "CronJob"]
+
 CxPolicy[result] {
 	document := input.document[i]
 
-    kind := document.kind
-    listKinds := ["Pod", "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "ReplicationController", "Job", "CronJob"]
+	kind := document.kind
 	k8sLib.checkKind(kind, listKinds)
 
 	metadata := document.metadata
@@ -26,8 +27,7 @@ CxPolicy[result] {
 CxPolicy[result] {
 	document := input.document[i]
 
-    kind := document.kind
-    listKinds := ["Pod", "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "ReplicationController", "Job", "CronJob"]
+	kind := document.kind
 	k8sLib.checkKind(kind, listKinds)
 
 	metadata := document.metadata

--- a/assets/queries/terraform/kubernetes/service_account_token_automount_not_disabled/metadata.json
+++ b/assets/queries/terraform/kubernetes/service_account_token_automount_not_disabled/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a9a13d4f-f17a-491b-b074-f54bffffcb4a",
+  "queryName": "Service Account Token Automount Not Disabled",
+  "severity": "MEDIUM",
+  "category": "Insecure Defaults",
+  "descriptionText": "Service Account Tokens are automatically mounted even if not necessary",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#automount_service_account_token",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/service_account_token_automount_not_disabled/query.rego
+++ b/assets/queries/terraform/kubernetes/service_account_token_automount_not_disabled/query.rego
@@ -1,0 +1,93 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+
+	object.get(resource.spec, "automount_service_account_token", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].spec", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_pod[%s].spec.automount_service_account_token is set", [name]),
+		"keyActualValue": sprintf("kubernetes_pod[%s].spec.automount_service_account_token is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod[name]
+
+	resource.spec.automount_service_account_token == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod[%s].spec.automount_service_account_token", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_pod[%s].spec.automount_service_account_token is set to false", [name]),
+		"keyActualValue": sprintf("kubernetes_pod[%s].spec.automount_service_account_token is set to true", [name]),
+	}
+}
+
+listKinds := {"kubernetes_deployment", "kubernetes_daemonset", "kubernetes_job", "kubernetes_stateful_set", "kubernetes_replication_controller"}
+
+CxPolicy[result] {
+	resource := input.document[i].resource
+
+	k8 := object.get(resource, listKinds[x], "undefined")
+	k8 != "undefined"
+
+	object.get(k8[name].spec.template.spec, "automount_service_account_token", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.template.spec", [listKinds[x], name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.template.spec.automount_service_account_token is set", [listKinds[x], name]),
+		"keyActualValue": sprintf("%s[%s].spec.template.spec.automount_service_account_token is undefined", [listKinds[x], name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource
+
+	k8 := object.get(resource, listKinds[x], "undefined")
+	k8 != "undefined"
+
+	k8[name].spec.template.spec.automount_service_account_token == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.template.spec.automount_service_account_token", [listKinds[x], name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.template.spec.automount_service_account_token is set to false", [listKinds[x], name]),
+		"keyActualValue": sprintf("%s[%s].spec.template.spec.automount_service_account_token is set to true", [listKinds[x], name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cron_job[name]
+
+	object.get(resource.spec.jobTemplate.spec.template.spec, "automount_service_account_token", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cron_job[%s].spec.jobTemplate.spec.template.spec", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.spec.automount_service_account_token is set", [name]),
+		"keyActualValue": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.spec.automount_service_account_token is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_cron_job[name]
+
+	resource.spec.job_template.spec.template.spec.automount_service_account_token == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.spec.automount_service_account_token", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.spec.automount_service_account_token is set to false", [name]),
+		"keyActualValue": sprintf("kubernetes_cron_job[%s].spec.job_template.spec.template.spec.automount_service_account_token is set to true", [name]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/service_account_token_automount_not_disabled/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/service_account_token_automount_not_disabled/test/negative.tf
@@ -1,0 +1,210 @@
+resource "kubernetes_deployment" "example9" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+        automount_service_account_token = false
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+
+resource "kubernetes_daemonset" "example22" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "something"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+
+        automount_service_account_token = false
+
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_cron_job" "demo32" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            automount_service_account_token = false
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_pod" "test62" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    automount_service_account_token = false
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/service_account_token_automount_not_disabled/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/service_account_token_automount_not_disabled/test/positive.tf
@@ -1,0 +1,208 @@
+resource "kubernetes_deployment" "example" {
+  metadata {
+    name = "terraform-example"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+    replicas = 3
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+
+resource "kubernetes_daemonset" "example2" {
+  metadata {
+    name      = "terraform-example"
+    namespace = "something"
+    labels = {
+      test = "MyExampleApp"
+    }
+  }
+
+  spec {
+
+    selector {
+      match_labels = {
+        test = "MyExampleApp"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          test = "MyExampleApp"
+        }
+      }
+
+      spec {
+
+        automount_service_account_token = true
+
+        container {
+          image = "nginx:1.7.8"
+          name  = "example"
+
+          resources {
+            limits = {
+              cpu    = "0.5"
+              memory = "512Mi"
+            }
+            requests = {
+              cpu    = "250m"
+              memory = "50Mi"
+            }
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/nginx_status"
+              port = 80
+
+              http_header {
+                name  = "X-Custom-Header"
+                value = "Awesome"
+              }
+            }
+
+            initial_delay_seconds = 3
+            period_seconds        = 3
+          }
+
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_cron_job" "demo3" {
+  metadata {
+    name = "demo"
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "1 0 * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            automount_service_account_token = true
+            container {
+              name    = "hello"
+              image   = "busybox"
+              command = ["/bin/sh", "-c", "date; echo Hello from the Kubernetes cluster"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_pod" "test6" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/service_account_token_automount_not_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/service_account_token_automount_not_disabled/test/positive_expected_result.json
@@ -1,0 +1,22 @@
+[
+  {
+    "queryName": "Service Account Token Automount Not Disabled",
+    "severity": "MEDIUM",
+    "line": 25
+  },
+  {
+    "queryName": "Service Account Token Automount Not Disabled",
+    "severity": "MEDIUM",
+    "line": 88
+  },
+  {
+    "queryName": "Service Account Token Automount Not Disabled",
+    "severity": "MEDIUM",
+    "line": 144
+  },
+  {
+    "queryName": "Service Account Token Automount Not Disabled",
+    "severity": "MEDIUM",
+    "line": 162
+  }
+]

--- a/assets/queries/terraform/kubernetes/service_type_is_nodeport/query.rego
+++ b/assets/queries/terraform/kubernetes/service_type_is_nodeport/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("kubernetes_service[%s].spec.type", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_service[name].spec.type is not 'NodePort'", [name]),
-		"keyActualValue": sprintf("kubernetes_service[name].spec.type is 'NodePort'", [name]),
+		"keyExpectedValue": sprintf("kubernetes_service[%s].spec.type is not 'NodePort'", [name]),
+		"keyActualValue": sprintf("kubernetes_service[%s].spec.type is 'NodePort'", [name]),
 	}
 }


### PR DESCRIPTION
Closes #2684

**Proposed Changes**

- Support "Service Account Token Automount Not Disabled" query for Terraform (same as "Service Account Token Automount Not Disabled" for Kubernetes). It is necessary to check if the attribute `automount_service_account_token` does not exist or is set to true

I submit this contribution under Apache-2.0 license.
