### PR TITLE
fix(report): corrected report directory generation

### DIFF
--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -117,6 +117,10 @@ func NewScanCmd() *cobra.Command {
 			if err := consoleHelpers.InitShouldFailArg(failOn); err != nil {
 				return err
 			}
+			directoryToCreate, _, _ := createReportDir(outputPath, "result", reportFormats)
+			if err := os.MkdirAll(directoryToCreate, os.ModePerm); err != nil {
+				return err
+			}
 			gracefulShutdown()
 			return scan(changedDefaultQueryPath)
 		},
@@ -555,21 +559,30 @@ func resolveOutputs(
 	return consoleHelpers.PrintResult(summary, failedQueries, printer)
 }
 
-func printOutput(outputPath, filename string, body interface{}, formats []string) error {
-	log.Debug().Msg("console.printOutput()")
-	if outputPath == "" {
-		return nil
-	}
-
+func createReportDir(outputPath, filename string, formats []string) (outDir, outFile string, outFormats []string) {
 	if strings.Contains(outputPath, ".") {
 		if len(formats) == 0 && filepath.Ext(outputPath) != "" {
-			formats = []string{filepath.Ext(outputPath)[1:]}
+			err := consoleHelpers.ValidateReportFormats([]string{filepath.Ext(outputPath)[1:]})
+			if err != nil {
+				log.Trace().Msgf("Not supported extension %s, will create directory instead", filepath.Ext(outputPath)[1:])
+			} else {
+				formats = []string{filepath.Ext(outputPath)[1:]}
+			}
 		}
 		if len(formats) == 1 && strings.HasSuffix(outputPath, formats[0]) {
 			filename = filepath.Base(outputPath)
 			outputPath = filepath.Dir(outputPath)
 		}
 	}
+	return outputPath, filename, formats
+}
+
+func printOutput(outputPath, filename string, body interface{}, formats []string) error {
+	log.Debug().Msg("console.printOutput()")
+	if outputPath == "" {
+		return nil
+	}
+	outputPath, filename, formats = createReportDir(outputPath, filename, formats)
 	if len(formats) == 0 {
 		formats = consoleHelpers.ListReportFormats()
 	}

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -75,7 +75,6 @@ func PrintHTMLReport(path, filename string, body interface{}) error {
 	fullPath := filepath.Join(path, filename)
 	t := template.Must(template.New("report.tmpl").Funcs(templateFuncs).Parse(htmlTemplate))
 
-	_ = os.MkdirAll(path, os.ModePerm)
 	f, err := os.OpenFile(filepath.Clean(fullPath), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	if err != nil {
 		return err

--- a/pkg/report/json.go
+++ b/pkg/report/json.go
@@ -13,7 +13,6 @@ func PrintJSONReport(path, filename string, body interface{}) error {
 		filename += ".json"
 	}
 	fullPath := filepath.Join(path, filename)
-	_ = os.MkdirAll(path, os.ModePerm)
 
 	f, err := os.OpenFile(filepath.Clean(fullPath), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #3158 

**Proposed Changes**
- If a output flag is used, now KICS creates destination folder before executing scan, so, if any problem happens, it throws error instead running scan

I submit this contribution under the Apache-2.0 license.
