### PR TITLE
feat(query) "Schema Items Undefined" for OpenAPI (#2975)

### DIFF
--- a/assets/queries/openAPI/schema_items_undefined/metadata.json
+++ b/assets/queries/openAPI/schema_items_undefined/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a8e859da-4a43-4e7f-94b8-25d6e3bf8e90",
+  "queryName": "Schema Items Undefined",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Schema items should be defined when the schema is set to an array.",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/schema_items_undefined/query.rego
+++ b/assets/queries/openAPI/schema_items_undefined/query.rego
@@ -52,7 +52,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema", [path, operation, parameter]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.items is set", [path, operation, parameter]),
-		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.items is not set", [path, operation, parameter]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.items is undefined", [path, operation, parameter]),
 	}
 }
 
@@ -70,7 +70,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema", [path, operation, c]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.items is set", [path, operation, c]),
-		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.items is not set", [path, operation, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.items is undefined", [path, operation, c]),
 	}
 }
 
@@ -88,7 +88,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema", [r, c]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.items is set", [r, c]),
-		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.items is not set", [r, c]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.items is undefined", [r, c]),
 	}
 }
 
@@ -106,7 +106,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("components.parameters.{{%s}}.schema", [parameter]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("components.parameters.{{%s}}.schema.items is set", [parameter]),
-		"keyActualValue": sprintf("components.parameters.{{%s}}.schema.items is not set", [parameter]),
+		"keyActualValue": sprintf("components.parameters.{{%s}}.schema.items is undefined", [parameter]),
 	}
 }
 
@@ -124,7 +124,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.schema", [r, c]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.items is set", [r, c]),
-		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.items is not set", [r, c]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.items is undefined", [r, c]),
 	}
 }
 
@@ -141,7 +141,7 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("components.schemas.{{%s}}", [s]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("components.schemas.{{%s}} is a required property", [s]),
-		"keyActualValue": sprintf("components.schemas.{{%s}} is not a required property", [s]),
+		"keyExpectedValue": sprintf("components.schemas.{{%s}}.items is set", [s]),
+		"keyActualValue": sprintf("components.schemas.{{%s}}.items is undefined", [s]),
 	}
 }

--- a/assets/queries/openAPI/schema_items_undefined/query.rego
+++ b/assets/queries/openAPI/schema_items_undefined/query.rego
@@ -1,0 +1,147 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].responses[r].content[c].schema
+
+	schema.type == "array"
+	not schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema", [path, operation, r, c]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema.items is set", [path, operation, r, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema.items is undefined", [path, operation, r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path].parameters[parameter].schema
+
+	schema.type == "array"
+	not schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.parameters.{{%s}}.schema", [path, parameter]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.parameters.{{%s}}.schema.items is set", [path, parameter]),
+		"keyActualValue": sprintf("paths.{{%s}}.parameters.{{%s}}.schema.items is undefined", [path, parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].parameters[parameter].schema
+
+	schema.type == "array"
+	not schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema", [path, operation, parameter]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.items is set", [path, operation, parameter]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.items is not set", [path, operation, parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].requestBody.content[c].schema
+
+	schema.type == "array"
+	not schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema", [path, operation, c]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.items is set", [path, operation, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.items is not set", [path, operation, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.requestBodies[r].content[c].schema
+
+	schema.type == "array"
+	not schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema", [r, c]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.items is set", [r, c]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.items is not set", [r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.parameters[parameter].schema
+
+	schema.type == "array"
+	not schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.parameters.{{%s}}.schema", [parameter]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("components.parameters.{{%s}}.schema.items is set", [parameter]),
+		"keyActualValue": sprintf("components.parameters.{{%s}}.schema.items is not set", [parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.responses[r].content[c].schema
+
+	schema.type == "array"
+	not schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.schema", [r, c]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.items is set", [r, c]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.items is not set", [r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.schemas[s]
+
+	schema.type == "array"
+	not schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.schemas.{{%s}}", [s]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("components.schemas.{{%s}} is a required property", [s]),
+		"keyActualValue": sprintf("components.schemas.{{%s}} is not a required property", [s]),
+	}
+}

--- a/assets/queries/openAPI/schema_items_undefined/test/negative1.json
+++ b/assets/queries/openAPI/schema_items_undefined/test/negative1.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_items_undefined/test/negative2.json
+++ b/assets/queries/openAPI/schema_items_undefined/test/negative2.json
@@ -1,0 +1,63 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_items_undefined/test/negative3.yaml
+++ b/assets/queries/openAPI/schema_items_undefined/test/negative3.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: array
+      items:
+        type: string
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - name

--- a/assets/queries/openAPI/schema_items_undefined/test/negative4.yaml
+++ b/assets/queries/openAPI/schema_items_undefined/test/negative4.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                properties:
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: string
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/schema_items_undefined/test/positive1.json
+++ b/assets/queries/openAPI/schema_items_undefined/test/positive1.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "array",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_items_undefined/test/positive2.json
+++ b/assets/queries/openAPI/schema_items_undefined/test/positive2.json
@@ -1,0 +1,60 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_items_undefined/test/positive3.yaml
+++ b/assets/queries/openAPI/schema_items_undefined/test/positive3.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: array
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - name

--- a/assets/queries/openAPI/schema_items_undefined/test/positive4.yaml
+++ b/assets/queries/openAPI/schema_items_undefined/test/positive4.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                properties:
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: string
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/schema_items_undefined/test/positive_expected_result.json
+++ b/assets/queries/openAPI/schema_items_undefined/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Schema Items Undefined",
+    "severity": "INFO",
+    "line": 50,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema Items Undefined",
+    "severity": "INFO",
+    "line": 22,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Schema Items Undefined",
+    "severity": "INFO",
+    "line": 27,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Schema Items Undefined",
+    "severity": "INFO",
+    "line": 15,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2975

**Proposed Changes**
- Added "Schema Items Undefined" query for OpenAPI. It checks if 'schema items' is undefined when the schema is set to an array. 

**Considerations**:
- The Schema Object exists in Components Object, Parameter Object, and Media Type Object.
- The Components Objects exists in OpenAPI Object.
- The Parameter Object exists in Path Object, Components Object, and Operation Object.
- The Media Type Object exists in Content.
- The Content exists in Responses Object and Request Body Object.
- The Responses Object exists in Component Object and Operation Object.
- The Request Body Object exists in Components Object and Operation Object.

I submit this contribution under Apache-2.0 license.
