### PR TITLE
Fixing fetching tags for shallow clones in release related workflows

### DIFF
--- a/.github/workflows/release-dkr-image.yml
+++ b/.github/workflows/release-dkr-image.yml
@@ -16,7 +16,7 @@ jobs:
         id: get-version
         run: |
           git fetch --prune --unshallow --tags
-          echo "::set-output name=version::$(git describe --tags --abbrev=0)"
+          echo "::set-output name=version::$(git describe --match='v*' --tags --abbrev=0)"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub

--- a/.github/workflows/release-dkr-image.yml
+++ b/.github/workflows/release-dkr-image.yml
@@ -2,7 +2,7 @@ name: release-docker-image
 
 on:
   release:
-    types: [published]
+    types: [created]
   workflow_dispatch:
 
 jobs:
@@ -14,7 +14,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Get Release version
         id: get-version
-        run: echo "::set-output name=version::$(git describe --tags --abbrev=0)"
+        run: |
+          git fetch --prune --unshallow --tags
+          echo "::set-output name=version::$(git describe --tags --abbrev=0)"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub

--- a/.github/workflows/update-docs-index.yaml
+++ b/.github/workflows/update-docs-index.yaml
@@ -3,7 +3,7 @@ name: update-docs-index
 on:
   workflow_dispatch:
   release:
-    type: [published]
+    type: [created]
 
 jobs:
   update-index:
@@ -16,14 +16,14 @@ jobs:
           access_token: ${{ github.token }}
       - name: Checkout project
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Get current date
         id: cdate
         run: echo "::set-output name=date::$(date +'%Y.%m.%d')"
       - name: Get release version
         id: cversion
-        run: echo "::set-output name=version::$(git describe --tags --abbrev=0 | cut -c2-)"
+        run: |
+          git fetch --prune --unshallow --tags
+          echo "::set-output name=version::$(git describe --tags --match='v*' --abbrev=0 | cut -c2-)"
       - name: Print variables
         run: |
           echo "Version :: ${{ steps.cversion.outputs.version }}"

--- a/.github/workflows/update-install-script.yaml
+++ b/.github/workflows/update-install-script.yaml
@@ -3,7 +3,7 @@ name: update-install-script
 on:
   workflow_dispatch:
   release:
-    type: [published]
+    type: [created]
 
 jobs:
   update-install:


### PR DESCRIPTION
Closes #2738

**Proposed Changes**

- This will fix the issue that github actions workflow runner could not fetch the latest tag and not running once a new release is published


I submit this contribution under Apache-2.0 license.
