### PR TITLE
fix(parser): fixed scanning helm chart returns false error

### DIFF
--- a/pkg/kics/resolver_sink.go
+++ b/pkg/kics/resolver_sink.go
@@ -26,8 +26,11 @@ func (s *Service) resolverSink(ctx context.Context, filename, scanID string) ([]
 	for idx, rfile := range resFiles.File {
 		s.Tracker.TrackFileFound()
 		excluded[idx] = rfile.FileName
-		documents, _, err := s.Parser.Parse(rfile.FileName, rfile.Content)
+		documents, retParse, err := s.Parser.Parse(rfile.FileName, rfile.Content)
 		if err != nil {
+			if retParse == "break" {
+				return []string{}, nil
+			}
 			return []string{}, errors.Wrap(err, "failed to parse file content")
 		}
 		for _, document := range documents {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -93,8 +93,7 @@ func (c *Parser) Parse(filePath string, fileContent []byte) ([]model.Document, m
 
 		return obj, c.parsers.GetKind(), nil
 	}
-
-	return nil, "", ErrNotSupportedFile
+	return nil, "break", ErrNotSupportedFile
 }
 
 // SupportedExtensions returns extensions supported by KICS


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3104

**Proposed Changes**
- Fixed scanning Helm chart with multiple types in kics returns a false error 


I submit this contribution under the Apache-2.0 license.
