### PR TITLE
feat(cli): parametrizing query execution timeout #3047

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ## Contribution
 
-We would like to THANK YOU for considering contributing to KICS!  
+We would like to THANK YOU for considering contributing to KICS!
 
-KICS is a true community project. It's built as an open source from day one, and anyone can find his own way to contribute to the project.  
+KICS is a true community project. It's built as an open source from day one, and anyone can find his own way to contribute to the project.
 
 Within just minutes, you can start making a difference, by sharing your expertise with a community of thousands of security experts and software developers.
 
@@ -12,7 +12,7 @@ Good news! You don't have to contribute code. There are plenty of ways you can c
 
 - Reporting new [bugs or issues](https://github.com/Checkmarx/kics/issues)
 - Help triaging issues
-- Improving and translating the documentation 
+- Improving and translating the documentation
 - Volunteering to maintain the project
 
 #### Code of Conduct
@@ -26,34 +26,35 @@ By participating and contributing to the project, you agree to uphold our [Code 
 Follow the instructions below to setup local KICS development environment and push your changes.
 
 1. Fork the `kics` repo on GitHub.
-1. Clone your fork locally:  
-   ```
+1. Clone your fork locally:
+   ```shell
    git clone https://github.com/Checkmarx/kics.git
    ```
-1. Create a branch for local development.  
-Use succinct but descriptive name (prefix with *feature/issue#-descriptive-name>* or *hotfix/issue#-descriptive-name*):  
-   ```
+1. Create a branch for local development.
+Use succinct but descriptive name (prefix with *feature/issue#-descriptive-name>* or *hotfix/issue#-descriptive-name*):
+   ```shell
    git checkout -b <name-of-your-issue>
    ```
 1. Make your changes locally.
-1. Validate your changes to reassure they meet project quality and contribution standards:  
-   ```
+1. Validate your changes to reassure they meet project quality and contribution standards:
+   ```shell
    golint .
-   ```  
    ```
+   ```shell
    go mod vendor
-   ```  
    ```
+   ```shell
    go test -mod=vendor -v ./...
    ```
-1. Commit your changes and push your branch to GitHub:  
-   ```
+1. Commit your changes and push your branch to GitHub:
+   ```shell
    git add .
-   ```  
    ```
-   git commit
-   ```  
+   We recommend following [conventional commits messages](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
+   ```shell
+   git commit -m "feat(CLI): add new flag --blabla"
    ```
+   ```shell
    git push --set-upstream origin <name-of-your-issue>
    ```
 1. Submit a pull request on GitHub website.

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,4 +1,4 @@
-<img alt="KICS - Keeping Infrastructure as Code Secure" src="../img/logo/kics-black.png" width="250">  
+<img alt="KICS - Keeping Infrastructure as Code Secure" src="../img/logo/kics-black.png" width="250">
 
 ---
 

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -70,6 +70,7 @@ KICS is able to infer the format without the need of file extension.
   "queries-path": "path to directory with queries (default ./assets/queries) (default './assets/queries')",
   "report-formats": "formats in which the results will be exported (json, sarif, html)",
   "type": "type of queries to use in the scan",
+  "timeout": "number of seconds the query has to execute before being canceled",
   "verbose": true,
   "profiling": "enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)"
 }
@@ -97,6 +98,7 @@ queries-path: "path to directory with queries (default ./assets/queries) (defaul
 report-formats: "formats in which the results will be exported (json, sarif, html)"
 silent: false
 type: "type of queries to use in the scan"
+timeout: "number of seconds the query has to execute before being canceled"
 verbose: true
 ```
 
@@ -122,6 +124,7 @@ queries-path = "path to directory with queries (default ./assets/queries) (defau
 report-formats = "formats in which the results will be exported (json, sarif, html)"
 silent = false
 type = "type of queries to use in the scan"
+timeout = "number of seconds the query has to execute before being canceled"
 verbose = true
 ```
 
@@ -147,6 +150,7 @@ verbose = true
 "report-formats" = "formats in which the results will be exported (json, sarif, html)"
 "silent" = false
 "type" = "type of queries to use in the scan"
+"timeout" = "number of seconds the query has to execute before being canceled"
 "verbose" = true
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ KICS is available as a <a href="https://hub.docker.com/r/checkmarx/kics" target=
 
 To scan a directory/file on your host you have to mount it as a volume to the container and specify the path on the container filesystem with the -p KICS parameter (see Scan Command Options section below)
 
-```txt
+```shell
 docker pull checkmarx/kics:latest
 docker run -v {​​​​path_to_host_folder_to_scan}​​​​:/path checkmarx/kics:latest scan -p "/path" -o "/path/results.json"
 ```
@@ -23,14 +23,14 @@ You can provide your own path to the queries directory with `-q` CLI option (see
 
 Run the following command to download and install kics. It will detect your current OS and download the appropriate binary package, defaults installation to `./bin` the queries will be placed alongside the binary in `./bin/assets/queries`:
 
-```sh
-curl -sfL https://raw.githubusercontent.com/Checkmarx/kics/master/install.sh | bash
+```shell
+curl -sfL 'https://raw.githubusercontent.com/Checkmarx/kics/master/install.sh' | bash
 ```
 
 If you want to place it somewhere else like `/usr/local/bin`:
 
-```sh
-sudo curl -sfL https://raw.githubusercontent.com/Checkmarx/kics/master/install.sh | bash -s -- -b /usr/local/bin
+```shell
+sudo curl -sfL 'https://raw.githubusercontent.com/Checkmarx/kics/master/install.sh' | bash -s -- -b /usr/local/bin
 ```
 
 #### Binary
@@ -45,23 +45,23 @@ So all you need is:
 1. Download KICS binaries based on your OS
 1. Extract files
 1. Run kics executable with the cli options as described below (note that kics binary should be located in the same directory as queries directory)
-   ```
-   ./kics scan -p <path-of-your-project-to-scan> -o <output-results.json>
+   ```shell
+   ./kics scan -p '<path-of-your-project-to-scan>' -o '<output-results.json>'
    ```
 
 #### Build from Sources
 
 1. Download and install Go from <a href="https://golang.org/dl/" target="_blank">https://golang.org/dl/</a>
 1. Clone the repository:
-   ```
+   ```shell
    git clone https://github.com/Checkmarx/kics.git
    ```
-   ```
+   ```shell
    cd kics
    ```
 1. Kick a scan!
-   ```
-   go run ./cmd/console/main.go scan -p <path-of-your-project-to-scan> -o <output-results.json>
+   ```shell
+   go run ./cmd/console/main.go scan -p '<path-of-your-project-to-scan>' -o '<output-results.json>'
    ```
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,7 +61,7 @@ So all you need is:
    ```
 1. Kick a scan!
    ```shell
-   go run ./cmd/console/main.go scan -p '<path-of-your-project-to-scan>' -o '<output-results.json>'
+   go run ./cmd/console/main.go scan -p '<path-of-your-project-to-scan>' --report-formats json -o ./results
    ```
 
 ---

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -2,7 +2,7 @@
 
 KICS queries are written in OPA (Rego).
 
-```Opa
+```rego
 CxPolicy [ result ] {
    resource := input.document[i].resource.aws_s3_bucket[name]
    role = "public-read"

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -51,13 +51,13 @@ Flags:
   -x, --exclude-results strings      exclude results by providing the similarity ID of a result
                                      can be provided multiple times or as a comma separated string
                                      example: 'fec62a97d569662093dbb9739360942f...,31263s5696620s93dbb973d9360942fc2a...'
-      --fail-on                      which kind of results should return an exit code different from 0
+      --fail-on strings              which kind of results should return an exit code different from 0
                                      accetps: high, medium, low and info
-                                     example: "high,low"
-      --ignoreOnExitFlag             defines which kind of non-zero exits code should be ignored
-                                     accepts: all, results, errors, none
-                                     example: if 'results' is set, only engine errors will make KICS exit code different from 0
+                                     example: "high,low" (default [high,medium,low,info])
   -h, --help                         help for scan
+      --ignore-on-exit string        defines which kind of non-zero exits code should be ignored
+                                     accepts: all, results, errors, none
+                                     example: if 'results' is set, only engine errors will make KICS exit code different from 0 (default "none")
       --minimal-ui                   simplified version of CLI output
       --no-progress                  hides the progress bar
   -o, --output-path string           directory path to store reports
@@ -67,6 +67,7 @@ Flags:
       --preview-lines int            number of lines to be display in CLI results (min: 1, max: 30) (default 3)
   -q, --queries-path string          path to directory with queries (default "./assets/queries")
       --report-formats strings       formats in which the results will be exported (json, sarif, html)
+      --timeout int                  number of seconds the query has to execute before being canceled (default 60)
   -t, --type strings                 case insensitive list of platform types to scan
                                      (Ansible, CloudFormation, Dockerfile, Kubernetes, OpenAPI, Terraform)
 
@@ -79,6 +80,7 @@ Global Flags:
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)
   -v, --verbose             write logs to stdout too (mutually exclusive with silent)
+
 ```
 
 The other commands have no further options.

--- a/e2e/fixtures/E2E_CLI_002
+++ b/e2e/fixtures/E2E_CLI_002
@@ -33,6 +33,7 @@ Flags:
       --preview-lines int            number of lines to be display in CLI results (min: 1, max: 30) (default 3)
   -q, --queries-path string          path to directory with queries (default "./assets/queries")
       --report-formats strings       formats in which the results will be exported (json, sarif, html)
+      --timeout int                  number of seconds the query has to execute before being canceled (default 60)
   -t, --type strings                 case insensitive list of platform types to scan
                                      (Ansible, CloudFormation, Dockerfile, Kubernetes, OpenAPI, Terraform)
 

--- a/e2e/fixtures/E2E_CLI_003
+++ b/e2e/fixtures/E2E_CLI_003
@@ -32,6 +32,7 @@ Flags:
       --preview-lines int            number of lines to be display in CLI results (min: 1, max: 30) (default 3)
   -q, --queries-path string          path to directory with queries (default "./assets/queries")
       --report-formats strings       formats in which the results will be exported (json, sarif, html)
+      --timeout int                  number of seconds the query has to execute before being canceled (default 60)
   -t, --type strings                 case insensitive list of platform types to scan
                                      (Ansible, CloudFormation, Dockerfile, Kubernetes, OpenAPI, Terraform)
 

--- a/e2e/fixtures/E2E_CLI_004
+++ b/e2e/fixtures/E2E_CLI_004
@@ -32,6 +32,7 @@ Flags:
       --preview-lines int            number of lines to be display in CLI results (min: 1, max: 30) (default 3)
   -q, --queries-path string          path to directory with queries (default "./assets/queries")
       --report-formats strings       formats in which the results will be exported (json, sarif, html)
+      --timeout int                  number of seconds the query has to execute before being canceled (default 60)
   -t, --type strings                 case insensitive list of platform types to scan
                                      (Ansible, CloudFormation, Dockerfile, Kubernetes, OpenAPI, Terraform)
 

--- a/e2e/fixtures/E2E_CLI_010
+++ b/e2e/fixtures/E2E_CLI_010
@@ -39,6 +39,7 @@ Flags:
       --preview-lines int            number of lines to be display in CLI results (min: 1, max: 30) (default 3)
   -q, --queries-path string          path to directory with queries (default "./assets/queries")
       --report-formats strings       formats in which the results will be exported (json, sarif, html)
+      --timeout int                  number of seconds the query has to execute before being canceled (default 60)
   -t, --type strings                 case insensitive list of platform types to scan
                                      (Ansible, CloudFormation, Dockerfile, Kubernetes, OpenAPI, Terraform)
 
@@ -48,6 +49,7 @@ Global Flags:
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
       --log-path string     path to log files, (defaults to ${PWD}/info.log)
       --no-color            disable CLI color output
+      --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)
   -v, --verbose             write logs to stdout too (mutually exclusive with silent)
 

--- a/e2e/fixtures/E2E_CLI_016_INVALID_SCAN_FLAG
+++ b/e2e/fixtures/E2E_CLI_016_INVALID_SCAN_FLAG
@@ -32,6 +32,7 @@ Flags:
       --preview-lines int            number of lines to be display in CLI results (min: 1, max: 30) (default 3)
   -q, --queries-path string          path to directory with queries (default "./assets/queries")
       --report-formats strings       formats in which the results will be exported (json, sarif, html)
+      --timeout int                  number of seconds the query has to execute before being canceled (default 60)
   -t, --type strings                 case insensitive list of platform types to scan
                                      (Ansible, CloudFormation, Dockerfile, Kubernetes, OpenAPI, Terraform)
 

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -33,8 +33,7 @@ const (
 	DefaultQueryURI             = "https://github.com/Checkmarx/kics/"
 	DefaultIssueType            = model.IssueTypeIncorrectValue
 
-	regoQuery      = `result = data.Cx.CxPolicy`
-	executeTimeout = 60 * time.Second
+	regoQuery = `result = data.Cx.CxPolicy`
 )
 
 // ErrNoResult - error representing when a query didn't return a result
@@ -75,9 +74,9 @@ type Inspector struct {
 	excludeResults map[string]bool
 	detector       *detector.DetectLine
 
-	enableCoverageReport    bool
-	coverageReport          cover.Report
-	queryExecTimeoutSeconds time.Duration
+	enableCoverageReport bool
+	coverageReport       cover.Report
+	queryExecTimeout     time.Duration
 }
 
 // QueryContext contains the context where the query is executed, which scan it belongs, basic information of query,
@@ -176,13 +175,13 @@ func NewInspector(
 	log.Info().Msgf("Query execution timeout=%v", queryExecTimeout)
 
 	return &Inspector{
-		queries:                 opaQueries,
-		vb:                      vb,
-		tracker:                 tracker,
-		failedQueries:           failedQueries,
-		excludeResults:          excludeResults,
-		detector:                lineDetctor,
-		queryExecTimeoutSeconds: queryExecTimeout,
+		queries:          opaQueries,
+		vb:               vb,
+		tracker:          tracker,
+		failedQueries:    failedQueries,
+		excludeResults:   excludeResults,
+		detector:         lineDetctor,
+		queryExecTimeout: queryExecTimeout,
 	}, nil
 }
 
@@ -273,7 +272,7 @@ func (c *Inspector) GetFailedQueries() map[string]error {
 }
 
 func (c *Inspector) doRun(ctx *QueryContext) ([]model.Vulnerability, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx.ctx, c.queryExecTimeoutSeconds)
+	timeoutCtx, cancel := context.WithTimeout(ctx.ctx, c.queryExecTimeout)
 	defer cancel()
 
 	options := []rego.EvalOption{rego.EvalInput(ctx.payload)}

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -75,8 +75,9 @@ type Inspector struct {
 	excludeResults map[string]bool
 	detector       *detector.DetectLine
 
-	enableCoverageReport bool
-	coverageReport       cover.Report
+	enableCoverageReport    bool
+	coverageReport          cover.Report
+	queryExecTimeoutSeconds time.Duration
 }
 
 // QueryContext contains the context where the query is executed, which scan it belongs, basic information of query,
@@ -104,7 +105,8 @@ func NewInspector(
 	vb VulnerabilityBuilder,
 	tracker Tracker,
 	excludeQueries source.ExcludeQueries,
-	excludeResults map[string]bool) (*Inspector, error) {
+	excludeResults map[string]bool,
+	queryTimeout int) (*Inspector, error) {
 	log.Debug().Msg("engine.NewInspector()")
 
 	metrics.Metric.Start("get_queries")
@@ -170,13 +172,17 @@ func NewInspector(
 		Add(helm.DetectKindLine{}, model.KindHELM).
 		Add(docker.DetectKindLine{}, model.KindDOCKER)
 
+	queryExecTimeout := time.Duration(queryTimeout) * time.Second
+	log.Info().Msgf("Query execution timeout=%v", queryExecTimeout)
+
 	return &Inspector{
-		queries:        opaQueries,
-		vb:             vb,
-		tracker:        tracker,
-		failedQueries:  failedQueries,
-		excludeResults: excludeResults,
-		detector:       lineDetctor,
+		queries:                 opaQueries,
+		vb:                      vb,
+		tracker:                 tracker,
+		failedQueries:           failedQueries,
+		excludeResults:          excludeResults,
+		detector:                lineDetctor,
+		queryExecTimeoutSeconds: queryExecTimeout,
 	}, nil
 }
 
@@ -267,7 +273,7 @@ func (c *Inspector) GetFailedQueries() map[string]error {
 }
 
 func (c *Inspector) doRun(ctx *QueryContext) ([]model.Vulnerability, error) {
-	timeoutCtx, cancel := context.WithTimeout(ctx.ctx, executeTimeout)
+	timeoutCtx, cancel := context.WithTimeout(ctx.ctx, c.queryExecTimeoutSeconds)
 	defer cancel()
 
 	options := []rego.EvalOption{rego.EvalInput(ctx.payload)}

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -296,6 +297,7 @@ func TestInspect(t *testing.T) { //nolint
 				coverageReport:       tt.fields.coverageReport,
 				excludeResults:       tt.fields.excludeResults,
 				detector:             inspDetector,
+				queryExecTimeout:     time.Duration(60) * time.Second,
 			}
 			got, err := c.Inspect(tt.args.ctx, tt.args.scanID, tt.args.files, true, []string{filepath.FromSlash("assets/queries/")})
 			if tt.wantErr {

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -348,12 +348,13 @@ func TestNewInspector(t *testing.T) { // nolint
 		},
 	})
 	type args struct {
-		ctx            context.Context
-		source         source.QueriesSource
-		vb             VulnerabilityBuilder
-		tracker        Tracker
-		excludeQueries source.ExcludeQueries
-		excludeResults map[string]bool
+		ctx              context.Context
+		source           source.QueriesSource
+		vb               VulnerabilityBuilder
+		tracker          Tracker
+		excludeQueries   source.ExcludeQueries
+		excludeResults   map[string]bool
+		queryExecTimeout int
 	}
 	tests := []struct {
 		name    string
@@ -372,7 +373,8 @@ func TestNewInspector(t *testing.T) { // nolint
 					ByIDs:        []string{},
 					ByCategories: []string{},
 				},
-				excludeResults: map[string]bool{},
+				excludeResults:   map[string]bool{},
+				queryExecTimeout: 60,
 			},
 			want: &Inspector{
 				vb:      vbs,
@@ -384,7 +386,14 @@ func TestNewInspector(t *testing.T) { // nolint
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewInspector(tt.args.ctx, tt.args.source, tt.args.vb, tt.args.tracker, tt.args.excludeQueries, tt.args.excludeResults)
+			got, err := NewInspector(tt.args.ctx,
+				tt.args.source,
+				tt.args.vb,
+				tt.args.tracker,
+				tt.args.excludeQueries,
+				tt.args.excludeResults,
+				tt.args.queryExecTimeout)
+
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewInspector() error: got = %v,\n wantErr = %v", err, tt.wantErr)
 				return

--- a/test/queries_content_test.go
+++ b/test/queries_content_test.go
@@ -241,6 +241,7 @@ func testQueryHasGoodReturnParams(t *testing.T, entry queryEntry) {
 		trk,
 		source.ExcludeQueries{ByIDs: []string{}, ByCategories: []string{}},
 		map[string]bool{},
+		60,
 	)
 	require.Nil(t, err)
 	require.NotNil(t, inspector)

--- a/test/queries_test.go
+++ b/test/queries_test.go
@@ -127,7 +127,7 @@ func testQuery(tb testing.TB, entry queryEntry, filesPath []string, expectedVuln
 		engine.DefaultVulnerabilityBuilder,
 		&tracker.CITracker{},
 		source.ExcludeQueries{ByIDs: []string{}, ByCategories: []string{}},
-		map[string]bool{})
+		map[string]bool{}, 60)
 
 	require.Nil(tb, err)
 	require.NotNil(tb, inspector)

--- a/test/similarity_id_test.go
+++ b/test/similarity_id_test.go
@@ -292,7 +292,7 @@ func createInspectorAndGetVulnerabilities(ctx context.Context, t testing.TB,
 		engine.DefaultVulnerabilityBuilder,
 		&tracker.CITracker{},
 		source.ExcludeQueries{ByIDs: []string{}, ByCategories: []string{}},
-		map[string]bool{})
+		map[string]bool{}, 60)
 
 	require.Nil(t, err)
 	require.NotNil(t, inspector)


### PR DESCRIPTION
Signed-off-by: Rogério Peixoto <rogerio.peixoto@checkmarx.com>

Closes #3047

**Proposed Changes**
- add --timeout flag that determines the number of seconds a rego query will be evaluated until it gets canceled.
- add the flag to the documentation
- small fixes across .md files

I submit this contribution under the Apache-2.0 license.
