### PR TITLE
feat(query): "Schema Object Incorrect Ref" for OpenAPI (#3072)

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -24,5 +24,5 @@ incorrect_ref(ref, object) {
 		"requestBody": "#/components/requestBodies",
 	}
 
-	not contains(ref, references[object])
+	regex.match(references[object], ref) == false
 }

--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -24,5 +24,5 @@ incorrect_ref(ref, object) {
 		"requestBody": "#/components/requestBodies",
 	}
 
-	not startswith(ref, references[object])
+	not contains(ref, references[object])
 }

--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -16,3 +16,13 @@ improperly_defined(params, value) {
 	params.in == "header"
 	params.name == value
 }
+
+incorrect_ref(ref, object) {
+	references := {
+		"schema": "#/components/schemas",
+		"responses": "#/components/responses",
+		"requestBody": "#/components/requestBodies",
+	}
+
+	not startswith(ref, references[object])
+}

--- a/assets/queries/openAPI/request_body_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/request_body_incorrect_ref/query.rego
@@ -7,12 +7,12 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 	req := doc.paths[n][oper].requestBody
 
-	not startswith(req["$ref"], "#/components/requestBodies")
+	openapi_lib.incorrect_ref(req["$ref"], "requestBody")
 
 	result := {
 		"documentId": doc.id,
 		"searchKey": sprintf("openapi.paths.%s.%s.requestBody.$ref={{%s}}", [n, oper, req["$ref"]]),
-		"issueType": "MissingAttribute",
+		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Request body ref points to '#components/requestBodies'",
 		"keyActualValue": "Request body ref doesn't point to '#components/requestBodies'",
 	}

--- a/assets/queries/openAPI/response_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/response_object_incorrect_ref/query.rego
@@ -7,13 +7,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 	response := doc.paths[n][oper].responses[code]
 
-	not startswith(response["$ref"], "#/components/responses")
+	openapi_lib.incorrect_ref(response["$ref"], "responses")
 
 	result := {
 		"documentId": doc.id,
 		"searchKey": sprintf("openapi.paths.%s.%s.responses.%s.$ref={{%s}}", [n, oper, code, response["$ref"]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "HTTP responses status codes are in range of [200-599]",
-		"keyActualValue": "HTTP responses status codes are not in range of [200-599]",
+		"keyExpectedValue": "Response ref points to '#/components/responses'",
+		"keyActualValue": "Response ref does not point to '#/components/responses'",
 	}
 }

--- a/assets/queries/openAPI/schema_object_incorrect_ref/metadata.json
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "4cac7ace-b0fb-477d-830d-65395d9109d9",
+  "queryName": "Schema Object Incorrect Ref",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Schema Body reference must always point to '#components/schemas'",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/schema_object_incorrect_ref/metadata.json
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Schema Object Incorrect Ref",
   "severity": "INFO",
   "category": "Structure and Semantics",
-  "descriptionText": "Schema Body reference must always point to '#components/schemas'",
+  "descriptionText": "Schema Object reference must always point to '#components/schemas'",
   "descriptionUrl": "https://swagger.io/specification/#schema-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/schema_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/query.rego
@@ -1,0 +1,115 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_ref := doc.paths[path][operation].responses[r].content[c].schema["$ref"]
+	openapi_lib.incorrect_ref(schema_ref, "schema")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema.$ref={{%s}}", [path, operation, r, c, schema_ref]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Schema reference points to '#components/schemas'",
+		"keyActualValue": "Schema reference does not point to '#components/schemas'",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_ref := doc.paths[path].parameters[parameter].schema["$ref"]
+	openapi_lib.incorrect_ref(schema_ref, "schema")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.parameters.{{%s}}.schema.$ref={{%s}}", [path, parameter, schema_ref]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Schema reference points to '#components/schemas'",
+		"keyActualValue": "Schema reference does not point to '#components/schemas'",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_ref := doc.paths[path][operation].parameters[parameter].schema["$ref"]
+	openapi_lib.incorrect_ref(schema_ref, "schema")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.$ref={{%s}}", [path, operation, parameter, schema_ref]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Schema reference points to '#components/schemas'",
+		"keyActualValue": "Schema reference does not point to '#components/schemas'",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_ref := doc.paths[path][operation].requestBody.content[c].schema["$ref"]
+	openapi_lib.incorrect_ref(schema_ref, "schema")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.$ref={{%s}}", [path, operation, c, schema_ref]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Schema reference points to '#components/schemas'",
+		"keyActualValue": "Schema reference does not point to '#components/schemas'",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_ref := doc.components.requestBodies[r].content[c].schema["$ref"]
+	openapi_lib.incorrect_ref(schema_ref, "schema")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.$ref={{%s}}", [r, c, schema_ref]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Schema reference points to '#components/schemas'",
+		"keyActualValue": "Schema reference does not point to '#components/schemas'",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_ref := doc.components.parameters[parameter].schema["$ref"]
+	openapi_lib.incorrect_ref(schema_ref, "schema")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.parameters.{{%s}}.schema.$ref={{%s}}", [parameter, schema_ref]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Schema reference points to '#components/schemas'",
+		"keyActualValue": "Schema reference does not point to '#components/schemas'",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schema_ref := doc.components.responses[r].content[c].schema["$ref"]
+	openapi_lib.incorrect_ref(schema_ref, "schema")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.$ref={{%s}}", [r, c, schema_ref]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Schema reference points to '#components/schemas'",
+		"keyActualValue": "Schema reference does not point to '#components/schemas'",
+	}
+}

--- a/assets/queries/openAPI/schema_object_incorrect_ref/test/negative1.json
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/test/negative1.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "code": {
+            "type": "string",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_incorrect_ref/test/negative2.json
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/test/negative2.json
@@ -1,0 +1,73 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "code": {
+            "type": "string",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "petType"
+        ],
+        "type": "object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_incorrect_ref/test/negative3.yaml
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/test/negative3.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/schema_object_incorrect_ref/test/negative4.yaml
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/test/negative4.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - petType

--- a/assets/queries/openAPI/schema_object_incorrect_ref/test/positive1.json
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/test/positive1.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "code": {
+            "type": "string",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemads/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_incorrect_ref/test/positive2.json
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/test/positive2.json
@@ -1,0 +1,68 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemads/GeneralError"
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "code": {
+            "type": "string",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "petType"
+        ],
+        "type": "object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_incorrect_ref/test/positive3.yaml
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/test/positive3.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemads/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/schema_object_incorrect_ref/test/positive4.yaml
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/test/positive4.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemads/GeneralError"
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        code:
+          type: string
+          format: int32
+        message:
+          type: string
+      required:
+        - petType

--- a/assets/queries/openAPI/schema_object_incorrect_ref/test/positive_expected_result.json
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Schema Object Incorrect Ref",
+    "severity": "INFO",
+    "line": 76,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema Object Incorrect Ref",
+    "severity": "INFO",
+    "line": 16,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Schema Object Incorrect Ref",
+    "severity": "INFO",
+    "line": 46,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Schema Object Incorrect Ref",
+    "severity": "INFO",
+    "line": 16,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3072

Proposed Changes
- Added "Schema Object Incorrect Ref" query for OpenAPI. It checks if schema object reference does not point to '#components/schemas'
- Updated "Response Object With Incorrect Ref": keyExpectedValue and keyActualValue
- Updated "Request Body With Incorrect Ref" : issueType
- The function 'regex.match' was chosen to also cover cases when '$ref' is a remote or a URL reference (function 'startswith' just covers cases when '$ref' is a local reference - https://swagger.io/docs/specification/using-ref/)

I submit this contribution under the Apache-2.0 license.
