### PR TITLE
fix(parser): Fixed Bug with invalid terraform returning panic #3304

### DIFF
--- a/pkg/kics/resolver_sink.go
+++ b/pkg/kics/resolver_sink.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Checkmarx/kics/pkg/model"
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -18,7 +17,8 @@ func (s *Service) resolverSink(ctx context.Context, filename, scanID string) ([]
 	}
 	resFiles, err := s.Resolver.Resolve(filename, kind)
 	if err != nil {
-		return []string{}, errors.Wrap(err, "failed to render file content")
+		log.Err(err).Msgf("failed to render file content")
+		return []string{}, nil
 	}
 
 	excluded := make([]string, len(resFiles.File))
@@ -31,7 +31,8 @@ func (s *Service) resolverSink(ctx context.Context, filename, scanID string) ([]
 			if retParse == "break" {
 				return []string{}, nil
 			}
-			return []string{}, errors.Wrap(err, "failed to parse file content")
+			log.Err(err).Msgf("failed to parse file content")
+			return []string{}, nil
 		}
 		for _, document := range documents {
 			_, err = json.Marshal(document)

--- a/pkg/kics/sink.go
+++ b/pkg/kics/sink.go
@@ -26,7 +26,8 @@ func (s *Service) sink(ctx context.Context, filename, scanID string, rc io.Reade
 
 	documents, kind, err := s.Parser.Parse(filename, *content)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse file content")
+		log.Err(err).Msgf("failed to parse file content: %s", filename)
+		return nil
 	}
 	for _, document := range documents {
 		_, err = json.Marshal(document)


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3304

**Proposed Changes**
- Fixed Bug with invalid terraform returning panic 
- Invalid files will now only be logged instead of returning an error

I submit this contribution under the Apache-2.0 license.
