### PR TITLE
feat(query): "ElastiCache Replication Group Not Encrypted At Rest" for Terraform (#3247)

### DIFF
--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/metadata.json
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "ElastiCache Replication Group Not Encrypted At Rest",
   "severity": "MEDIUM",
   "category": "Encryption",
-  "descriptionText": "Check if ElastiCache Replication Group encryption is disabled at Rest",
+  "descriptionText": "ElastiCache Replication Group encryption should be enabled at Rest",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#at_rest_encryption_enabled",
   "platform": "Terraform"
 }

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/metadata.json
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "76976de7-c7b1-4f64-a94f-90c1345914c2",
+  "queryName": "ElastiCache Replication Group Not Encrypted At Rest",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "Check if ElastiCache Replication Group encryption is disabled at Rest",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#at_rest_encryption_enabled",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/query.rego
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_elasticache_replication_group[name]
+
+	object.get(resource, "at_rest_encryption_enabled", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticache_replication_group[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "The attribute 'at_rest_encryption_enabled' is set to true",
+		"keyActualValue": "The attribute 'at_rest_encryption_enabled' is undefined",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_elasticache_replication_group[name]
+
+	resource.at_rest_encryption_enabled != true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticache_replication_group[%s].at_rest_encryption_enabled", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The attribute 'at_rest_encryption_enabled' is set to true",
+		"keyActualValue": "The attribute 'at_rest_encryption_enabled' is not set to true",
+	}
+}

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/negative.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/negative.tf
@@ -1,0 +1,11 @@
+resource "aws_elasticache_replication_group" "example3" {
+  automatic_failover_enabled    = true
+  availability_zones            = ["us-west-2a", "us-west-2b"]
+  replication_group_id          = "tf-rep-group-1"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis3.2"
+  port                          = 6379
+  at_rest_encryption_enabled    = true
+}

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive1.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive1.tf
@@ -1,0 +1,10 @@
+resource "aws_elasticache_replication_group" "example" {
+  automatic_failover_enabled    = true
+  availability_zones            = ["us-west-2a", "us-west-2b"]
+  replication_group_id          = "tf-rep-group-1"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis3.2"
+  port                          = 6379
+}

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive2.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive2.tf
@@ -1,0 +1,11 @@
+resource "aws_elasticache_replication_group" "example2" {
+  automatic_failover_enabled    = true
+  availability_zones            = ["us-west-2a", "us-west-2b"]
+  replication_group_id          = "tf-rep-group-1"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis3.2"
+  port                          = 6379
+  at_rest_encryption_enabled    = false
+}

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "ElastiCache Replication Group Not Encrypted At Rest",
+    "severity": "MEDIUM",
+    "line": 1
+  },
+  {
+    "queryName": "ElastiCache Replication Group Not Encrypted At Rest",
+    "severity": "MEDIUM",
+    "line": 10
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3247 

**Proposed Changes**
- Added "ElastiCache Replication Group Not Encrypted At Rest" query for Terraform. It checks if ElastiCache Replication Group is not encrypted at Rest through attribute 'at_rest_encryption_enabled'

I submit this contribution under Apache-2.0 license.
