### PR TITLE
fix(similarity-id): scan is not computing the Similarity ID for file path

### DIFF
--- a/pkg/engine/similarity_id.go
+++ b/pkg/engine/similarity_id.go
@@ -11,7 +11,7 @@ import (
 func ComputeSimilarityID(basePaths []string, filePath, queryID, searchKey, searchValue string) (*string, error) {
 	basePath := ""
 	for _, path := range basePaths {
-		if strings.Contains(filePath, filepath.ToSlash(path)) {
+		if strings.Contains(filepath.ToSlash(filePath), filepath.ToSlash(path)) {
 			basePath = filepath.ToSlash(path)
 			break
 		}

--- a/pkg/engine/similarity_id_test.go
+++ b/pkg/engine/similarity_id_test.go
@@ -155,7 +155,7 @@ var (
 			},
 		},
 		{
-			name: "Windows path hardcoded",
+			name: "Windows path to file",
 			calls: []computeSimilarityIDParams{
 				{
 					basePaths:   []string{".\\my\\test\\file.tf"},

--- a/pkg/engine/similarity_id_test.go
+++ b/pkg/engine/similarity_id_test.go
@@ -155,6 +155,28 @@ var (
 			},
 		},
 		{
+			name: "Windows path hardcoded",
+			calls: []computeSimilarityIDParams{
+				{
+					basePaths:   []string{".\\my\\test\\file.tf"},
+					filePath:    ".\\my\\test\\file.tf",
+					queryID:     "e96ccbb0-8d74-49ef-87f8-b9613b63b6a8",
+					searchKey:   "Resources.MySearchKeyExample",
+					searchValue: "TCP,22",
+				},
+				{
+					basePaths:   []string{filepath.Join(".", "my", "test", "file.tf")},
+					filePath:    filepath.Join(".", "my", "test", "file.tf"),
+					queryID:     "e96ccbb0-8d74-49ef-87f8-b9613b63b6a8",
+					searchKey:   "Resources.MySearchKeyExample",
+					searchValue: "TCP,22",
+				},
+			},
+			expectedFunction: func(t *testing.T, firstHash, secondHash *string) {
+				require.Equal(t, *firstHash, *secondHash)
+			},
+		},
+		{
 			name: "Relative directory resolution",
 			calls: []computeSimilarityIDParams{
 				{


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #3055 

**Proposed Changes**
- Changed base path comparation, when trying to compute similarity-id

I submit this contribution under the Apache-2.0 license.
