### PR TITLE
Add "Secrets As Environment Variables" query for Terraform Closes #2701

### DIFF
--- a/assets/queries/terraform/kubernetes/secrets_as_environment_variables/metadata.json
+++ b/assets/queries/terraform/kubernetes/secrets_as_environment_variables/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "6d8f1a10-b6cd-48f0-b960-f7c535d5cdb8",
+  "queryName": "Secrets As Environment Variables",
+  "severity": "LOW",
+  "category": "Secret Management",
+  "descriptionText": "Container should not use secrets as environment variables",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#secret_key_ref",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/secrets_as_environment_variables/query.rego
+++ b/assets/queries/terraform/kubernetes/secrets_as_environment_variables/query.rego
@@ -1,0 +1,117 @@
+package Cx
+
+types := {"init_container", "container"}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType][name]
+
+	containers := resource[name].spec[types[x]]
+
+	is_array(containers) == true
+
+	hasSecretKeyRef(containers[y])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s]", [resourceType, name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].env.value_from.secret_key_ref is undefined", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].env.value_from.secret_key_ref is set", [resourceType, name, types[x]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	containers := resource[name].spec[types[x]]
+
+	is_object(containers) == true
+
+	hasSecretKeyRef(containers)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s.env", [resourceType, name, types[x]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.env.value_from.secret_key_ref is undefined", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.env.value_from.secret_key_ref is set", [resourceType, name, types[x]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	containers := resource[name].spec[types[x]]
+
+	is_array(containers) == true
+
+	hasSecretRef(containers[y])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].env_from.secret_ref is undefined", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].env_from.secret_ref is set", [resourceType, name, types[x], y]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	containers := resource[name].spec[types[x]]
+
+	is_object(containers) == true
+
+	hasSecretRef(containers)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s.env_from", [resourceType, name, types[x]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.env_from.secret_ref is undefined", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.env_from.secret_ref is set", [resourceType, name, types[x]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	containers := resource[name].spec[types[x]]
+
+	is_object(containers) == true
+
+	hasSecretKeyRef(containers)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.%s.env", [resourceType, name, types[x]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.env.value_from.secret_key_ref is undefined", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.env.value_from.secret_key_ref is set", [resourceType, name, types[x]]),
+	}
+}
+
+hasSecretKeyRef(container) {
+	is_array(container.env) == true
+
+	object.get(container.env[x].value_from, "secret_key_ref", "undefined") != "undefined"
+}
+
+hasSecretKeyRef(container) {
+	is_object(container.env) == true
+
+	object.get(container.env.value_from, "secret_key_ref", "undefined") != "undefined"
+}
+
+hasSecretRef(container) {
+	is_array(container.env) == true
+
+	object.get(container.env_from, "secret_ref", "undefined") != "undefined"
+}
+
+hasSecretRef(container) {
+	is_object(container.env) == true
+
+	object.get(container.env_from, "secret_ref", "undefined") != "undefined"
+}

--- a/assets/queries/terraform/kubernetes/secrets_as_environment_variables/query.rego
+++ b/assets/queries/terraform/kubernetes/secrets_as_environment_variables/query.rego
@@ -74,24 +74,6 @@ CxPolicy[result] {
 	}
 }
 
-CxPolicy[result] {
-	resource := input.document[i].resource[resourceType]
-
-	containers := resource[name].spec[types[x]]
-
-	is_object(containers) == true
-
-	hasSecretKeyRef(containers)
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("%s[%s].spec.%s.env", [resourceType, name, types[x]]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s[%s].spec.%s.env.value_from.secret_key_ref is undefined", [resourceType, name, types[x]]),
-		"keyActualValue": sprintf("%s[%s].spec.%s.env.value_from.secret_key_ref is set", [resourceType, name, types[x]]),
-	}
-}
-
 hasSecretKeyRef(container) {
 	is_array(container.env) == true
 

--- a/assets/queries/terraform/kubernetes/secrets_as_environment_variables/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/secrets_as_environment_variables/test/negative.tf
@@ -1,0 +1,52 @@
+resource "kubernetes_pod" "test55" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/secrets_as_environment_variables/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/secrets_as_environment_variables/test/positive.tf
@@ -1,0 +1,60 @@
+resource "kubernetes_pod" "test" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+
+        value_from =  {
+            secret_key_ref = "hjjhjh"
+        }
+      }
+
+      env_from {
+        secret_ref = "wwww"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/secrets_as_environment_variables/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/secrets_as_environment_variables/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "Secrets As Environment Variables",
+    "severity": "LOW",
+    "line": 11
+  },
+  {
+    "queryName": "Secrets As Environment Variables",
+    "severity": "LOW",
+    "line": 20
+  }
+]


### PR DESCRIPTION
Closes #2701

**Proposed Changes**

- Support "Secrets As Environment Variables" query for Terraform (same as "Secrets As Environment Variables" for Kubernetes). It is necessary to check if the attributes `env.value_from.secret_key_ref` or `env_from.secret_ref` are set

I submit this contribution under Apache-2.0 license.
