### PR TITLE
feat(query): "Server Object Variable Not Used" for OpenAPI (#2968)

### DIFF
--- a/assets/queries/openAPI/server_object_variable_not_used/metadata.json
+++ b/assets/queries/openAPI/server_object_variable_not_used/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "8aee4754-970d-4c5f-8142-a49dfe388b1a",
+  "queryName": "Server Object Variable Not Used",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Every defined Server Variable Object should be used in a Service URL.",
+  "descriptionUrl": "https://swagger.io/specification/#server-variable-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/server_object_variable_not_used/query.rego
+++ b/assets/queries/openAPI/server_object_variable_not_used/query.rego
@@ -1,0 +1,128 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	server := doc.servers[s]
+
+	server.variables[x]
+	variables_not_used(x, server.url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("servers.variables.{{%s}}", [x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("servers.variables.{{%s}} is used in 'servers[%d].url'", [x, s]),
+		"keyActualValue": sprintf("servers.variables.{{%s}} is not used in 'servers[%d].url'", [x, s]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	server := doc.paths[path][operation].servers[s]
+
+	server.variables[x]
+	variables_not_used(x, server.url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.servers.variables.{{%s}}", [path, operation, x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.servers.variables.{{%s}} is used in 'paths.{{%s}}.{{%s}}.servers.{{%d}}.url'", [path, operation, x, path, operation, s]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.servers.variables.{{%s}} is not used in 'paths.{{%s}}.{{%s}}.servers.{{%d}}.url '", [path, operation, x, path, operation, s]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	server := doc.paths[path].servers[s]
+
+	server.variables[x]
+	variables_not_used(x, server.url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.servers.variables.{{%s}}", [path, x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.servers.variables.{{%s}} is used in 'paths.{{%s}}.servers.{{%d}}.url'", [path, x, path, s]),
+		"keyActualValue": sprintf("paths.{{%s}}.servers.variables.{{%s}} is not used in 'paths.{{%s}}.servers.{{%d}}.url'", [path, x, path, s]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	server := doc.components.links[l].server
+
+	server.variables[x]
+	variables_not_used(x, server.url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.links.{{%s}}.server.variables.{{%s}}", [l, x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.links.{{%s}}.server.variables.{{%s}} is used in 'components.links.{{%s}}.server.url'", [l, x, l]),
+		"keyActualValue": sprintf("components.links.{{%s}}.server.variables.{{%s}} is not used in 'components.links.{{%s}}.server.url'", [l, x, l]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	server := doc.components.responses[r].links[l].server
+
+	server.variables[x]
+	variables_not_used(x, server.url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.links.{{%s}}.server.variables.{{%s}}", [r, l, x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.links.{{%s}}.server.variables.{{%s}} is used in 'components.responses.{{%s}}.links.{{%s}}.server.url'", [r, l, x, r, l]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.links.{{%s}}.server.variables.{{%s}} is not used in 'components.responses.{{%s}}.links.{{%s}}.server.url'", [r, l, x, r, l]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	server := doc.paths[path][operation].responses[r].links[l].server
+
+	server.variables[x]
+	variables_not_used(x, server.url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}.server.variables.{{%s}}", [path, operation, r, l, x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}.server.variables.{{%s}} is used in 'paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}.server.url'", [path, operation, r, l, x, path, operation, r, l]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}.server.variables.{{%s}} is not used in 'paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}.server.url'", [path, operation, r, l, x, path, operation, r, l]),
+	}
+}
+
+exists(var, vars) {
+	var_in_url := replace(vars[_], "{", "")
+	clean_var := replace(var_in_url, "}", "")
+	var == clean_var
+}
+
+variables_not_used(var, url) {
+	url_variables := regex.find_n("{[a-zA-Z]+}", url, -1)
+	url_variables != []
+	not exists(var, url_variables)
+}
+
+variables_not_used(var, url) {
+	url_variables := regex.find_n("{[a-zA-Z]+}", url, -1)
+	url_variables == []
+}

--- a/assets/queries/openAPI/server_object_variable_not_used/test/negative1.json
+++ b/assets/queries/openAPI/server_object_variable_not_used/test/negative1.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            },
+            "links": {
+              "address": {
+                "server": {
+                  "url": "https://development.{server}.com/{base}",
+                  "variables": {
+                    "base": {
+                      "default": "v2"
+                    },
+                    "server": {
+                      "default": "gigant-server"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/server_object_variable_not_used/test/negative2.json
+++ b/assets/queries/openAPI/server_object_variable_not_used/test/negative2.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://development.{server}.com/{base}",
+            "description": "Development server",
+            "variables": {
+              "base": {
+                "default": "v2"
+              },
+              "server": {
+                "default": "gigant-server"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/server_object_variable_not_used/test/negative3.yaml
+++ b/assets/queries/openAPI/server_object_variable_not_used/test/negative3.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+          links:
+            address:
+              server:
+                url: https://development.{server}.com/{base}
+                variables:
+                  base:
+                    default: v2
+                  server:
+                    default: gigant-server

--- a/assets/queries/openAPI/server_object_variable_not_used/test/negative4.yaml
+++ b/assets/queries/openAPI/server_object_variable_not_used/test/negative4.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+      servers:
+        - url: https://development.{server}.com/{base}
+          description: Development server
+          variables:
+            base:
+              default: v2
+            server:
+              default: gigant-server

--- a/assets/queries/openAPI/server_object_variable_not_used/test/positive1.json
+++ b/assets/queries/openAPI/server_object_variable_not_used/test/positive1.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            },
+            "links": {
+              "address": {
+                "server": {
+                  "url": "https://development.{server}.com/{base}",
+                  "variables": {
+                    "base": {
+                      "default": "v2"
+                    },
+                    "server": {
+                      "default": "gigant-server"
+                    },
+                    "another": {
+                      "default": "another"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/server_object_variable_not_used/test/positive2.json
+++ b/assets/queries/openAPI/server_object_variable_not_used/test/positive2.json
@@ -1,0 +1,44 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://development.gigant-server.com/v2",
+            "description": "Development server",
+            "variables": {
+              "base": {
+                "default": "v2"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/server_object_variable_not_used/test/positive3.yaml
+++ b/assets/queries/openAPI/server_object_variable_not_used/test/positive3.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+          links:
+            address:
+              server:
+                url: https://development.{server}.com/{base}
+                variables:
+                  base:
+                    default: v2
+                  server:
+                    default: gigant-server
+                  another:
+                    default: another

--- a/assets/queries/openAPI/server_object_variable_not_used/test/positive4.yaml
+++ b/assets/queries/openAPI/server_object_variable_not_used/test/positive4.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid: # the unique user id
+                    type: string
+                    format: uuid
+      servers:
+        - url: https://development.gigant-server.com/v2
+          description: Development server
+          variables:
+            base:
+              default: v2

--- a/assets/queries/openAPI/server_object_variable_not_used/test/positive_expected_result.json
+++ b/assets/queries/openAPI/server_object_variable_not_used/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Server Object Variable Not Used",
+    "severity": "INFO",
+    "line": 38,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Server Object Variable Not Used",
+    "severity": "INFO",
+    "line": 35,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Server Object Variable Not Used",
+    "severity": "INFO",
+    "line": 30,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Server Object Variable Not Used",
+    "severity": "INFO",
+    "line": 25,
+    "filename": "positive4.yaml"
+  }
+]

--- a/assets/queries/openAPI/server_url_not_absolute/query.rego
+++ b/assets/queries/openAPI/server_url_not_absolute/query.rego
@@ -13,8 +13,8 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("servers.url=%s", [url]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("servers.{{%s}}.url has an absolute URL", [s]),
-		"keyActualValue": sprintf("servers.{{%s}}.url does not have an absolute URL", [s]),
+		"keyExpectedValue": sprintf("servers.{{%d}}.url has an absolute URL", [s]),
+		"keyActualValue": sprintf("servers.{{%d}}.url does not have an absolute URL", [s]),
 	}
 }
 
@@ -29,8 +29,8 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("paths.{{%s}}.{{%s}}.servers.url=%s", [path, operation, url]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.servers.{{%s}}.url has an absolute URL", [path, operation, s]),
-		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.servers.{{%s}}.url does not have an absolute URL", [path, operation, s]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.servers.{{%d}}.url has an absolute URL", [path, operation, s]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.servers.{{%d}}.url does not have an absolute URL", [path, operation, s]),
 	}
 }
 
@@ -45,8 +45,8 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("paths.{{%s}}.servers.url=%s", [path, url]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("paths.{{%s}}.servers.{{%s}}.url has an absolute URL", [path, s]),
-		"keyActualValue": sprintf("paths.{{%s}}.servers.{{%s}}.url does not have an absolute URL", [path, s]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.servers.{{%d}}.url has an absolute URL", [path, s]),
+		"keyActualValue": sprintf("paths.{{%s}}.servers.{{%d}}.url does not have an absolute URL", [path, s]),
 	}
 }
 
@@ -77,8 +77,8 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("components.responses.{{%s}}.links.{{%s}}.server.url", [r, l]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("components.responses.{{%s}}.links.{{%s}}.server.url has an absolute URL", [l]),
-		"keyActualValue": sprintf("components.responses.{{%s}}.links.{{%s}}.server.url does not have an absolute URL", [l]),
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.links.{{%s}}.server.url has an absolute URL", [r, l]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.links.{{%s}}.server.url does not have an absolute URL", [r, l]),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2968

**Proposed Changes**
- Added "Server Object Variable Not Used" query for OpenAPI. It checks if 'servers[s].variables[x]' is not used in Service URL (in case of OpenAPI Object, Path Object and Operation Object). and if 'server.variables[x]' is not used in Service URL (in case of Link Object).

**Considerations**
- The Link Object exists in Components Object and Response Object.
- The Response Object exists in Component Object and Operation Object.

I submit this contribution under Apache-2.0 license.
