### PR TITLE
feat(query): "Response on operations that should not have a body has declared content" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/metadata.json
+++ b/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/metadata.json
@@ -1,5 +1,5 @@
 {
-  "id": "a92be1d5-d762-484a-86d6-8cd0907ba100",
+  "id": "12a7210b-f4b4-47d0-acac-0a819e2a0ca3",
   "queryName": "Response on operations that should not have a body has declared content",
   "severity": "MEDIUM",
   "category": "Networking and Firewall",

--- a/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/metadata.json
+++ b/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a92be1d5-d762-484a-86d6-8cd0907ba100",
+  "queryName": "Response on operations that should not have a body has declared content",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "If a response is head or its code is 204 or 304, it shouldn't have a content defined",
+  "descriptionUrl": "https://swagger.io/docs/specification/describing-responses/",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/query.rego
+++ b/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/query.rego
@@ -1,0 +1,48 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	operation := doc.paths[path][op]
+
+	operation_should_have_content := ["get", "put", "post", "delete", "options", "patch", "trace"]
+	common_lib.equalsOrInArray(operation_should_have_content, lower(op))
+
+	response_code_should_not_have_content := ["204", "304"]
+
+	response := operation.responses[code]
+	common_lib.equalsOrInArray(response_code_should_not_have_content, lower(code))
+
+	object.get(response, "content", "undefined") != "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content", [path, op, code]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content is not defined", [path, op, code]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content is defined", [path, op, code]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	operation := doc.paths[path].head
+
+	response := operation.responses[code]
+
+	object.get(response, "content", "undefined") != "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.responses.{{%s}}.content", [path, code]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.responses.{{%s}}.content is not defined", [path, code]),
+		"keyActualValue": sprintf("paths.{{%s}}.responses.{{%s}}.content is defined", [path, code]),
+	}
+}

--- a/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/negative1.json
+++ b/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/negative1.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "delete": {
+        "operationId": "deleteVersion",
+        "summary": "Deletes API versions",
+        "responses": {
+          "204": {
+            "description": "no content"
+          }
+        }
+      },
+      "head": {
+        "operationId": "headers",
+        "summary": "headers",
+        "responses": {
+          "200": {
+            "description": "no content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/negative2.yaml
+++ b/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/negative2.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.com
+paths:
+  "/":
+    delete:
+      operationId: deleteVersion
+      summary: Deletes API versions
+      responses:
+        "204":
+          description: no content
+    head:
+      operationId: headers
+      summary: headers
+      responses:
+        "200":
+          description: no content

--- a/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/positive1.json
+++ b/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/positive1.json
@@ -1,0 +1,60 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteVersion",
+        "summary": "Deletes API versions",
+        "responses": {
+          "204": {
+            "description": "has content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/ApiVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiVersion": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "ApiVersion"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/positive2.json
+++ b/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/positive2.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "head": {
+        "operationId": "headers",
+        "summary": "headers",
+        "responses": {
+          "200": {
+            "description": "has content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/ApiVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiVersion": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "ApiVersion"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/positive3.yaml
+++ b/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/positive3.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.com
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+    delete:
+      operationId: deleteVersion
+      summary: Deletes API versions
+      responses:
+        "204":
+          description: wrong example
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/ApiVersion"
+components:
+  schemas:
+    ApiVersion:
+      type: object
+      discriminator:
+        propertyName: ApiVersion
+      properties:
+        code:
+          type: integer
+          format: int32
+        version:
+          type: string

--- a/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/positive4.yaml
+++ b/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/positive4.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.com
+paths:
+  "/":
+    head:
+      operationId: headers
+      summary: headers
+      responses:
+        "200":
+          description: wrong example
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/ApiVersion"
+components:
+  schemas:
+    ApiVersion:
+      type: object
+      discriminator:
+        propertyName: ApiVersion
+      properties:
+        code:
+          type: integer
+          format: int32
+        version:
+          type: string

--- a/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/positive_expected_result.json
+++ b/assets/queries/openAPI/response_operations_body_schema_incorrect_defined/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Response on operations that should not have a body has declared content",
+    "severity": "MEDIUM",
+    "line": 29,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Response on operations that should not have a body has declared content",
+    "severity": "MEDIUM",
+    "line": 20,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Response on operations that should not have a body has declared content",
+    "severity": "MEDIUM",
+    "line": 23,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Response on operations that should not have a body has declared content",
+    "severity": "MEDIUM",
+    "line": 17,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #3137 

**Proposed Changes**
- Added query to check if a HEAD response or responses with 204 or 304 codes are defining content

I submit this contribution under the Apache-2.0 license.
