### PR TITLE
Add "ALB Is Not Integrated With WAF" query for Terraform Closes #2783

### DIFF
--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/query.rego
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/query.rego
@@ -6,30 +6,30 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 
 	cloudFormationLib.isLoadBalancer(resource)
-	not internalALB(resource)
-	not associatedWAF(name)
+	not internal_alb(resource)
+	not associated_waf(name)
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'Resources.%s' has an 'internal' scheme and a 'WebACLAssociation' associated", [name]),
-		"keyActualValue": sprintf("'Resources.%s' doesn't have an 'internal' scheme or a 'WebACLAssociation' associated", [name]),
+		"keyExpectedValue": sprintf("'Resources.%s' does not have an 'internal' scheme and has a 'WebACLAssociation' associated", [name]),
+		"keyActualValue": sprintf("'Resources.%s' does not have an 'internal' scheme and a 'WebACLAssociation' associated", [name]),
 	}
 }
 
-internalALB(resource) {
+internal_alb(resource) {
 	scheme := resource.Properties.Scheme
 	scheme == "internal"
 }
 
-associatedWAF(target_alb) {
+associated_waf(target_alb) {
 	resource := input.document[_].Resources[_]
 	resource.Type == "AWS::WAFRegional::WebACLAssociation"
 	resource.Properties.ResourceArn.Ref == target_alb
 }
 
-associatedWAF(target_alb) {
+associated_waf(target_alb) {
 	resource := input.document[_].Resources[_]
 	resource.Type == "AWS::WAFRegional::WebACLAssociation"
 	resource.Properties.ResourceArn == target_alb

--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/negative1.yaml
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/negative1.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
-    MyLoadBalancer:
+    MyLoadBalancer9:
         Type: AWS::ElasticLoadBalancing::LoadBalancer
         Properties:
           AvailabilityZones:
@@ -19,6 +19,6 @@ Resources:
       Type: "AWS::WAFRegional::WebACLAssociation"
       Properties:
         ResourceArn:
-          Ref: MyLoadBalancer
+          Ref: MyLoadBalancer9
         WebACLId:
           Ref: MyWebACL

--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/negative2.json
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/negative2.json
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
   "Resources": {
-    "MyLoadBalancer": {
+    "MyLoadBalancer8": {
       "Properties": {
         "Listeners": [
           {
@@ -30,7 +30,7 @@
           "Ref": "MyWebACL"
         },
         "ResourceArn": {
-          "Ref": "MyLoadBalancer"
+          "Ref": "MyLoadBalancer8"
         }
       }
     }

--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/positive1.yaml
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/positive1.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
-  MyLoadBalancer:
+  MyLoadBalancer22:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       AvailabilityZones:

--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/positive3.json
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/positive3.json
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
   "Resources": {
-    "MyLoadBalancer": {
+    "MyLoadBalancer22222222": {
       "Properties": {
         "Listeners": [
           {

--- a/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/positive4.json
+++ b/assets/queries/cloudFormation/alb_is_not_integrated_with_waf/test/positive4.json
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
   "Resources": {
-    "MyLoadBalancerV2": {
+    "MyLoadBalancerV22222": {
       "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "Properties": {
         "Scheme": "internet-facing",

--- a/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/metadata.json
+++ b/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "0afa6ab8-a047-48cf-be07-93a2f8c34cf7",
+  "queryName": "ALB Is Not Integrated With WAF",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "All Application Load Balancers (ALB) must be protected with Web Application Firewall (WAF) service",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_web_acl_association",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/query.rego
+++ b/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy[result] {
+	lb := {"aws_alb", "aws_lb"}
+	resource := input.document[i].resource[lb[idx]][name]
+	not is_internal_alb(resource)
+	not associated_waf(name)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s]", [lb[idx], name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'%s[%s]' is not 'internal' and has a 'aws_wafregional_web_acl_association' associated", [lb[idx], name]),
+		"keyActualValue": sprintf("'%s[%s]' is not 'internal' and does not have a 'aws_wafregional_web_acl_association' associated", [lb[idx], name]),
+	}
+}
+
+is_internal_alb(resource) {
+	resource.internal == true
+}
+
+associated_waf(name) {
+	waf := input.document[_].resource.aws_wafregional_web_acl_association[waf_name]
+	attribute := waf.resource_arn
+	attribute_split := split(attribute, ".")
+	options := {"${aws_alb", "${aws_lb"}
+	attribute_split[0] == options[x]
+	attribute_split[1] == name
+}

--- a/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/test/negative.tf
+++ b/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/test/negative.tf
@@ -1,0 +1,9 @@
+resource "aws_alb" "foo33" {
+  internal = false
+  subnets  = [aws_subnet.foo.id, aws_subnet.bar.id]
+}
+
+resource "aws_wafregional_web_acl_association" "foo_waf33" {
+  resource_arn = aws_alb.foo33.arn
+  web_acl_id   = aws_wafregional_web_acl.foo.id
+}

--- a/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/test/positive.tf
+++ b/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/test/positive.tf
@@ -1,0 +1,10 @@
+resource "aws_alb" "foo" {
+  internal = false
+  subnets  = [aws_subnet.foo.id, aws_subnet.bar.id]
+}
+
+resource "aws_wafregional_web_acl_association" "foo_waf" {
+  resource_arn = aws_alb.fooooo.arn
+  web_acl_id   = aws_wafregional_web_acl.foo.id
+}
+

--- a/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "ALB Is Not Integrated With WAF",
+    "severity": "MEDIUM",
+    "line": 1
+  }
+]


### PR DESCRIPTION
Closes #2783

**Proposed Changes**
- Support "ALB Is Not Integrated With WAF" query for Terraform (same as "ALB Is Not Integrated With WAF" for CloudFormation)
- Correcting expected and actual value in "ALB Is Not Integrated With WAF" query for CloudFormation

I submit this contribution under Apache-2.0 license.
