### PR TITLE
Add "Server URL Not Absolute" query for OpenAPI #2930

### DIFF
--- a/assets/queries/openAPI/server_url_not_absolute/metadata.json
+++ b/assets/queries/openAPI/server_url_not_absolute/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a0bf7382-5d5a-4224-924c-3db8466026c9",
+  "queryName": "Server URL Not Absolute",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "The Server URL should be an absolute URL",
+  "descriptionUrl": "https://swagger.io/specification/#server-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/server_url_not_absolute/query.rego
+++ b/assets/queries/openAPI/server_url_not_absolute/query.rego
@@ -1,0 +1,99 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	url := doc.servers[s].url
+	not openapi_lib.is_valid_url(url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("servers.url=%s", [url]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("servers.{{%s}}.url has an absolute URL", [s]),
+		"keyActualValue": sprintf("servers.{{%s}}.url does not have an absolute URL", [s]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	url := doc.paths[path][operation].servers[s].url
+	not openapi_lib.is_valid_url(url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.servers.url=%s", [path, operation, url]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.servers.{{%s}}.url has an absolute URL", [path, operation, s]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.servers.{{%s}}.url does not have an absolute URL", [path, operation, s]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	url := doc.paths[path].servers[s].url
+	not openapi_lib.is_valid_url(url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.servers.url=%s", [path, url]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.servers.{{%s}}.url has an absolute URL", [path, s]),
+		"keyActualValue": sprintf("paths.{{%s}}.servers.{{%s}}.url does not have an absolute URL", [path, s]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	url := doc.components.links[l].server.url
+	not openapi_lib.is_valid_url(url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.links.{{%s}}.server.url", [l]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.links.{{%s}}.server.url has an absolute URL", [l]),
+		"keyActualValue": sprintf("components.links.{{%s}}.server.url does not have an absolute URL", [l]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	url := doc.components.responses[r].links[l].server.url
+	not openapi_lib.is_valid_url(url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.links.{{%s}}.server.url", [r, l]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.links.{{%s}}.server.url has an absolute URL", [l]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.links.{{%s}}.server.url does not have an absolute URL", [l]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	url := doc.paths[path][operation].responses[r].links[l].server.url
+	not openapi_lib.is_valid_url(url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}.server.url", [path, operation, r, l]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}.server.url has an absolute URL", [path, operation, r, l]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}.server.url does not have an absolute URL", [path, operation, r, l]),
+	}
+}

--- a/assets/queries/openAPI/server_url_not_absolute/test/negative1.json
+++ b/assets/queries/openAPI/server_url_not_absolute/test/negative1.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            },
+            "links": {
+              "address": {
+                "server": {
+                  "url": "https://development.gigantic-server.com/v1"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/server_url_not_absolute/test/negative2.json
+++ b/assets/queries/openAPI/server_url_not_absolute/test/negative2.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://development.gigantic-server.com/v1",
+            "description": "Development server"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/server_url_not_absolute/test/negative3.yaml
+++ b/assets/queries/openAPI/server_url_not_absolute/test/negative3.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+          links:
+            address:
+              server:
+                url: https://development.gigantic-server.com/v1

--- a/assets/queries/openAPI/server_url_not_absolute/test/negative4.yaml
+++ b/assets/queries/openAPI/server_url_not_absolute/test/negative4.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+      servers:
+        - url: https://development.gigantic-server.com/v1
+          description: Development server

--- a/assets/queries/openAPI/server_url_not_absolute/test/positive1.json
+++ b/assets/queries/openAPI/server_url_not_absolute/test/positive1.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            },
+            "links": {
+              "address": {
+                "server": {
+                  "url": "/development.gigantic-server.com/v1"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/server_url_not_absolute/test/positive2.json
+++ b/assets/queries/openAPI/server_url_not_absolute/test/positive2.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "/development.gigantic-server.com/v1",
+            "description": "Development server"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/server_url_not_absolute/test/positive3.yaml
+++ b/assets/queries/openAPI/server_url_not_absolute/test/positive3.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+          links:
+            address:
+              server:
+                url: /development.gigantic-server.com/v1

--- a/assets/queries/openAPI/server_url_not_absolute/test/positive4.yaml
+++ b/assets/queries/openAPI/server_url_not_absolute/test/positive4.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+      servers:
+        - url: /development.gigantic-server.com/v1
+          description: Development server

--- a/assets/queries/openAPI/server_url_not_absolute/test/positive_expected_result.json
+++ b/assets/queries/openAPI/server_url_not_absolute/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Server URL Not Absolute",
+    "severity": "INFO",
+    "line": 30,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Server URL Not Absolute",
+    "severity": "INFO",
+    "line": 32,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Server URL Not Absolute",
+    "severity": "INFO",
+    "line": 24,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Server URL Not Absolute",
+    "severity": "INFO",
+    "line": 22,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2930

**Proposed Changes**
- Added "Server URL Not Absolute" query for OpenAPI. It checks if 'servers[s].url' is not an absolute URL (in case of OpenAPI Object, Path Object and Operation Object). and if 'server.url' is not an absolute URL(in case of Link Object).

**Considerations**
- The Link Object exists in Components Object and Response Object.
- The Response Object exists in Component Object and Operation Object.

I submit this contribution under Apache-2.0 license.