### PR TITLE
feat(query): Added API Gateway Method Settings Cache Not Encrypted #3276

### DIFF
--- a/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b7c9a40c-23e4-4a2d-8d39-a3352f10f288",
+  "queryName": "API Gateway Method Settings Cache Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "API Gateway Method Settings Cache should be encrypted",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_method_settings#cache_data_encrypted",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/query.rego
@@ -1,0 +1,37 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_api_gateway_method_settings[name].settings
+	check_cache_enabled(resource)
+	resource.cache_data_encrypted == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_api_gateway_method_settings[{{%s}}].settings.cache_data_encrypted", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "aws_api_gateway_method_settings.settings.cache_data_encrypted is set to true",
+		"keyActualValue": "aws_api_gateway_method_settings.settings.cache_data_encrypted is set to false",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_api_gateway_method_settings[name].settings
+	check_cache_enabled(resource)
+	object.get(resource, "cache_data_encrypted", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_api_gateway_method_settings[{{%s}}].settings", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_api_gateway_method_settings.settings.cache_data_encrypted is set to true",
+		"keyActualValue": "aws_api_gateway_method_settings.settings.cache_data_encrypted is missing",
+	}
+}
+
+check_cache_enabled(resource) = false {
+	object.get(resource, "caching_enabled", "undefined") == "undefined"
+} else {
+	resource.caching_enabled == true
+} else = false {
+	true
+}

--- a/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/query.rego
@@ -2,7 +2,7 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_api_gateway_method_settings[name].settings
-	check_cache_enabled(resource)
+	resource.caching_enabled == true
 	resource.cache_data_encrypted == false
 
 	result := {
@@ -16,7 +16,7 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_api_gateway_method_settings[name].settings
-	check_cache_enabled(resource)
+	resource.caching_enabled == true
 	object.get(resource, "cache_data_encrypted", "undefined") == "undefined"
 
 	result := {
@@ -26,12 +26,4 @@ CxPolicy[result] {
 		"keyExpectedValue": "aws_api_gateway_method_settings.settings.cache_data_encrypted is set to true",
 		"keyActualValue": "aws_api_gateway_method_settings.settings.cache_data_encrypted is missing",
 	}
-}
-
-check_cache_enabled(resource) = false {
-	object.get(resource, "caching_enabled", "undefined") == "undefined"
-} else {
-	resource.caching_enabled == true
-} else = false {
-	true
 }

--- a/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/test/negative1.tf
+++ b/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/test/negative1.tf
@@ -1,0 +1,65 @@
+resource "aws_api_gateway_rest_api" "example" {
+  body = jsonencode({
+    openapi = "3.0.1"
+    info = {
+      title   = "example"
+      version = "1.0"
+    }
+    paths = {
+      "/path1" = {
+        get = {
+          x-amazon-apigateway-integration = {
+            httpMethod           = "GET"
+            payloadFormatVersion = "1.0"
+            type                 = "HTTP_PROXY"
+            uri                  = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+          }
+        }
+      }
+    }
+  })
+
+  name = "example"
+}
+
+resource "aws_api_gateway_stage" "example" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "example"
+}
+
+resource "aws_api_gateway_method_settings" "path_specific" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    metrics_enabled = true
+    logging_level   = "INFO"
+    caching_enabled = true
+    cache_data_encrypted = true
+  }
+}
+
+resource "aws_api_gateway_method_settings" "path_specific_2" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    metrics_enabled = true
+    logging_level   = "INFO"
+  }
+}
+
+resource "aws_api_gateway_method_settings" "path_specific_3" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    metrics_enabled = true
+    logging_level   = "INFO"
+    caching_enabled = false
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/test/positive1.tf
+++ b/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/test/positive1.tf
@@ -1,0 +1,53 @@
+resource "aws_api_gateway_rest_api" "example" {
+  body = jsonencode({
+    openapi = "3.0.1"
+    info = {
+      title   = "example"
+      version = "1.0"
+    }
+    paths = {
+      "/path1" = {
+        get = {
+          x-amazon-apigateway-integration = {
+            httpMethod           = "GET"
+            payloadFormatVersion = "1.0"
+            type                 = "HTTP_PROXY"
+            uri                  = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+          }
+        }
+      }
+    }
+  })
+
+  name = "example"
+}
+
+resource "aws_api_gateway_stage" "example" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "example"
+}
+
+resource "aws_api_gateway_method_settings" "path_specific" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    metrics_enabled = true
+    logging_level   = "INFO"
+    caching_enabled = true
+    cache_data_encrypted = false
+  }
+}
+resource "aws_api_gateway_method_settings" "path_specific_2" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "path1/GET"
+
+  settings {
+    metrics_enabled = true
+    logging_level   = "INFO"
+    caching_enabled = true
+  }
+}

--- a/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_method_settings_cache_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "API Gateway Method Settings Cache Not Encrypted",
+    "severity": "HIGH",
+    "line": 40,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "API Gateway Method Settings Cache Not Encrypted",
+    "severity": "HIGH",
+    "line": 48,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3276

**Proposed Changes**
- Added API Gateway Method Settings Cache Not Encrypted query for Terraform

API Gateway Method Settings Cache should be encrypted

I submit this contribution under the Apache-2.0 license.
