### PR TITLE
Add "Readiness Probe Is Not Configured" query for Terraform Closes #2712

### DIFF
--- a/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/metadata.json
+++ b/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "8657197e-3f87-4694-892b-8144701d83c1",
+  "queryName": "Readiness Probe Is Not Configured",
+  "severity": "MEDIUM",
+  "category": "Availability",
+  "descriptionText": "Check if Readiness Probe is not configured.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#readiness_probe",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/query.rego
+++ b/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/query.rego
@@ -15,10 +15,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("%s[%s].spec.container", [resourceType, name]),
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("%s[%s].spec.container.readiness_probe is set", [resourceType, name]),
-		"keyActualValue": sprintf("%s[%s].spec.containter.readiness_probe is undefined", [resourceType, name]),
+		"keyExpectedValue": sprintf("%s[%s].spec.%s.readiness_probe is set", [resourceType, name, types[x]]),
+		"keyActualValue": sprintf("%s[%s].spec.%s.readiness_probe is undefined", [resourceType, name, types[x]]),
 	}
 }
 
@@ -35,10 +35,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("%s[%s].spec.container", [resourceType, name]),
+		"searchKey": sprintf("%s[%s].spec.%s", [resourceType, name, types[x]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("%s[%s].spec.container[%d].readiness_probe is set", [resourceType, name, y]),
-		"keyActualValue": sprintf("%s[%s].spec.containter[%d].readiness_probe is undefined", [resourceType, name, y]),
+		"keyExpectedValue": sprintf("%s[%s].spec.%s[%d].readiness_probe is set", [resourceType, name, types[x], y]),
+		"keyActualValue": sprintf("%s[%s].spec.%s[%d].readiness_probe is undefined", [resourceType, name, types[x], y]),
 	}
 }
 

--- a/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/query.rego
+++ b/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/query.rego
@@ -1,0 +1,49 @@
+package Cx
+
+types := {"init_container", "container"}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	not resourceEqual(resourceType)
+
+	container := resource[name].spec[types[x]]
+
+	is_object(container) == true
+
+	object.get(container, "readiness_probe", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.container", [resourceType, name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.container.readiness_probe is set", [resourceType, name]),
+		"keyActualValue": sprintf("%s[%s].spec.containter.readiness_probe is undefined", [resourceType, name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourceType]
+
+	not resourceEqual(resourceType)
+
+	container := resource[name].spec[types[x]]
+
+	is_array(container) == true
+
+	object.get(container[y], "readiness_probe", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].spec.container", [resourceType, name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s[%s].spec.container[%d].readiness_probe is set", [resourceType, name, y]),
+		"keyActualValue": sprintf("%s[%s].spec.containter[%d].readiness_probe is undefined", [resourceType, name, y]),
+	}
+}
+
+resourceEqual(type) {
+	resources := {"kubernetes_cron_job", "kubernetes_job"}
+
+	type == resources[_]
+}

--- a/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/test/negative.tf
@@ -1,0 +1,56 @@
+resource "kubernetes_pod" "test2" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      readiness_probe {
+        initial_delay_seconds = 10
+      }
+
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/test/positive.tf
+++ b/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/test/positive.tf
@@ -1,0 +1,52 @@
+resource "kubernetes_pod" "test" {
+  metadata {
+    name = "terraform-example"
+  }
+
+  spec {
+    container {
+      image = "nginx:1.7.9"
+      name  = "example"
+
+      env {
+        name  = "environment"
+        value = "test"
+      }
+
+      port {
+        container_port = 8080
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/nginx_status"
+          port = 80
+
+          http_header {
+            name  = "X-Custom-Header"
+            value = "Awesome"
+          }
+        }
+
+        initial_delay_seconds = 3
+        period_seconds        = 3
+      }
+    }
+
+    dns_config {
+      nameservers = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
+      searches    = ["example.com"]
+
+      option {
+        name  = "ndots"
+        value = 1
+      }
+
+      option {
+        name = "use-vc"
+      }
+    }
+
+    dns_policy = "None"
+  }
+}

--- a/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/test/positive_expected_result.json
+++ b/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Readiness Probe Is Not Configured",
+    "severity": "MEDIUM",
+    "line": 7
+  }
+]


### PR DESCRIPTION
Closes #2712

**Proposed Changes**

- Support "Readiness Probe Is Not Configured" query for Terraform (same as "Readiness Probe Is Not Configured" for Kubernetes). It is necessary to check if `spec.container.readiness_probe` is not set

I submit this contribution under Apache-2.0 license.
