### PR TITLE
fix(ci): filtering paths that can trigger tests workflows #2728

### DIFF
--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -9,10 +9,11 @@ jobs:
     name: integration-tests
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.0
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
         with:
-          access_token: ${{ github.token }}
+          cancel_others: true
+          paths_ignore: '["docs/**", "**/**.md", "examples"]'
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -6,8 +6,22 @@ on:
     branches: [master]
 
 jobs:
+  pre_job:
+    name: check_run
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+    - name: Check file changes
+      id: skip_check
+      uses: fkirc/skip-duplicate-actions@master
+      with:
+        cancel_others: true
+        paths_ignore: '["docs/**", "**/**.md", "examples"]'
   lint:
     name: lint
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -23,6 +37,8 @@ jobs:
         skip-go-installation: true
   go-generate:
     name: go-generate
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
@@ -38,6 +54,8 @@ jobs:
       run: make generate
   unit-tests:
     name: unit-tests
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     strategy:
       matrix:
         go-version: [1.16.x]
@@ -80,6 +98,8 @@ jobs:
         echo "::endgroup::"
   security-scan:
     name: security-scan
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on


### PR DESCRIPTION
Closes #2728

**Proposed Changes**
- filtering changes in paths: `"docs/**"`, `"**/**.md"`, `"examples"` from triggering tests workflows

I submit this contribution under the Apache-2.0 license.
