### PR TITLE
Added Responses With Wrong HTTP Status Code query for OpenAPI #2897

### DIFF
--- a/assets/queries/openAPI/responses_wrong_http_status_code/metadata.json
+++ b/assets/queries/openAPI/responses_wrong_http_status_code/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "d86655c0-92f6-4ffc-b4d5-5b5775804c27",
+  "queryName": "Responses With Wrong HTTP Status Code",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "HTTP Responses status code should be in range of [200-599]",
+  "descriptionUrl": "https://swagger.io/specification/#responses-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/responses_wrong_http_status_code/query.rego
+++ b/assets/queries/openAPI/responses_wrong_http_status_code/query.rego
@@ -1,0 +1,35 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses[code]
+
+	check_status_code(code)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses.{{%s}}", [n, oper, code]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "HTTP responses status codes are in range of [200-599]",
+		"keyActualValue": "HTTP responses status codes are not in range of [200-599]",
+	}
+}
+
+check_status_code(code) {
+	s_code := split(code, "")
+	n := to_number(s_code[0])
+	n < 1
+}
+
+check_status_code(code) {
+	s_code := split(code, "")
+	n := to_number(s_code[0])
+	n > 5
+}
+
+check_status_code(code) {
+	count(code) != 3
+}

--- a/assets/queries/openAPI/responses_wrong_http_status_code/test/negative1.json
+++ b/assets/queries/openAPI/responses_wrong_http_status_code/test/negative1.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "3xx": {
+            "description": "[300-399] response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/responses_wrong_http_status_code/test/negative2.yaml
+++ b/assets/queries/openAPI/responses_wrong_http_status_code/test/negative2.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+        "3xx":
+          description: "[300-399] response"
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/responses_wrong_http_status_code/test/positive1.json
+++ b/assets/queries/openAPI/responses_wrong_http_status_code/test/positive1.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "50": {
+            "description": "500 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "6xx": {
+            "description": "[600-699] response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/responses_wrong_http_status_code/test/positive2.yaml
+++ b/assets/queries/openAPI/responses_wrong_http_status_code/test/positive2.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "50":
+          description: Server error response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+        "6xx":
+          description: "[600-699] response"
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/responses_wrong_http_status_code/test/positive_expected_result.json
+++ b/assets/queries/openAPI/responses_wrong_http_status_code/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Responses With Wrong HTTP Status Code",
+    "severity": "INFO",
+    "line": 13,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Responses With Wrong HTTP Status Code",
+    "severity": "INFO",
+    "line": 39,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Responses With Wrong HTTP Status Code",
+    "severity": "INFO",
+    "line": 11,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Responses With Wrong HTTP Status Code",
+    "severity": "INFO",
+    "line": 25,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #2897

**Proposed Changes**
- Add Responses With Wrong HTTP Status Code query for OpenAPI 

I submit this contribution under Apache-2.0 license.
