### PR TITLE
feat(query): Added Security Group Rules Without Description query for Terraform #3228

### DIFF
--- a/assets/queries/terraform/aws/security_group_rules_without_description/metadata.json
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "68eb4bf3-f9bf-463d-b5cf-e029bb446d2e",
+  "queryName": "Security Group Rules Without Description",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "It's considered a best practice for all rules in AWS Security Group to have a description",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#description",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/security_group_rules_without_description/query.rego
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_security_group[name]
+	types := {"ingress", "egress"}
+	object.get(resource[types[y]], "description", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_security_group[{{%s}}].%s", [name, types[y]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_security_group[{{%s}}].%s description is defined", [name, types[y]]),
+		"keyActualValue": sprintf("aws_security_group[{{%s}}].%s description is missing", [name, types[y]]),
+	}
+}

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/negative1.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/negative1.tf
@@ -1,0 +1,18 @@
+resource "aws_security_group" "allow_tls" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description      = "TLS from VPC"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = [aws_vpc.main.cidr_block]
+    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
+  }
+
+  tags = {
+    Name = "allow_tls"
+  }
+}

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/positive1.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/positive1.tf
@@ -1,0 +1,25 @@
+resource "aws_security_group" "allow_tls" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = [aws_vpc.main.cidr_block]
+    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name = "allow_tls"
+  }
+}

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Security Group Rules Without Description",
+    "severity": "INFO",
+    "line": 6,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "Security Group Rules Without Description",
+    "severity": "INFO",
+    "line": 14,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3228

**Proposed Changes**
- Added Security Group Rules Without Description query for Terraform

It's considered a best practice for all rules in AWS Security Group to have a description

I submit this contribution under the Apache-2.0 license.
