### PR TITLE
Release docker image is not being triggered on new release #2795

### DIFF
--- a/.github/workflows/release-dkr-image.yml
+++ b/.github/workflows/release-dkr-image.yml
@@ -2,13 +2,14 @@ name: release-docker-image
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
 
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    if: "!github.event.release.prerelease"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Closes #2795

**Proposed Changes**
- Check if `published` release is not a prerelease before pushing changes

I submit this contribution under Apache-2.0 license.
