### PR TITLE
feat(query): Added DOCDB Cluster Without KMS query for Terraform #3269

### DIFF
--- a/assets/queries/terraform/aws/docdb_cluster_without_kms/metadata.json
+++ b/assets/queries/terraform/aws/docdb_cluster_without_kms/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "4766d3ea-241c-4ee6-93ff-c380c996bd1a",
+  "queryName": "DOCDB Cluster Without KMS",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "AWS DOCDB Cluster should be encrypted with a KMS encryption key",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster#kms_key_id",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/docdb_cluster_without_kms/query.rego
+++ b/assets/queries/terraform/aws/docdb_cluster_without_kms/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_docdb_cluster[name]
+	object.get(resource, "kms_key_id", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_docdb_cluster[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_docdb_cluster.kms_key_id is defined",
+		"keyActualValue": "aws_docdb_cluster.kms_key_id is missing",
+	}
+}

--- a/assets/queries/terraform/aws/docdb_cluster_without_kms/test/negative1.tf
+++ b/assets/queries/terraform/aws/docdb_cluster_without_kms/test/negative1.tf
@@ -1,0 +1,11 @@
+resource "aws_docdb_cluster" "docdb" {
+  cluster_identifier      = "my-docdb-cluster"
+  engine                  = "docdb"
+  master_username         = "foo"
+  master_password         = "mustbeeightchars"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+  skip_final_snapshot     = true
+  storage_encrypted = true
+  kms_key_id = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+}

--- a/assets/queries/terraform/aws/docdb_cluster_without_kms/test/positive1.tf
+++ b/assets/queries/terraform/aws/docdb_cluster_without_kms/test/positive1.tf
@@ -1,0 +1,9 @@
+resource "aws_docdb_cluster" "docdb" {
+  cluster_identifier      = "my-docdb-cluster"
+  engine                  = "docdb"
+  master_username         = "foo"
+  master_password         = "mustbeeightchars"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+  skip_final_snapshot     = true
+}

--- a/assets/queries/terraform/aws/docdb_cluster_without_kms/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/docdb_cluster_without_kms/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "DOCDB Cluster Without KMS",
+    "severity": "HIGH",
+    "line": 1,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3269

**Proposed Changes**
- Added DOCDB Cluster Without KMS query for Terraform

AWS DOCDB Cluster should be encrypted with a KMS encryption key

I submit this contribution under the Apache-2.0 license.
