### PR TITLE
Add "Root Containers Admitted" query for Terraform Closes #2710

### DIFF
--- a/assets/queries/k8s/root_containers_admitted/query.rego
+++ b/assets/queries/k8s/root_containers_admitted/query.rego
@@ -5,7 +5,7 @@ CxPolicy[result] {
 	document.kind == "PodSecurityPolicy"
 	spec := document.spec
 
-	privilege := {"privileged", "allowPrivilegeEscalation", "readOnlyRootFilesystem"}
+	privilege := {"privileged", "allowPrivilegeEscalation"}
 
 	spec[privilege[p]] == true
 

--- a/assets/queries/k8s/root_containers_admitted/test/negative.yaml
+++ b/assets/queries/k8s/root_containers_admitted/test/negative.yaml
@@ -46,4 +46,4 @@ spec:
       # Forbid adding the root group.
       - min: 1
         max: 65535
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true

--- a/assets/queries/k8s/root_containers_admitted/test/positive.yaml
+++ b/assets/queries/k8s/root_containers_admitted/test/positive.yaml
@@ -34,4 +34,3 @@ spec:
     ranges:
       - min: 0
         max: 65535
-  readOnlyRootFilesystem: true

--- a/assets/queries/terraform/kubernetes/root_containers_admitted/metadata.json
+++ b/assets/queries/terraform/kubernetes/root_containers_admitted/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "4c415497-7410-4559-90e8-f2c8ac64ee38",
+  "queryName": "Root Containers Admitted",
+  "severity": "MEDIUM",
+  "category": "Best Practices",
+  "descriptionText": "Containers must not be allowed to run with root privileges, which means the attributes 'privileged' and 'allow_privilege_escalation' must be set to false, 'run_as_user.rule' must be set to 'MustRunAsNonRoot', and adding the root group must be forbidden",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod_security_policy#run_as_user",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/root_containers_admitted/query.rego
+++ b/assets/queries/terraform/kubernetes/root_containers_admitted/query.rego
@@ -1,0 +1,64 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod_security_policy[name]
+
+	privilege := {"privileged", "allow_privilege_escalation"}
+
+	resource.spec[privilege[p]] == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec.%s", [name, privilege[p]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_pod_security_policy[%s].spec.%s is set to false", [name, privilege[p]]),
+		"keyActualValue": sprintf("kubernetes_pod_security_policy[%s].spec.%s is set to true", [name, privilege[p]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod_security_policy[name]
+
+	resource.spec.run_as_user.rule != "MustRunAsNonRoot"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec.run_as_user.rule", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_pod_security_policy[%s].spec.run_as_user.rule is equal to 'MustRunAsNonRoot'", [name]),
+		"keyActualValue": sprintf("kubernetes_pod_security_policy[%s].spec.run_as_user.rule is not equal to 'MustRunAsNonRoot'", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod_security_policy[name]
+
+	groups := {"fs_group", "supplemental_groups"}
+
+	resource.spec[groups[p]].rule != "MustRunAs"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec.%s.rule", [name, groups[p]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_pod_security_policy[%s].spec.%s.rule limits its ranges", [name, groups[p]]),
+		"keyActualValue": sprintf("kubernetes_pod_security_policy[%s].spec.%s.rule does not limit its ranges", [name, groups[p]]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.kubernetes_pod_security_policy[name]
+
+	groups := {"fs_group", "supplemental_groups"}
+
+	resource.spec[groups[p]].rule == "MustRunAs"
+	resource.spec[groups[p]].range.min == 0
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec.%s.range.min", [name, groups[p]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("kubernetes_pod_security_policy[%s].spec.%s.range.min does not allow range '0' (root)", [name, groups[p]]),
+		"keyActualValue": sprintf("kubernetes_pod_security_policy[%s].spec.%s.range.min allows range '0' (root)", [name, groups[p]]),
+	}
+}

--- a/assets/queries/terraform/kubernetes/root_containers_admitted/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/root_containers_admitted/test/negative.tf
@@ -1,0 +1,44 @@
+resource "kubernetes_pod_security_policy" "example2" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = false
+    allow_privilege_escalation = false
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "MustRunAsNonRoot"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    read_only_root_filesystem = true
+  }
+}

--- a/assets/queries/terraform/kubernetes/root_containers_admitted/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/root_containers_admitted/test/positive.tf
@@ -1,0 +1,42 @@
+resource "kubernetes_pod_security_policy" "example" {
+  metadata {
+    name = "terraform-example"
+  }
+  spec {
+    privileged                 = true
+    allow_privilege_escalation = true
+
+    volumes = [
+      "configMap",
+      "emptyDir",
+      "projected",
+      "secret",
+      "downwardAPI",
+      "persistentVolumeClaim",
+    ]
+
+    run_as_user {
+      rule = "RunAsAny"
+    }
+
+    se_linux {
+      rule = "RunAsAny"
+    }
+
+    supplemental_groups {
+      rule = "RunAsAny"
+      range {
+        min = 1
+        max = 65535
+      }
+    }
+
+    fs_group {
+      rule = "MustRunAs"
+      range {
+        min = 0
+        max = 65535
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/kubernetes/root_containers_admitted/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/root_containers_admitted/test/positive_expected_result.json
@@ -2,12 +2,17 @@
   {
     "queryName": "Root Containers Admitted",
     "severity": "MEDIUM",
-    "line": 12
+    "line": 6
   },
   {
     "queryName": "Root Containers Admitted",
     "severity": "MEDIUM",
-    "line": 13
+    "line": 7
+  },
+  {
+    "queryName": "Root Containers Admitted",
+    "severity": "MEDIUM",
+    "line": 19
   },
   {
     "queryName": "Root Containers Admitted",
@@ -17,11 +22,6 @@
   {
     "queryName": "Root Containers Admitted",
     "severity": "MEDIUM",
-    "line": 31
-  },
-  {
-    "queryName": "Root Containers Admitted",
-    "severity": "MEDIUM",
-    "line": 32
+    "line": 37
   }
 ]


### PR DESCRIPTION
Closes #2710

**Proposed Changes**

- Support "Root Containers Admitted" query for Terraform (same as "Root Containers Admitted" for Kubernetes). It is necessary to check if the attributes 'privileged' and 'allow_privilege_escalation' are set to true and 'run_as_user.rule' is not set to 'MustRunAsNonRoot'.
- Correcting "Root Containers Admitted" query for K8s (excluding the check of attribute 'readOnlyRootFilesystem') 

I submit this contribution under Apache-2.0 license.
