### PR TITLE
Add query "Global Server Object Uses HTTP" #2837

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -1,6 +1,6 @@
 package generic.openapi
 
-checkOpenAPI(doc) = version {
+check_openapi(doc) = version {
   object.get(doc, "openapi", "undefined") != "undefined"
   version = doc.openapi
   regex.match("^3\\.0\\.\\d+$", doc.openapi)

--- a/assets/queries/openAPI/global_server_uses_http/metadata.json
+++ b/assets/queries/openAPI/global_server_uses_http/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "2d8c175a-6d90-412b-8b0e-e034ea49a1fe",
+  "queryName": "Global Server Object Uses HTTP",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "Global server object URL should use 'https' protocol instead of 'http'",
+  "descriptionUrl": "https://swagger.io/specification/#server-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/global_server_uses_http/query.rego
+++ b/assets/queries/openAPI/global_server_uses_http/query.rego
@@ -1,0 +1,36 @@
+package Cx
+
+import data.generic.openapi as openAPILib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openAPILib.check_openapi(doc) != "undefined"
+    object.get(doc, "servers", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": "openapi",
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Global servers array should be defined",
+		"keyActualValue": "Global servers array is not defined",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openAPILib.check_openapi(doc) != "undefined"
+	object.get(doc, "servers", "undefined") != "undefined"
+
+    count(doc.servers) > 0
+    object.get(doc.servers[j], "url", "undefined") != "undefined"
+    serverObj := doc.servers[j]
+    not startswith(serverObj.url, "https")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("servers.url.%s", [serverObj.url]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Global servers' URL should use HTTPS protocol",
+		"keyActualValue": "Global servers' URL are not using HTTPS protocol",
+	}
+}

--- a/assets/queries/openAPI/global_server_uses_http/test/negative1.json
+++ b/assets/queries/openAPI/global_server_uses_http/test/negative1.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://development.gigantic-server.com/v1",
+      "description": "Development server"
+    },
+    {
+      "url": "https://staging.gigantic-server.com/v1",
+      "description": "Staging server"
+    },
+    {
+      "url": "https://api.gigantic-server.com/v1",
+      "description": "Production server"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "security":[
+    {
+      "exampleSecurity": []
+    }
+  ],
+  "components": {
+    "exampleSecurity": {
+      "type": "https"
+    }
+  }
+}

--- a/assets/queries/openAPI/global_server_uses_http/test/negative2.yaml
+++ b/assets/queries/openAPI/global_server_uses_http/test/negative2.yaml
@@ -1,0 +1,37 @@
+---
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+servers:
+  - url: https://development.gigantic-server.com/v1
+    description: Development server
+  - url: https://staging.gigantic-server.com/v1
+    description: Staging server
+  - url: https://api.gigantic-server.com/v1
+    description: Production server
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - exampleSecurity: []
+components:
+  exampleSecurity:
+    type: https

--- a/assets/queries/openAPI/global_server_uses_http/test/positive1.json
+++ b/assets/queries/openAPI/global_server_uses_http/test/positive1.json
@@ -1,0 +1,53 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://development.gigantic-server.com/v1",
+      "description": "Development server"
+    },
+    {
+      "url": "http://staging.gigantic-server.com/v1",
+      "description": "Staging server"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/global_server_uses_http/test/positive2.yaml
+++ b/assets/queries/openAPI/global_server_uses_http/test/positive2.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+servers:
+  - url: https://development.gigantic-server.com/v1
+    description: Development server
+  - url: http://staging.gigantic-server.com/v1
+    description: Staging server
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/global_server_uses_http/test/positive3.yaml
+++ b/assets/queries/openAPI/global_server_uses_http/test/positive3.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security: []

--- a/assets/queries/openAPI/global_server_uses_http/test/positive_expected_result.json
+++ b/assets/queries/openAPI/global_server_uses_http/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+	{
+		"queryName": "Global Server Object Uses HTTP",
+		"severity": "MEDIUM",
+		"line": 13,
+		"filename": "positive1.json"
+	},
+	{
+		"queryName": "Global Server Object Uses HTTP",
+		"severity": "MEDIUM",
+		"line": 8,
+		"filename": "positive2.yaml"
+	},
+	{
+		"queryName": "Global Server Object Uses HTTP",
+		"severity": "MEDIUM",
+		"line": 1,
+		"filename": "positive3.yaml"
+	}
+]

--- a/assets/queries/openAPI/security_empty_array/query.rego
+++ b/assets/queries/openAPI/security_empty_array/query.rego
@@ -4,7 +4,7 @@ import data.generic.openapi as openAPILib
 
 CxPolicy[result] {
 	doc := input.document[i]
-	openAPILib.checkOpenAPI(doc) != "undefined"
+	openAPILib.check_openapi(doc) != "undefined"
 	object.get(doc, "security", "undefined") == "undefined"
 
 	result := {
@@ -18,7 +18,7 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	doc := input.document[i]
-	openAPILib.checkOpenAPI(doc) != "undefined"
+	openAPILib.check_openapi(doc) != "undefined"
 	object.get(doc, "security", "undefined") != "undefined"
 
 	count(doc.security) == 0


### PR DESCRIPTION
Closes #2837

**Proposed Changes**
- Add query "Global Server Object Uses HTTP" that checks if:
- servers global object is defined
- servers global object count > 0
- servers global object's URL uses HTTP

I submit this contribution under Apache-2.0 license.
