### PR TITLE
feat(query): Updated Viewer Protocol Policy Allows HTTP query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/viewer_protocol_policy_allows_http/query.rego
+++ b/assets/queries/terraform/aws/viewer_protocol_policy_allows_http/query.rego
@@ -2,7 +2,7 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_cloudfront_distribution[name]
-	resource.default_cache_behavior.viewer_protocol_policy == "allow-all"
+	path := check_allow_all(resource.default_cache_behavior)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -15,13 +15,22 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_cloudfront_distribution[name]
-	resource.ordered_cache_behavior.viewer_protocol_policy == "allow-all"
+	path = check_allow_all(resource.ordered_cache_behavior)
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("resource.aws_cloudfront_distribution[%s].ordered_cache_behavior.viewer_protocol_policy", [name]),
+		"searchKey": sprintf("resource.aws_cloudfront_distribution[%s].ordered_cache_behavior.{{%s}}.viewer_protocol_policy", [name, path[_].path_pattern]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("resource.aws_cloudfront_distribution[%s].ordered_cache_behavior.viewer_protocol_policy is 'https-only' or 'redirect-to-https'", [name]),
 		"keyActualValue": sprintf("resource.aws_cloudfront_distribution[%s].ordered_cache_behavior.viewer_protocol_policy isn't 'https-only' or 'redirect-to-https'", [name]),
 	}
+}
+
+check_allow_all(resource) = path {
+	is_array(resource)
+	path := {x | resource[n].viewer_protocol_policy == "allow-all"; x := resource[n]}
+} else = path {
+	not is_array(resource)
+	resource.viewer_protocol_policy == "allow-all"
+	path := {x | x := resource}
 }


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Updated Viewer Protocol Policy Allows HTTP query for Terraform

aws_cloudfront_distribution.ordered_cache_behavior can be an array

I submit this contribution under the Apache-2.0 license.
