### PR TITLE
feat(query): "Header Response Named as 'Content-Type'" for OpenAPI (#3009)

### DIFF
--- a/assets/queries/openAPI/header_response_named_as_content_type/metadata.json
+++ b/assets/queries/openAPI/header_response_named_as_content_type/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "d4e43db5-54d8-4dda-b3c2-0dc6f31a46bd",
+  "queryName": "Header Response Named as 'Content-Type'",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "The Header Response should not be named as 'Content-Type'. If so, it will be ignored.",
+  "descriptionUrl": "https://swagger.io/specification/#response-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/header_response_named_as_content_type/query.rego
+++ b/assets/queries/openAPI/header_response_named_as_content_type/query.rego
@@ -1,0 +1,36 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses[r].headers[h]
+
+	lower(h) == "content-type"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}}", [n, oper, r, h]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}} is not 'Content-Type'", [n, oper, r, h]),
+		"keyActualValue": sprintf("openapi.paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}} is 'Content-Type'", [n, oper, r, h]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema := doc.components.responses[r].headers[h]
+
+	lower(h) == "content-type"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.headers.{{%s}}", [r, h]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.headers.{{%s}} is not 'Content-Type'", [r, h]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.headers.{{%s}} is 'Content-Type'", [r, h]),
+	}
+}

--- a/assets/queries/openAPI/header_response_named_as_content_type/test/negative1.json
+++ b/assets/queries/openAPI/header_response_named_as_content_type/test/negative1.json
@@ -1,0 +1,78 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "50": {
+            "description": "500 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "6xx": {
+            "description": "[600-699] response",
+            "headers": {
+              "Pet": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/header_response_named_as_content_type/test/negative2.yaml
+++ b/assets/queries/openAPI/header_response_named_as_content_type/test/negative2.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "50":
+          description: Server error response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+        "6xx":
+          description: "[600-699] response"
+          headers:
+            Pet:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Pet"
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/header_response_named_as_content_type/test/positive1.json
+++ b/assets/queries/openAPI/header_response_named_as_content_type/test/positive1.json
@@ -1,0 +1,78 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "50": {
+            "description": "500 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "6xx": {
+            "description": "[600-699] response",
+            "headers": {
+              "Content-Type": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/header_response_named_as_content_type/test/positive2.yaml
+++ b/assets/queries/openAPI/header_response_named_as_content_type/test/positive2.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "50":
+          description: Server error response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+        "6xx":
+          description: "[600-699] response"
+          headers:
+            Content-Type:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Pet"
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/header_response_named_as_content_type/test/positive_expected_result.json
+++ b/assets/queries/openAPI/header_response_named_as_content_type/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Header Response Named as 'Content-Type'",
+    "severity": "INFO",
+    "line": 13,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Header Response Named as 'Content-Type'",
+    "severity": "INFO",
+    "line": 39,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Header Response Named as 'Content-Type'",
+    "severity": "INFO",
+    "line": 11,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Header Response Named as 'Content-Type'",
+    "severity": "INFO",
+    "line": 25,
+    "filename": "positive2.yaml"
+  }
+]

--- a/assets/queries/openAPI/header_response_named_as_content_type/test/positive_expected_result.json
+++ b/assets/queries/openAPI/header_response_named_as_content_type/test/positive_expected_result.json
@@ -2,25 +2,13 @@
   {
     "queryName": "Header Response Named as 'Content-Type'",
     "severity": "INFO",
-    "line": 13,
+    "line": 42,
     "filename": "positive1.json"
   },
   {
     "queryName": "Header Response Named as 'Content-Type'",
     "severity": "INFO",
-    "line": 39,
-    "filename": "positive1.json"
-  },
-  {
-    "queryName": "Header Response Named as 'Content-Type'",
-    "severity": "INFO",
-    "line": 11,
-    "filename": "positive2.yaml"
-  },
-  {
-    "queryName": "Header Response Named as 'Content-Type'",
-    "severity": "INFO",
-    "line": 25,
+    "line": 28,
     "filename": "positive2.yaml"
   }
 ]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3009

**Proposed Changes**
- Added "Header Response Named as 'Content-Type'" query for OpenAPI. It checks if  some header of Response Object is named as 'Content-Type'

**Considerations**:
- The Response Object exists in  Components Object and Operation Object.

I submit this contribution under Apache-2.0 license.
