### PR TITLE
Added "Invalid Content Type For Multiple Files Upload" query for OpenAPI Closes#2919

### DIFF
--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/metadata.json
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "26f06397-36d8-4ce7-b993-17711261d777",
+  "queryName": "Invalid Content Type For Multiple Files Upload",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Content Type should be set to 'multipart/form-data' in case of uploading an arbitrary number of files (array)",
+  "descriptionUrl": "https://swagger.io/docs/specification/describing-request-body/file-upload/",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/query.rego
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/query.rego
@@ -1,0 +1,43 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+options := {"file", "filename"}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	property := doc.paths[path][operation].requestBody.content[c].schema.properties[p]
+	p == options[x]
+
+	property.type == "array"
+	c != "multipart/form-data"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}", [path, operation, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}} is set to 'multipart/form-data'", [path, operation, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}} is not set to 'multipart/form-data'", [path, operation, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	property := doc.components.requestBodies[r].content[c].schema.properties[p]
+	p == options[x]
+
+	property.type == "array"
+	c != "multipart/form-data"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}", [r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}} is set to 'multipart/form-data'", [r, c]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}} is not set to 'multipart/form-data'", [r, c]),
+	}
+}

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/query.rego
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/query.rego
@@ -12,6 +12,7 @@ CxPolicy[result] {
 	p == options[x]
 
 	property.type == "array"
+	property.items.format == "binary"
 	c != "multipart/form-data"
 
 	result := {
@@ -31,6 +32,7 @@ CxPolicy[result] {
 	p == options[x]
 
 	property.type == "array"
+	property.items.format == "binary"
 	c != "multipart/form-data"
 
 	result := {

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/negative1.json
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/negative1.json
@@ -1,0 +1,35 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "filename": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/negative2.json
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/negative2.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "email": "user@gmail.com"
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "CreateCustomer": {
+        "description": "Create a new customer",
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "filename": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/negative3.yaml
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/negative3.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: "contact"
+    email: "user@gmail.com"
+paths:
+  "/":
+    get:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                filename:
+                  type: array
+                  items:
+                    type: string
+                    format: binary

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/negative4.yaml
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/negative4.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: "contact"
+    email: "user@gmail.com"
+components:
+  requestBodies:
+    CreateCustomer:
+      description: Create a new customer
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              filename:
+                type: array
+                items:
+                  type: string
+                  format: binary

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/positive1.json
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/positive1.json
@@ -1,0 +1,35 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "filename": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/positive2.json
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/positive2.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "email": "user@gmail.com"
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "CreateCustomer": {
+        "description": "Create a new customer",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "filename": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/positive3.yaml
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/positive3.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: "contact"
+    email: "user@gmail.com"
+paths:
+  "/":
+    get:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filename:
+                  type: array
+                  items:
+                    type: string
+                    format: binary

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/positive4.yaml
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/positive4.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: "contact"
+    email: "user@gmail.com"
+components:
+  requestBodies:
+    CreateCustomer:
+      description: Create a new customer
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              filename:
+                type: array
+                items:
+                  type: string
+                  format: binary

--- a/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/positive_expected_result.json
+++ b/assets/queries/openAPI/invalid_content_type_for_multiple_files_upload/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Invalid Content Type For Multiple Files Upload",
+    "severity": "INFO",
+    "line": 16,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Invalid Content Type For Multiple Files Upload",
+    "severity": "INFO",
+    "line": 16,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Invalid Content Type For Multiple Files Upload",
+    "severity": "INFO",
+    "line": 13,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Invalid Content Type For Multiple Files Upload",
+    "severity": "INFO",
+    "line": 13,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2919

**Proposed Changes**
- Added "Invalid Content Type For Multiple Files Upload" query for OpenAPI (it checks if Content Type is not set to 'multipart/form-data' in case of uploading an arbitrary number of files (array))

I submit this contribution under Apache-2.0 license.
