### PR TITLE
added: new E2E tests scenarios (third iteration)

### DIFF
--- a/e2e/fixtures/samples/config.json
+++ b/e2e/fixtures/samples/config.json
@@ -1,0 +1,6 @@
+{
+    "path": "fixtures/samples/terraform-single.tf",
+    "verbose": true,
+    "type": "Dockerfile,Kubernetes,Terraform",
+    "queries-path": "../assets/queries"
+}


### PR DESCRIPTION
Closes #

**Proposed Changes**
- Add new E2E test scenarios that cover the new flags.

| Test Name   | Description                                                                                                                                            | Expected Output | Exit Status Code |
|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|------------------|
| E2E-CLI-024 |                                      KICS command with version should display the version of the kics in the CLI.                                      |   match regex   |         0        |
| E2E-CLI-025 |       KICS scan command with --fail-on flag should return status code different from 0 only when results match the severity provided in this flag      |   status code   |      30, 20      |
| E2E-CLI-026 | KICS scan command with --ignore-on-exit flag should not return status code for provided input. Example: '--ignore-on-exit errors' -> Returns 0 if an error was found, instead of 126/130... |   status code   |   126, 0, 40, 0  |
| E2E-CLI-027 |                      KICS scan command with --exclude-paths should not perform the scan on the files/folders provided by this flag                     |   match regex   |        50        |
| E2E-CLI-028 |                    KICS scan command with --log-format should modify the view structure of output messages in the CLI (json/pretty)                    |   match regex   |        40        |
| E2E-CLI-029 |                      KICS scan command with --config flag should load a config file that provides commands and arguments to kics.                      |   status code   |      40, 126     |
| E2E-CLI-030 |                      Kics scan command with --output-path flags should export the result files to the path provided by this flag.                      |   status code   |        40        |
| E2E-CLI-031 |           KICS scan command with --report-formats and -output-path flags should export the results only in the formats provided by this flag.          |   status code   |        40        |

I submit this contribution under the Apache-2.0 license.
