### PR TITLE
feat(query): Added S3 Bucket Object Not Encrypted query for Terraform #3279

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "5fb49a69-8d46-4495-a2f8-9c8c622b2b6e",
+  "queryName": "S3 Bucket Object Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "S3 Bucket Object should have server-side encryption enabled",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object#server_side_encryption",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_s3_bucket_object[name]
+	object.get(resource, "server_side_encryption", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_s3_bucket_object[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_s3_bucket_object.server_side_encryption is defined",
+		"keyActualValue": "aws_s3_bucket_object.server_side_encryption is missing",
+	}
+}

--- a/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/test/negative1.tf
+++ b/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/test/negative1.tf
@@ -1,0 +1,19 @@
+resource "aws_s3_bucket" "examplebucket" {
+  bucket = "examplebuckettftest"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  object_lock_configuration {
+    object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_object" "examplebucket_object" {
+  key                    = "someobject"
+  bucket                 = aws_s3_bucket.examplebucket.id
+  source                 = "index.html"
+  server_side_encryption = "AES256"
+}

--- a/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/test/positive1.tf
+++ b/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/test/positive1.tf
@@ -1,0 +1,18 @@
+resource "aws_s3_bucket" "examplebucket" {
+  bucket = "examplebuckettftest"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  object_lock_configuration {
+    object_lock_enabled = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_object" "examplebucket_object" {
+  key                    = "someobject"
+  bucket                 = aws_s3_bucket.examplebucket.id
+  source                 = "index.html"
+}

--- a/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_object_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "S3 Bucket Object Not Encrypted",
+    "severity": "HIGH",
+    "line": 14,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3279

**Proposed Changes**
- Added S3 Bucket Object Not Encrypted query for Terraform

S3 Bucket Object should have server-side encryption enabled

I submit this contribution under the Apache-2.0 license.
