### PR TITLE
feat(query): "Link Object With Both 'operationId' And 'operationRef'" for OpenAPI (#3026)

### DIFF
--- a/assets/queries/openAPI/link_object_operation_id_does_not_target_an_operation_object/query.rego
+++ b/assets/queries/openAPI/link_object_operation_id_does_not_target_an_operation_object/query.rego
@@ -6,14 +6,15 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	not check_link(doc, doc.components.links.address.operationId)
+	op := doc.components.links[l].operationId
+	not check_link(doc, op)
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": "components.links.address.operationId",
+		"searchKey": sprintf("components.links.{{%s}}.operationId", [l]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "components.links.address.operationId points to an operationId of an operation object",
-		"keyActualValue": "components.links.address.operationId does not point to an operationId of an operation object",
+		"keyExpectedValue": sprintf("components.links.{{%s}}.operationId points to an operationId of an operation object", [l]),
+		"keyActualValue": sprintf("components.links.{{%s}}.operationId does not point to an operationId of an operation object", [l]),
 	}
 }
 
@@ -21,15 +22,15 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	op := doc.components.responses[r].links.address.operationId
+	op := doc.components.responses[r].links[l].operationId
 	not check_link(doc, op)
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("components.responses.{{%s}}.links.address.operationId", [r]),
+		"searchKey": sprintf("components.responses.{{%s}}.links.{{%s}}.operationId", [r, l]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("components.responses.%s.links.address.operationId points to an operationId of an operation object", [r]),
-		"keyActualValue": sprintf("components.responses.%s.links.address.operationId does not point to an operationId of an operation object", [r]),
+		"keyExpectedValue": sprintf("components.responses.%s.links.%s.operationId points to an operationId of an operation object", [r, l]),
+		"keyActualValue": sprintf("components.responses.%s.links.%s.operationId does not point to an operationId of an operation object", [r, l]),
 	}
 }
 
@@ -37,15 +38,15 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	op := doc.paths[path][operation].responses[r].links.address.operationId
+	op := doc.paths[path][operation].responses[r].links[l].operationId
 	not check_link(doc, op)
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.links.address.operationId", [path, operation, r]),
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}.operationId", [path, operation, r, l]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("paths%s.%s.responses.%s.links.address.operationId points to an operationId of an operation object", [path, operation, r]),
-		"keyActualValue": sprintf("paths.%s.%s.responses.%s.links.address.operationId does not point to an operationId of an operation object", [path, operation, r]),
+		"keyExpectedValue": sprintf("paths%s.%s.responses.%s.links.%s.operationId points to an operationId of an operation object", [path, operation, r, l]),
+		"keyActualValue": sprintf("paths.%s.%s.responses.%s.links.%s.operationId does not point to an operationId of an operation object", [path, operation, r, l]),
 	}
 }
 

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/metadata.json
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "60fb6621-9f02-473b-9424-ba9a825747d3",
+  "queryName": "Link Object With Both 'operationId' And 'operationRef'",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Link object 'OperationId' should not have both 'operationId' and 'operationRef' defined since they are mutually exclusive.",
+  "descriptionUrl": "https://swagger.io/specification/#link-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/query.rego
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/query.rego
@@ -1,0 +1,56 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	link := doc.components.links[l]
+	check_link(link)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.links.{{%s}}", [l]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.links.%s has both 'operationId' and 'operationRef' defined", [l]),
+		"keyActualValue": sprintf("components.links.%s does not have both 'operationId' and 'operationRef' defined", [l]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	link := doc.components.responses[r].links[l]
+	check_link(link)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.links.{{%s}}", [r, l]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.responses.%s.links.%s has both 'operationId' and 'operationRef' defined", [r, l]),
+		"keyActualValue": sprintf("components.responses.%s.links.%s does not have both 'operationId' and 'operationRef' defined", [r, l]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	link := doc.paths[path][operation].responses[r].links[l]
+	check_link(link)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}", [path, operation, r, l]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths%s.%s.responses.%s.links.%s has both 'operationId' and 'operationRef' defined", [path, operation, r, l]),
+		"keyActualValue": sprintf("paths.%s.%s.responses.%s.links.%s does not have both 'operationId' and 'operationRef' defined", [path, operation, r, l]),
+	}
+}
+
+check_link(link) {
+	object.get(link, "operationId", "undefined") != "undefined"
+	object.get(link, "operationRef", "undefined") != "undefined"
+}

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative1.json
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative1.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{userid}/address": {
+      "parameters": [
+        {
+          "name": "userid",
+          "in": "path",
+          "required": true,
+          "description": "the user identifier, as userId",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getUserAddress",
+        "responses": {
+          "200": {
+            "description": "the user's address"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "200": {
+        "description": "the user being returned",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "uuid": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        },
+        "links": {
+          "address": {
+            "operationId": "getUserAddress",
+            "parameters": {
+              "userId": "$request.path.id"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Pet": {
+        "$ref": "../models/pet.yaml"
+      },
+      "User": {
+        "$ref": "https://api.example.com/v2/openapi.yaml#/components/schemas/User"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative2.json
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative2.json
@@ -1,0 +1,60 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "links": {
+              "address": {
+                "operationId": "getUserAddress",
+                "parameters": {
+                  "userId": "$request.path.id"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{userid}/address": {
+      "parameters": [
+        {
+          "name": "userid",
+          "in": "path",
+          "required": true,
+          "description": "the user identifier, as userId",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getUserAddress",
+        "responses": {
+          "200": {
+            "description": "the user's address"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative3.json
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative3.json
@@ -1,0 +1,75 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{userid}/address": {
+      "parameters": [
+        {
+          "name": "userid",
+          "in": "path",
+          "required": true,
+          "description": "the user identifier, as userId",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getUserAddress",
+        "responses": {
+          "200": {
+            "description": "the user's address"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "$ref": "../models/pet.yaml"
+      },
+      "User": {
+        "$ref": "https://api.example.com/v2/openapi.yaml#/components/schemas/User"
+      }
+    },
+    "responses": {
+      "GenericError": {
+        "$ref": "../template-api.yaml#/components/responses/GenericError"
+      }
+    },
+    "links": {
+      "address": {
+        "operationId": "getUserAddress",
+        "parameters": {
+          "userId": "$request.path.id"
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative4.yaml
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative4.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                    format: uuid
+  "/users/{userid}/address":
+    parameters:
+      - name: userid
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    get:
+      operationId: getUserAddress
+      responses:
+        "200":
+          description: the user's address
+components:
+  schemas:
+    Pet:
+      $ref: "../models/pet.yaml"
+    User:
+      $ref: "https://api.example.com/v2/openapi.yaml#/components/schemas/User"
+  responses:
+    "200":
+      description: the user being returned
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              uuid:
+                type: string
+                format: uuid
+      links:
+        address:
+          operationId: getUserAddress
+          parameters:
+            userId: $request.path.id

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative5.yaml
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative5.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                    format: uuid
+          links:
+            address:
+              operationId: getUserAddress
+              parameters:
+                userId: $request.path.id
+  "/users/{userid}/address":
+    parameters:
+      - name: userid
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    get:
+      operationId: getUserAddress
+      responses:
+        "200":
+          description: the user's address

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative6.yaml
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/negative6.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                    format: uuid
+  "/users/{userid}/address":
+    parameters:
+      - name: userid
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    get:
+      operationId: getUserAddress
+      responses:
+        "200":
+          description: the user's address
+components:
+  schemas:
+    Pet:
+      $ref: "../models/pet.yaml"
+    User:
+      $ref: "https://api.example.com/v2/openapi.yaml#/components/schemas/User"
+  responses:
+    GenericError:
+      $ref: "../template-api.yaml#/components/responses/GenericError"
+  links:
+    address:
+      operationId: getUserAddress
+      parameters:
+        userId: $request.path.id

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive1.json
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive1.json
@@ -1,0 +1,89 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{userid}/address": {
+      "parameters": [
+        {
+          "name": "userid",
+          "in": "path",
+          "required": true,
+          "description": "the user identifier, as userId",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getUserAddress",
+        "responses": {
+          "200": {
+            "description": "the user's address"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "200": {
+        "description": "the user being returned",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "uuid": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        },
+        "links": {
+          "address": {
+            "operationId": "getUserAddress",
+            "operationRef": "/",
+            "parameters": {
+              "userId": "$request.path.id"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Pet": {
+        "$ref": "../models/pet.yaml"
+      },
+      "User": {
+        "$ref": "https://api.example.com/v2/openapi.yaml#/components/schemas/User"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive2.json
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive2.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "format": "uuid",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "links": {
+              "address": {
+                "operationId": "getUserAddress",
+                "operationRef": "/",
+                "parameters": {
+                  "userId": "$request.path.id"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{userid}/address": {
+      "parameters": [
+        {
+          "name": "userid",
+          "in": "path",
+          "required": true,
+          "description": "the user identifier, as userId",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getUserAddress",
+        "responses": {
+          "200": {
+            "description": "the user's address"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive3.json
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive3.json
@@ -1,0 +1,76 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "the user being returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{userid}/address": {
+      "parameters": [
+        {
+          "name": "userid",
+          "in": "path",
+          "required": true,
+          "description": "the user identifier, as userId",
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getUserAddress",
+        "responses": {
+          "200": {
+            "description": "the user's address"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "$ref": "../models/pet.yaml"
+      },
+      "User": {
+        "$ref": "https://api.example.com/v2/openapi.yaml#/components/schemas/User"
+      }
+    },
+    "responses": {
+      "GenericError": {
+        "$ref": "../template-api.yaml#/components/responses/GenericError"
+      }
+    },
+    "links": {
+      "address": {
+        "operationId": "getUserAddress",
+        "operationRef": "/",
+        "parameters": {
+          "userId": "$request.path.id"
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive4.yaml
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive4.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                    format: uuid
+  "/users/{userid}/address":
+    parameters:
+      - name: userid
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    get:
+      operationId: getUserAddress
+      responses:
+        "200":
+          description: the user's address
+components:
+  schemas:
+    Pet:
+      $ref: "../models/pet.yaml"
+    User:
+      $ref: "https://api.example.com/v2/openapi.yaml#/components/schemas/User"
+  responses:
+    "200":
+      description: the user being returned
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              uuid:
+                type: string
+                format: uuid
+      links:
+        address:
+          operationId: getUserAddress
+          operationRef: /
+          parameters:
+            userId: $request.path.id

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive5.yaml
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive5.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                    format: uuid
+          links:
+            address:
+              operationId: getUserAddress
+              operationRef: /
+              parameters:
+                userId: $request.path.id
+  "/users/{userid}/address":
+    parameters:
+      - name: userid
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    get:
+      operationId: getUserAddress
+      responses:
+        "200":
+          description: the user's address

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive6.yaml
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive6.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      responses:
+        "200":
+          description: the user being returned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  uuid:
+                    type: string
+                    format: uuid
+  "/users/{userid}/address":
+    parameters:
+      - name: userid
+        in: path
+        required: true
+        description: the user identifier, as userId
+        schema:
+          type: string
+    get:
+      operationId: getUserAddress
+      responses:
+        "200":
+          description: the user's address
+components:
+  schemas:
+    Pet:
+      $ref: "../models/pet.yaml"
+    User:
+      $ref: "https://api.example.com/v2/openapi.yaml#/components/schemas/User"
+  responses:
+    GenericError:
+      $ref: "../template-api.yaml#/components/responses/GenericError"
+  links:
+    address:
+      operationId: getUserAddress
+      operationRef: /
+      parameters:
+        userId: $request.path.id

--- a/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive_expected_result.json
+++ b/assets/queries/openAPI/link_object_with_both_operation_id_and_operation_ref/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "Link Object With Both 'operationId' And 'operationRef'",
+    "severity": "INFO",
+    "line": 70,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Link Object With Both 'operationId' And 'operationRef'",
+    "severity": "INFO",
+    "line": 27,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Link Object With Both 'operationId' And 'operationRef'",
+    "severity": "INFO",
+    "line": 67,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Link Object With Both 'operationId' And 'operationRef'",
+    "severity": "INFO",
+    "line": 50,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Link Object With Both 'operationId' And 'operationRef'",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive5.yaml"
+  },
+  {
+    "queryName": "Link Object With Both 'operationId' And 'operationRef'",
+    "severity": "INFO",
+    "line": 42,
+    "filename": "positive6.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3026

**Proposed Changes**
-  Added "Link Object With Both 'operationId' And 'operationRef" query for OpenAPI (it checks if Link Object has has both 'operationId' and 'operationRef' defined)
- Correcting "Link Object OperationId Does Not Target Operation Object": wrong access to 'links'


I submit this contribution under Apache-2.0 license.
