### PR TITLE
feat(query): "Parameter Object Content With Multiple Entries" for OpenAPI (#3068)

### DIFF
--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/metadata.json
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "8bfed1c6-2d59-4924-bc7f-9b9d793ed0df",
+  "queryName": "Parameter Object Content With Multiple Entries",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "The map content property of the parameter object should only contain one entry",
+  "descriptionUrl": "https://swagger.io/specification/#parameter-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/query.rego
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/query.rego
@@ -1,0 +1,55 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	params := doc.paths[name].parameters[n]
+
+	multiple_entries(params)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.%s.parameters", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.%s.parameters.%d.content has one entry", [name, n]),
+		"keyActualValue": sprintf("paths.%s.parameters.%d.content has multiple entries", [name, n]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	params := doc.paths[name][oper].parameters[n]
+
+	multiple_entries(params)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.%s.%s.parameters", [name, oper]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("openapi.paths.%s.%s.parameters.%d.content has one entry", [name, oper, n]),
+		"keyActualValue": sprintf("openapi.paths.%s.%s.parameters.%d.content has multiple entries", [name, oper, n]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	params := doc.components.parameters[n]
+
+	multiple_entries(params)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": "components.parameters",
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.parameters.%s.content has one entry", [n]),
+		"keyActualValue": sprintf("components.parameters.%s.content has multiple entries", [n]),
+	}
+}
+
+multiple_entries(params) {
+	count(params.content) > 1
+}

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/negative1.json
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/negative1.json
@@ -1,0 +1,93 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "List API versions",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "user": {
+                    "summary": "User Example",
+                    "externalValue": "http://foo.bar/examples/user-example.json"
+                  }
+                }
+              }
+            },
+            "name": "id",
+            "in": "path",
+            "description": "ID of the API version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "rel": "self",
+                              "href": "http://127.0.0.1:8774/v2/"
+                            }
+                          ],
+                          "status": "CURRENT"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "200 response"
+          }
+        },
+        "operationId": "listVersionsv2"
+      }
+    },
+    "/user/{id}": {
+      "parameters": [
+        {
+          "description": "ID of the API version",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              },
+              "examples": {
+                "user": {
+                  "summary": "User Example",
+                  "externalValue": "http://foo.bar/examples/user-example.json"
+                }
+              }
+            }
+          },
+          "name": "id",
+          "in": "path"
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/negative2.json
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/negative2.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "idParam": {
+        "name": "id",
+        "in": "path",
+        "description": "ID of the API version",
+        "required": true,
+        "schema": {
+          "type": "int"
+        },
+        "content": {
+          "application/xml": {
+            "examples": {
+              "user": {
+                "externalValue": "http://foo.bar/examples/user-example.xml",
+                "summary": "User Example in XML"
+              }
+            },
+            "schema": {
+              "$ref": "#/components/schemas/User"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/negative3.yaml
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/negative3.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      parameters:
+        - name: id
+          in: path
+          description: ID of the API version
+          required: true
+          schema:
+            type: integer
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/User"
+              examples:
+                user:
+                  summary: User Example
+                  externalValue: "http://foo.bar/examples/user-example.json"
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+  /user/{id}:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the API version
+        required: true
+        schema:
+          type: integer
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/User"
+            examples:
+              user:
+                summary: User Example
+                externalValue: "http://foo.bar/examples/user-example.json"

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/negative4.yaml
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/negative4.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  parameters:
+    idParam:
+      name: id
+      in: path
+      description: ID of the API version
+      required: true
+      schema:
+        type: int
+      content:
+        "application/json":
+          schema:
+            $ref: "#/components/schemas/User"
+          examples:
+            user:
+              summary: User Example
+              externalValue: "http://foo.bar/examples/user-example.json"

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/positive1.json
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/positive1.json
@@ -1,0 +1,115 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "List API versions",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "user": {
+                    "summary": "User Example",
+                    "externalValue": "http://foo.bar/examples/user-example.json"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "user": {
+                    "summary": "User Example in XML",
+                    "externalValue": "http://foo.bar/examples/user-example.xml"
+                  }
+                }
+              }
+            },
+            "name": "id",
+            "in": "path",
+            "description": "ID of the API version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "rel": "self",
+                              "href": "http://127.0.0.1:8774/v2/"
+                            }
+                          ],
+                          "status": "CURRENT"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "200 response"
+          }
+        },
+        "operationId": "listVersionsv2"
+      }
+    },
+    "/user/{id}": {
+      "parameters": [
+        {
+          "description": "ID of the API version",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              },
+              "examples": {
+                "user": {
+                  "summary": "User Example",
+                  "externalValue": "http://foo.bar/examples/user-example.json"
+                }
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              },
+              "examples": {
+                "user": {
+                  "summary": "User Example in XML",
+                  "externalValue": "http://foo.bar/examples/user-example.xml"
+                }
+              }
+            }
+          },
+          "name": "id",
+          "in": "path"
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/positive2.json
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/positive2.json
@@ -1,0 +1,80 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "idParam": {
+        "name": "id",
+        "in": "path",
+        "description": "ID of the API version",
+        "required": true,
+        "schema": {
+          "type": "int"
+        },
+        "content": {
+          "application/xml": {
+            "examples": {
+              "user": {
+                "externalValue": "http://foo.bar/examples/user-example.xml",
+                "summary": "User Example in XML"
+              }
+            },
+            "schema": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/User"
+            },
+            "examples": {
+              "user": {
+                "externalValue": "http://foo.bar/examples/user-example.json",
+                "summary": "User Example"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/positive3.yaml
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/positive3.yaml
@@ -1,0 +1,69 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      parameters:
+        - name: id
+          in: path
+          description: ID of the API version
+          required: true
+          schema:
+            type: integer
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/User"
+              examples:
+                user:
+                  summary: User Example
+                  externalValue: "http://foo.bar/examples/user-example.json"
+            "application/xml":
+              schema:
+                $ref: "#/components/schemas/User"
+              examples:
+                user:
+                  summary: User Example in XML
+                  externalValue: "http://foo.bar/examples/user-example.xml"
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+  /user/{id}:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the API version
+        required: true
+        schema:
+          type: integer
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/User"
+            examples:
+              user:
+                summary: User Example
+                externalValue: "http://foo.bar/examples/user-example.json"
+          "application/xml":
+            schema:
+              $ref: "#/components/schemas/User"
+            examples:
+              user:
+                summary: User Example in XML
+                externalValue: "http://foo.bar/examples/user-example.xml"

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/positive4.yaml
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/positive4.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  parameters:
+    idParam:
+      name: id
+      in: path
+      description: ID of the API version
+      required: true
+      schema:
+        type: int
+      content:
+        "application/json":
+          schema:
+            $ref: "#/components/schemas/User"
+          examples:
+            user:
+              summary: User Example
+              externalValue: "http://foo.bar/examples/user-example.json"
+        "application/xml":
+          schema:
+            $ref: "#/components/schemas/User"
+          examples:
+            user:
+              summary: User Example in XML
+              externalValue: "http://foo.bar/examples/user-example.xml"

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/positive_expected_result.json
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "Parameter Object Content With Multiple Entries",
+    "severity": "INFO",
+    "line": 11,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameter Object Content With Multiple Entries",
+    "severity": "INFO",
+    "line": 78,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameter Object Content With Multiple Entries",
+    "severity": "INFO",
+    "line": 44,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Parameter Object Content With Multiple Entries",
+    "severity": "INFO",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Parameter Object Content With Multiple Entries",
+    "severity": "INFO",
+    "line": 48,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Parameter Object Content With Multiple Entries",
+    "severity": "INFO",
+    "line": 26,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3068

**Proposed Changes**
- Added "Parameter Object Content With Multiple Entries'" query for OpenAPI. It checks if  the map content property of the parameter object has multiple entries

**Considerations**:
- The Parameter Object exists in Path Object, Components Object, and Operation Object.

I submit this contribution under Apache-2.0 license.
