### PR TITLE
feat(query): "Media Type Object Without Schema" for OpenAPI

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -76,3 +76,17 @@ resolve_path(pathItem) = resolved {
 } else = pathItem {
 	true
 }
+
+# It verifies if the path contains an operation. If true, keeps the operation type and the response code related to it
+is_operation(path) = info {
+	path[0] == "paths"
+	operations := {"get", "post", "put", "delete", "options", "head", "patch", "trace"}
+	operations[z] == path[2]
+	path[j] == "responses"
+	idx := j + 1
+	code := path[idx]
+	op := operations[z]
+	info := {"code": code, "operation": op}
+} else = info {
+	info := {}
+}

--- a/assets/queries/openAPI/media_type_object_without_schema/metadata.json
+++ b/assets/queries/openAPI/media_type_object_without_schema/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "f79b9d26-e945-44e7-98a1-b93f0f7a68a0",
+  "queryName": "Media Type Object Without Schema",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "The Media Type Object should have the attribute 'schema' defined",
+  "descriptionUrl": "https://swagger.io/specification/#media-type-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/media_type_object_without_schema/query.rego
+++ b/assets/queries/openAPI/media_type_object_without_schema/query.rego
@@ -1,0 +1,40 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	content = value.content
+	info := openapi_lib.is_operation(path)
+	openapi_lib.content_allowed(info.operation, info.code)
+	object.get(content[x], "schema", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.content", [openapi_lib.concat_path(path)]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "The attribute 'schema' is set",
+		"keyActualValue": "The attribute 'schema' is undefined",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	content = value.content
+	openapi_lib.is_operation(path) == {}
+	object.get(content[x], "schema", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.content", [openapi_lib.concat_path(path)]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "The attribute 'schema' is set",
+		"keyActualValue": "The attribute 'schema' is undefined",
+	}
+}

--- a/assets/queries/openAPI/media_type_object_without_schema/test/negative1.json
+++ b/assets/queries/openAPI/media_type_object_without_schema/test/negative1.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ],
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/data": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            },
+            "encoding": {
+              "code": {
+                "contentType": "image/png, image/jpeg"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/media_type_object_without_schema/test/negative2.json
+++ b/assets/queries/openAPI/media_type_object_without_schema/test/negative2.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "string",
+                "format": "binary",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "code": {
+                  "contentType": "image/png, image/jpeg"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/media_type_object_without_schema/test/negative3.yaml
+++ b/assets/queries/openAPI/media_type_object_without_schema/test/negative3.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    format: binary
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                format: binary
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"
+          encoding:
+            code:
+              contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/media_type_object_without_schema/test/negative4.yaml
+++ b/assets/queries/openAPI/media_type_object_without_schema/test/negative4.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: string
+              format: binary
+              properties:
+                code:
+                  type: string
+                  format: binary
+            encoding:
+              code:
+                contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/media_type_object_without_schema/test/positive1.json
+++ b/assets/queries/openAPI/media_type_object_without_schema/test/positive1.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ],
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/data": {
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            },
+            "encoding": {
+              "code": {
+                "contentType": "image/png, image/jpeg"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/media_type_object_without_schema/test/positive2.json
+++ b/assets/queries/openAPI/media_type_object_without_schema/test/positive2.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "encoding": {
+                "code": {
+                  "contentType": "image/png, image/jpeg"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/media_type_object_without_schema/test/positive3.yaml
+++ b/assets/queries/openAPI/media_type_object_without_schema/test/positive3.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"
+          encoding:
+            code:
+              contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/media_type_object_without_schema/test/positive4.yaml
+++ b/assets/queries/openAPI/media_type_object_without_schema/test/positive4.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg
+      requestBody:
+        content:
+          multipart/form-data:
+            encoding:
+              code:
+                contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/media_type_object_without_schema/test/positive_expected_result.json
+++ b/assets/queries/openAPI/media_type_object_without_schema/test/positive_expected_result.json
@@ -1,0 +1,50 @@
+[
+  {
+    "queryName": "Media Type Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 15,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Media Type Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 48,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Media Type Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 15,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Media Type Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 27,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Media Type Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 13,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Media Type Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 30,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Media Type Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 13,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Media Type Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 19,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Media Type Object Without Schema" query for OpenAPI. It checks if the Media Type Object does not have 'schema' defined

I submit this contribution under the Apache-2.0 license.
