### PR TITLE
feat(query): "Header Object Without Schema" for OpenAPI (#3145)

### DIFF
--- a/assets/queries/openAPI/header_object_without_schema/metadata.json
+++ b/assets/queries/openAPI/header_object_without_schema/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "50de3b5b-6465-4e06-a9b0-b4c2ba34326b",
+  "queryName": "Header Object Without Schema",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "The header object should have schema defined",
+  "descriptionUrl": "https://swagger.io/specification/#header-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/header_object_without_schema/query.rego
+++ b/assets/queries/openAPI/header_object_without_schema/query.rego
@@ -1,0 +1,121 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header := doc.components.headers[h]
+	not_defined(header)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.headers.{{%s}}", [h]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("components.headers.{{%s}} has schema defined", [h]),
+		"keyActualValue": sprintf("components.headers.{{%s}} does not have schema defined", [h]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header_info := check_content_header(doc.paths[path][operation].responses[r])
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}.headers.{{%s}}}", [path, operation, r, header_info.c, header_info.e, header_info.h]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}.headers.{{%s}}} has schema defined", [path, operation, r, header_info.c, header_info.e, header_info.h]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}.headers.{{%s}} does not have schema defined", [path, operation, r, header_info.c, header_info.e, header_info.h]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header_info := check_content_header(doc.paths[path][operation].requestBody)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}}.headers.{{%s}}", [path, operation, header_info.c, header_info.e, header_info.h]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}}.headers.{{%s}} has schema defined", [path, operation, header_info.c, header_info.e, header_info.h]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.encoding.{{%s}}.headers.{{%s}} does not have schema defined", [path, operation, header_info.c, header_info.e, header_info.h]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header_info := check_content_header(doc.components.requestBodies[r])
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}}.headers.{{%s}}", [r, header_info.c, header_info.e, header_info.h]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}}.headers.{{%s}} has schema defined", [r, header_info.c, header_info.e, header_info.h]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.encoding.{{%s}}.headers.{{%s}} does not have schema defined", [r, header_info.c, header_info.e, header_info.h]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header_info := check_content_header(doc.components.responses[r])
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}.headers.{{%s}}}", [r, header_info.c, header_info.e, header_info.h]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}.headers.{{%s}}} has schema defined", [r, header_info.c, header_info.e, header_info.h]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.content.{{%s}}.encoding.{{%s}}.headers.{{%s}}} does not have schema defined", [r, header_info.c, header_info.e, header_info.h]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header := doc.components.responses[r].headers[h]
+	not_defined(header)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}.headers.{{%s}}", [r, h]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("components.responses.{{%s}}.headers.{{%s}} has schema defined", [r, h]),
+		"keyActualValue": sprintf("components.responses.{{%s}}.headers.{{%s}} does not have schema defined", [r, h]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	header := doc.paths[n][oper].responses[r].headers[h]
+	not_defined(header)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}}", [n, oper, r, h]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}} has schema defined", [n, oper, r, h]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}} does not have schema defined", [n, oper, r, h]),
+	}
+}
+
+not_defined(header) {
+	object.get(header, "schema", "undefined") == "undefined"
+}
+
+check_content_header(r) = header_info {
+	header := r.content[c].encoding[e].headers[h]
+	not_defined(header)
+	header_info := {"c": c, "e": e, "h": h}
+}

--- a/assets/queries/openAPI/header_object_without_schema/test/negative1.json
+++ b/assets/queries/openAPI/header_object_without_schema/test/negative1.json
@@ -1,0 +1,86 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ResponseExample": {
+        "description": "200 response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "discriminator": {
+                "propertyName": "petType"
+              },
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "encoding": {
+              "code": {
+                "headers": {
+                  "X-Rate-Limit-Limit": {
+                    "description": "The number of allowed requests in the current period",
+                    "schema": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/header_object_without_schema/test/negative2.json
+++ b/assets/queries/openAPI/header_object_without_schema/test/negative2.json
@@ -1,0 +1,77 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "50": {
+            "description": "500 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "6xx": {
+            "description": "[600-699] response",
+            "headers": {
+              "X-Rate-Limit-Limit": {
+                "description": "The number of allowed requests in the current period",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/header_object_without_schema/test/negative3.yaml
+++ b/assets/queries/openAPI/header_object_without_schema/test/negative3.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  responses:
+    ResponseExample:
+      description: 200 response
+      content:
+        application/json:
+          schema:
+            type: object
+            discriminator:
+              propertyName: petType
+            properties:
+              code:
+                type: string
+                format: binary
+              message:
+                type: string
+          encoding:
+            code:
+              headers:
+                X-Rate-Limit-Limit:
+                  description: The number of allowed requests in the current period
+                  schema:
+                    type: integer

--- a/assets/queries/openAPI/header_object_without_schema/test/negative4.yaml
+++ b/assets/queries/openAPI/header_object_without_schema/test/negative4.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "50":
+          description: Server error response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+        "6xx":
+          description: "[600-699] response"
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/header_object_without_schema/test/positive1.json
+++ b/assets/queries/openAPI/header_object_without_schema/test/positive1.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ResponseExample": {
+        "description": "200 response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "discriminator": {
+                "propertyName": "petType"
+              },
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "encoding": {
+              "code": {
+                "headers": {
+                  "X-Rate-Limit-Limit": {
+                    "description": "The number of allowed requests in the current period"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/header_object_without_schema/test/positive2.json
+++ b/assets/queries/openAPI/header_object_without_schema/test/positive2.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "50": {
+            "description": "500 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "6xx": {
+            "description": "[600-699] response",
+            "headers": {
+              "X-Rate-Limit-Limit": {
+                "description": "The number of allowed requests in the current period"
+              }
+            },
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/header_object_without_schema/test/positive3.yaml
+++ b/assets/queries/openAPI/header_object_without_schema/test/positive3.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  responses:
+    ResponseExample:
+      description: 200 response
+      content:
+        application/json:
+          schema:
+            type: object
+            discriminator:
+              propertyName: petType
+            properties:
+              code:
+                type: string
+                format: binary
+              message:
+                type: string
+          encoding:
+            code:
+              headers:
+                X-Rate-Limit-Limit:
+                  description: The number of allowed requests in the current period

--- a/assets/queries/openAPI/header_object_without_schema/test/positive4.yaml
+++ b/assets/queries/openAPI/header_object_without_schema/test/positive4.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "50":
+          description: Server error response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+        "6xx":
+          description: "[600-699] response"
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/header_object_without_schema/test/positive_expected_result.json
+++ b/assets/queries/openAPI/header_object_without_schema/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Header Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 71,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Header Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 42,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Header Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 43,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Header Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 28,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3145

**Proposed Changes**
- Added "Header Object Without Schema" query for OpenAPI. It checks if  the header object does not have schema defined

**Considerations**:
- The Header Object exists in Components Object, Response Object and Encoding Object.
- The Response Object exists in Components Object and Operation Object.

I submit this contribution under Apache-2.0 license.
