### PR TITLE
feat(query): Added DynamoDB Table Not Encrypted query for Terraform #3273

### DIFF
--- a/assets/queries/terraform/aws/dynamodb_table_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/dynamodb_table_not_encrypted/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "ce089fd4-1406-47bd-8aad-c259772bb294",
+  "queryName": "DynamoDB Table Not Encrypted",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "AWS DynamoDB Tables should have server-side encryption",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#server_side_encryption",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/dynamodb_table_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/dynamodb_table_not_encrypted/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_dynamodb_table[name]
+	resource.server_side_encryption.enabled == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_dynamodb_table[{{%s}}].server_side_encryption.enabled", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "aws_dynamodb_table.server_side_encryption.enabled is set to true",
+		"keyActualValue": "aws_dynamodb_table.server_side_encryption.enabled is set to false",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_dynamodb_table[name]
+	object.get(resource, "server_side_encryption", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_dynamodb_table[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_dynamodb_table.server_side_encryption.enabled is set to true",
+		"keyActualValue": "aws_dynamodb_table.server_side_encryption is missing",
+	}
+}

--- a/assets/queries/terraform/aws/dynamodb_table_not_encrypted/test/negative1.tf
+++ b/assets/queries/terraform/aws/dynamodb_table_not_encrypted/test/negative1.tf
@@ -1,0 +1,24 @@
+resource "aws_dynamodb_table" "example" {
+  name             = "example"
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name = "us-east-2"
+  }
+
+  replica {
+    region_name = "us-west-2"
+  }
+}

--- a/assets/queries/terraform/aws/dynamodb_table_not_encrypted/test/positive1.tf
+++ b/assets/queries/terraform/aws/dynamodb_table_not_encrypted/test/positive1.tf
@@ -1,0 +1,45 @@
+resource "aws_dynamodb_table" "example" {
+  name             = "example"
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name = "us-east-2"
+  }
+
+  replica {
+    region_name = "us-west-2"
+  }
+}
+
+resource "aws_dynamodb_table" "example_2" {
+  name             = "example"
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  server_side_encryption {
+    enabled = false
+  }
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name = "us-east-2"
+  }
+
+  replica {
+    region_name = "us-west-2"
+  }
+}

--- a/assets/queries/terraform/aws/dynamodb_table_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/dynamodb_table_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "DynamoDB Table Not Encrypted",
+    "severity": "MEDIUM",
+    "line": 1,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "DynamoDB Table Not Encrypted",
+    "severity": "MEDIUM",
+    "line": 30,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3273

**Proposed Changes**
- Added DynamoDB Table Not Encrypted query for Terraform

AWS DynamoDB Tables should have server-side encryption

I submit this contribution under the Apache-2.0 license.
