### PR TITLE
feat(query): Added Athena Database Not Encrypted query for Terraform #3242

### DIFF
--- a/assets/queries/terraform/aws/athena_database_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/athena_database_not_encrypted/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b2315cae-b110-4426-81e0-80bb8640cdd3",
+  "queryName": "Athena Database Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "AWS Athena Database data in S3 should be encrypted",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_database#encryption_configuration",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/athena_database_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/athena_database_not_encrypted/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_athena_database[name]
+	object.get(resource, "encryption_configuration", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_athena_database[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_athena_database[{{%s}}] encryption_configuration is defined", [name]),
+		"keyActualValue": sprintf("aws_athena_database[{{%s}}] encryption_configuration is missing", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/athena_database_not_encrypted/test/negative1.tf
+++ b/assets/queries/terraform/aws/athena_database_not_encrypted/test/negative1.tf
@@ -1,0 +1,13 @@
+resource "aws_s3_bucket" "hoge" {
+  bucket = "hoge"
+}
+
+resource "aws_athena_database" "hoge" {
+  name   = "database_name"
+  bucket = aws_s3_bucket.hoge.bucket
+
+  encryption_configuration {
+    encryption_option = "SSE_KMS"
+    kms_key           = "SSE_KMS"
+ }
+}

--- a/assets/queries/terraform/aws/athena_database_not_encrypted/test/positive1.tf
+++ b/assets/queries/terraform/aws/athena_database_not_encrypted/test/positive1.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "hoge" {
+  bucket = "hoge"
+}
+
+resource "aws_athena_database" "hoge" {
+  name   = "database_name"
+  bucket = aws_s3_bucket.hoge.bucket
+}

--- a/assets/queries/terraform/aws/athena_database_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/athena_database_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Athena Database Not Encrypted",
+    "severity": "HIGH",
+    "line": 5,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3242

**Proposed Changes**
- Added Athena Database Not Encrypted query for Terraform

AWS Athena Database data in S3 should be encrypted

I submit this contribution under the Apache-2.0 license.
