### PR TITLE
Added "Non-Array Schema With Items" query for OpenAPI (#2978)

### DIFF
--- a/assets/queries/openAPI/non_array_schema_with_items/metadata.json
+++ b/assets/queries/openAPI/non_array_schema_with_items/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "20cb3159-b219-496b-8dac-54ae3ab2021a",
+  "queryName": "Non Array Schema With Items",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Non-Array Schema should not have 'items' defined",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/non_array_schema_with_items/metadata.json
+++ b/assets/queries/openAPI/non_array_schema_with_items/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "20cb3159-b219-496b-8dac-54ae3ab2021a",
-  "queryName": "Non Array Schema With Items",
+  "queryName": "Non-Array Schema With Items",
   "severity": "INFO",
   "category": "Structure and Semantics",
   "descriptionText": "Non-Array Schema should not have 'items' defined",

--- a/assets/queries/openAPI/non_array_schema_with_items/query.rego
+++ b/assets/queries/openAPI/non_array_schema_with_items/query.rego
@@ -1,0 +1,147 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].responses[r].content[c].schema
+
+	schema.type != "array"
+	schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema.items", [path, operation, r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema.items is undefined", [path, operation, r, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema.items is set", [path, operation, r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path].parameters[parameter].schema
+
+	schema.type != "array"
+	schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.parameters.{{%s}}.schema.items", [path, parameter]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.parameters.{{%s}}.schema.items is undefined", [path, parameter]),
+		"keyActualValue": sprintf("paths.{{%s}}.parameters.{{%s}}.schema.items is set", [path, parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].parameters[parameter].schema
+
+	schema.type != "array"
+	schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.items", [path, operation, parameter]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.items is undefined", [path, operation, parameter]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.items is set", [path, operation, parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].requestBody.content[c].schema
+
+	schema.type != "array"
+	schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.items", [path, operation, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.items is undefined", [path, operation, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.items is set", [path, operation, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.requestBodies[r].content[c].schema
+
+	schema.type != "array"
+	schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.items", [r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.items is undefined", [r, c]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.items is set", [r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.parameters[parameter].schema
+
+	schema.type != "array"
+	schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.parameters.{{%s}}.schema.items", [parameter]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.parameters.{{%s}}.schema.items is undefined", [parameter]),
+		"keyActualValue": sprintf("components.parameters.{{%s}}.schema.items is set", [parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.responses[r].content[c].schema
+
+	schema.type != "array"
+	schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.items", [r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.items is undefined", [r, c]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.items is set", [r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.schemas[s]
+
+	schema.type != "array"
+	schema.items
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.schemas.{{%s}}.items", [s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.schemas.{{%s}}.items is undefined", [s]),
+		"keyActualValue": sprintf("components.schemas.{{%s}}.items is set", [s]),
+	}
+}

--- a/assets/queries/openAPI/non_array_schema_with_items/test/negative1.json
+++ b/assets/queries/openAPI/non_array_schema_with_items/test/negative1.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/non_array_schema_with_items/test/negative2.json
+++ b/assets/queries/openAPI/non_array_schema_with_items/test/negative2.json
@@ -1,0 +1,63 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/non_array_schema_with_items/test/negative3.yaml
+++ b/assets/queries/openAPI/non_array_schema_with_items/test/negative3.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: array
+      items:
+        type: string
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - name

--- a/assets/queries/openAPI/non_array_schema_with_items/test/negative4.yaml
+++ b/assets/queries/openAPI/non_array_schema_with_items/test/negative4.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                properties:
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: string
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/non_array_schema_with_items/test/positive1.json
+++ b/assets/queries/openAPI/non_array_schema_with_items/test/positive1.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "items": {
+          "type": "string"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/non_array_schema_with_items/test/positive2.json
+++ b/assets/queries/openAPI/non_array_schema_with_items/test/positive2.json
@@ -1,0 +1,63 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "items": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/non_array_schema_with_items/test/positive3.yaml
+++ b/assets/queries/openAPI/non_array_schema_with_items/test/positive3.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      items:
+        type: string
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - name

--- a/assets/queries/openAPI/non_array_schema_with_items/test/positive4.yaml
+++ b/assets/queries/openAPI/non_array_schema_with_items/test/positive4.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                items:
+                  type: string
+                properties:
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: string
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/non_array_schema_with_items/test/positive_expected_result.json
+++ b/assets/queries/openAPI/non_array_schema_with_items/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Non Array Schema With Items",
+    "severity": "INFO",
+    "line": 52,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Non Array Schema With Items",
+    "severity": "INFO",
+    "line": 24,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Non Array Schema With Items",
+    "severity": "INFO",
+    "line": 29,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Non Array Schema With Items",
+    "severity": "INFO",
+    "line": 17,
+    "filename": "positive4.yaml"
+  }
+]

--- a/assets/queries/openAPI/non_array_schema_with_items/test/positive_expected_result.json
+++ b/assets/queries/openAPI/non_array_schema_with_items/test/positive_expected_result.json
@@ -1,24 +1,24 @@
 [
   {
-    "queryName": "Non Array Schema With Items",
+    "queryName": "Non-Array Schema With Items",
     "severity": "INFO",
     "line": 52,
     "filename": "positive1.json"
   },
   {
-    "queryName": "Non Array Schema With Items",
+    "queryName": "Non-Array Schema With Items",
     "severity": "INFO",
     "line": 24,
     "filename": "positive2.json"
   },
   {
-    "queryName": "Non Array Schema With Items",
+    "queryName": "Non-Array Schema With Items",
     "severity": "INFO",
     "line": 29,
     "filename": "positive3.yaml"
   },
   {
-    "queryName": "Non Array Schema With Items",
+    "queryName": "Non-Array Schema With Items",
     "severity": "INFO",
     "line": 17,
     "filename": "positive4.yaml"


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2978

**Proposed Changes**
- Added "Non-Array Schema With Items" query for OpenAPI. It checks if 'schema items' is setwhen the schema is not set to an array.

**Considerations**:
- The Schema Object exists in Components Object, Parameter Object, and Media Type Object.
- The Components Objects exists in OpenAPI Object.
- The Parameter Object exists in Path Object, Components Object, and Operation Object.
- The Media Type Object exists in Content.
- The Content exists in Responses Object and Request Body Object.
- The Responses Object exists in Component Object and Operation Object.
- The Request Body Object exists in Components Object and Operation Object.

I submit this contribution under Apache-2.0 license.
