### PR TITLE
feat(query): "ElastiCache Redis Cluster Without Backup" for Terraform (#3218)

### DIFF
--- a/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/metadata.json
+++ b/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "8fdb08a0-a868-4fdf-9c27-ccab0237f1ab",
+  "queryName": "ElastiCache Redis Cluster Without Backup",
+  "severity": "MEDIUM",
+  "category": "Backup",
+  "descriptionText": "ElastiCache Redis cluster should have 'snapshot_retention_limit' higher than 0",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster#snapshot_retention_limit",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/query.rego
+++ b/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/query.rego
@@ -1,0 +1,31 @@
+package Cx
+
+CxPolicy[result] {
+	cluster := input.document[i].resource.aws_elasticache_cluster[name]
+
+	cluster.engine == "redis"
+	object.get(cluster, "snapshot_retention_limit", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticache_cluster[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'snapshot_retention_limit' is higher than 0",
+		"keyActualValue": "'snapshot_retention_limit' is undefined",
+	}
+}
+
+CxPolicy[result] {
+	cluster := input.document[i].resource.aws_elasticache_cluster[name]
+
+	cluster.engine == "redis"
+	cluster.snapshot_retention_limit = 0
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticache_cluster[%s].snapshot_retention_limit", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'snapshot_retention_limit' is higher than 0",
+		"keyActualValue": "'snapshot_retention_limit' is 0",
+	}
+}

--- a/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/test/negative.tf
+++ b/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/test/negative.tf
@@ -1,0 +1,9 @@
+resource "aws_elasticache_cluster" "negative1" {
+  cluster_id           = "cluster"
+  engine               = "redis"
+  node_type            = "cache.m5.large"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis6.x"
+
+  snapshot_retention_limit = 5
+}

--- a/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/test/negative.tf
+++ b/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/test/negative.tf
@@ -3,7 +3,22 @@ resource "aws_elasticache_cluster" "negative1" {
   engine               = "redis"
   node_type            = "cache.m5.large"
   num_cache_nodes      = 1
-  parameter_group_name = "default.redis6.x"
+  parameter_group_name = aws_elasticache_parameter_group.default.id
 
   snapshot_retention_limit = 5
+}
+
+resource "aws_elasticache_parameter_group" "default" {
+  name   = "cache-params"
+  family = "redis2.8"
+
+  parameter {
+    name  = "activerehashing"
+    value = "yes"
+  }
+
+  parameter {
+    name  = "min-slaves-to-write"
+    value = "2"
+  }
 }

--- a/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/test/positive.tf
+++ b/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/test/positive.tf
@@ -1,0 +1,17 @@
+resource "aws_elasticache_cluster" "positive1" {
+  cluster_id           = "cluster"
+  engine               = "redis"
+  node_type            = "cache.m5.large"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis6.x"
+}
+
+resource "aws_elasticache_cluster" "positive2" {
+  cluster_id           = "cluster"
+  engine               = "redis"
+  node_type            = "cache.m5.large"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis6.x"
+
+  snapshot_retention_limit = 0
+}

--- a/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/test/positive.tf
+++ b/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/test/positive.tf
@@ -3,7 +3,7 @@ resource "aws_elasticache_cluster" "positive1" {
   engine               = "redis"
   node_type            = "cache.m5.large"
   num_cache_nodes      = 1
-  parameter_group_name = "default.redis6.x"
+  parameter_group_name = aws_elasticache_parameter_group.default.id
 }
 
 resource "aws_elasticache_cluster" "positive2" {
@@ -11,7 +11,22 @@ resource "aws_elasticache_cluster" "positive2" {
   engine               = "redis"
   node_type            = "cache.m5.large"
   num_cache_nodes      = 1
-  parameter_group_name = "default.redis6.x"
+  parameter_group_name = aws_elasticache_parameter_group.default.id
 
   snapshot_retention_limit = 0
+}
+
+resource "aws_elasticache_parameter_group" "default" {
+  name   = "cache-params"
+  family = "redis2.8"
+
+  parameter {
+    name  = "activerehashing"
+    value = "yes"
+  }
+
+  parameter {
+    name  = "min-slaves-to-write"
+    value = "2"
+  }
 }

--- a/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticache_redis_cluster_without_backup/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "ElastiCache Redis Cluster Without Backup",
+    "severity": "MEDIUM",
+    "line": 1
+  },
+  {
+    "queryName": "ElastiCache Redis Cluster Without Backup",
+    "severity": "MEDIUM",
+    "line": 16
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3218

**Proposed Changes**
- Added "ElastiCache Redis Cluster Without Backup" query for Terraform. It checks if ElastiCache Redis cluster does not have 'snapshot_retention_limit' higher than 0

I submit this contribution under Apache-2.0 license.
