### PR TITLE
feat(query): "Success Response Code Undefined for Get Operation" for OpenAPI (#3096)

### DIFF
--- a/assets/queries/openAPI/success_response_code_undefined_get_operation/metadata.json
+++ b/assets/queries/openAPI/success_response_code_undefined_get_operation/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b2f275be-7d64-4064-b418-be6b431363a7",
+  "queryName": "Success Response Code Undefined for Get Operation",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Get should define at least one success response (200 or 202)",
+  "descriptionUrl": "https://swagger.io/specification/#operation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/success_response_code_undefined_get_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_undefined_get_operation/query.rego
@@ -5,16 +5,14 @@ import data.generic.openapi as openapi_lib
 CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
-	response := doc.paths[n][oper].responses
-
-	oper == "get"
+	response := doc.paths[n].get.responses
 
 	object.get(response, "200", "undefined") == "undefined"
 	object.get(response, "202", "undefined") == "undefined"
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"searchKey": sprintf("paths.{{%s}}.get.responses", [n]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Get should have at least one successful code (200 or 202)",
 		"keyActualValue": "Get does not have any successful code",

--- a/assets/queries/openAPI/success_response_code_undefined_get_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_undefined_get_operation/query.rego
@@ -1,0 +1,22 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+
+	oper == "get"
+
+	object.get(response, "200", "undefined") == "undefined"
+	object.get(response, "202", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Get should have at least one successful code (200 or 202)",
+		"keyActualValue": "Get does not have any successful code",
+	}
+}

--- a/assets/queries/openAPI/success_response_code_undefined_get_operation/test/negative1.json
+++ b/assets/queries/openAPI/success_response_code_undefined_get_operation/test/negative1.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "get": {
+        "operationId": "getItem",
+        "summary": "Get item",
+        "responses": {
+          "200": {
+            "description": "success"
+          },
+          "default": {
+            "description": "Success"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateItem",
+        "summary": "Update item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_undefined_get_operation/test/negative2.yaml
+++ b/assets/queries/openAPI/success_response_code_undefined_get_operation/test/negative2.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    get:
+      operationId: getItem
+      summary: Get item
+      responses:
+        "200":
+          description: success
+        default:
+          description: Success
+    patch:
+      operationId: updateItem
+      summary: Update item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/assets/queries/openAPI/success_response_code_undefined_get_operation/test/positive1.json
+++ b/assets/queries/openAPI/success_response_code_undefined_get_operation/test/positive1.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "get": {
+        "operationId": "getItem",
+        "summary": "Get item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/success_response_code_undefined_get_operation/test/positive2.yaml
+++ b/assets/queries/openAPI/success_response_code_undefined_get_operation/test/positive2.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    get:
+      operationId: getItem
+      summary: Get item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/assets/queries/openAPI/success_response_code_undefined_get_operation/test/positive_expected_result.json
+++ b/assets/queries/openAPI/success_response_code_undefined_get_operation/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Success Response Code Undefined for Get Operation",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Success Response Code Undefined for Get Operation",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3096

Proposed Changes
- Added "Success Response Code Undefined for Get Operation" query for OpenAPI. It checks if get operation does not have the '200' or '202' successful code set

I submit this contribution under the Apache-2.0 license.
