### PR TITLE
feat(query): "Request Body Object With Incorrect Media Type" for OpenAPI (#3070)

### DIFF
--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/metadata.json
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "58f06434-a88c-4f74-826c-db7e10cc7def",
+  "queryName": "Request Body Object With Incorrect Media Type",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "The field 'content' of the request body object should be set to 'multipart' or 'application/x-www-form-urlencoded' when field 'encoding' is set.",
+  "descriptionUrl": "https://swagger.io/specification/#media-type-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/query.rego
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/query.rego
@@ -1,0 +1,40 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	content := doc.paths[path][operation].requestBody.content[x]
+	incorrect_media_type(content, x)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}", [path, operation, x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}} is 'multipart' or 'application/x-www-form-urlencoded' when 'encoding' is set", [path, operation, x]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}} is not 'multipart' or 'application/x-www-form-urlencoded' when 'encoding' is set", [path, operation, x]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	content := doc.components.requestBodies[r].content[x]
+	incorrect_media_type(content, x)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}}", [r, x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}} is 'multipart' or 'application/x-www-form-urlencoded' when 'encoding' is set", [r, x]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}} is not 'multipart' or 'application/x-www-form-urlencoded' when 'encoding' is set", [r, x]),
+	}
+}
+
+incorrect_media_type(content, media_type) {
+	object.get(content, "encoding", "undefined") != "undefined"
+	regex.match("((^multipart/[a-zA-Z-]+)|application/x-www-form-urlencoded)", media_type) == false
+}

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/query.rego
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/query.rego
@@ -36,5 +36,7 @@ CxPolicy[result] {
 
 incorrect_media_type(content, media_type) {
 	object.get(content, "encoding", "undefined") != "undefined"
-	regex.match("((^multipart/[a-zA-Z-]+)|application/x-www-form-urlencoded)", media_type) == false
+
+	media_types := {"multipart/", "application/x-www-form-urlencoded"}
+	count({x | m := media_types[x]; startswith(media_type, m) == true}) == 0
 }

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/negative1.json
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/negative1.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ],
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/data": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            },
+            "encoding": {
+              "code": {
+                "contentType": "image/png, image/jpeg"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/negative2.json
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/negative2.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "string",
+                "format": "binary",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "code": {
+                  "contentType": "image/png, image/jpeg"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/negative3.yaml
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/negative3.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                format: binary
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"
+          encoding:
+            code:
+              contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/negative4.yaml
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/negative4.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: string
+              format: binary
+              properties:
+                code:
+                  type: string
+                  format: binary
+            encoding:
+              code:
+                contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/positive1.json
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/positive1.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ],
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            },
+            "encoding": {
+              "code": {
+                "contentType": "image/png, image/jpeg"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/positive2.json
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/positive2.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "code": {
+                  "contentType": "image/png, image/jpeg"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/positive3.yaml
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/positive3.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                format: binary
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"
+          encoding:
+            code:
+              contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/positive4.yaml
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/positive4.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+              properties:
+                code:
+                  type: string
+                  format: binary
+            encoding:
+              code:
+                contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/positive_expected_result.json
+++ b/assets/queries/openAPI/request_body_object_with_incorrect_media_type/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Request Body Object With Incorrect Media Type",
+    "severity": "INFO",
+    "line": 64,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Request Body Object With Incorrect Media Type",
+    "severity": "INFO",
+    "line": 43,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Request Body Object With Incorrect Media Type",
+    "severity": "INFO",
+    "line": 41,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Request Body Object With Incorrect Media Type",
+    "severity": "INFO",
+    "line": 30,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3070

**Proposed Changes**
- Added "Request Body Object With Incorrect Media Type" query for OpenAPI. It checks if  the field 'content' of the request body object is not set to 'multipart' or 'application/x-www-form-urlencoded' when field 'encoding' is set

**Considerations**:
- The Request Body Object exists in Components Object and Operation Object.

I submit this contribution under Apache-2.0 license.
