### PR TITLE
feat(query): "Encoding Header 'Content-Type' Improperly Defined" for OpenAPI (#3024)

### DIFF
--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/metadata.json
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "4cd8de87-b595-48b6-ab3c-1904567135ab",
+  "queryName": "Encoding Header 'Content-Type' Improperly Defined",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "Encoding Map Key should not define a 'Content-Type' in the 'headers' field. If so, it will be ignored.",
+  "descriptionUrl": "https://swagger.io/specification/#media-type-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/query.rego
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/query.rego
@@ -1,0 +1,71 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header := doc.paths[path][operation].responses[r].content[c].encoding[e].headers[h]
+	not undefined(header)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}", [path, operation, r, c, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [path, operation, r, c, e]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [path, operation, r, c, e]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header := doc.paths[path][operation].requestBody.content[c].encoding[e].headers[h]
+	not undefined(header)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}}", [path, operation, c, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [path, operation, c, e]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [path, operation, c, e]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header := doc.components.requestBodies[r].content[c].encoding[e].headers[h]
+	not undefined(header)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}}", [r, c, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [r, c, e]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [r, c, e]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header := doc.components.responses[r].content[c].encoding[e].headers[h]
+	not undefined(header)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}", [r, c, e]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [r, c, e]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [r, c, e]),
+	}
+}
+
+undefined(header) {
+	object.get(header, "contentType", "undefined") = "undefined"
+}

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/query.rego
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/query.rego
@@ -6,15 +6,14 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	header := doc.paths[path][operation].responses[r].content[c].encoding[e].headers[h]
-	not undefined(header)
+	header_info := check_content_header(doc.paths[path][operation].responses[r])
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}", [path, operation, r, c, e]),
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}", [path, operation, r, header_info.c, header_info.e]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [path, operation, r, c, e]),
-		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [path, operation, r, c, e]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [path, operation, r, header_info.c, header_info.e]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [path, operation, r, header_info.c, header_info.e]),
 	}
 }
 
@@ -22,15 +21,14 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	header := doc.paths[path][operation].requestBody.content[c].encoding[e].headers[h]
-	not undefined(header)
+	header_info := check_content_header(doc.paths[path][operation].requestBody)
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}}", [path, operation, c, e]),
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}}", [path, operation, header_info.c, header_info.e]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [path, operation, c, e]),
-		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [path, operation, c, e]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [path, operation, header_info.c, header_info.e]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [path, operation, header_info.c, header_info.e]),
 	}
 }
 
@@ -38,15 +36,14 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	header := doc.components.requestBodies[r].content[c].encoding[e].headers[h]
-	not undefined(header)
+	header_info := check_content_header(doc.components.requestBodies[r])
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}}", [r, c, e]),
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}}", [r, header_info.c, header_info.e]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [r, c, e]),
-		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [r, c, e]),
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [r, header_info.c, header_info.e]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [r, header_info.c, header_info.e]),
 	}
 }
 
@@ -54,18 +51,19 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	header := doc.components.responses[r].content[c].encoding[e].headers[h]
-	not undefined(header)
+	header_info := check_content_header(doc.components.responses[r])
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}", [r, c, e]),
+		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}", [r, header_info.c, header_info.e]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [r, c, e]),
-		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [r, c, e]),
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} does not define 'Content-Type' in the 'headers' field", [r, header_info.c, header_info.e]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}} defines 'Content-Type' in the 'headers' field", [r, header_info.c, header_info.e]),
 	}
 }
 
-undefined(header) {
-	object.get(header, "contentType", "undefined") = "undefined"
+check_content_header(r) = header_info {
+	header := r.content[c].encoding[e].headers[h]
+	object.get(header, "contentType", "undefined") != "undefined"
+	header_info := {"c": c, "e": e}
 }

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/negative1.json
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/negative1.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ResponseExample": {
+        "description": "200 response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "discriminator": {
+                "propertyName": "petType"
+              },
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "encoding": {
+              "code": {
+                "contentType": "image/png, image/jpeg"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/negative2.json
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/negative2.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/negative3.yaml
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/negative3.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  responses:
+    ResponseExample:
+      description: 200 response
+      content:
+        application/json:
+          schema:
+            type: object
+            discriminator:
+              propertyName: petType
+            properties:
+              code:
+                type: string
+                format: binary
+              message:
+                type: string
+          encoding:
+            code:
+              contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/negative4.yaml
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/negative4.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/positive1.json
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/positive1.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ResponseExample": {
+        "description": "200 response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "discriminator": {
+                "propertyName": "petType"
+              },
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "encoding": {
+              "profileImage": {
+                "headers": {
+                  "Content-Type": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/positive2.json
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/positive2.json
@@ -1,0 +1,53 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "encoding": {
+                  "profileImage": {
+                    "headers": {
+                      "Content-Type": {
+                        "contentType": "image/png, image/jpeg"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/positive3.yaml
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/positive3.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  responses:
+    ResponseExample:
+      description: 200 response
+      content:
+        application/json:
+          schema:
+            type: object
+            discriminator:
+              propertyName: petType
+            properties:
+              code:
+                type: string
+                format: binary
+              message:
+                type: string
+          encoding:
+            profileImage:
+              headers:
+                Content-Type:
+                  contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/positive4.yaml
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/positive4.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                profileImage:
+                  headers:
+                    Content-Type:
+                      contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/positive_expected_result.json
+++ b/assets/queries/openAPI/encoding_header_content_type_improperly_defined/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Encoding Header 'Content-Type' Improperly Defined",
+    "severity": "INFO",
+    "line": 70,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Encoding Header 'Content-Type' Improperly Defined",
+    "severity": "INFO",
+    "line": 36,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Encoding Header 'Content-Type' Improperly Defined",
+    "severity": "INFO",
+    "line": 42,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Encoding Header 'Content-Type' Improperly Defined",
+    "severity": "INFO",
+    "line": 26,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3024

**Proposed Changes**
- Added "Encoding Header 'Content-Type' Improperly Defined" query for OpenAPI. It checks if  'encoding[e]' defines 'Content-Type' in the 'headers' field

**Considerations**:
- The Media Type Object exists in Content.
- The Content exists in Responses Object and Request Body Object.
- The Responses Object exists in Component Object and Operation Object.
- The Request Body Object exists in Components Object and Operation Object.

I submit this contribution under Apache-2.0 license.
