### PR TITLE
feat(query): "OperationId Not Unique" for OpenAPI (#2970)

### DIFF
--- a/assets/queries/openAPI/operation_id_not_unique/metadata.json
+++ b/assets/queries/openAPI/operation_id_not_unique/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "c254adc4-ef25-46e1-8270-b7944adb4198",
+  "queryName": "OperationId Not Unique",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "OperationId should be unique when defined",
+  "descriptionUrl": "https://swagger.io/specification/#operation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/operation_id_not_unique/query.rego
+++ b/assets/queries/openAPI/operation_id_not_unique/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	targert_op_id := doc.paths[path][operation].operationId
+
+	count({op | op_id := doc.paths[_][op].operationId; targert_op_id == op_id}) > 1
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.operationId", [path, operation]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.operationId is unique", [path, operation]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.operationId is not unique", [path, operation]),
+	}
+}

--- a/assets/queries/openAPI/operation_id_not_unique/test/negative1.json
+++ b/assets/queries/openAPI/operation_id_not_unique/test/negative1.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "op_id1",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "op_id2",
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/operation_id_not_unique/test/negative2.yaml
+++ b/assets/queries/openAPI/operation_id_not_unique/test/negative2.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: op_id3
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    post:
+      operationId: op_id4
+      responses:
+        "201":
+          description: Created

--- a/assets/queries/openAPI/operation_id_not_unique/test/positive1.json
+++ b/assets/queries/openAPI/operation_id_not_unique/test/positive1.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "operation_id",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "operation_id",
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/operation_id_not_unique/test/positive2.yaml
+++ b/assets/queries/openAPI/operation_id_not_unique/test/positive2.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: op_id
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    post:
+      operationId: op_id
+      responses:
+        "201":
+          description: Created

--- a/assets/queries/openAPI/operation_id_not_unique/test/positive_expected_result.json
+++ b/assets/queries/openAPI/operation_id_not_unique/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "OperationId Not Unique",
+    "severity": "INFO",
+    "line": 15,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "OperationId Not Unique",
+    "severity": "INFO",
+    "line": 46,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "OperationId Not Unique",
+    "severity": "INFO",
+    "line": 8,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "OperationId Not Unique",
+    "severity": "INFO",
+    "line": 25,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2970

**Proposed Changes**
- Added "OperationId Not Unique" query for OpenAPI. It checks if any 'operationId' defined in an Operation Object is not unique

I submit this contribution under Apache-2.0 license.
