### PR TITLE
Added New Flag 'ci'

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,6 +80,7 @@ Available Commands:
   version        Displays the current version
 
 Flags:
+      --ci                 display only log messages to CLI output
   -h, --help               help for kics
   -l, --log-file           writes log messages to log file
       --log-level string   determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,6 +126,7 @@ Flags:
                                      (Ansible, CloudFormation, Dockerfile, Kubernetes, Terraform)
 
 Global Flags:
+      --ci                 display only log messages to CLI output
   -l, --log-file           writes log messages to log file
       --log-level string   determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
       --log-path string    path to log files, (defaults to ${PWD}/info.log)

--- a/internal/console/kics.go
+++ b/internal/console/kics.go
@@ -33,6 +33,7 @@ var (
 	logLevel string
 	noColor  bool
 	silent   bool
+	ci       bool
 
 	warnings = make(map[string]bool)
 
@@ -68,6 +69,11 @@ func initialize() error {
 		"write logs to stdout too (mutually exclusive with silent)")
 	rootCmd.PersistentFlags().BoolVarP(&silent, "silent", "s", false, "silence stdout messages (mutually exclusive with verbose)")
 	rootCmd.PersistentFlags().BoolVarP(&noColor, "no-color", "", false, "disable CLI color output")
+	rootCmd.PersistentFlags().BoolVarP(&ci,
+		"ci",
+		"",
+		false,
+		"display only log messages to CLI output")
 
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		return err
@@ -116,6 +122,7 @@ func setupLogs() error {
 
 	if noColor {
 		color.Disable()
+		consoleLogger.NoColor = true
 	}
 
 	if logPath == "" {
@@ -136,6 +143,12 @@ func setupLogs() error {
 
 	if silent {
 		color.SetOutput(io.Discard)
+		os.Stdout = nil
+	}
+
+	if ci {
+		color.SetOutput(io.Discard)
+		consoleLogger = zerolog.ConsoleWriter{Out: os.Stdout, NoColor: true}
 		os.Stdout = nil
 	}
 


### PR DESCRIPTION
Closes #2690 #2691

**Proposed Changes**

- Added flag 'ci' to remove unwanted output for CI environment ( only print log messages)
- Fixed Bug where flag 'no-color' wasn't removing colors from log messages

I submit this contribution under Apache-2.0 license.
