### PR TITLE
Add "CMK Is Unusable" query for Terraform and Ansible Closes #2766

### DIFF
--- a/assets/queries/ansible/aws/cmk_is_unusable/metadata.json
+++ b/assets/queries/ansible/aws/cmk_is_unusable/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "133fee21-37ef-45df-a563-4d07edc169f4",
+  "queryName": "CMK Is Unusable",
+  "severity": "MEDIUM",
+  "category": "Availability",
+  "descriptionText": "AWS Key Management Service (KMS) must only possess usable Customer Master Keys (CMK), which means the CMKs must have the attribute 'enabled' set to true and the attribute 'pending_window' must be undefined.",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/aws_kms_module.html#parameter-enabled",
+  "platform": "Ansible"
+}

--- a/assets/queries/ansible/aws/cmk_is_unusable/query.rego
+++ b/assets/queries/ansible/aws/cmk_is_unusable/query.rego
@@ -1,0 +1,35 @@
+package Cx
+
+import data.generic.ansible as ansLib
+
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	kms := task["community.aws.aws_kms"]
+	ansLib.checkState(kms)
+
+	kms.enabled == false
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.aws_kms}}.enabled", [task.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "community.aws.aws_kms.enabled is set to true",
+		"keyActualValue": "community.aws.aws_kms.enabled is set to false",
+	}
+}
+
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	kms := task["community.aws.aws_kms"]
+	ansLib.checkState(kms)
+
+	kms.pending_window
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{community.aws.aws_kms}}.pending_window", [task.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "community.aws.aws_kms.pending_window is undefined",
+		"keyActualValue": "community.aws.aws_kms.pending_windowis is set",
+	}
+}

--- a/assets/queries/ansible/aws/cmk_is_unusable/test/negative1.yaml
+++ b/assets/queries/ansible/aws/cmk_is_unusable/test/negative1.yaml
@@ -1,0 +1,6 @@
+- name: Update IAM policy on an existing KMS key
+  community.aws.aws_kms:
+    alias: my-kms-key
+    policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [ { <SOME STATEMENT> } ]}'
+    state: present
+    enabled: true

--- a/assets/queries/ansible/aws/cmk_is_unusable/test/positive1.yaml
+++ b/assets/queries/ansible/aws/cmk_is_unusable/test/positive1.yaml
@@ -1,0 +1,6 @@
+- name: Update IAM policy on an existing KMS key1
+  community.aws.aws_kms:
+    alias: my-kms-key
+    policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [ { <SOME STATEMENT> } ]}'
+    state: present
+    enabled: false

--- a/assets/queries/ansible/aws/cmk_is_unusable/test/positive2.yaml
+++ b/assets/queries/ansible/aws/cmk_is_unusable/test/positive2.yaml
@@ -1,0 +1,6 @@
+- name: Update IAM policy on an existing KMS key2
+  community.aws.aws_kms:
+    alias: my-kms-key
+    policy: '{"Version": "2012-10-17", "Id": "my-kms-key-permissions", "Statement": [ { <SOME STATEMENT> } ]}'
+    state: present
+    pending_window: 8

--- a/assets/queries/ansible/aws/cmk_is_unusable/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cmk_is_unusable/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "CMK Is Unusable",
+    "severity": "MEDIUM",
+    "line": 6,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "CMK Is Unusable",
+    "severity": "MEDIUM",
+    "line": 6,
+    "fileName": "positive2.yaml"
+  }
+]

--- a/assets/queries/terraform/aws/cmk_is_unusable/metadata.json
+++ b/assets/queries/terraform/aws/cmk_is_unusable/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "7350fa23-dcf7-4938-916d-6a60b0c73b50",
+  "queryName": "CMK Is Unusable",
+  "severity": "MEDIUM",
+  "category": "Availability",
+  "descriptionText": "AWS Key Management Service (KMS) must only possess usable Customer Master Keys (CMK), which means the CMKs must have the attribute 'is_enabled' set to true",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key#is_enabled",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/cmk_is_unusable/query.rego
+++ b/assets/queries/terraform/aws/cmk_is_unusable/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_kms_key[name]
+
+	resource.is_enabled == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_kms_key[%s].is_enabled", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_kms_key[%s].is_enabled is set to true", [name]),
+		"keyActualValue": sprintf("aws_kms_key[%s].is_enabled is set to false", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/cmk_is_unusable/test/negative.tf
+++ b/assets/queries/terraform/aws/cmk_is_unusable/test/negative.tf
@@ -1,0 +1,4 @@
+resource "aws_kms_key" "a3" {
+  description             = "KMS key 1"
+  is_enabled = true
+}

--- a/assets/queries/terraform/aws/cmk_is_unusable/test/positive.tf
+++ b/assets/queries/terraform/aws/cmk_is_unusable/test/positive.tf
@@ -1,0 +1,4 @@
+resource "aws_kms_key" "a" {
+  description             = "KMS key 1"
+  is_enabled = false
+}

--- a/assets/queries/terraform/aws/cmk_is_unusable/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cmk_is_unusable/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "CMK Is Unusable",
+    "severity": "MEDIUM",
+    "line": 3
+  }
+]


### PR DESCRIPTION
Closes #2766

**Proposed Changes**
- Support "CMK Is Unusable" query for Terraform and Ansible (same as "CMK Is Unusable" for CloudFormation)

  1.  In the case of Terraform, it is necessary to check if the attribute 'is_enabled' is set to false
  2.  In the case of Ansible, it is necessary to check if the attribute 'enabled' is set to false or if the attribute 'pending_window' is set

I submit this contribution under Apache-2.0 license.
