### PR TITLE
feat(query): "Encoding Map Key Mismatch Schema Defined Properties" for OpenAPI (#2997)

### DIFF
--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/metadata.json
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "cd7a52cf-8d7f-4cfe-bbeb-6306d23f576b",
+  "queryName": "Encoding Map Key Mismatch Schema Defined Properties",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Encoding Map Key should be set in schema defined properties",
+  "descriptionUrl": "https://swagger.io/specification/#media-type-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/query.rego
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/query.rego
@@ -1,0 +1,80 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_properties := doc.paths[path][operation].responses[r].content[c].schema.properties
+	encoding_key := doc.paths[path][operation].responses[r].content[c].encoding[e]
+
+	not match(schema_properties, e)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}", [path, operation, r, c, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} is set in schema defined properties", [path, operation, r, c, e]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} is not set in schema defined properties", [path, operation, r, c, e]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_properties := doc.paths[path][operation].requestBody.content[c].schema.properties
+	encoding_key := doc.paths[path][operation].requestBody.content[c].encoding[e]
+
+	not match(schema_properties, e)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}}", [path, operation, c, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}} is set in schema defined properties", [path, operation, c, e]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}} is not set in schema defined properties", [path, operation, c, e]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_properties := doc.components.requestBodies[r].content[c].schema.properties
+	encoding_key := doc.components.requestBodies[r].content[c].encoding[e]
+
+	not match(schema_properties, e)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}}", [r, c, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}} is set in schema defined properties", [r, c, e]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}} is not set in schema defined properties", [r, c, e]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_properties := doc.components.responses[r].content[c].schema.properties
+	encoding_key := doc.components.responses[r].content[c].encoding[e]
+
+	not match(schema_properties, e)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}", [r, c, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} is set in schema defined properties", [r, c, e]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} is not set in schema defined properties", [r, c, e]),
+	}
+}
+
+match(properties, encoding_key) {
+	property := properties[x]
+	x == encoding_key
+}

--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/negative1.json
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/negative1.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ResponseExample": {
+        "description": "200 response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "discriminator": {
+                "propertyName": "petType"
+              },
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "encoding": {
+              "code": {
+                "contentType": "image/png, image/jpeg"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/negative2.json
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/negative2.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/negative3.yaml
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/negative3.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  responses:
+    ResponseExample:
+      description: 200 response
+      content:
+        application/json:
+          schema:
+            type: object
+            discriminator:
+              propertyName: petType
+            properties:
+              code:
+                type: string
+                format: binary
+              message:
+                type: string
+          encoding:
+            code:
+              contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/negative4.yaml
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/negative4.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/positive1.json
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/positive1.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ResponseExample": {
+        "description": "200 response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "discriminator": {
+                "propertyName": "petType"
+              },
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "encoding": {
+              "profileImage": {
+                "contentType": "image/png, image/jpeg"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/positive2.json
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/positive2.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "encoding": {
+                  "profileImage": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/positive3.yaml
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/positive3.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  responses:
+    ResponseExample:
+      description: 200 response
+      content:
+        application/json:
+          schema:
+            type: object
+            discriminator:
+              propertyName: petType
+            properties:
+              code:
+                type: string
+                format: binary
+              message:
+                type: string
+          encoding:
+            profileImage:
+              contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/positive4.yaml
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/positive4.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                profileImage:
+                  contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/positive_expected_result.json
+++ b/assets/queries/openAPI/encoding_map_key_mismatch_schema_defined_properties/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Encoding Map Key Mismatch Schema Defined Properties",
+    "severity": "INFO",
+    "line": 70,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Encoding Map Key Mismatch Schema Defined Properties",
+    "severity": "INFO",
+    "line": 36,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Encoding Map Key Mismatch Schema Defined Properties",
+    "severity": "INFO",
+    "line": 42,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Encoding Map Key Mismatch Schema Defined Properties",
+    "severity": "INFO",
+    "line": 26,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2997

**Proposed Changes**
- Added "Encoding Map Key Mismatch Schema Defined Properties" query for OpenAPI. It checks if  'encoding[e]' is not set in schema defined properties

**Considerations**:
- The Media Type Object exists in Content.
- The Content exists in Responses Object and Request Body Object.
- The Responses Object exists in Component Object and Operation Object.
- The Request Body Object exists in Components Object and Operation Object.

I submit this contribution under Apache-2.0 license.
