### PR TITLE
feat(query): Added ECS Task Definition Volume Not Encrypted query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "4d46ff3b-7160-41d1-a310-71d6d370b08f",
+  "queryName": "ECS Task Definition Volume Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "AWS ECS Task Definition EFS data in transit between AWS ECS host and AWS EFS server should be encrypted",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition#transit_encryption",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_ecs_task_definition[name]
+	resource.volume.efs_volume_configuration.transit_encryption == "DISABLED"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ecs_task_definition[{{%s}}].volume.efs_volume_configuration.transit_encryption", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "aws_ecs_task_definition.volume.efs_volume_configuration.transit_encryption value is 'ENABLED'",
+		"keyActualValue": "aws_ecs_task_definition.volume.efs_volume_configuration.transit_encryption value is 'DISABLED'",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_ecs_task_definition[name]
+	enc := resource.volume.efs_volume_configuration
+	object.get(enc, "transit_encryption", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ecs_task_definition[{{%s}}].volume.efs_volume_configuration", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_ecs_task_definition.volume.efs_volume_configuration.transit_encryption value is 'ENABLED'",
+		"keyActualValue": "aws_ecs_task_definition.volume.efs_volume_configuration.transit_encryption is missing",
+	}
+}

--- a/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/negative1.tf
+++ b/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/negative1.tf
@@ -1,0 +1,19 @@
+resource "aws_ecs_task_definition" "service" {
+  family                = "service"
+  container_definitions = file("task-definitions/service.json")
+
+  volume {
+    name = "service-storage"
+
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.fs.id
+      root_directory          = "/opt/data"
+      transit_encryption      = "ENABLED"
+      transit_encryption_port = 2999
+      authorization_config {
+        access_point_id = aws_efs_access_point.test.id
+        iam             = "ENABLED"
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/positive1.tf
+++ b/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/positive1.tf
@@ -1,0 +1,38 @@
+resource "aws_ecs_task_definition" "service" {
+  family                = "service"
+  container_definitions = file("task-definitions/service.json")
+
+  volume {
+    name = "service-storage"
+
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.fs.id
+      root_directory          = "/opt/data"
+      transit_encryption      = "DISABLED"
+      transit_encryption_port = 2999
+      authorization_config {
+        access_point_id = aws_efs_access_point.test.id
+        iam             = "ENABLED"
+      }
+    }
+  }
+}
+
+resource "aws_ecs_task_definition" "service_2" {
+  family                = "service"
+  container_definitions = file("task-definitions/service.json")
+
+  volume {
+    name = "service-storage"
+
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.fs.id
+      root_directory          = "/opt/data"
+      transit_encryption_port = 2999
+      authorization_config {
+        access_point_id = aws_efs_access_point.test.id
+        iam             = "ENABLED"
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/positive2.tf
+++ b/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/positive2.tf
@@ -1,4 +1,4 @@
-resource "aws_ecs_task_definition" "service" {
+resource "aws_ecs_task_definition" "service_2" {
   family                = "service"
   container_definitions = file("task-definitions/service.json")
 
@@ -8,7 +8,6 @@ resource "aws_ecs_task_definition" "service" {
     efs_volume_configuration {
       file_system_id          = aws_efs_file_system.fs.id
       root_directory          = "/opt/data"
-      transit_encryption      = "DISABLED"
       transit_encryption_port = 2999
       authorization_config {
         access_point_id = aws_efs_access_point.test.id

--- a/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "ECS Task Definition Volume Not Encrypted",
+    "severity": "HIGH",
+    "line": 11,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "ECS Task Definition Volume Not Encrypted",
+    "severity": "HIGH",
+    "line": 28,
+    "filename": "positive1.tf"
+  }
+]

--- a/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ecs_task_definition_volume_not_encrypted/test/positive_expected_result.json
@@ -8,7 +8,7 @@
   {
     "queryName": "ECS Task Definition Volume Not Encrypted",
     "severity": "HIGH",
-    "line": 28,
-    "filename": "positive1.tf"
+    "line": 8,
+    "filename": "positive2.tf"
   }
 ]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added ECS Task Definition Volume Not Encrypted query for Terraform

AWS ECS Task Definition EFS data in transit between AWS ECS host and AWS EFS server should be encrypted

I submit this contribution under the Apache-2.0 license.
