### PR TITLE
feat(query): Added DOCDB Cluster Not Encrypted query for Terraform #3271

### DIFF
--- a/assets/queries/terraform/aws/docdb_cluster_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/docdb_cluster_not_encrypted/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "bc1f9009-84a0-490f-ae09-3e0ea6d74ad6",
+  "queryName": "DOCDB Cluster Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "AWS DOCDB Cluster storage should be encrypted",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster#storage_encrypted",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/docdb_cluster_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/docdb_cluster_not_encrypted/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_docdb_cluster[name]
+	object.get(resource, "storage_encrypted", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_docdb_cluster[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_docdb_cluster.storage_encrypted is set to true",
+		"keyActualValue": "aws_docdb_cluster.storage_encrypted is missing",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_docdb_cluster[name]
+	resource.storage_encrypted == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_docdb_cluster[{{%s}}].storage_encrypted", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "aws_docdb_cluster.storage_encrypted is set to true",
+		"keyActualValue": "aws_docdb_cluster.storage_encrypted is set to false",
+	}
+}

--- a/assets/queries/terraform/aws/docdb_cluster_not_encrypted/test/negative1.tf
+++ b/assets/queries/terraform/aws/docdb_cluster_not_encrypted/test/negative1.tf
@@ -1,0 +1,10 @@
+resource "aws_docdb_cluster" "docdb" {
+  cluster_identifier      = "my-docdb-cluster"
+  engine                  = "docdb"
+  master_username         = "foo"
+  master_password         = "mustbeeightchars"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+  skip_final_snapshot     = true
+  storage_encrypted = true
+}

--- a/assets/queries/terraform/aws/docdb_cluster_not_encrypted/test/positive1.tf
+++ b/assets/queries/terraform/aws/docdb_cluster_not_encrypted/test/positive1.tf
@@ -1,0 +1,20 @@
+resource "aws_docdb_cluster" "docdb" {
+  cluster_identifier      = "my-docdb-cluster"
+  engine                  = "docdb"
+  master_username         = "foo"
+  master_password         = "mustbeeightchars"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+  skip_final_snapshot     = true
+}
+
+resource "aws_docdb_cluster" "docdb_2" {
+  cluster_identifier      = "my-docdb-cluster"
+  engine                  = "docdb"
+  master_username         = "foo"
+  master_password         = "mustbeeightchars"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+  skip_final_snapshot     = true
+  storage_encrypted = false
+}

--- a/assets/queries/terraform/aws/docdb_cluster_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/docdb_cluster_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "DOCDB Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 1,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "DOCDB Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 19,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3271

**Proposed Changes**
- Added DOCDB Cluster Not Encrypted query for Terraform

AWS DOCDB Cluster storage should be encrypted

I submit this contribution under the Apache-2.0 license.
