### PR TITLE
feat(query): added query "Elasticsearch Domain Not Encrypted Node To Node" query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/metadata.json
+++ b/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "967eb3e6-26fc-497d-8895-6428beb6e8e2",
+  "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "Elasticsearch Domain encryption should be enabled node to node",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain#node_to_node_encryption",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/query.rego
+++ b/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_elasticsearch_domain[name]
+
+	object.get(resource, "node_to_node_encryption", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticsearch_domain[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "The attribute 'node_to_node_encryption' is set to true",
+		"keyActualValue": "The attribute 'node_to_node_encryption' is undefined",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_elasticsearch_domain[name].node_to_node_encryption
+
+	not resource.enabled
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticsearch_domain[{{%s}}].node_to_node_encryption.enabled", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The attribute 'node_to_node_encryption' is set to true",
+		"keyActualValue": "The attribute 'node_to_node_encryption' is not set to true",
+	}
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative1.tf
+++ b/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative1.tf
@@ -1,0 +1,20 @@
+resource "aws_elasticsearch_domain" "negative1" {
+  domain_name           = "example"
+  elasticsearch_version = "1.5"
+
+  cluster_config {
+    instance_type = "r4.large.elasticsearch"
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  node_to_node_encryption {
+    enabled = true
+  }
+
+  tags = {
+    Domain = "TestDomain"
+  }
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive1.tf
+++ b/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive1.tf
@@ -1,0 +1,16 @@
+resource "aws_elasticsearch_domain" "positive1" {
+  domain_name           = "example"
+  elasticsearch_version = "1.5"
+
+  cluster_config {
+    instance_type = "r4.large.elasticsearch"
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  tags = {
+    Domain = "TestDomain"
+  }
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive2.tf
+++ b/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive2.tf
@@ -1,0 +1,20 @@
+resource "aws_elasticsearch_domain" "positive1" {
+  domain_name           = "example"
+  elasticsearch_version = "1.5"
+
+  cluster_config {
+    instance_type = "r4.large.elasticsearch"
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  node_to_node_encryption {
+    enabled = false
+  }
+
+  tags = {
+    Domain = "TestDomain"
+  }
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 1
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 14
+  }
+]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>
**Proposed Changes**
- Added query "Elasticsearch Domain Not Encrypted Node To Node" query for Terraform

I submit this contribution under the Apache-2.0 license.
