### PR TITLE
feat(query): Added DAX Cluster Not Encrypted query for Terraform #3266

### DIFF
--- a/assets/queries/terraform/aws/dax_cluster_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/dax_cluster_not_encrypted/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "f11aec39-858f-4b6f-b946-0a1bf46c0c87",
+  "queryName": "DAX Cluster Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "AWS DAX Cluster should have server-side encryption at rest",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dax_cluster#enabled",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/dax_cluster_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/dax_cluster_not_encrypted/query.rego
@@ -1,0 +1,42 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_dax_cluster[name]
+	object.get(resource, "server_side_encryption", "undefined") != "undefined"
+	object.get(resource.server_side_encryption, "enabled", "undefined") != "undefined"
+	not resource.server_side_encryption.enabled
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_dax_cluster[{{%s}}].server_side_encryption.enabled", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "aws_dax_cluster.server_side_encryption.enabled is set to true",
+		"keyActualValue": "aws_dax_cluster.server_side_encryption.enabled is set to false",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_dax_cluster[name]
+	object.get(resource, "server_side_encryption", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_dax_cluster[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_dax_cluster.server_side_encryption.enabled is set to true",
+		"keyActualValue": "aws_dax_cluster.server_side_encryption is missing",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_dax_cluster[name]
+	object.get(resource.server_side_encryption, "enabled", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_dax_cluster[{{%s}}].server_side_encryption", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_dax_cluster.server_side_encryption.enabled is set to true",
+		"keyActualValue": "aws_dax_cluster.server_side_encryption.enabled is missing",
+	}
+}

--- a/assets/queries/terraform/aws/dax_cluster_not_encrypted/test/negative1.tf
+++ b/assets/queries/terraform/aws/dax_cluster_not_encrypted/test/negative1.tf
@@ -1,0 +1,10 @@
+resource "aws_dax_cluster" "bar" {
+  cluster_name       = "cluster-example"
+  iam_role_arn       = data.aws_iam_role.example.arn
+  node_type          = "dax.r4.large"
+  replication_factor = 1
+
+  server_side_encryption {
+    enabled = true
+  }
+}

--- a/assets/queries/terraform/aws/dax_cluster_not_encrypted/test/positive1.tf
+++ b/assets/queries/terraform/aws/dax_cluster_not_encrypted/test/positive1.tf
@@ -1,0 +1,27 @@
+resource "aws_dax_cluster" "bar_1" {
+  cluster_name       = "cluster-example"
+  iam_role_arn       = data.aws_iam_role.example.arn
+  node_type          = "dax.r4.large"
+  replication_factor = 1
+}
+
+resource "aws_dax_cluster" "bar_2" {
+  cluster_name       = "cluster-example"
+  iam_role_arn       = data.aws_iam_role.example.arn
+  node_type          = "dax.r4.large"
+  replication_factor = 1
+
+  server_side_encryption {
+  }
+}
+
+resource "aws_dax_cluster" "bar_3" {
+  cluster_name       = "cluster-example"
+  iam_role_arn       = data.aws_iam_role.example.arn
+  node_type          = "dax.r4.large"
+  replication_factor = 1
+
+  server_side_encryption {
+    enabled = false
+  }
+}

--- a/assets/queries/terraform/aws/dax_cluster_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/dax_cluster_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 1,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 14,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 25,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3266

**Proposed Changes**
- DAX Cluster Not Encrypted query for Terraform

AWS DAX Cluster should have server-side encryption at rest

I submit this contribution under the Apache-2.0 license.
