### PR TITLE
feat(query): Added Secretsmanager Secret Without KMS query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/secretsmanager_secret_without_kms/metadata.json
+++ b/assets/queries/terraform/aws/secretsmanager_secret_without_kms/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a2f548f2-188c-4fff-b172-e9a6acb216bd",
+  "queryName": "Secretsmanager Secret Without KMS",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "AWS Secretmanager should use AWS KMS customer master key (CMK) to encrypt the secret values in the versions stored in the secret",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret#kms_key_id",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/secretsmanager_secret_without_kms/query.rego
+++ b/assets/queries/terraform/aws/secretsmanager_secret_without_kms/query.rego
@@ -1,0 +1,14 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_secretsmanager_secret[name]
+	object.get(resource, "kms_key_id", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_secretsmanager_secret[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_secretsmanager_secret.kms_key_id is defined",
+		"keyActualValue": "aws_secretsmanager_secret.kms_key_id is missing",
+	}
+}

--- a/assets/queries/terraform/aws/secretsmanager_secret_without_kms/test/negative1.tf
+++ b/assets/queries/terraform/aws/secretsmanager_secret_without_kms/test/negative1.tf
@@ -1,0 +1,4 @@
+resource "aws_secretsmanager_secret" "example" {
+  name = "example"
+  kms_key_id = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+}

--- a/assets/queries/terraform/aws/secretsmanager_secret_without_kms/test/positive1.tf
+++ b/assets/queries/terraform/aws/secretsmanager_secret_without_kms/test/positive1.tf
@@ -1,0 +1,3 @@
+resource "aws_secretsmanager_secret" "example" {
+  name = "example"
+}

--- a/assets/queries/terraform/aws/secretsmanager_secret_without_kms/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/secretsmanager_secret_without_kms/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Secretsmanager Secret Without KMS",
+    "severity": "MEDIUM",
+    "line": 1,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added Secretsmanager Secret Without KMS query for Terraform

"AWS Secretmanager should use AWS KMS customer master key (CMK) to encrypt the secret values in the versions stored in the secret

I submit this contribution under the Apache-2.0 license.
