### PR TITLE
feat(query): 'EC2 instance monitoring disabled' for AWS Terraform

### DIFF
--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/metadata.json
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "23b70e32-032e-4fa6-ba5c-82f56b9980e6",
   "queryName": "EC2 Instance Monitoring Disabled",
-  "severity": "MEDIUM",
+  "severity": "INFO",
   "category": "Observability",
   "descriptionText": "EC2 Instance should have detailed monitoring enabled. With detailed monitoring enabled data is available in 1-minute periods",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#monitoring",

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/metadata.json
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "23b70e32-032e-4fa6-ba5c-82f56b9980e6",
+  "queryName": "EC2 Instance Monitoring Disabled",
+  "severity": "MEDIUM",
+  "category": "Observability",
+  "descriptionText": "EC2 Instance should have detailed monitoring enabled. With detailed monitoring enabled data is available in 1-minute periods",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#monitoring",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_instance[name]
 
-    resource.monitoring == false
+	resource.monitoring == false
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
@@ -21,7 +21,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("aws_instance.%s", [name]),
+		"searchKey": sprintf("aws_instance.{{%s}}.monitoring", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("aws_instance.%s.monitoring should be true", [name]),
 		"keyActualValue": sprintf("aws_instance.%s.monitoring is false", [name]),

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
@@ -7,7 +7,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("aws_instance.%s", [name]),
+		"searchKey": sprintf("aws_instance.{{%s}}", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("aws_instance.%s.monitoring should be defined", [name]),
 		"keyActualValue": sprintf("aws_instance.%s.monitoring is undefined", [name]),

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
@@ -22,7 +22,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_instance.{{%s}}.monitoring", [name]),
-		"issueType": "MissingAttribute",
+		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_instance.%s.monitoring should be true", [name]),
 		"keyActualValue": sprintf("aws_instance.%s.monitoring is false", [name]),
 	}

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_instance[name]
+
+	object.get(resource, "monitoring", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_instance.%s", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_instance.%s.monitoring should be defined", [name]),
+		"keyActualValue": sprintf("aws_instance.%s.monitoring is undefined", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_instance[name]
+
+    resource.monitoring == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_instance.%s", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_instance.%s.monitoring should be true", [name]),
+		"keyActualValue": sprintf("aws_instance.%s.monitoring is false", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/negative1.tf
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/negative1.tf
@@ -1,0 +1,25 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "monitoring_negative1" {
+  ami           = data.aws_ami.ubuntu.id
+  monitoring    = true
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/positive1.tf
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/positive1.tf
@@ -1,0 +1,24 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "monitoring_positive1" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/positive2.tf
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/positive2.tf
@@ -1,0 +1,25 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "monitoring_positive2" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+  monitoring    = false
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/positive_expected_result.json
@@ -8,7 +8,7 @@
   {
     "queryName": "EC2 Instance Monitoring Disabled",
     "severity": "INFO",
-    "line": 17,
+    "line": 20,
     "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/positive_expected_result.json
@@ -1,13 +1,13 @@
 [
   {
     "queryName": "EC2 Instance Monitoring Disabled",
-    "severity": "MEDIUM",
+    "severity": "INFO",
     "line": 17,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "EC2 Instance Monitoring Disabled",
-    "severity": "MEDIUM",
+    "severity": "INFO",
     "line": 17,
     "fileName": "positive2.tf"
   }

--- a/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ec2_instance_monitoring_disabled/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "EC2 Instance Monitoring Disabled",
+    "severity": "MEDIUM",
+    "line": 17,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "EC2 Instance Monitoring Disabled",
+    "severity": "MEDIUM",
+    "line": 17,
+    "fileName": "positive2.tf"
+  }
+]


### PR DESCRIPTION
**Proposed Changes**
- Check if AWS EC2 instance detailed monitoring is enabled to increase observability.

I submit this contribution under the Apache-2.0 license.
