### PR TITLE
feat(query): "Operation Without Successful HTTP Status Code" for OpenAPI (#3022)

### DIFF
--- a/assets/queries/openAPI/operation_without_successful_http_status_code/metadata.json
+++ b/assets/queries/openAPI/operation_without_successful_http_status_code/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "48e9e1fe-cf79-45b5-93e6-8b55ae5dadfd",
+  "queryName": "Operation Without Successful HTTP Status Code",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "Operation Object should have at least one successful HTTP status code defined",
+  "descriptionUrl": "https://swagger.io/specification/#operation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/operation_without_successful_http_status_code/query.rego
+++ b/assets/queries/openAPI/operation_without_successful_http_status_code/query.rego
@@ -7,7 +7,7 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 	responses := doc.paths[n][oper].responses
 
-	count({x | response := responses[x]; regex.match(`^2[0-9]{2}$`, x) == true}) == 0
+	count({x | response := responses[x]; regex.match(`^20[0124]$`, x) == true}) == 0
 
 	result := {
 		"documentId": doc.id,

--- a/assets/queries/openAPI/operation_without_successful_http_status_code/query.rego
+++ b/assets/queries/openAPI/operation_without_successful_http_status_code/query.rego
@@ -1,0 +1,19 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	responses := doc.paths[n][oper].responses
+
+	count({x | response := responses[x]; regex.match(`^2[0-9]{2}$`, x) == true}) == 0
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.{{%s}}.responses has at least one successful HTTP status code defined", [n, oper]),
+		"keyActualValue": sprintf("openapi.paths.{{%s}}.{{%s}}.responses does not have at least one successful HTTP status code defined", [n, oper]),
+	}
+}

--- a/assets/queries/openAPI/operation_without_successful_http_status_code/test/negative1.json
+++ b/assets/queries/openAPI/operation_without_successful_http_status_code/test/negative1.json
@@ -1,0 +1,43 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/operation_without_successful_http_status_code/test/negative2.yaml
+++ b/assets/queries/openAPI/operation_without_successful_http_status_code/test/negative2.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/operation_without_successful_http_status_code/test/positive1.json
+++ b/assets/queries/openAPI/operation_without_successful_http_status_code/test/positive1.json
@@ -1,0 +1,43 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "300": {
+            "description": "300 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/operation_without_successful_http_status_code/test/positive2.yaml
+++ b/assets/queries/openAPI/operation_without_successful_http_status_code/test/positive2.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "300":
+          description: 300 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/operation_without_successful_http_status_code/test/positive_expected_result.json
+++ b/assets/queries/openAPI/operation_without_successful_http_status_code/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Operation Without Successful HTTP Status Code",
+    "severity": "INFO",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Operation Without Successful HTTP Status Code",
+    "severity": "INFO",
+    "line": 10,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3022

**Proposed Changes**
- Added "Operation Without Successful HTTP Status Code" query for OpenAPI (it checks if responses of Operation Object has at least one successful HTTP status code defined)

I submit this contribution under Apache-2.0 license.
