### PR TITLE
Added "Success Response Code Defined for Put Operation" query for OpenAPI (#2925)

### DIFF
--- a/assets/queries/openAPI/success_response_code_defined_put_operation/metadata.json
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "3b497874-ae59-46dd-8d72-1868a3b8f150",
+  "queryName": "Success Response Code Defined for Put Operation",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Put should define at least one success response (200, 201, 202 or 204)",
+  "descriptionUrl": "https://swagger.io/specification/#operation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/metadata.json
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/metadata.json
@@ -1,5 +1,5 @@
 {
-  "id": "3b497874-ae59-46dd-8d72-1868a3b8f150",
+  "id": "60b5f56b-66ff-4e1c-9b62-5753e16825bc",
   "queryName": "Success Response Code Defined for Put Operation",
   "severity": "MEDIUM",
   "category": "Networking and Firewall",

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses", [n, oper]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "Delete should have at least one successful code (200, 201, 202 or 204)",
-		"keyActualValue": "Delete does not have any successful code",
+		"keyExpectedValue": "Put should have at least one successful code (200, 201, 202 or 204)",
+		"keyActualValue": "Put does not have any successful code",
 	}
 }

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/query.rego
@@ -1,0 +1,24 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+
+	oper == "put"
+
+	object.get(response, "200", "undefined") == "undefined"
+	object.get(response, "201", "undefined") == "undefined"
+	object.get(response, "202", "undefined") == "undefined"
+	object.get(response, "204", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Delete should have at least one successful code (200, 201, 202 or 204)",
+		"keyActualValue": "Delete does not have any successful code",
+	}
+}

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/negative1.json
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/negative1.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "delete": {
+        "operationId": "deleteItem",
+        "summary": "Delete item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "updateItem",
+        "summary": "Update item",
+        "responses": {
+          "204": {
+            "description": "Item deleted successfully"
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/negative1.json
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/negative1.json
@@ -22,8 +22,11 @@
         "operationId": "updateItem",
         "summary": "Update item",
         "responses": {
+          "201": {
+            "description": "Item created successfully"
+          },
           "204": {
-            "description": "Item deleted successfully"
+            "description": "Item updated successfully"
           },
           "default": {
             "description": "Error",

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/negative2.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/negative2.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    delete:
+      operationId: deleteItem
+      summary: Delete item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+    put:
+      operationId: updateItem
+      summary: Update item
+      responses:
+        '204':
+          description: Item deleted successfully
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/negative2.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/negative2.yaml
@@ -16,8 +16,10 @@ paths:
       operationId: updateItem
       summary: Update item
       responses:
+        '201':
+          description: Item created successfully
         '204':
-          description: Item deleted successfully
+          description: Item updated successfully
         default:
           description: Error
           schema:

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive1.json
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive1.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "put": {
+        "operationId": "updateItem",
+        "summary": "Updated item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive2.json
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive2.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "delete": {
+        "operationId": "deleteItem",
+        "summary": "Delete item",
+        "responses": {
+          "204": {
+            "description": "Item updated successfully"
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "updateItem",
+        "summary": "Update item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive2.json
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive2.json
@@ -11,7 +11,7 @@
         "summary": "Delete item",
         "responses": {
           "204": {
-            "description": "Item updated successfully"
+            "description": "Item deleted successfully"
           },
           "default": {
             "description": "Error",

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive3.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive3.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    put:
+      operationId: updateItem
+      summary: Updated item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive4.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive4.yaml
@@ -9,7 +9,7 @@ paths:
       summary: Delete item
       responses:
         '204':
-          description: Item updated successfully
+          description: Item deleted successfully
         default:
           description: Error
           schema:

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive4.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive4.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    delete:
+      operationId: deleteItem
+      summary: Delete item
+      responses:
+        '204':
+          description: Item updated successfully
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+    put:
+      operationId: updateItem
+      summary: Update item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive_expected_result.json
+++ b/assets/queries/openAPI/success_response_code_defined_put_operation/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Success Response Code Defined for Put Operation",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Success Response Code Defined for Put Operation",
+    "severity": "MEDIUM",
+    "line": 27,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Success Response Code Defined for Put Operation",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Success Response Code Defined for Put Operation",
+    "severity": "MEDIUM",
+    "line": 20,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Closes #2925 

**Proposed Changes**
- Added "Success Response Code Defined for Put Operation" query for OpenAPI

I submit this contribution under Apache-2.0 license.
