### PR TITLE
feat(query): "Header Parameter Named as 'Content-Type'" for OpenAPI (#3007)

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -11,3 +11,8 @@ check_openapi(doc) = version {
 is_valid_url(url) {
 	regex.match(`^(https?):\/\/(-\.)?([^\s\/?\.#-]+([-\.\/])?)+(\/[^\s]*)?$`, url)
 }
+
+improperly_defined(params, value) {
+	params.in == "header"
+	params.name == value
+}

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/metadata.json
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "72d259ca-9741-48dd-9f62-eb11f2936b37",
+  "queryName": "Header Parameter Named as 'Content-Type'",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "The header Parameter should not be named as 'Content-Type'. If so, it will be ignored.",
+  "descriptionUrl": "https://swagger.io/specification/#parameter-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/query.rego
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/query.rego
@@ -7,7 +7,7 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 	params := doc.paths[name].parameters[n]
 
-	improperly_defined(params)
+	openapi_lib.improperly_defined(params, "Content-Type")
 
 	result := {
 		"documentId": doc.id,
@@ -23,7 +23,7 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 	params := doc.paths[name][oper].parameters[n]
 
-	improperly_defined(params)
+	openapi_lib.improperly_defined(params, "Content-Type")
 
 	result := {
 		"documentId": doc.id,
@@ -39,7 +39,7 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 	params := doc.components.parameters[n]
 
-	improperly_defined(params)
+	openapi_lib.improperly_defined(params, "Content-Type")
 
 	result := {
 		"documentId": doc.id,
@@ -48,9 +48,4 @@ CxPolicy[result] {
 		"keyExpectedValue": sprintf("openapi.components.parameters.name={{%s}} is not 'Content-Type'", [params.name]),
 		"keyActualValue": sprintf("openapi.components.parameters.name={{%s}} is 'Content-Type'", [params.name]),
 	}
-}
-
-improperly_defined(params) {
-	params.in == "header"
-	params.name == "Content-Type"
 }

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/query.rego
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/query.rego
@@ -1,0 +1,56 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	params := doc.paths[name].parameters[n]
+
+	improperly_defined(params)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} is not 'Content-Type'", [name, params.name]),
+		"keyActualValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} is 'Content-Type'", [name, params.name]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	params := doc.paths[name][oper].parameters[n]
+
+	improperly_defined(params)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} is not 'Content-Type'", [name, oper, params.name]),
+		"keyActualValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} is 'Content-Type'", [name, oper, params.name]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	params := doc.components.parameters[n]
+
+	improperly_defined(params)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.components.parameters.name={{%s}}", [params.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("openapi.components.parameters.name={{%s}} is not 'Content-Type'", [params.name]),
+		"keyActualValue": sprintf("openapi.components.parameters.name={{%s}} is 'Content-Type'", [params.name]),
+	}
+}
+
+improperly_defined(params) {
+	params.in == "header"
+	params.name == "Content-Type"
+}

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/test/negative1.json
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/test/negative1.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "query",
+          "description": "ID of the API the version",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/users/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "id",
+            "required": true,
+            "description": "The user ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/test/negative2.yaml
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/test/negative2.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: header
+        description: ID of the API version
+        required: true
+        schema:
+          type: integer
+  /users/{id}:
+    get:
+      parameters:
+        - in: header
+          name: id
+          required: true
+          description: The user ID
+          schema:
+            type: integer
+            minimum: 1

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/test/negative3.json
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/test/negative3.json
@@ -1,0 +1,66 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "header",
+          "description": "ID of the API the version",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/test/negative4.yaml
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/test/negative4.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: header
+        description: ID of the API version
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/test/positive1.json
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/test/positive1.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "Content-Type",
+          "in": "header",
+          "description": "ID of the API the version",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/users/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Content-Type",
+            "required": true,
+            "description": "The user ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/test/positive2.yaml
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/test/positive2.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: Content-Type
+        in: header
+        description: ID of the API version
+        required: true
+        schema:
+          type: integer
+  /users/{id}:
+    get:
+      parameters:
+        - in: header
+          name: Content-Type
+          required: true
+          description: The user ID
+          schema:
+            type: integer
+            minimum: 1

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/test/positive3.json
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/test/positive3.json
@@ -1,0 +1,66 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "Content-Type",
+          "in": "header",
+          "description": "ID of the API the version",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/test/positive4.yaml
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/test/positive4.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: Content-Type
+        in: header
+        description: ID of the API version
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/test/positive_expected_result.json
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "Header Parameter Named as 'Content-Type'",
+    "severity": "INFO",
+    "line": 43,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Header Parameter Named as 'Content-Type'",
+    "severity": "INFO",
+    "line": 58,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Header Parameter Named as 'Content-Type'",
+    "severity": "INFO",
+    "line": 26,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Header Parameter Named as 'Content-Type'",
+    "severity": "INFO",
+    "line": 36,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Header Parameter Named as 'Content-Type'",
+    "severity": "INFO",
+    "line": 43,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Header Parameter Named as 'Content-Type'",
+    "severity": "INFO",
+    "line": 26,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3007

**Proposed Changes**
- Added "Header Parameter Named as 'Content-Type'" query for OpenAPI. It checks if  'parameters[p].name' is 'Content-Type' when 'parameters[p].in' is 'header'

**Considerations**:
- The Parameter Object exists in Path Object, Components Object, and Operation Object.

I submit this contribution under Apache-2.0 license.
