### PR TITLE
fix(logs): do not append to existing log file #3139

### DIFF
--- a/internal/console/printer/printer.go
+++ b/internal/console/printer/printer.go
@@ -226,7 +226,7 @@ func LogPath(opt interface{}, changed bool) error {
 			return err
 		}
 	}
-	loggerFile, err = os.OpenFile(filepath.Clean(logPath), os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	loggerFile, err = os.OpenFile(filepath.Clean(logPath), os.O_CREATE|os.O_WRONLY, os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -241,7 +241,7 @@ func LogFile(opt interface{}, changed bool) error {
 		if err != nil {
 			return err
 		}
-		loggerFile, err = os.OpenFile(filepath.Clean(logPath), os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
+		loggerFile, err = os.OpenFile(filepath.Clean(logPath), os.O_CREATE|os.O_WRONLY, os.ModePerm)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes #3139

**Proposed Changes**
- do not append to existing log file, instead recreate the log file

I submit this contribution under the Apache-2.0 license.
