### PR TITLE
feat(query): "Components Object Fixed Field Key Improperly Named" for OpenAPI (#3065)

### DIFF
--- a/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/metadata.json
+++ b/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "151331e2-11f4-4bb6-bd35-9a005e695087",
+  "queryName": "Components Object Fixed Field Key Improperly Named",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Components object fixed fields (schemas, responses, parameters, examples, requestBodies, headers, securitySchemes, links, and callbacks) should use keys that match the following REGEX: `^[a-zA-Z0-9\\.\\-_]+$`",
+  "descriptionUrl": "https://swagger.io/specification/#components-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/query.rego
+++ b/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/query.rego
@@ -7,7 +7,7 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	obj := doc.components[field][key]
-	regex.match(`^[a-zA-Z0-9\\.\\-_]+$`, key) == false
+	not is_alphanumeric(key)
 
 	result := {
 		"documentId": doc.id,
@@ -16,4 +16,8 @@ CxPolicy[result] {
 		"keyExpectedValue": sprintf("components.{{%s}}.{{%s}} is properly named", [field, key]),
 		"keyActualValue": sprintf("components.{{%s}}.{{%s}}is improperly named", [field, key]),
 	}
+}
+
+is_alphanumeric(key) {
+	regex.match(`^[a-zA-Z0-9\\.\\-_]+$`, key) == true
 }

--- a/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/query.rego
+++ b/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/query.rego
@@ -1,0 +1,19 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	obj := doc.components[field][key]
+	regex.match(`^[a-zA-Z0-9\\.\\-_]+$`, key) == false
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.{{%s}}.{{%s}}", [field, key]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.{{%s}}.{{%s}} is properly named", [field, key]),
+		"keyActualValue": sprintf("components.{{%s}}.{{%s}}is improperly named", [field, key]),
+	}
+}

--- a/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/test/negative1.json
+++ b/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/test/negative1.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "code": {
+            "type": "string",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/test/negative2.yaml
+++ b/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/test/negative2.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - petType

--- a/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/test/positive1.json
+++ b/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/test/positive1.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "General Error": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "code": {
+            "type": "string",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/test/positive2.yaml
+++ b/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/test/positive2.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    General Error:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - petType

--- a/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/test/positive_expected_result.json
+++ b/assets/queries/openAPI/components_object_fixed_field_key_improperly_named/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Components Object Fixed Field Key Improperly Named",
+    "severity": "INFO",
+    "line": 45,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Components Object Fixed Field Key Improperly Named",
+    "severity": "INFO",
+    "line": 27,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3065

Proposed Changes
- Added "Components Object Fixed Field Key Improperly Named" query for OpenAPI. It checks if components object fixed fields (schemas, responses, parameters, examples, requestBodies, headers, securitySchemes, links, and callbacks) use keys that not match the following REGEX: `^[a-zA-Z0-9\\.\\-_]+$`

I submit this contribution under the Apache-2.0 license.
