### PR TITLE
Updated query Service Does Not Target Pod #2793

### DIFF
--- a/assets/queries/k8s/service_does_not_target_pod/query.rego
+++ b/assets/queries/k8s/service_does_not_target_pod/query.rego
@@ -39,6 +39,12 @@ confirmPorts(servicePorts) {
 	types := {"initContainers", "containers"}
 	containers := pod.spec[types[x]][j]
 	containers.ports[k].containerPort == servicePorts.targetPort
+} else {
+	stateful_set := input.document[i]
+	stateful_set.kind == "StatefulSet"
+	types := {"initContainers", "containers"}
+	containers := stateful_set.spec.template.spec[types[x]][j]
+	containers.ports[k].containerPort == servicePorts.targetPort
 } else = false {
 	true
 }
@@ -47,6 +53,10 @@ contains(string) {
 	pod := input.document[i]
 	pod.kind == "Pod"
 	pod.metadata.labels[_] == string
+} else {
+	stateful_set := input.document[i]
+	stateful_set.kind == "StatefulSet"
+	stateful_set.metadata.labels[_] == string
 } else = false {
 	true
 }


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #2793

**Proposed Changes**
- Updated query Service Does Not Target Pod 
- Query will now look for pods defined inside the template of a StatefulSet

I submit this contribution under Apache-2.0 license.
