### PR TITLE
feat(query): "Property 'style' of Encoding Object Ignored" for OpenAPI (#3186)

### DIFF
--- a/assets/queries/openAPI/property_type_encoding_object_ignored/metadata.json
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "d3ea644a-9a5c-4fee-941f-f8a6786c0470",
+  "queryName": "Property 'style' of Encoding Object Ignored",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "Property 'style' of the encoding object should be defined when the media type of the request body is 'application/x-www-form-urlencoded'. If not, it will be ignored.",
+  "descriptionUrl": "https://swagger.io/specification/#encoding-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/property_type_encoding_object_ignored/query.rego
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/query.rego
@@ -1,0 +1,40 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	content := doc.paths[path][operation].requestBody.content[x]
+	improperly_defined(content, x)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}", [path, operation, x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}} is 'application/x-www-form-urlencoded' when 'style' is set", [path, operation, x]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}} is not 'application/x-www-form-urlencoded' when 'style' is set", [path, operation, x]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	content := doc.components.requestBodies[r].content[x]
+	improperly_defined(content, x)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}", [r, x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}} is 'application/x-www-form-urlencoded' when 'style' is set", [r, x]),
+		"keyActualValue": sprintf("components.requestBodies.{{%s}}.content.{{%s}} is not 'application/x-www-form-urlencoded' when 'style' is set", [r, x]),
+	}
+}
+
+improperly_defined(content, x) {
+	x != "application/x-www-form-urlencoded"
+	object.get(content.encoding[e], "style", "undefined") != "undefined"
+}

--- a/assets/queries/openAPI/property_type_encoding_object_ignored/test/negative1.json
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/test/negative1.json
@@ -1,0 +1,76 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ],
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "application/x-www-form-urlencoded": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            },
+            "encoding": {
+              "code": {
+                "contentType": "image/png, image/jpeg",
+                "allowReserved": true,
+                "style": "simple"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_type_encoding_object_ignored/test/negative2.json
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/test/negative2.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "string",
+                "format": "binary",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "code": {
+                  "contentType": "image/png, image/jpeg",
+                  "allowReserved": true,
+                  "style": "simple"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_type_encoding_object_ignored/test/negative3.yaml
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/test/negative3.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                format: binary
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"
+          encoding:
+            code:
+              contentType: image/png, image/jpeg
+              allowReserved: true
+              style: simple

--- a/assets/queries/openAPI/property_type_encoding_object_ignored/test/negative4.yaml
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/test/negative4.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: string
+              format: binary
+              properties:
+                code:
+                  type: string
+                  format: binary
+            encoding:
+              code:
+                contentType: image/png, image/jpeg
+                allowReserved: true
+                style: simple

--- a/assets/queries/openAPI/property_type_encoding_object_ignored/test/positive1.json
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/test/positive1.json
@@ -1,0 +1,76 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ],
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/data": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            },
+            "encoding": {
+              "code": {
+                "contentType": "image/png, image/jpeg",
+                "allowReserved": true,
+                "style": "simple"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_type_encoding_object_ignored/test/positive2.json
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/test/positive2.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "multipart/data": {
+              "schema": {
+                "type": "string",
+                "format": "binary",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "code": {
+                  "contentType": "image/png, image/jpeg",
+                  "allowReserved": true,
+                  "style": "simple"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_type_encoding_object_ignored/test/positive3.yaml
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/test/positive3.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/data:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                format: binary
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"
+          encoding:
+            code:
+              contentType: image/png, image/jpeg
+              allowReserved: true
+              style: simple

--- a/assets/queries/openAPI/property_type_encoding_object_ignored/test/positive4.yaml
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/test/positive4.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg
+      requestBody:
+        content:
+          multipart/data:
+            schema:
+              type: string
+              format: binary
+              properties:
+                code:
+                  type: string
+                  format: binary
+            encoding:
+              code:
+                contentType: image/png, image/jpeg
+                allowReserved: true
+                style: simple

--- a/assets/queries/openAPI/property_type_encoding_object_ignored/test/positive_expected_result.json
+++ b/assets/queries/openAPI/property_type_encoding_object_ignored/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Property 'style' of Encoding Object Ignored",
+    "severity": "INFO",
+    "line": 49,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Property 'style' of Encoding Object Ignored",
+    "severity": "INFO",
+    "line": 43,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Property 'style' of Encoding Object Ignored",
+    "severity": "INFO",
+    "line": 31,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Property 'style' of Encoding Object Ignored",
+    "severity": "INFO",
+    "line": 30,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3186

**Proposed Changes**
- Added "Property 'style' of Encoding Object Ignored" query for OpenAPI. It checks if the property 'style' of the encoding object is defined when the media type of the request body is not 'application/x-www-form-urlencoded'

I submit this contribution under Apache-2.0 license.
