### PR TITLE
fix(log): changed terraform vars not found log level

### DIFF
--- a/pkg/parser/terraform/variables.go
+++ b/pkg/parser/terraform/variables.go
@@ -117,7 +117,7 @@ func getInputVariables(currentPath string) {
 
 	_, err = os.Stat(filepath.Join(currentPath, "terraform.tfvars"))
 	if err != nil {
-		log.Info().Msg("terraform.tfvars not found")
+		log.Trace().Msgf("terraform.tfvars not found on %s", currentPath)
 	} else {
 		tfVarsFiles = append(tfVarsFiles, filepath.Join(currentPath, "terraform.tfvars"))
 	}


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Changed terraform vars not found log level

I submit this contribution under the Apache-2.0 license.
