### PR TITLE
Removed windows+arm64 from goreleaser #2942

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,15 +9,14 @@ builds:
       - windows
     goarch:
       - amd64
-      - arm
       - arm64
     ignore:
       - goos: darwin
         goarch: 386
       - goos: linux
         goarm: 7
-      - goos: linux
-        goarm: 6
+      - goos: windows
+        goarm: 7
     ldflags:
       - -X github.com/Checkmarx/kics/internal/constants.Version={{.Version}}
       - -X github.com/Checkmarx/kics/internal/constants.SCMCommit={{.Commit}}


### PR DESCRIPTION
Closes #2942

**Proposed Changes**
- Removed Windows + Arm arch build from goreleaser

I submit this contribution under Apache-2.0 license.
