### PR TITLE
Added "Success Response Code Defined for Patch Operation" query for OpenAPI

### DIFF
--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/metadata.json
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "3b497874-ae59-46dd-8d72-1868a3b8f150",
+  "queryName": "Success Response Code Defined for Patch Operation",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Patch should define at least one success response (200, 201, 202 or 204)",
+  "descriptionUrl": "https://swagger.io/specification/#operation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/metadata.json
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/metadata.json
@@ -1,5 +1,5 @@
 {
-  "id": "3b497874-ae59-46dd-8d72-1868a3b8f150",
+  "id": "1908a8ee-927d-4166-8f18-241152170cc1",
   "queryName": "Success Response Code Defined for Patch Operation",
   "severity": "MEDIUM",
   "category": "Networking and Firewall",

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/query.rego
@@ -1,0 +1,24 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+
+	oper == "patch"
+
+	object.get(response, "200", "undefined") == "undefined"
+	object.get(response, "201", "undefined") == "undefined"
+	object.get(response, "202", "undefined") == "undefined"
+	object.get(response, "204", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Delete should have at least one successful code (200, 201, 202 or 204)",
+		"keyActualValue": "Delete does not have any successful code",
+	}
+}

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses", [n, oper]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "Delete should have at least one successful code (200, 201, 202 or 204)",
-		"keyActualValue": "Delete does not have any successful code",
+		"keyExpectedValue": "Patch should have at least one successful code (200, 201, 202 or 204)",
+		"keyActualValue": "Patch does not have any successful code",
 	}
 }

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/negative1.json
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/negative1.json
@@ -23,7 +23,7 @@
         "summary": "Update item",
         "responses": {
           "204": {
-            "description": "Item deleted successfully"
+            "description": "Item updated successfully"
           },
           "default": {
             "description": "Error",

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/negative1.json
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/negative1.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "delete": {
+        "operationId": "deleteItem",
+        "summary": "Delete item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateItem",
+        "summary": "Update item",
+        "responses": {
+          "204": {
+            "description": "Item deleted successfully"
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/negative2.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/negative2.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    delete:
+      operationId: deleteItem
+      summary: Delete item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+    patch:
+      operationId: updateItem
+      summary: Update item
+      responses:
+        '204':
+          description: Item deleted successfully
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/negative2.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/negative2.yaml
@@ -17,7 +17,7 @@ paths:
       summary: Update item
       responses:
         '204':
-          description: Item deleted successfully
+          description: Item updated successfully
         default:
           description: Error
           schema:

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive1.json
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive1.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "patch": {
+        "operationId": "updateItem",
+        "summary": "Updated item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive2.json
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive2.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "delete": {
+        "operationId": "deleteItem",
+        "summary": "Delete item",
+        "responses": {
+          "204": {
+            "description": "Item updated successfully"
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateItem",
+        "summary": "Update item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive2.json
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive2.json
@@ -11,7 +11,7 @@
         "summary": "Delete item",
         "responses": {
           "204": {
-            "description": "Item updated successfully"
+            "description": "Item deleted successfully"
           },
           "default": {
             "description": "Error",

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive3.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive3.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    patch:
+      operationId: updateItem
+      summary: Updated item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive4.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive4.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    delete:
+      operationId: deleteItem
+      summary: Delete item
+      responses:
+        '204':
+          description: Item updated successfully
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+    patch:
+      operationId: updateItem
+      summary: Update item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive4.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive4.yaml
@@ -9,7 +9,7 @@ paths:
       summary: Delete item
       responses:
         '204':
-          description: Item updated successfully
+          description: Item deleted successfully
         default:
           description: Error
           schema:

--- a/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive_expected_result.json
+++ b/assets/queries/openAPI/success_response_code_defined_patch_operation/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Success Response Code Defined for Patch Operation",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Success Response Code Defined for Patch Operation",
+    "severity": "MEDIUM",
+    "line": 27,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Success Response Code Defined for Patch Operation",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Success Response Code Defined for Patch Operation",
+    "severity": "MEDIUM",
+    "line": 20,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #2923 

**Proposed Changes**
- Added "Success Response Code Defined for Patch Operation" query for OpenAPI

I submit this contribution under Apache-2.0 license.
