### PR TITLE
feat(query): Added "Response on operations that should have a body has undefined" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/response_operations_body_schema_undefined/metadata.json
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a92be1d5-d762-484a-86d6-8cd0907ba100",
+  "queryName": "Response on operations that should have a body has undefined schema",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "If a response is not head or its code is not 204 or 304, it should have a schema defined",
+  "descriptionUrl": "https://swagger.io/docs/specification/describing-responses/",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/query.rego
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/query.rego
@@ -1,0 +1,80 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	operation := doc.paths[path][op]
+
+	operation_should_have_content := ["get", "put", "post", "delete", "options", "patch", "trace"]
+	common_lib.equalsOrInArray(operation_should_have_content, lower(op))
+
+	response_code_should_not_have_content := ["204", "304"]
+
+	response := operation.responses[code]
+	not common_lib.equalsOrInArray(response_code_should_not_have_content, lower(code))
+
+	object.get(response, "content", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}", [path, op, code]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content is defined", [path, op, code]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content is undefined", [path, op, code]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	operation := doc.paths[path][op]
+
+	operation_should_have_content := ["get", "put", "post", "delete", "options", "patch", "trace"]
+	common_lib.equalsOrInArray(operation_should_have_content, lower(op))
+
+	response_code_should_not_have_content := ["204", "304"]
+
+	response := operation.responses[code]
+	not common_lib.equalsOrInArray(response_code_should_not_have_content, lower(code))
+
+	count(response.content) == 0
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content", [path, op, code]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content should have at least one content-type defined", [path, op, code]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content has no content-type defined", [path, op, code]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	operation := doc.paths[path][op]
+
+	operation_should_have_content := ["get", "put", "post", "delete", "options", "patch", "trace"]
+	common_lib.equalsOrInArray(operation_should_have_content, lower(op))
+
+	response_code_should_not_have_content := ["204", "304"]
+
+	response := operation.responses[code]
+	not common_lib.equalsOrInArray(response_code_should_not_have_content, lower(code))
+
+	response_body := response.content[content_type]
+	object.get(response_body, "schema", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}", [path, op, code, content_type]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema should be defined", [path, op, code, content_type]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema is undefined", [path, op, code, content_type]),
+	}
+}

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/negative1.json
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/negative1.json
@@ -1,0 +1,60 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/ApiVersion"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteVersion",
+        "summary": "Deletes API versions",
+        "responses": {
+          "204": {
+            "description": "no content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiVersion": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "ApiVersion"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/negative2.yaml
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/negative2.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.com
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/ApiVersion"
+    delete:
+      operationId: deleteVersion
+      summary: Deletes API versions
+      responses:
+        '204':
+          description: no content
+components:
+  schemas:
+    ApiVersion:
+      type: object
+      discriminator:
+        propertyName: ApiVersion
+      properties:
+        code:
+          type: integer
+          format: int32
+        version:
+          type: string

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive1.json
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive1.json
@@ -1,0 +1,53 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteVersion",
+        "summary": "Deletes API versions",
+        "responses": {
+          "204": {
+            "description": "no content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiVersion": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "ApiVersion"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive2.json
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive2.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteVersion",
+        "summary": "Deletes API versions",
+        "responses": {
+          "204": {
+            "description": "no content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiVersion": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "ApiVersion"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive3.json
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive3.json
@@ -1,0 +1,73 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/pdf": {},
+              "application/json": {}
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/ApiVersion"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteVersion",
+        "summary": "Deletes API versions",
+        "responses": {
+          "204": {
+            "description": "no content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiVersion": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "ApiVersion"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive4.json
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive4.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {}
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteVersion",
+        "summary": "Deletes API versions",
+        "responses": {
+          "204": {
+            "description": "no content"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiVersion": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "ApiVersion"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive5.yaml
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive5.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.com
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+    delete:
+      operationId: deleteVersion
+      summary: Deletes API versions
+      responses:
+        "204":
+          description: no content
+components:
+  schemas:
+    ApiVersion:
+      type: object
+      discriminator:
+        propertyName: ApiVersion
+      properties:
+        code:
+          type: integer
+          format: int32
+        version:
+          type: string

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive6.yaml
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive6.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.com
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json: {}
+    delete:
+      operationId: deleteVersion
+      summary: Deletes API versions
+      responses:
+        "204":
+          description: no content
+components:
+  schemas:
+    ApiVersion:
+      type: object
+      discriminator:
+        propertyName: ApiVersion
+      properties:
+        code:
+          type: integer
+          format: int32
+        version:
+          type: string

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive7.yaml
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive7.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.com
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/pdf: {}
+            application/json: {}
+    post:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/ApiVersion"
+    delete:
+      operationId: deleteVersion
+      summary: Deletes API versions
+      responses:
+        "204":
+          description: no content
+components:
+  schemas:
+    ApiVersion:
+      type: object
+      discriminator:
+        propertyName: ApiVersion
+      properties:
+        code:
+          type: integer
+          format: int32
+        version:
+          type: string

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive8.yaml
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive8.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.com
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content: {}
+    delete:
+      operationId: deleteVersion
+      summary: Deletes API versions
+      responses:
+        "204":
+          description: no content
+components:
+  schemas:
+    ApiVersion:
+      type: object
+      discriminator:
+        propertyName: ApiVersion
+      properties:
+        code:
+          type: integer
+          format: int32
+        version:
+          type: string

--- a/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive_expected_result.json
+++ b/assets/queries/openAPI/response_operations_body_schema_undefined/test/positive_expected_result.json
@@ -1,0 +1,62 @@
+[
+  {
+    "queryName": "Response on operations that should have a body has undefined schema",
+    "severity": "MEDIUM",
+    "line": 18,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response on operations that should have a body has undefined schema",
+    "severity": "MEDIUM",
+    "line": 21,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Response on operations that should have a body has undefined schema",
+    "severity": "MEDIUM",
+    "line": 21,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Response on operations that should have a body has undefined schema",
+    "severity": "MEDIUM",
+    "line": 22,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Response on operations that should have a body has undefined schema",
+    "severity": "MEDIUM",
+    "line": 20,
+    "filename": "positive4.json"
+  },
+  {
+    "queryName": "Response on operations that should have a body has undefined schema",
+    "severity": "MEDIUM",
+    "line": 15,
+    "filename": "positive5.yaml"
+  },
+  {
+    "queryName": "Response on operations that should have a body has undefined schema",
+    "severity": "MEDIUM",
+    "line": 18,
+    "filename": "positive6.yaml"
+  },
+  {
+    "queryName": "Response on operations that should have a body has undefined schema",
+    "severity": "MEDIUM",
+    "line": 18,
+    "filename": "positive7.yaml"
+  },
+  {
+    "queryName": "Response on operations that should have a body has undefined schema",
+    "severity": "MEDIUM",
+    "line": 19,
+    "filename": "positive7.yaml"
+  },
+  {
+    "queryName": "Response on operations that should have a body has undefined schema",
+    "severity": "MEDIUM",
+    "line": 17,
+    "filename": "positive8.yaml"
+  }
+]


### PR DESCRIPTION
schema" query for OpenAPI

Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #3132 

**Proposed Changes**
- Added query that checks if an action different from `head` and has a code different from `204` or `304` response content is defined

I submit this contribution under the Apache-2.0 license.
