### PR TITLE
Added log when terraform.tfvars not found

### DIFF
--- a/pkg/parser/terraform/variables.go
+++ b/pkg/parser/terraform/variables.go
@@ -115,7 +115,10 @@ func getInputVariables(currentPath string) {
 		log.Error().Msg("Error getting .auto.tfvars files")
 	}
 
-	if _, err := os.Stat(filepath.Join(currentPath, "terraform.tfvars")); err == nil {
+	_, err = os.Stat(filepath.Join(currentPath, "terraform.tfvars"))
+	if err != nil {
+		log.Info().Msg("terraform.tfvars not found")
+	} else {
 		tfVarsFiles = append(tfVarsFiles, filepath.Join(currentPath, "terraform.tfvars"))
 	}
 


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- When terraform.tfvars is not found on terraform directory, this will be logged

I submit this contribution under Apache-2.0 license.
