### PR TITLE
feat(query): Added IAM User With Access To Console query to Terraform

### DIFF
--- a/assets/queries/terraform/aws/iam_user_with_access_to_console/metadata.json
+++ b/assets/queries/terraform/aws/iam_user_with_access_to_console/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "9ec311bf-dfd9-421f-8498-0b063c8bc552",
+  "queryName": "IAM User With Access To Console",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "AWS IAM Users should not have access to console",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_login_profile",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/iam_user_with_access_to_console/query.rego
+++ b/assets/queries/terraform/aws/iam_user_with_access_to_console/query.rego
@@ -1,0 +1,19 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_iam_user_login_profile[name]
+	user := resource.user
+	search := clean_user(user)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s", [search[0][1]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s doesn't have aws_iam_user_login_profile", [search[0][1]]),
+		"keyActualValue": sprintf("%s has aws_iam_user_login_profile", [search[0][1]]),
+	}
+}
+
+clean_user(user) = search {
+	search := regex.find_all_string_submatch_n("\\${(.*?)\\}", user, -1)
+}

--- a/assets/queries/terraform/aws/iam_user_with_access_to_console/test/negative1.tf
+++ b/assets/queries/terraform/aws/iam_user_with_access_to_console/test/negative1.tf
@@ -1,0 +1,5 @@
+resource "aws_iam_user" "example" {
+  name          = "example"
+  path          = "/"
+  force_destroy = true
+}

--- a/assets/queries/terraform/aws/iam_user_with_access_to_console/test/positive1.tf
+++ b/assets/queries/terraform/aws/iam_user_with_access_to_console/test/positive1.tf
@@ -1,0 +1,10 @@
+resource "aws_iam_user" "example" {
+  name          = "example"
+  path          = "/"
+  force_destroy = true
+}
+
+resource "aws_iam_user_login_profile" "example_login" {
+  user    = aws_iam_user.example.name
+  pgp_key = "keybase:some_person_that_exists"
+}

--- a/assets/queries/terraform/aws/iam_user_with_access_to_console/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_user_with_access_to_console/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "IAM User With Access To Console",
+    "severity": "MEDIUM",
+    "line": 2,
+    "filename": "positive1.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added IAM User With Access To Console query to Terraform

AWS IAM Users should not have access to the console

I submit this contribution under the Apache-2.0 license.
