### PR TITLE
Added "Invalid Contact Email" query for OpenAPI #Closes2879

### DIFF
--- a/assets/queries/openAPI/invalid_contact_email/metadata.json
+++ b/assets/queries/openAPI/invalid_contact_email/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b1a7fcb0-2afe-4d5c-a6a1-4e6311fc29e7",
+  "queryName": "Invalid Contact Email",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "Contact Object Email should be a valid email",
+  "descriptionUrl": "https://swagger.io/specification/#contact-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/invalid_contact_email/query.rego
+++ b/assets/queries/openAPI/invalid_contact_email/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	regex.match(`^[\w-\._]+@([\w-]+\.)+[\w-_]{2,4}$`, doc.info.contact.email) == false
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": "info.contact.email",
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "info.contact.email has a valid email",
+		"keyActualValue": "info.contact.email has an invalid email",
+	}
+}

--- a/assets/queries/openAPI/invalid_contact_email/test/negative1.json
+++ b/assets/queries/openAPI/invalid_contact_email/test/negative1.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/invalid_contact_email/test/negative1.json
+++ b/assets/queries/openAPI/invalid_contact_email/test/negative1.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Simple API overview",
+    "title": "Simple API Overview",
     "version": "1.0.0",
     "contact": {
       "name": "contact",

--- a/assets/queries/openAPI/invalid_contact_email/test/negative2.yaml
+++ b/assets/queries/openAPI/invalid_contact_email/test/negative2.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Simple API overview
+  title: Simple API Overview
   version: 1.0.0
   contact:
     name: "contact"

--- a/assets/queries/openAPI/invalid_contact_email/test/negative2.yaml
+++ b/assets/queries/openAPI/invalid_contact_email/test/negative2.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+  contact:
+    name: "contact"
+    url: "https://www.google.com/"
+    email: "user@gmail.com"
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - exampleSecurity: []
+components:
+  exampleSecurity:
+    type: http
+    scheme: basic

--- a/assets/queries/openAPI/invalid_contact_email/test/positive1.json
+++ b/assets/queries/openAPI/invalid_contact_email/test/positive1.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/invalid_contact_email/test/positive1.json
+++ b/assets/queries/openAPI/invalid_contact_email/test/positive1.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Simple API overview",
+    "title": "Simple API Overview",
     "version": "1.0.0",
     "contact": {
       "name": "contact",

--- a/assets/queries/openAPI/invalid_contact_email/test/positive2.yaml
+++ b/assets/queries/openAPI/invalid_contact_email/test/positive2.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+  contact:
+    name: "contact"
+    url: "https://www.google.com/"
+    email: "user@gmail.c"
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - exampleSecurity: []
+components:
+  exampleSecurity:
+    type: http
+    scheme: basic

--- a/assets/queries/openAPI/invalid_contact_email/test/positive2.yaml
+++ b/assets/queries/openAPI/invalid_contact_email/test/positive2.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Simple API overview
+  title: Simple API Overview
   version: 1.0.0
   contact:
     name: "contact"

--- a/assets/queries/openAPI/invalid_contact_email/test/positive_expected_result.json
+++ b/assets/queries/openAPI/invalid_contact_email/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Invalid Contact Email",
+    "severity": "INFO",
+    "line": 9,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Invalid Contact Email",
+    "severity": "INFO",
+    "line": 8,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2879

**Proposed Changes**
- Added "Invalid Contact Email" query for OpenAPI (it checks if doc.info.contact.email does not match the defined URL validation regex

I submit this contribution under Apache-2.0 license.
