### PR TITLE
feat(query): Added Athena Workgroup Not Encrypted query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/athena_workgroup_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/athena_workgroup_not_encrypted/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "d364984a-a222-4b5f-a8b0-e23ab19ebff3",
+  "queryName": "Athena Workgroup Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "Athena Workgroup query results should be encrypted, for all queries that run in the workgroup",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_workgroup#encryption_configuration",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/athena_workgroup_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/athena_workgroup_not_encrypted/query.rego
@@ -1,0 +1,40 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_athena_workgroup[name]
+	object.get(resource, "configuration", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_athena_workgroup[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_athena_workgroup[{{%s}}].configuration.result_configuration.encryption_configuration is defined", [name]),
+		"keyActualValue": sprintf("aws_athena_workgroup[{{%s}}].configuration is missing", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_athena_workgroup[name]
+	object.get(resource.configuration, "result_configuration", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_athena_workgroup[{{%s}}].configuration", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_athena_workgroup[{{%s}}].configuration.result_configuration.encryption_configuration is defined", [name]),
+		"keyActualValue": sprintf("aws_athena_workgroup[{{%s}}].configuration.result_configuration is missing", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_athena_workgroup[name]
+	object.get(resource.configuration.result_configuration, "encryption_configuration", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_athena_workgroup[{{%s}}].configuration.result_configuration", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_athena_workgroup[{{%s}}].configuration.result_configuration.encryption_configuration is defined", [name]),
+		"keyActualValue": sprintf("aws_athena_workgroup[{{%s}}].configuration.result_configuration.encryption_configuration is missing", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/athena_workgroup_not_encrypted/test/negative1.tf
+++ b/assets/queries/terraform/aws/athena_workgroup_not_encrypted/test/negative1.tf
@@ -1,0 +1,17 @@
+resource "aws_athena_workgroup" "example" {
+  name = "example"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.example.bucket}/output/"
+
+      encryption_configuration {
+        encryption_option = "SSE_KMS"
+        kms_key_arn       = aws_kms_key.example.arn
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/aws/athena_workgroup_not_encrypted/test/positive1.tf
+++ b/assets/queries/terraform/aws/athena_workgroup_not_encrypted/test/positive1.tf
@@ -1,0 +1,25 @@
+resource "aws_athena_workgroup" "example" {
+  name = "example"
+}
+
+resource "aws_athena_workgroup" "example_2" {
+  name = "example"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+  }
+}
+
+resource "aws_athena_workgroup" "example_3" {
+  name = "example"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.example.bucket}/output/"
+    }
+  }
+}

--- a/assets/queries/terraform/aws/athena_workgroup_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/athena_workgroup_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+  {
+    "queryName": "Athena Workgroup Not Encrypted",
+    "severity": "HIGH",
+    "line": 1,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "Athena Workgroup Not Encrypted",
+    "severity": "HIGH",
+    "line": 8,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "Athena Workgroup Not Encrypted",
+    "severity": "HIGH",
+    "line": 21,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added Athena Workgroup Not Encrypted query for Terraform

Athena Workgroup query results should be encrypted, for all queries that run in the workgroup

I submit this contribution under the Apache-2.0 license.
