### PR TITLE
feat(query): Added Sagemaker Notebook Instance Without KMS query to Terraform

### DIFF
--- a/assets/queries/terraform/aws/sagemaker_notebook_instance_without_kms/metadata.json
+++ b/assets/queries/terraform/aws/sagemaker_notebook_instance_without_kms/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "f3674e0c-f6be-43fa-b71c-bf346d1aed99",
+  "queryName": "Sagemaker Notebook Instance Without KMS",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "AWS SageMaker should encrypt model artifacts at rest using Amazon S3 server-side encryption with an AWS KMS",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_notebook_instance#kms_key_id",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/sagemaker_notebook_instance_without_kms/query.rego
+++ b/assets/queries/terraform/aws/sagemaker_notebook_instance_without_kms/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_sagemaker_notebook_instance[name]
+	object.get(resource, "kms_key_id", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_sagemaker_notebook_instance[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_sagemaker_notebook_instance.kms_key_id is defined",
+		"keyActualValue": "aws_sagemaker_notebook_instance.kms_key_id is missing",
+	}
+}

--- a/assets/queries/terraform/aws/sagemaker_notebook_instance_without_kms/test/negative1.tf
+++ b/assets/queries/terraform/aws/sagemaker_notebook_instance_without_kms/test/negative1.tf
@@ -1,0 +1,10 @@
+resource "aws_sagemaker_notebook_instance" "ni" {
+  name          = "my-notebook-instance"
+  role_arn      = aws_iam_role.role.arn
+  instance_type = "ml.t2.medium"
+  kms_key_id = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+
+  tags = {
+    Name = "foo"
+  }
+}

--- a/assets/queries/terraform/aws/sagemaker_notebook_instance_without_kms/test/positive1.tf
+++ b/assets/queries/terraform/aws/sagemaker_notebook_instance_without_kms/test/positive1.tf
@@ -1,0 +1,9 @@
+resource "aws_sagemaker_notebook_instance" "ni" {
+  name          = "my-notebook-instance"
+  role_arn      = aws_iam_role.role.arn
+  instance_type = "ml.t2.medium"
+
+  tags = {
+    Name = "foo"
+  }
+}

--- a/assets/queries/terraform/aws/sagemaker_notebook_instance_without_kms/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sagemaker_notebook_instance_without_kms/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Sagemaker Notebook Instance Without KMS",
+    "severity": "HIGH",
+    "line": 1,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Sagemaker Notebook Instance Without KMS query to Terraform

AWS SageMaker should encrypt model artifacts at rest using Amazon S3 server-side encryption with an AWS KMS

I submit this contribution under the Apache-2.0 license.
