### PR TITLE
fix(report): generate report for all supported formats, if no format is defined

### DIFF
--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -284,18 +284,23 @@ func GetDefaultQueryPath(queriesPath string) (string, error) {
 	return queriesDirectory, nil
 }
 
+// ListReportFormats return a slice with all supported report formats
+func ListReportFormats() []string {
+	supportedFormats := make([]string, 0, len(reportGenerators))
+	for reportFormats := range reportGenerators {
+		supportedFormats = append(supportedFormats, reportFormats)
+	}
+	return supportedFormats
+}
+
 // ValidateReportFormats returns an error if output format is not supported
 func ValidateReportFormats(formats []string) error {
 	log.Debug().Msg("helpers.ValidateReportFormats()")
 
-	validFormats := make([]string, 0, len(reportGenerators))
-	for reportFormats := range reportGenerators {
-		validFormats = append(validFormats, reportFormats)
-	}
 	for _, format := range formats {
 		if _, ok := reportGenerators[format]; !ok {
 			return fmt.Errorf(
-				fmt.Sprintf("Report format not supported: %s\nSupportted formats:\n  %s\n", format, strings.Join(validFormats, "\n")),
+				fmt.Sprintf("Report format not supported: %s\nSupportted formats:\n  %s\n", format, strings.Join(ListReportFormats(), "\n")),
 			)
 		}
 	}

--- a/internal/console/helpers/helpers_test.go
+++ b/internal/console/helpers/helpers_test.go
@@ -471,3 +471,11 @@ func TestHelpers_WordWrap(t *testing.T) {
 		})
 	}
 }
+
+func TestHelpers_ListReportFormats(t *testing.T) {
+	formats := ListReportFormats()
+	for _, format := range formats {
+		_, ok := reportGenerators[format]
+		require.True(t, ok)
+	}
+}

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -500,6 +500,9 @@ func printOutput(outputPath, filename string, body interface{}, formats []string
 			outputPath = filepath.Dir(outputPath)
 		}
 	}
+	if len(formats) == 0 {
+		formats = consoleHelpers.ListReportFormats()
+	}
 
 	log.Debug().Msgf("Output formats provided [%v]", strings.Join(formats, ","))
 


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #2957 

**Proposed Changes**
- Changed KICS behaviour to generate reports if an `output-path` is defined without a file extension and `report-formats` is not defined

I submit this contribution under Apache-2.0 license.
