### PR TITLE
Add "API Gateway Deployment Without Access Log Setting" query for Terraform Closes #2760

### DIFF
--- a/assets/queries/cloudFormation/api_gateway_deployment_without_access_log_setting/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_deployment_without_access_log_setting/query.rego
@@ -5,7 +5,7 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::ApiGateway::Deployment"
 
-	not check_resources_type(document[i].Resources)
+	not check_resources_type("AWS::ApiGateway::Stage")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -21,6 +21,7 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::ApiGateway::Deployment"
 
+	check_resources_type("AWS::ApiGateway::Stage")
 	not settings_are_equal(document[i].Resources, name)
 
 	result := {
@@ -37,9 +38,10 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::ApiGateway::Deployment"
 
+	check_resources_type("AWS::ApiGateway::Stage")
 	settings_are_equal(document[i].Resources, name)
 
-    object.get(resource.Properties, "StageDescription", "undefined") = "undefined"
+	object.get(resource.Properties, "StageDescription", "undefined") = "undefined"
 
 	result := {
 		"documentId": input.document[i].id,
@@ -55,6 +57,7 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::ApiGateway::Deployment"
 
+	check_resources_type("AWS::ApiGateway::Stage")
 	settings_are_equal(document[i].Resources, name)
 
 	object.get(resource.Properties.StageDescription, "AccessLogSetting", "undefined") = "undefined"
@@ -68,8 +71,9 @@ CxPolicy[result] {
 	}
 }
 
-check_resources_type(resource) {
-	resource[_].Type == "AWS::ApiGateway::Stage"
+check_resources_type(resourceType) {
+	resource := input.document[_].Resources
+	resource[_].Type == resourceType
 }
 
 settings_are_equal(resource, deploymentName) {

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/metadata.json
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "625abc0e-f980-4ac9-a775-f7519ee34296",
+  "queryName": "API Gateway Deployment Without Access Log Setting",
+  "severity": "MEDIUM",
+  "category": "Observability",
+  "descriptionText": "API Gateway Deployment should have access log setting defined when connected to an API Gateway Stage.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/query.rego
@@ -1,0 +1,70 @@
+package Cx
+
+CxPolicy[result] {
+	document := input.document[i]
+	deployment = document.resource.aws_api_gateway_deployment[name]
+
+	count({x | resource := input.document[_].resource[x]; x == "aws_api_gateway_stage"}) == 0
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("aws_api_gateway_deployment[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_api_gateway_deployment[%s] has a 'aws_api_gateway_stage' resource associated", [name]),
+		"keyActualValue": sprintf("aws_api_gateway_deployment[%s] doesn't have a 'aws_api_gateway_stage' resource associated", [name]),
+	}
+}
+
+CxPolicy[result] {
+	document := input.document[i]
+	deployment = document.resource.aws_api_gateway_deployment[name]
+
+	count({x | resource := input.document[_].resource[x]; x == "aws_api_gateway_stage"}) != 0
+
+	not settings_are_equal(name)
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("aws_api_gateway_deployment[%s]", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_api_gateway_deployment[%s] has a 'aws_api_gateway_stage' resource associated with 'access_log_settings' set", [name]),
+		"keyActualValue": sprintf("aws_api_gateway_deployment[%s] doesn't have a 'aws_api_gateway_stage' resource associated with 'access_log_settings' set", [name]),
+	}
+}
+
+CxPolicy[result] {
+	document := input.document[i]
+	deployment = document.resource.aws_api_gateway_deployment[name]
+
+	count({x | resource := input.document[_].resource[x]; x == "aws_api_gateway_stage"}) != 0
+
+	settings_are_equal(name)
+
+	object.get(deployment, "stage_description", "undefined") == "undefined"
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("aws_api_gateway_deployment[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_api_gateway_deployment[%s].stage_description is set", [name]),
+		"keyActualValue": sprintf("aws_api_gateway_deployment[%s].stage_description is undefined", [name]),
+	}
+}
+
+settings_are_equal(name) {
+	count({x |
+		stage := input.document[_].resource[x]
+		x == "aws_api_gateway_stage"
+		has_reference(stage[y].deployment_id, name)
+		has_access_log_settings(stage[y])
+	}) != 0
+}
+
+has_reference(deploymentId, name) {
+	expected := sprintf("aws_api_gateway_deployment.%s.id", [name])
+	contains(deploymentId, expected) == true
+}
+
+has_access_log_settings(resource) {
+	object.get(resource, "access_log_settings", "undefined") != "undefined"
+}

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/test/negative1.tf
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/test/negative1.tf
@@ -1,0 +1,20 @@
+resource "aws_api_gateway_deployment" "example5" {
+  rest_api_id   = "some rest api id"
+  stage_name = "some name"
+  stage_description = "some description"
+
+  tags {
+    project = "ProjectName"
+  }
+}
+
+resource "aws_api_gateway_stage" "example0" {
+  deployment_id = aws_api_gateway_deployment.example5.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "example"
+
+  access_log_settings {
+    destination_arn = "dest"
+    format = "format"
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/test/positive1.tf
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/test/positive1.tf
@@ -1,0 +1,13 @@
+resource "aws_api_gateway_deployment" "examplee" {
+  rest_api_id   = "some rest api id"
+  stage_name = "some name"
+  tags {
+    project = "ProjectName"
+  }
+}
+
+resource "aws_api_gateway_stage" "example00" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "example"
+}

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/test/positive2.tf
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/test/positive2.tf
@@ -1,0 +1,13 @@
+resource "aws_api_gateway_deployment" "example3" {
+  rest_api_id   = "some rest api id"
+  stage_name = "some name"
+  tags {
+    project = "ProjectName"
+  }
+}
+
+resource "aws_api_gateway_stage" "example000" {
+  deployment_id = aws_api_gateway_deployment.example3.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "example"
+}

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/test/positive3.tf
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/test/positive3.tf
@@ -1,0 +1,18 @@
+resource "aws_api_gateway_deployment" "example4" {
+  rest_api_id   = "some rest api id"
+  stage_name = "some name"
+  tags {
+    project = "ProjectName"
+  }
+}
+
+resource "aws_api_gateway_stage" "example0000" {
+  deployment_id = aws_api_gateway_deployment.example4.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "example"
+
+  access_log_settings {
+    destination_arn = "dest"
+    format = "format"
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_deployment_without_access_log_setting/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+  {
+    "queryName": "API Gateway Deployment Without Access Log Setting",
+    "severity": "MEDIUM",
+    "line": 1,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "API Gateway Deployment Without Access Log Setting",
+    "severity": "MEDIUM",
+    "line": 1,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "API Gateway Deployment Without Access Log Setting",
+    "severity": "MEDIUM",
+    "line": 1,
+    "fileName": "positive3.tf"
+  }
+]


### PR DESCRIPTION
Closes #2760

**Proposed Changes**
- Support "API Gateway Deployment Without Access Log Setting" query for Terraform (same as "API Gateway Deployment Without Access Log Setting" for CloudFormation). It is necessary to check if: 

    1.  when an API Gateway Deployment is set, there is no API Gateway Stage defined
    2.  when an API Gateway Deployment is set, there is no API  Gateway Stage with 'access_log_settings' set associated with it
    3.  an API Gateway Deployment has an API  Gateway Stage with 'access_log_settings' set associated but does not have the attribute 'stage_description' set

I submit this contribution under Apache-2.0 license.
