### PR TITLE
feat(query): Added EC2 Not EBS Optimized query for Terraform #3223

### DIFF
--- a/assets/queries/terraform/aws/ec2_not_ebs_optimized/metadata.json
+++ b/assets/queries/terraform/aws/ec2_not_ebs_optimized/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "60224630-175a-472a-9e23-133827040766",
+  "queryName": "EC2 Not EBS Optimized",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "It's considered a best practice for an EC2 instance to use an EBS optimized instance. This provides the best performance for your EBS volumes by minimizing contention between Amazon EBS I/O and other traffic from your instance",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#ebs_optimized",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/ec2_not_ebs_optimized/query.rego
+++ b/assets/queries/terraform/aws/ec2_not_ebs_optimized/query.rego
@@ -1,0 +1,31 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource[name]
+	name == "aws_instance"
+	res := resource[m]
+	res.ebs_optimized == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_instance[{{%s}}].ebs_optimized", [m]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "aws_instance.ebs_optimized is set to true",
+		"keyActualValue": "aws_instance.ebs_optimized is set to false",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[name]
+	name == "aws_instance"
+	res := resource[m]
+	object.get(res, "ebs_optimized", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_instance[{{%s}}]", [m]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_instance.ebs_optimized is set to true",
+		"keyActualValue": "aws_instance.ebs_optimized is missing",
+	}
+}

--- a/assets/queries/terraform/aws/ec2_not_ebs_optimized/test/negative1.tf
+++ b/assets/queries/terraform/aws/ec2_not_ebs_optimized/test/negative1.tf
@@ -1,0 +1,25 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+  ebs_optimized = true
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}

--- a/assets/queries/terraform/aws/ec2_not_ebs_optimized/test/positive1.tf
+++ b/assets/queries/terraform/aws/ec2_not_ebs_optimized/test/positive1.tf
@@ -1,0 +1,24 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}

--- a/assets/queries/terraform/aws/ec2_not_ebs_optimized/test/positive2.tf
+++ b/assets/queries/terraform/aws/ec2_not_ebs_optimized/test/positive2.tf
@@ -1,0 +1,25 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "web" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+  ebs_optimized = false
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}

--- a/assets/queries/terraform/aws/ec2_not_ebs_optimized/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ec2_not_ebs_optimized/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "EC2 Not EBS Optimized",
+    "severity": "INFO",
+    "line": 17,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "EC2 Not EBS Optimized",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive2.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3223

**Proposed Changes**
- Added EC2 Not EBS Optimized query for Terraform

It's considered a best practice for an EC2 instance to use an EBS optimized instance. This provides the best performance for your EBS volumes by minimizing contention between Amazon EBS I/O and other traffic from your instance

I submit this contribution under the Apache-2.0 license.
