### PR TITLE
feat(query): "Invalid License URL" for OpenAPI (#3019)

### DIFF
--- a/assets/queries/openAPI/invalid_license_url/metadata.json
+++ b/assets/queries/openAPI/invalid_license_url/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "9239c289-9e4c-4d92-8be1-9d506057c971",
+  "queryName": "Invalid License URL",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "License Object URL should be a valid URL",
+  "descriptionUrl": "https://swagger.io/specification/#license-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/invalid_license_url/query.rego
+++ b/assets/queries/openAPI/invalid_license_url/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	not openapi_lib.is_valid_url(doc.info.license.url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": "info.license.url",
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "info.license.url has a valid URL",
+		"keyActualValue": "info.license.url has an invalid URL",
+	}
+}

--- a/assets/queries/openAPI/invalid_license_url/test/negative1.json
+++ b/assets/queries/openAPI/invalid_license_url/test/negative1.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/invalid_license_url/test/negative2.yaml
+++ b/assets/queries/openAPI/invalid_license_url/test/negative2.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  license:
+    name: "Apache 2.0"
+    url: "https://www.apache.org/licenses/LICENSE-2.0.html"
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - exampleSecurity: []
+components:
+  exampleSecurity:
+    type: http
+    scheme: basic

--- a/assets/queries/openAPI/invalid_license_url/test/positive1.json
+++ b/assets/queries/openAPI/invalid_license_url/test/positive1.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/ LICENSE-2.0.html"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/invalid_license_url/test/positive2.yaml
+++ b/assets/queries/openAPI/invalid_license_url/test/positive2.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  license:
+    name: "Apache 2.0"
+    url: "https://www.apache.org/licenses/ LICENSE-2.0.html"
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - exampleSecurity: []
+components:
+  exampleSecurity:
+    type: http
+    scheme: basic

--- a/assets/queries/openAPI/invalid_license_url/test/positive_expected_result.json
+++ b/assets/queries/openAPI/invalid_license_url/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Invalid License URL",
+    "severity": "INFO",
+    "line": 8,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Invalid License URL",
+    "severity": "INFO",
+    "line": 7,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3019

**Proposed Changes**
- Added "Invalid License URL" query for OpenAPI (it checks if doc.info.license.url does not match the defined URL validation regex

I submit this contribution under Apache-2.0 license.