### PR TITLE
fix(metrics): fix 'NaN' results on profiling cpu flag (#3080)

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/google/pprof/profile"
@@ -130,5 +131,11 @@ func formatTotal(b int64, typeMap map[string]float64) string {
 			mesure = k
 		}
 	}
-	return fmt.Sprintf("%.2f%s", value/formatter, mesure)
+
+	metric := value / formatter
+	if math.IsNaN(metric) {
+		metric = 0
+	}
+
+	return fmt.Sprintf("%.2f%s", metric, mesure)
 }


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3080

**Proposed Changes**
- Check if metric value is NaN and if So return 0

I submit this contribution under the Apache-2.0 license.
