### PR TITLE
feat(query): Added Security Group Without Description query for Terraform #3230

### DIFF
--- a/assets/queries/terraform/aws/security_group_without_description/metadata.json
+++ b/assets/queries/terraform/aws/security_group_without_description/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "cb3f5ed6-0d18-40de-a93d-b3538db31e8c",
+  "queryName": "Security Group Without Description",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "It's considered a best practice for AWS Security Group to have a description",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#description",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/security_group_without_description/query.rego
+++ b/assets/queries/terraform/aws/security_group_without_description/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_security_group[name]
+	object.get(resource, "description", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_security_group[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_security_group[{{%s}}] description is defined", [name]),
+		"keyActualValue": sprintf("aws_security_group[{{%s}}] description is missing", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/security_group_without_description/test/negative1.tf
+++ b/assets/queries/terraform/aws/security_group_without_description/test/negative1.tf
@@ -1,0 +1,18 @@
+resource "aws_security_group" "allow_tls" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description      = "TLS from VPC"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = [aws_vpc.main.cidr_block]
+    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
+  }
+
+  tags = {
+    Name = "allow_tls"
+  }
+}

--- a/assets/queries/terraform/aws/security_group_without_description/test/positive1.tf
+++ b/assets/queries/terraform/aws/security_group_without_description/test/positive1.tf
@@ -1,0 +1,17 @@
+resource "aws_security_group" "allow_tls" {
+  name        = "allow_tls"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description      = "TLS from VPC"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = [aws_vpc.main.cidr_block]
+    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
+  }
+
+  tags = {
+    Name = "allow_tls"
+  }
+}

--- a/assets/queries/terraform/aws/security_group_without_description/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/security_group_without_description/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Security Group Without Description",
+    "severity": "INFO",
+    "line": 1,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3230

**Proposed Changes**
- Added Security Group Without Description query for Terraform

It's considered a best practice for AWS Security Group to have a description

I submit this contribution under the Apache-2.0 license.
