### PR TITLE
feat(query): "Property 'allowReserved' Improperly Defined" for OpenAPI (#2993)

### DIFF
--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/metadata.json
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "7f203940-39c4-4ea7-91ee-7aba16bca9e2",
+  "queryName": "Property 'allowReserved' Improperly Defined",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Property 'allowReserved' should be only defined for query parameters",
+  "descriptionUrl": "https://swagger.io/specification/#parameter-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/query.rego
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/query.rego
@@ -1,0 +1,56 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	params := doc.paths[name].parameters[n]
+
+	improperly_defined(params)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} has 'in' set to 'query' when 'allowReserved' is set", [name, params.name]),
+		"keyActualValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowReserved' is set", [name, params.name]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	params := doc.paths[name][oper].parameters[n]
+
+	improperly_defined(params)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} has 'in' set to 'query' when 'allowReserved' is set", [name, oper, params.name]),
+		"keyActualValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowReserved' is set", [name, oper, params.name]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	params := doc.components.parameters[n]
+
+	improperly_defined(params)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.components.parameters.name={{%s}}", [params.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("openapi.components.parameters.name={{%s}} has 'in' set to 'query' when 'allowReserved' is set", [params.name]),
+		"keyActualValue": sprintf("openapi.components.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowReserved' is set", [params.name]),
+	}
+}
+
+improperly_defined(params) {
+	object.get(params, "allowReserved", "undefined") != "undefined"
+	params.in != "query"
+}

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative1.json
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative1.json
@@ -44,6 +44,7 @@
           "in": "query",
           "description": "ID of the API the version",
           "required": true,
+          "allowReserved": true,
           "schema": {
             "type": "integer"
           }
@@ -57,6 +58,7 @@
             "in": "query",
             "name": "id",
             "required": true,
+            "allowReserved": true,
             "description": "The user ID",
             "schema": {
               "type": "integer",

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative1.json
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative1.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "query",
+          "description": "ID of the API the version",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/users/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "description": "The user ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative2.yaml
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative2.yaml
@@ -27,6 +27,7 @@ paths:
         in: query
         description: ID of the API version
         required: true
+        allowReserved: true
         schema:
           type: integer
   /users/{id}:
@@ -35,6 +36,7 @@ paths:
         - in: query
           name: id
           required: true
+          allowReserved: true
           description: The user ID
           schema:
             type: integer

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative2.yaml
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative2.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: query
+        description: ID of the API version
+        required: true
+        schema:
+          type: integer
+  /users/{id}:
+    get:
+      parameters:
+        - in: query
+          name: id
+          required: true
+          description: The user ID
+          schema:
+            type: integer
+            minimum: 1

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative3.json
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative3.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "query",
+          "description": "ID of the API the version",
+          "required": true,
+          "allowReserved": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative4.yaml
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/negative4.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: query
+        description: ID of the API version
+        required: true
+        allowReserved: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/positive1.json
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/positive1.json
@@ -1,0 +1,72 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of the API the version",
+          "required": true,
+          "allowReserved": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/users/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "allowReserved": true,
+            "description": "The user ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/positive2.yaml
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/positive2.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: path
+        description: ID of the API version
+        required: true
+        allowReserved: true
+        schema:
+          type: integer
+  /users/{id}:
+    get:
+      parameters:
+        - in: path
+          name: id
+          required: true
+          allowReserved: true
+          description: The user ID
+          schema:
+            type: integer
+            minimum: 1

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/positive3.json
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/positive3.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of the API the version",
+          "required": true,
+          "allowReserved": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/positive4.yaml
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/positive4.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: path
+        description: ID of the API version
+        required: true
+        allowReserved: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/positive_expected_result.json
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "Property 'allowReserved' Improperly Defined",
+    "severity": "INFO",
+    "line": 59,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Property 'allowReserved' Improperly Defined",
+    "severity": "INFO",
+    "line": 43,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Property 'allowReserved' Improperly Defined",
+    "severity": "INFO",
+    "line": 26,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Property 'allowReserved' Improperly Defined",
+    "severity": "INFO",
+    "line": 37,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Property 'allowReserved' Improperly Defined",
+    "severity": "INFO",
+    "line": 43,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Property 'allowReserved' Improperly Defined",
+    "severity": "INFO",
+    "line": 26,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2993

**Proposed Changes**
- Added "Property 'allowReserved' Improperly Defined" query for OpenAPI. It checks if  'parameters[p].in' is not set to 'query' when 'parameters[p].allowReserved' is set

**Considerations**:
- The Parameter Object exists in Path Object, Components Object, and Operation Object.

I submit this contribution under Apache-2.0 license.
