### PR TITLE
feat(query): "Invalid Global External Documentation URL" for OpenAPI (#2999)

### DIFF
--- a/assets/queries/openAPI/invalid_global_external_documentation_url/metadata.json
+++ b/assets/queries/openAPI/invalid_global_external_documentation_url/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b2d9dbf6-539c-4374-a1fd-210ddf5563a8",
+  "queryName": "Invalid Global External Documentation URL",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "Global External Documentation URL should be a valid URL",
+  "descriptionUrl": "https://swagger.io/specification/#external-documentation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/invalid_global_external_documentation_url/query.rego
+++ b/assets/queries/openAPI/invalid_global_external_documentation_url/query.rego
@@ -1,0 +1,19 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	url := doc.externalDocs.url
+	not openapi_lib.is_valid_url(url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": "externalDocs.url",
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "externalDocs.url has a valid URL",
+		"keyActualValue": "externalDocs.url does not have a valid URL",
+	}
+}

--- a/assets/queries/openAPI/invalid_global_external_documentation_url/test/negative1.json
+++ b/assets/queries/openAPI/invalid_global_external_documentation_url/test/negative1.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "externalDocs": {
+    "url": "http://docs.my-api.com/store-orders.htm"
+  }
+}

--- a/assets/queries/openAPI/invalid_global_external_documentation_url/test/negative2.yaml
+++ b/assets/queries/openAPI/invalid_global_external_documentation_url/test/negative2.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+externalDocs:
+  url: http://docs.my-api.com/store-orders.htm

--- a/assets/queries/openAPI/invalid_global_external_documentation_url/test/positive1.json
+++ b/assets/queries/openAPI/invalid_global_external_documentation_url/test/positive1.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "externalDocs": {
+    "url": "/"
+  }
+}

--- a/assets/queries/openAPI/invalid_global_external_documentation_url/test/positive2.yaml
+++ b/assets/queries/openAPI/invalid_global_external_documentation_url/test/positive2.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+externalDocs:
+  url: /

--- a/assets/queries/openAPI/invalid_global_external_documentation_url/test/positive_expected_result.json
+++ b/assets/queries/openAPI/invalid_global_external_documentation_url/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Invalid Global External Documentation URL",
+    "severity": "INFO",
+    "line": 49,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Invalid Global External Documentation URL",
+    "severity": "INFO",
+    "line": 26,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #2999

**Proposed Changes**
- Added "Invalid Global External Documentation URL" query for OpenAPI (it checks if 'externalDocs.url' is not a valid URL)

I submit this contribution under Apache-2.0 license.
