### PR TITLE
feat(query): "Security Operation Field Undefined" for OpenAPI (#2984)

### DIFF
--- a/assets/queries/openAPI/security_operation_field_undefined/metadata.json
+++ b/assets/queries/openAPI/security_operation_field_undefined/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "20a482d5-c5d9-4a7a-b7a4-60d0805047b4",
+  "queryName": "Security Operation Field Undefined",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Security operation field should be defined in '#/components/securitySchemes'",
+  "descriptionUrl": "https://swagger.io/specification/#operation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/security_operation_field_undefined/query.rego
+++ b/assets/queries/openAPI/security_operation_field_undefined/query.rego
@@ -1,0 +1,24 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	security_field := doc.paths[path][operation].security[s][field]
+
+	not exists(field, doc)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.%s", [path, operation, field]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.security[%d].%s is defined in '#/components/securitySchemes'", [path, operation, s, field]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.security[%d].%s is not defined in '#/components/securitySchemes'", [path, operation, s, field]),
+	}
+}
+
+exists(security_field, doc) {
+	object.get(doc.components.securitySchemes, security_field, "undefined") != "undefined"
+}

--- a/assets/queries/openAPI/security_operation_field_undefined/query.rego
+++ b/assets/queries/openAPI/security_operation_field_undefined/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": doc.id,
 		"searchKey": sprintf("paths.{{%s}}.{{%s}}.%s", [path, operation, field]),
-		"issueType": "IncorrectValue",
+		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.security[%d].%s is defined in '#/components/securitySchemes'", [path, operation, s, field]),
 		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.security[%d].%s is not defined in '#/components/securitySchemes'", [path, operation, s, field]),
 	}

--- a/assets/queries/openAPI/security_operation_field_undefined/test/negative1.json
+++ b/assets/queries/openAPI/security_operation_field_undefined/test/negative1.json
@@ -1,0 +1,71 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "regularSecurity": {
+        "type": "http",
+        "scheme": "basic"
+      },
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            },
+            "authorizationUrl": "http://example.org/api/oauth/dialog"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_operation_field_undefined/test/negative2.yaml
+++ b/assets/queries/openAPI/security_operation_field_undefined/test/negative2.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  securitySchemes:
+    regularSecurity:
+      type: http
+      scheme: basic
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets

--- a/assets/queries/openAPI/security_operation_field_undefined/test/positive1.json
+++ b/assets/queries/openAPI/security_operation_field_undefined/test/positive1.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_operation_field_undefined/test/positive2.json
+++ b/assets/queries/openAPI/security_operation_field_undefined/test/positive2.json
@@ -1,0 +1,59 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "regularSecurity": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_operation_field_undefined/test/positive3.yaml
+++ b/assets/queries/openAPI/security_operation_field_undefined/test/positive3.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/security_operation_field_undefined/test/positive4.yaml
+++ b/assets/queries/openAPI/security_operation_field_undefined/test/positive4.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  securitySchemes:
+    regularSecurity:
+      type: http
+      scheme: basic

--- a/assets/queries/openAPI/security_operation_field_undefined/test/positive_expected_result.json
+++ b/assets/queries/openAPI/security_operation_field_undefined/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Security Operation Field Undefined",
+    "severity": "INFO",
+    "line": 14,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Security Operation Field Undefined",
+    "severity": "INFO",
+    "line": 14,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Security Operation Field Undefined",
+    "severity": "INFO",
+    "line": 11,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Security Operation Field Undefined",
+    "severity": "INFO",
+    "line": 11,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2984 

**Proposed Changes**
- Added "Security Operation Field Undefined" query for OpenAPI. It checks if a security operation field is not defined in '#/components/securitySchemes'

I submit this contribution under Apache-2.0 license.
