### PR TITLE
feat(query): "Schema With Both ReadOnly And WriteOnly" for OpenAPI (#2981)

### DIFF
--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/metadata.json
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "d2361d58-361c-49f0-9e50-b957fd608b29",
+  "queryName": "Schema With Both ReadOnly And WriteOnly",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Schema should not have both 'writeOnly' and 'readOnly' set to true",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/query.rego
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/query.rego
@@ -1,0 +1,145 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].responses[r].content[c].schema
+
+	both(schema)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema", [path, operation, r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema does not have both 'writeOnly' and 'readOnly' set to true", [path, operation, r, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema has both 'writeOnly' and 'readOnly' set to true", [path, operation, r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path].parameters[parameter].schema
+
+	both(schema)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.parameters.{{%s}}.schema", [path, parameter]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.parameters.{{%s}}.schema does not have both 'writeOnly' and 'readOnly' set to true", [path, parameter]),
+		"keyActualValue": sprintf("paths.{{%s}}.parameters.{{%s}}.schema has both 'writeOnly' and 'readOnly' set to true", [path, parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].parameters[parameter].schema
+
+	both(schema)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema", [path, operation, parameter]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema does not have both 'writeOnly' and 'readOnly' set to true", [path, operation, parameter]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema has both 'writeOnly' and 'readOnly' set to true", [path, operation, parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.paths[path][operation].requestBody.content[c].schema
+
+	both(schema)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema", [path, operation, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema does not have both 'writeOnly' and 'readOnly' set to true", [path, operation, c]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema has both 'writeOnly' and 'readOnly' set to true", [path, operation, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.requestBodies[r].content[c].schema
+
+	both(schema)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema", [r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema does not have both 'writeOnly' and 'readOnly' set to true", [r, c]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema has both 'writeOnly' and 'readOnly' set to true", [r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.parameters[parameter].schema
+
+	both(schema)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.parameters.{{%s}}.schema", [parameter]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.parameters.{{%s}}.schema does not have both 'writeOnly' and 'readOnly' set to true", [parameter]),
+		"keyActualValue": sprintf("components.parameters.{{%s}}.schema has both 'writeOnly' and 'readOnly' set to true", [parameter]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.responses[r].content[c].schema
+
+	both(schema)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.schema", [r, c]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema does not have both 'writeOnly' and 'readOnly' set to true", [r, c]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.schema has both 'writeOnly' and 'readOnly' set to true", [r, c]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.schemas[s]
+
+	both(schema)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.schemas.{{%s}}", [s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.schemas.{{%s}} does not have both 'writeOnly' and 'readOnly' set to true", [s]),
+		"keyActualValue": sprintf("components.schemas.{{%s}} has both 'writeOnly' and 'readOnly' set to true", [s]),
+	}
+}
+
+both(schema) {
+	options := {true, "true"}
+	schema.properties.id.readOnly == options[x]
+	schema.properties.id.writeOnly == options[x]
+}

--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/negative1.json
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/negative1.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "properties": {
+          "id": {
+            "type": "integer",
+            "readOnly": "true"
+          },
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/negative2.json
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/negative2.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "readOnly": "true"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/negative3.yaml
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/negative3.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: array
+      items:
+        type: string
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - name

--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/negative4.yaml
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/negative4.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                properties:
+                  id:
+                    type: integer
+                    readOnly: true
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: string
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/positive1.json
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/positive1.json
@@ -1,0 +1,75 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "properties": {
+          "id": {
+            "type": "integer",
+            "writeOnly": "true",
+            "readOnly": "true"
+          },
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/positive2.json
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/positive2.json
@@ -1,0 +1,68 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "writeOnly": "true",
+                      "readOnly": "true"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/positive3.yaml
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/positive3.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: array
+      items:
+        type: string
+      properties:
+        id:
+          type: integer
+          readOnly: true
+          writeOnly: true
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - name

--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/positive4.yaml
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/positive4.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                properties:
+                  id:
+                    type: integer
+                    readOnly: true
+                    writeOnly: true
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: string
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/positive_expected_result.json
+++ b/assets/queries/openAPI/schema_with_both_read_only_and_write_only/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Schema With Both ReadOnly And WriteOnly",
+    "severity": "INFO",
+    "line": 50,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema With Both ReadOnly And WriteOnly",
+    "severity": "INFO",
+    "line": 22,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Schema With Both ReadOnly And WriteOnly",
+    "severity": "INFO",
+    "line": 27,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Schema With Both ReadOnly And WriteOnly",
+    "severity": "INFO",
+    "line": 15,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2981

**Proposed Changes**
- Added "Schema With Both ReadOnly And WriteOnly" query for OpenAPI. It checks if schema has both 'writeOnly' and 'readOnly' set to true

**Considerations**:
- The Schema Object exists in Components Object, Parameter Object, and Media Type Object.
- The Components Objects exists in OpenAPI Object.
- The Parameter Object exists in Path Object, Components Object, and Operation Object.
- The Media Type Object exists in Content.
- The Content exists in Responses Object and Request Body Object.
- The Responses Object exists in Component Object and Operation Object.
- The Request Body Object exists in Components Object and Operation Object.


I submit this contribution under Apache-2.0 license.
