### PR TITLE
feat(query): Added ElastiCache Replication Group Not Encrypted At Transit 

### DIFF
--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/metadata.json
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "1afbb3fa-cf6c-4a3d-b730-95e9f4df343e",
+  "queryName": "ElastiCache Replication Group Not Encrypted At Transit",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "ElastiCache Replication Group encryption should be enabled at Transit",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#transit_encryption_enabled",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/query.rego
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/query.rego
@@ -1,0 +1,29 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_elasticache_replication_group[name]
+
+	object.get(resource, "transit_encryption_enabled", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticache_replication_group[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "The attribute 'transit_encryption_enabled' is set to true",
+		"keyActualValue": "The attribute 'transit_encryption_enabled' is undefined",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_elasticache_replication_group[name]
+
+	resource.transit_encryption_enabled != true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticache_replication_group[%s].transit_encryption_enabled", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The attribute 'transit_encryption_enabled' is set to true",
+		"keyActualValue": "The attribute 'transit_encryption_enabled' is not set to true",
+	}
+}

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/negative1.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/negative1.tf
@@ -1,0 +1,12 @@
+resource "aws_elasticache_replication_group" "example3" {
+  automatic_failover_enabled    = true
+  availability_zones            = ["us-west-2a", "us-west-2b"]
+  replication_group_id          = "tf-rep-group-1"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis3.2"
+  port                          = 6379
+  at_rest_encryption_enabled    = true
+  transit_encryption_enabled    = true
+}

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive1.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive1.tf
@@ -1,0 +1,10 @@
+resource "aws_elasticache_replication_group" "example" {
+  automatic_failover_enabled    = true
+  availability_zones            = ["us-west-2a", "us-west-2b"]
+  replication_group_id          = "tf-rep-group-1"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis3.2"
+  port                          = 6379
+}

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive2.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive2.tf
@@ -1,0 +1,11 @@
+resource "aws_elasticache_replication_group" "example" {
+  automatic_failover_enabled    = true
+  availability_zones            = ["us-west-2a", "us-west-2b"]
+  replication_group_id          = "tf-rep-group-1"
+  replication_group_description = "test description"
+  node_type                     = "cache.m4.large"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis3.2"
+  port                          = 6379
+  transit_encryption_enabled    = false
+}

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "ElastiCache Replication Group Not Encrypted At Transit",
+    "severity": "MEDIUM",
+    "line": 1,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "ElastiCache Replication Group Not Encrypted At Transit",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive2.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>


**Proposed Changes**
- Added ElastiCache Replication Group Not Encrypted At Transit query for Terraform

ElastiCache Replication Group encryption should be enabled at Transit

I submit this contribution under the Apache-2.0 license.
