### PR TITLE
feat(query): "Numeric Schema Without Format" for OpenAPI

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -88,6 +88,5 @@ is_operation(path) = info {
 	op := operations[z]
 	info := {"code": code, "operation": op}
 } else = info {
-	path[0] != "paths"
 	info := {}
 }

--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -76,3 +76,17 @@ resolve_path(pathItem) = resolved {
 } else = pathItem {
 	true
 }
+
+is_operation(path) = info {
+	path[0] == "paths"
+	operations := {"get", "post", "put", "delete", "options", "head", "patch", "trace"}
+	operations[z] == path[2]
+	path[j] == "responses"
+	idx := j + 1
+	code := path[idx]
+	op := operations[z]
+	info := {"code": code, "operation": op}
+} else = info {
+	path[0] != "paths"
+	info := {}
+}

--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -77,6 +77,7 @@ resolve_path(pathItem) = resolved {
 	true
 }
 
+# It verifies if the path contains an operation. If true, keeps the operation type and the response code related to it
 is_operation(path) = info {
 	path[0] == "paths"
 	operations := {"get", "post", "put", "delete", "options", "head", "patch", "trace"}

--- a/assets/queries/openAPI/numeric_schema_without_format/metadata.json
+++ b/assets/queries/openAPI/numeric_schema_without_format/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "fbf699b5-ef74-4542-9cf1-f6eeac379373",
+  "queryName": "Numeric Schema Without Format",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "Numeric schema (type set to 'integer' or 'number') should have 'format' defined.",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/numeric_schema_without_format/query.rego
+++ b/assets/queries/openAPI/numeric_schema_without_format/query.rego
@@ -1,0 +1,42 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+numeric := {"integer", "number"}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	schema = value.schema
+	info := openapi_lib.is_operation(path)
+	openapi_lib.content_allowed(info.operation, info.code)
+	openapi_lib.undefined_properties_in_schema(doc, schema, numeric[x], "format")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Numeric schema has 'format' defined",
+		"keyActualValue": "Numeric schema does not have 'format' defined",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	schema = value.schema
+	openapi_lib.is_operation(path) == {}
+	openapi_lib.undefined_properties_in_schema(doc, schema, numeric[x], "format")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Numeric schema has 'format' defined",
+		"keyActualValue": "Numeric schema does not have 'format' defined",
+	}
+}

--- a/assets/queries/openAPI/numeric_schema_without_format/test/negative1.json
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/negative1.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 50
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/numeric_schema_without_format/test/negative2.json
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/negative2.json
@@ -1,0 +1,73 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 50
+          }
+        },
+        "required": [
+          "petType"
+        ],
+        "type": "object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/numeric_schema_without_format/test/negative3.yaml
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/negative3.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 50
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/numeric_schema_without_format/test/negative4.yaml
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/negative4.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 50
+      required:
+        - petType

--- a/assets/queries/openAPI/numeric_schema_without_format/test/positive1.json
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/positive1.json
@@ -1,0 +1,87 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 50
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/numeric_schema_without_format/test/positive2.json
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/positive2.json
@@ -1,0 +1,72 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 50
+          }
+        },
+        "required": [
+          "petType"
+        ],
+        "type": "object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/numeric_schema_without_format/test/positive3.yaml
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/positive3.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: integer
+          minimum: 0
+          maximum: 50
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/numeric_schema_without_format/test/positive4.yaml
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/positive4.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: integer
+          minimum: 0
+          maximum: 50
+      required:
+        - petType

--- a/assets/queries/openAPI/numeric_schema_without_format/test/positive_expected_result.json
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Numeric Schema Without Format",
+    "severity": "MEDIUM",
+    "line": 74,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Numeric Schema Without Format",
+    "severity": "MEDIUM",
+    "line": 20,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Numeric Schema Without Format",
+    "severity": "MEDIUM",
+    "line": 45,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Numeric Schema Without Format",
+    "severity": "MEDIUM",
+    "line": 15,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Numeric Schema Without Format" query for OpenAPI. It checks if the numeric schema (type set to 'integer' or 'number') does not have 'format' defined

**Considerations**:
-  The function `is_operation` (in \kics\assets\libraries\openapi\library.rego) verifies if the path contains an operation. If true, keeps the type of operation and the response code related to it. This function is useful to discard HEAD operations with response code equal to '204' or '304' (through `content_allowed`)

I submit this contribution under Apache-2.0 license.

