### PR TITLE
fix(engine): move failed to read ssl cert and swagger spec to trace level

### DIFF
--- a/pkg/parser/utils/file_utils.go
+++ b/pkg/parser/utils/file_utils.go
@@ -28,7 +28,7 @@ func readFile(filePath string) (map[string]interface{}, error) {
 
 	content, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Error().Msgf("Failed to read %s", filePath)
+		log.Trace().Msgf("failed to read %s", filePath)
 		return nil, err
 	}
 


### PR DESCRIPTION

I submit this contribution under the Apache-2.0 license.
