### PR TITLE
Fix nightly releases being created as draft

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -56,7 +56,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: v0.160.0
-          args: release --rm-dist --config="./.goreleaser-nightly.yml"
+          args: release --rm-dist --snapshot --skip-validate --config="./.goreleaser-nightly.yml"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: delete release


### PR DESCRIPTION
Closes #2798

**Proposed Changes**
- locking goreleaser version to v0.160.0 where this workflow worked
- skipping tag validation to avoid the goreleaser check preventing tags that do not follow semantic versioning pattern to trigger releases

I submit this contribution under Apache-2.0 license.
