### PR TITLE
feat(query): add 'default response is undefined on operations' query for openapi 3.0

### DIFF
--- a/assets/queries/openAPI/default_response_undefined_operations/metadata.json
+++ b/assets/queries/openAPI/default_response_undefined_operations/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "86e3702f-c868-44b2-b61d-ea5316c18110",
+  "queryName": "Default Response Undefined On Operations",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Operations responses should have a default response defined",
+  "descriptionUrl": "https://swagger.io/specification/#responses-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/default_response_undefined_operations/query.rego
+++ b/assets/queries/openAPI/default_response_undefined_operations/query.rego
@@ -1,0 +1,19 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	response := doc.paths[n][oper].responses
+
+	object.get(response, "default", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Default field should be defined on responses",
+		"keyActualValue": "Default field is not defined on responses",
+	}
+}

--- a/assets/queries/openAPI/default_response_undefined_operations/test/negative1.json
+++ b/assets/queries/openAPI/default_response_undefined_operations/test/negative1.json
@@ -1,0 +1,60 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "delete": {
+        "operationId": "deleteItem",
+        "summary": "Delete item",
+        "responses": {
+          "204": {
+            "description": "Item deleted successfully"
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateItem",
+        "summary": "Update item",
+        "responses": {
+          "204": {
+            "description": "Item updated successfully"
+          },
+          "default": {
+            "description": "Error",
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/default_response_undefined_operations/test/negative2.yaml
+++ b/assets/queries/openAPI/default_response_undefined_operations/test/negative2.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    delete:
+      operationId: deleteItem
+      summary: Delete item
+      responses:
+        '204':
+          description: Item deleted successfully
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+    patch:
+      operationId: updateItem
+      summary: Update item
+      responses:
+        '204':
+          description: Item updated successfully
+        default:
+          description: Error
+          schema:
+            "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/default_response_undefined_operations/test/positive1.json
+++ b/assets/queries/openAPI/default_response_undefined_operations/test/positive1.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "patch": {
+        "operationId": "updateItem",
+        "summary": "Updated item",
+        "responses": {
+          "204": {
+            "description": "Item deleted successfully"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/default_response_undefined_operations/test/positive2.json
+++ b/assets/queries/openAPI/default_response_undefined_operations/test/positive2.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/item": {
+      "delete": {
+        "operationId": "deleteItem",
+        "summary": "Delete item",
+        "responses": {
+          "204": {
+            "description": "Item deleted successfully"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateItem",
+        "summary": "Update item",
+        "responses": {
+          "204": {
+            "description": "Item updated successfully"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/default_response_undefined_operations/test/positive3.yaml
+++ b/assets/queries/openAPI/default_response_undefined_operations/test/positive3.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    patch:
+      operationId: updateItem
+      summary: Updated item
+      responses:
+        '204':
+          description: Item deleted successfully
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/default_response_undefined_operations/test/positive4.yaml
+++ b/assets/queries/openAPI/default_response_undefined_operations/test/positive4.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  "/item":
+    delete:
+      operationId: deleteItem
+      summary: Delete item
+      responses:
+        '204':
+          description: Item deleted successfully
+    patch:
+      operationId: updateItem
+      summary: Update item
+      responses:
+        '204':
+          description: Item updated successfully
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+      - code
+      - message

--- a/assets/queries/openAPI/default_response_undefined_operations/test/positive_expected_result.json
+++ b/assets/queries/openAPI/default_response_undefined_operations/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "Default Response Undefined On Operations",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Default Response Undefined On Operations",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Default Response Undefined On Operations",
+    "severity": "MEDIUM",
+    "line": 21,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Default Response Undefined On Operations",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Default Response Undefined On Operations",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Default Response Undefined On Operations",
+    "severity": "MEDIUM",
+    "line": 16,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #3120 

**Proposed Changes**
- Created default response is undefined on operations query

I submit this contribution under the Apache-2.0 license.
