### PR TITLE
feat(query): "Success Response Code Undefined for Head Operation" for OpenAPI (#3091)

### DIFF
--- a/assets/queries/openAPI/success_response_code_undefined_head_operation/metadata.json
+++ b/assets/queries/openAPI/success_response_code_undefined_head_operation/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "3b066059-f411-4554-ac8d-96f32bff90da",
+  "queryName": "Success Response Code Undefined for Head Operation",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Head should define at least one success response (200 or 202)",
+  "descriptionUrl": "https://swagger.io/specification/#operation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/success_response_code_undefined_head_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_undefined_head_operation/query.rego
@@ -5,16 +5,14 @@ import data.generic.openapi as openapi_lib
 CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
-	response := doc.paths[n][oper].responses
-
-	oper == "head"
+	response := doc.paths[n].head.responses
 
 	object.get(response, "200", "undefined") == "undefined"
 	object.get(response, "202", "undefined") == "undefined"
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"searchKey": sprintf("paths.{{%s}}.head.responses", [n]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Head should have at least one successful code (200 or 202)",
 		"keyActualValue": "Head does not have any successful code",

--- a/assets/queries/openAPI/success_response_code_undefined_head_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_undefined_head_operation/query.rego
@@ -1,0 +1,22 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+
+	oper == "head"
+
+	object.get(response, "200", "undefined") == "undefined"
+	object.get(response, "202", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Head should have at least one successful code (200 or 202)",
+		"keyActualValue": "Head does not have any successful code",
+	}
+}

--- a/assets/queries/openAPI/success_response_code_undefined_head_operation/test/negative1.json
+++ b/assets/queries/openAPI/success_response_code_undefined_head_operation/test/negative1.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "head": {
+        "operationId": "headItem",
+        "summary": "Head item",
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "default": {
+            "description": "Success"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateItem",
+        "summary": "Update item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_undefined_head_operation/test/negative2.yaml
+++ b/assets/queries/openAPI/success_response_code_undefined_head_operation/test/negative2.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    head:
+      operationId: headItem
+      summary: Head item
+      responses:
+        "200":
+          description: success
+        default:
+          description: Success
+    patch:
+      operationId: updateItem
+      summary: Update item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/assets/queries/openAPI/success_response_code_undefined_head_operation/test/positive1.json
+++ b/assets/queries/openAPI/success_response_code_undefined_head_operation/test/positive1.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "head": {
+        "operationId": "headItem",
+        "summary": "Head item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_undefined_head_operation/test/positive2.yaml
+++ b/assets/queries/openAPI/success_response_code_undefined_head_operation/test/positive2.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    head:
+      operationId: headItem
+      summary: Head item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/assets/queries/openAPI/success_response_code_undefined_head_operation/test/positive_expected_result.json
+++ b/assets/queries/openAPI/success_response_code_undefined_head_operation/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Success Response Code Undefined for Head Operation",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Success Response Code Undefined for Head Operation",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3091

Proposed Changes
- Added "Success Response Code Undefined for Head Operation" query for OpenAPI. It checks if head operation does not have the '200' or '202' successful code set

I submit this contribution under the Apache-2.0 license.
