### PR TITLE
Add "Schema Discriminator Not Required" query for OpenAPI Closes#2900

### DIFF
--- a/assets/queries/openAPI/schema_discriminator_not_required/metadata.json
+++ b/assets/queries/openAPI/schema_discriminator_not_required/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b481d46c-9c61-480f-86d9-af07146dc4a4",
+  "queryName": "Schema Discriminator Not Required",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "The discriminator property in the Schema Object should be a required property",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/schema_discriminator_not_required/query.rego
+++ b/assets/queries/openAPI/schema_discriminator_not_required/query.rego
@@ -57,16 +57,16 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	schema := doc.paths[path][operation].requestBody[r].content[c].schema
+	schema := doc.paths[path][operation].requestBody.content[c].schema
 	discriminator := schema.discriminator.propertyName
 	not required(schema, discriminator)
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.{{%s}}.content.{{%s}}.schema.discriminator.propertyName", [path, operation, r, c]),
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.discriminator.propertyName", [path, operation, c]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.{{%s}}.content.{{%s}}.schema.discriminator.propertyName is a required property", [path, operation, r, c]),
-		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.{{%s}}.content.{{%s}}.schema.discriminator.propertyName is not a required property", [path, operation, r, c]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.discriminator.propertyName is a required property", [path, operation, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.discriminator.propertyName is not a required property", [path, operation, c]),
 	}
 }
 

--- a/assets/queries/openAPI/schema_discriminator_not_required/query.rego
+++ b/assets/queries/openAPI/schema_discriminator_not_required/query.rego
@@ -1,0 +1,143 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].responses[r].content[c].schema
+	discriminator := schema.discriminator.propertyName
+	not required(schema, discriminator)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema.discriminator.propertyName", [path, operation, r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema.discriminator.propertyName is a required property", [path, operation, r, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema.discriminator.propertyName is not a required property", [path, operation, r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path].parameters[parameter].schema
+	discriminator := schema.discriminator.propertyName
+	not required(schema, discriminator)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.parameters.{{%s}}.schema.discriminator.propertyName", [path, parameter]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.parameters.{{%s}}.schema.discriminator.propertyName is a required property", [path, parameter]),
+		"keyActualValue": sprintf("paths.{{%s}}.parameters.{{%s}}.schema.discriminator.propertyName is not a required property", [path, parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].parameters[parameter].schema
+	discriminator := schema.discriminator.propertyName
+	not required(schema, discriminator)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.discriminator.propertyName", [path, operation, parameter]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.discriminator.propertyName is a required property", [path, operation, parameter]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.discriminator.propertyName is not a required property", [path, operation, parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].requestBody[r].content[c].schema
+	discriminator := schema.discriminator.propertyName
+	not required(schema, discriminator)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.{{%s}}.content.{{%s}}.schema.discriminator.propertyName", [path, operation, r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.{{%s}}.content.{{%s}}.schema.discriminator.propertyName is a required property", [path, operation, r, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.{{%s}}.content.{{%s}}.schema.discriminator.propertyName is not a required property", [path, operation, r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.requestBodies[r].content[c].schema
+	discriminator := schema.discriminator.propertyName
+	not required(schema, discriminator)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.discriminator.propertyName", [r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.discriminator.propertyName is a required property", [r, c]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.discriminator.propertyName is not a required property", [r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.parameters[parameter].schema
+	discriminator := schema.discriminator.propertyName
+	not required(schema, discriminator)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.parameters.{{%s}}.schema.discriminator.propertyName", [parameter]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.parameters.{{%s}}.schema.discriminator.propertyName is a required property", [parameter]),
+		"keyActualValue": sprintf("components.parameters.{{%s}}.schema.discriminator.propertyName is not a required property", [parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.responses[r].content[c].schema
+	discriminator := schema.discriminator.propertyName
+	not required(schema, discriminator)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.discriminator.propertyName", [r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.discriminator.propertyName is a required property", [r, c]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.discriminator.propertyName is not a required property", [r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.schemas[s]
+	discriminator := schema.discriminator.propertyName
+	not required(schema, discriminator)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.schemas.{{%s}}.discriminator.propertyName", [s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.schemas.{{%s}}.discriminator.propertyName is a required property", [s]),
+		"keyActualValue": sprintf("components.schemas.{{%s}}.discriminator.propertyName is not a required property", [s]),
+	}
+}
+
+required(schema, discriminator) {
+	schema.required[_] == discriminator
+}

--- a/assets/queries/openAPI/schema_discriminator_not_required/test/negative1.json
+++ b/assets/queries/openAPI/schema_discriminator_not_required/test/negative1.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_discriminator_not_required/test/negative2.json
+++ b/assets/queries/openAPI/schema_discriminator_not_required/test/negative2.json
@@ -1,0 +1,66 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ]
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_discriminator_not_required/test/negative3.yaml
+++ b/assets/queries/openAPI/schema_discriminator_not_required/test/negative3.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - exampleSecurity: []
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - petType

--- a/assets/queries/openAPI/schema_discriminator_not_required/test/negative4.yaml
+++ b/assets/queries/openAPI/schema_discriminator_not_required/test/negative4.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: string
+                required:
+                  - petType
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - exampleSecurity: []

--- a/assets/queries/openAPI/schema_discriminator_not_required/test/positive1.json
+++ b/assets/queries/openAPI/schema_discriminator_not_required/test/positive1.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_discriminator_not_required/test/positive2.json
+++ b/assets/queries/openAPI/schema_discriminator_not_required/test/positive2.json
@@ -1,0 +1,63 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_discriminator_not_required/test/positive3.yaml
+++ b/assets/queries/openAPI/schema_discriminator_not_required/test/positive3.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - exampleSecurity: []
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - name

--- a/assets/queries/openAPI/schema_discriminator_not_required/test/positive4.yaml
+++ b/assets/queries/openAPI/schema_discriminator_not_required/test/positive4.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: string
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - exampleSecurity: []

--- a/assets/queries/openAPI/schema_discriminator_not_required/test/positive_expected_result.json
+++ b/assets/queries/openAPI/schema_discriminator_not_required/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Schema Discriminator Not Required",
+    "severity": "INFO",
+    "line": 53,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema Discriminator Not Required",
+    "severity": "INFO",
+    "line": 25,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Schema Discriminator Not Required",
+    "severity": "INFO",
+    "line": 32,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Schema Discriminator Not Required",
+    "severity": "INFO",
+    "line": 18,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2900

**Proposed Changes**
- Added "Schema Discriminator Not Required" query for OpenAPI (it checks if 'schema.discriminator.propertyName' is not a required property)

**Considerations**
- The Schema Object exists in Components Object, Parameter Object, and Media Type Object. 
- The Components Objects exists in OpenAPI Object. 
- The Parameter Object exists in Path Object, Components Object, and Operation Object.
- The Media Type Object exists in Content.
- The Content exists in Responses Object and Request Body Object.
- The Responses Object exists in Component Object and Operation Object.
- The Request Body Object exists in Components Object and Operation Object.

I submit this contribution under Apache-2.0 license.
