### PR TITLE
feat(query): update "Configuration Aggregator to All Regions Disabled" for Terraform (#3195)

### DIFF
--- a/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/query.rego
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/query.rego
@@ -9,7 +9,21 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_config_configuration_aggregator[%s].%s.all_regions", [name, type]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'aws_db_instance[%s].[%s].all_regions' is true", [name, type]),
-		"keyActualValue": sprintf("'aws_db_instance[%s].[%s].all_regions' is false", [name, type]),
+		"keyExpectedValue": sprintf("'aws_db_instance[%s].%s.all_regions' is set to true", [name, type]),
+		"keyActualValue": sprintf("'aws_db_instance[%s].%s.all_regions' is set to false", [name, type]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_config_configuration_aggregator[name]
+
+	object.get(resource[type], "all_regions", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_config_configuration_aggregator[%s].%s", [name, type]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'aws_db_instance[%s].%s.all_regions' is set to true", [name, type]),
+		"keyActualValue": sprintf("'aws_db_instance[%s].%s.all_regions' is undefined", [name, type]),
 	}
 }

--- a/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive.tf
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive.tf
@@ -2,8 +2,7 @@ resource "aws_config_configuration_aggregator" "positive1" {
   name = "example"
 
   account_aggregation_source {
-    all_regions = false
-
+    role_arn    = aws_iam_role.organization.arn
   }
 }
 

--- a/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive.tf
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive.tf
@@ -2,7 +2,8 @@ resource "aws_config_configuration_aggregator" "positive1" {
   name = "example"
 
   account_aggregation_source {
-    role_arn    = aws_iam_role.organization.arn
+    account_ids = ["123456789012"]
+    regions     = ["us-east-2", "us-east-1", "us-west-1", "us-west-2"]
   }
 }
 

--- a/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive_expected_result.json
@@ -7,6 +7,6 @@
   {
     "queryName": "Configuration Aggregator to All Regions Disabled",
     "severity": "HIGH",
-    "line": 15
+    "line": 16
   }
 ]

--- a/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive_expected_result.json
@@ -2,11 +2,11 @@
   {
     "queryName": "Configuration Aggregator to All Regions Disabled",
     "severity": "HIGH",
-    "line": 5
+    "line": 4
   },
   {
     "queryName": "Configuration Aggregator to All Regions Disabled",
     "severity": "HIGH",
-    "line": 16
+    "line": 15
   }
 ]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3195

**Proposed Changes**
- Updated "Configuration Aggregator to All Regions Disabled" query for Terraform. It also checks if the property 'all_regions' is undefined

I submit this contribution under Apache-2.0 license.
