### PR TITLE
feat(query); "Response Code Missing" for OpenAPI (#3101)

### DIFF
--- a/assets/queries/openAPI/response_code_missing/metadata.json
+++ b/assets/queries/openAPI/response_code_missing/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "6c35d2c6-09f2-4e5c-a094-e0e91327071d",
+  "queryName": "Response Code Missing",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "500, 429 and 400 responses should be defined for all operations, except head operation. 415 response should be defined for the post, put, and patch operations. 404 response should be defined for the get, put, head, delete operations. 200 response should be defined for options operation. 401 and 403 response should be defined for all operations when the security field is defined.",
+  "descriptionUrl": "https://swagger.io/specification/#operation-object",
+  "platform": "OpenAPI",
+  "aggregation": 8
+}

--- a/assets/queries/openAPI/response_code_missing/query.rego
+++ b/assets/queries/openAPI/response_code_missing/query.rego
@@ -1,0 +1,92 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+	oper != "head"
+
+	responses := {"500", "429", "400"}
+	object.get(response, responses[x], "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s response is set", [responses[x]]),
+		"keyActualValue": sprintf("%s response is undefined", [responses[x]]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+	operations := {"post", "put", "patch"}
+	oper == operations[x]
+
+	object.get(response, "415", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "415 response is set",
+		"keyActualValue": "415 response is undefined",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+	operations := {"get", "put", "head", "delete"}
+	oper == operations[x]
+
+	object.get(response, "404", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "404 response is set",
+		"keyActualValue": "404 response is undefined",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+	oper == "options"
+
+	object.get(response, "200", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "200 response is set",
+		"keyActualValue": "200 response is undefined",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+	object.get(doc, "security", "undefined") != "undefined"
+	responses := {"401", "403"}
+
+	object.get(response, responses[x], "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s response is set when security field is defined", [responses[x]]),
+		"keyActualValue": sprintf("%s response is undefined when security field is defined", [responses[x]]),
+	}
+}

--- a/assets/queries/openAPI/response_code_missing/test/negative1.json
+++ b/assets/queries/openAPI/response_code_missing/test/negative1.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "put": {
+        "operationId": "putItem",
+        "summary": "Put item",
+        "responses": {
+          "500": {
+            "description": "500 response"
+          },
+          "429": {
+            "description": "429 response"
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "404": {
+            "description": "404 response"
+          },
+          "415": {
+            "description": "415 response"
+          }
+        }
+      },
+      "options": {
+        "operationId": "optionsItem",
+        "summary": "Options item",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          },
+          "500": {
+            "description": "500 response"
+          },
+          "429": {
+            "description": "429 response"
+          },
+          "400": {
+            "description": "400 response"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_code_missing/test/negative2.json
+++ b/assets/queries/openAPI/response_code_missing/test/negative2.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "put": {
+        "operationId": "putItem",
+        "summary": "Put item",
+        "responses": {
+          "500": {
+            "description": "500 response"
+          },
+          "429": {
+            "description": "429 response"
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "404": {
+            "description": "404 response"
+          },
+          "415": {
+            "description": "415 response"
+          },
+          "401": {
+            "description": "401 response"
+          },
+          "403": {
+            "description": "403 response"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "petstore_auth": [
+        "write:pets",
+        "read:pets"
+      ]
+    }
+  ],
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_code_missing/test/negative3.yaml
+++ b/assets/queries/openAPI/response_code_missing/test/negative3.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    put:
+      operationId: putItem
+      summary: Put item
+      responses:
+        "500":
+          description: 500 response
+        "429":
+          description: 429 response
+        "400":
+          description: 400 response
+        "404":
+          description: 404 response
+        "415":
+          description: 415 response
+    options:
+      operationId: optionsItem
+      summary: Options item
+      responses:
+        "200":
+          description: 200 response
+        "500":
+          description: 500 response
+        "429":
+          description: 429 response
+        "400":
+          description: 400 response
+
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/assets/queries/openAPI/response_code_missing/test/negative4.yaml
+++ b/assets/queries/openAPI/response_code_missing/test/negative4.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    put:
+      operationId: putItem
+      summary: Put item
+      responses:
+        "500":
+          description: 500 response
+        "429":
+          description: 429 response
+        "400":
+          description: 400 response
+        "404":
+          description: 404 response
+        "415":
+          description: 415 response
+        "401":
+          description: 401 response
+        "403":
+          description: 403 response
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
+security:
+  - petstore_auth:
+      - write:pets
+      - read:pets

--- a/assets/queries/openAPI/response_code_missing/test/positive1.json
+++ b/assets/queries/openAPI/response_code_missing/test/positive1.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "put": {
+        "operationId": "putItem",
+        "summary": "Put item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "options": {
+        "operationId": "optionsItem",
+        "summary": "Options item",
+        "responses": {
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_code_missing/test/positive2.json
+++ b/assets/queries/openAPI/response_code_missing/test/positive2.json
@@ -1,0 +1,59 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "put": {
+        "operationId": "putItem",
+        "summary": "Put item",
+        "responses": {
+          "500": {
+            "description": "500 response"
+          },
+          "429": {
+            "description": "429 response"
+          },
+          "400": {
+            "description": "400 response"
+          },
+          "404": {
+            "description": "404 response"
+          },
+          "415": {
+            "description": "415 response"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "petstore_auth": [
+        "write:pets",
+        "read:pets"
+      ]
+    }
+  ],
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_code_missing/test/positive3.yaml
+++ b/assets/queries/openAPI/response_code_missing/test/positive3.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    put:
+      operationId: putItem
+      summary: Put item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+    options:
+      operationId: optionsItem
+      summary: Options item
+      responses:
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/assets/queries/openAPI/response_code_missing/test/positive4.yaml
+++ b/assets/queries/openAPI/response_code_missing/test/positive4.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    put:
+      operationId: putItem
+      summary: Put item
+      responses:
+        "500":
+          description: 500 response
+        "429":
+          description: 429 response
+        "400":
+          description: 400 response
+        "404":
+          description: 404 response
+        "415":
+          description: 415 response
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message
+security:
+  - petstore_auth:
+      - write:pets
+      - read:pets

--- a/assets/queries/openAPI/response_code_missing/test/positive_expected_result.json
+++ b/assets/queries/openAPI/response_code_missing/test/positive_expected_result.json
@@ -1,0 +1,134 @@
+[
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 24,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 24,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 24,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 24,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 18,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 18,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 18,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 18,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Response Code Missing",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3101

Proposed Changes
- Added "Response Code Missing" query for OpenAPI. It checks if:
    - 500, 429 and 400 responses are not defined for all operations, except head operation.
    - 415 response is not defined for the post, put, and patch operations. 
    - 404 response is not defined for the get, put, head, delete operations.
    - 200 response is not defined for options operation.
    - 401 and 403 response are not defined for all operations when the security field is defined.

I submit this contribution under the Apache-2.0 license.