### PR TITLE
Added Success Response Code Defined for Post Operation query for OpenAPI (#2927)

### DIFF
--- a/assets/queries/openAPI/success_response_code_defined_post_operation/metadata.json
+++ b/assets/queries/openAPI/success_response_code_defined_post_operation/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "f368dd2d-9344-4146-a05b-7c6faa1269ad",
+  "queryName": "Success Response Code Defined for Post Operation",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Post should define at least one success response (200, 201, 202 or 204)",
+  "descriptionUrl": "https://swagger.io/specification/#operation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/success_response_code_defined_post_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_defined_post_operation/query.rego
@@ -1,0 +1,24 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+
+	oper == "post"
+
+	object.get(response, "200", "undefined") == "undefined"
+	object.get(response, "201", "undefined") == "undefined"
+	object.get(response, "202", "undefined") == "undefined"
+	object.get(response, "204", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Post should have at least one successful code (200, 201, 202 or 204)",
+		"keyActualValue": "Post does not have any successful code",
+	}
+}

--- a/assets/queries/openAPI/success_response_code_defined_post_operation/test/negative1.json
+++ b/assets/queries/openAPI/success_response_code_defined_post_operation/test/negative1.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "delete": {
+        "operationId": "deleteItem",
+        "summary": "Delete item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "updateItem",
+        "summary": "Create item",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_defined_post_operation/test/negative2.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_post_operation/test/negative2.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    delete:
+      operationId: deleteItem
+      summary: Delete item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+    post:
+      operationId: updateItem
+      summary: Create item
+      responses:
+        '200':
+          description: OK
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/success_response_code_defined_post_operation/test/positive1.json
+++ b/assets/queries/openAPI/success_response_code_defined_post_operation/test/positive1.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "post": {
+        "operationId": "createItem",
+        "summary": "Create item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_defined_post_operation/test/positive2.json
+++ b/assets/queries/openAPI/success_response_code_defined_post_operation/test/positive2.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "delete": {
+        "operationId": "deleteItem",
+        "summary": "Delete item",
+        "responses": {
+          "204": {
+            "description": "Item deleted successfully"
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createItem",
+        "summary": "Create item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_defined_post_operation/test/positive3.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_post_operation/test/positive3.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    post:
+      operationId: createItem
+      summary: Create item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/success_response_code_defined_post_operation/test/positive4.yaml
+++ b/assets/queries/openAPI/success_response_code_defined_post_operation/test/positive4.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    delete:
+      operationId: deleteItem
+      summary: Delete item
+      responses:
+        '204':
+          description: Item deleted successfully
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+    post:
+      operationId: createItem
+      summary: Create item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/success_response_code_defined_post_operation/test/positive_expected_result.json
+++ b/assets/queries/openAPI/success_response_code_defined_post_operation/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Success Response Code Defined for Post Operation",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Success Response Code Defined for Post Operation",
+    "severity": "MEDIUM",
+    "line": 27,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Success Response Code Defined for Post Operation",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Success Response Code Defined for Post Operation",
+    "severity": "MEDIUM",
+    "line": 20,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #2927 

**Proposed Changes**
- Added Success Response Code Defined for Post Operation query for OpenAPI 

I submit this contribution under Apache-2.0 license.
