### PR TITLE
Fixing documentation publishing without forcing changes #2799

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -34,9 +34,15 @@ jobs:
       - run: |
           git config --global user.name "KICSBot"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      - name: Create develop docs
-        run: mike deploy develop -u
-      - name: Publish changes
+      - name: Pull changes from gh-pages branch
         run: |
           git checkout gh-pages
-          git push origin gh-pages --force
+          git pull origin gh-pages
+          git checkout master
+      - name: Update develop docs
+        # this will create a new commit in gh-pages branch
+        run: mike deploy develop -u
+      - name: Publish changes in gh-pages
+        run: |
+          git checkout gh-pages
+          git push origin gh-pages

--- a/.github/workflows/update-docs-index.yaml
+++ b/.github/workflows/update-docs-index.yaml
@@ -3,12 +3,13 @@ name: update-docs-index
 on:
   workflow_dispatch:
   release:
-    type: [created]
+    type: [published]
 
 jobs:
   update-index:
     name: Update index docs links
     runs-on: ubuntu-latest
+    if: "!github.event.release.prerelease"
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
@@ -56,12 +57,18 @@ jobs:
         run: |
           git config --global user.name "KICSBot"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Pull changes from gh-pages branch
+        run: |
+          git checkout gh-pages
+          git pull origin gh-pages
+          git checkout master
       - name: Deploy mike version
+        # this will create a new commit in gh-pages branch
         run: |
           mike deploy ${{ steps.cversion.outputs.version }} latest -u
           mike set-default ${{ steps.cversion.outputs.version }}
       - name: Publish changes
         run: |
           git checkout gh-pages
-          git push origin gh-pages --force
+          git push origin gh-pages
 


### PR DESCRIPTION
Closes #2799

**Proposed Changes**
- Pull latest changes in `gh-pages` before trying to add new commits to this branch
- Publish changes by the end of the workflow

I submit this contribution under Apache-2.0 license.
