### PR TITLE
feat(query): added "Components Response Definition Is Unused" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/components_response_definition_unused/metadata.json
+++ b/assets/queries/openAPI/components_response_definition_unused/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "9c3ea128-7e9a-4b4c-8a32-75ad17a2d3ae",
+  "queryName": "Components Response Definition Is Unused",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "Components responses definitions should be referenced or removed from Open API definition",
+  "descriptionUrl": "https://swagger.io/specification/#components-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/components_response_definition_unused/query.rego
+++ b/assets/queries/openAPI/components_response_definition_unused/query.rego
@@ -1,0 +1,19 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	doc.components.responses[response]
+	openapi_lib.check_reference_exists(doc, response, "responses")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.responses.{{%s}}", [response]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Response should be used as reference somewhere",
+		"keyActualValue": "Response is not used as reference",
+	}
+}

--- a/assets/queries/openAPI/components_response_definition_unused/test/negative1.json
+++ b/assets/queries/openAPI/components_response_definition_unused/test/negative1.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      }
+    },
+    "responses": {
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/components_response_definition_unused/test/negative2.yaml
+++ b/assets/queries/openAPI/components_response_definition_unused/test/negative2.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '404':
+          "$ref": "#/components/responses/NotFound"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        required:
+        - code
+        - message
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Error"

--- a/assets/queries/openAPI/components_response_definition_unused/test/positive1.json
+++ b/assets/queries/openAPI/components_response_definition_unused/test/positive1.json
@@ -1,0 +1,62 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "$ref": "#/components/schemas/MyObject"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "required": [
+            "code",
+            "message"
+          ]
+        }
+      },
+      "MyObject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "responses": {
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/components_response_definition_unused/test/positive2.yaml
+++ b/assets/queries/openAPI/components_response_definition_unused/test/positive2.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          "$ref": "#/components/schemas/MyObject"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        required:
+        - code
+        - message
+    MyObject:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Error"

--- a/assets/queries/openAPI/components_response_definition_unused/test/positive_expected_result.json
+++ b/assets/queries/openAPI/components_response_definition_unused/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Components Response Definition Is Unused",
+    "severity": "INFO",
+    "line": 50,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Components Response Definition Is Unused",
+    "severity": "INFO",
+    "line": 33,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #3235 

**Proposed Changes**
- Added "Components Response Definition Is Unused" for OpenAPI

I submit this contribution under the Apache-2.0 license.
