### PR TITLE
feat(query): "Success Response Code Undefined for Trace Operation" for OpenAPI (#3078)

### DIFF
--- a/assets/queries/openAPI/success_response_code_undefined_trace_operation/metadata.json
+++ b/assets/queries/openAPI/success_response_code_undefined_trace_operation/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "105e20dd-8449-4d71-95c6-d5dac96639af",
+  "queryName": "Success Response Code Undefined for Trace Operation",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Trace should define the '200' successful code",
+  "descriptionUrl": "https://swagger.io/specification/#operation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/success_response_code_undefined_trace_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_undefined_trace_operation/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+	oper == "trace"
+
+	object.get(response, "200", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Trace should have the '200' successful code set",
+		"keyActualValue": "Trace does not have the '200' successful code set",
+	}
+}

--- a/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/negative1.json
+++ b/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/negative1.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "trace": {
+        "operationId": "traceItem",
+        "summary": "Trace item",
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "default": {
+            "description": "Sucess"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateItem",
+        "summary": "Update item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/negative1.json
+++ b/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/negative1.json
@@ -14,7 +14,7 @@
             "description": "success"
           },
           "default": {
-            "description": "Sucess"
+            "description": "Success"
           }
         }
       },

--- a/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/negative2.yaml
+++ b/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/negative2.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    trace:
+      operationId: traceItem
+      summary: Trace item
+      responses:
+        "200":
+          description: success
+        default:
+          description: Success
+    patch:
+      operationId: updateItem
+      summary: Update item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/positive1.json
+++ b/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/positive1.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "trace": {
+        "operationId": "traceItem",
+        "summary": "Trace item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/positive2.yaml
+++ b/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/positive2.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    trace:
+      operationId: traceItem
+      summary: Trace item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/positive_expected_result.json
+++ b/assets/queries/openAPI/success_response_code_undefined_trace_operation/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Success Response Code Undefined for Trace Operation",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Success Response Code Undefined for Trace Operation",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3078

Proposed Changes
- Added "Success Response Code Undefined for Trace Operation" query for OpenAPI. It checks if trace operation does not have the '200' successful code set

I submit this contribution under the Apache-2.0 license.
