### PR TITLE
feat(query): "Parameter Object Without Schema" for OpenAPI

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -76,3 +76,17 @@ resolve_path(pathItem) = resolved {
 } else = pathItem {
 	true
 }
+
+# It verifies if the path contains an operation. If true, keeps the operation type and the response code related to it
+is_operation(path) = info {
+	path[0] == "paths"
+	operations := {"get", "post", "put", "delete", "options", "head", "patch", "trace"}
+	operations[z] == path[2]
+	path[j] == "responses"
+	idx := j + 1
+	code := path[idx]
+	op := operations[z]
+	info := {"code": code, "operation": op}
+} else = info {
+	info := {}
+}

--- a/assets/queries/openAPI/parameter_object_without_schema/metadata.json
+++ b/assets/queries/openAPI/parameter_object_without_schema/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "8fe1846f-52cc-4413-ace9-1933d7d23672",
+  "queryName": "Parameter Object Without Schema",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "The Parameter Object should have the attribute 'schema' defined",
+  "descriptionUrl": "https://swagger.io/specification/#parameter-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/parameter_object_without_schema/query.rego
+++ b/assets/queries/openAPI/parameter_object_without_schema/query.rego
@@ -1,0 +1,40 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	parameters = value.parameters
+	info := openapi_lib.is_operation(path)
+	openapi_lib.content_allowed(info.operation, info.code)
+	object.get(parameters[x], "schema", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.parameters", [openapi_lib.concat_path(path)]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "The attribute 'schema' is set",
+		"keyActualValue": "The attribute 'schema' is undefined",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	parameters = value.parameters
+	openapi_lib.is_operation(path) == {}
+	object.get(parameters[x], "schema", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.parameters", [openapi_lib.concat_path(path)]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "The attribute 'schema' is set",
+		"keyActualValue": "The attribute 'schema' is undefined",
+	}
+}

--- a/assets/queries/openAPI/parameter_object_without_schema/test/negative1.json
+++ b/assets/queries/openAPI/parameter_object_without_schema/test/negative1.json
@@ -1,0 +1,93 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "List API versions",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "user": {
+                    "summary": "User Example",
+                    "externalValue": "http://foo.bar/examples/user-example.json"
+                  }
+                }
+              }
+            },
+            "name": "id",
+            "in": "path",
+            "description": "ID of the API version",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "rel": "self",
+                              "href": "http://127.0.0.1:8774/v2/"
+                            }
+                          ],
+                          "status": "CURRENT"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "200 response"
+          }
+        },
+        "operationId": "listVersionsv2"
+      }
+    },
+    "/user/{id}": {
+      "parameters": [
+        {
+          "description": "ID of the API version",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          },
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              },
+              "examples": {
+                "user": {
+                  "summary": "User Example",
+                  "externalValue": "http://foo.bar/examples/user-example.json"
+                }
+              }
+            }
+          },
+          "name": "id",
+          "in": "path"
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/parameter_object_without_schema/test/negative2.json
+++ b/assets/queries/openAPI/parameter_object_without_schema/test/negative2.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "idParam": {
+        "name": "id",
+        "in": "path",
+        "description": "ID of the API version",
+        "required": true,
+        "schema": {
+          "type": "int"
+        },
+        "content": {
+          "application/xml": {
+            "examples": {
+              "user": {
+                "externalValue": "http://foo.bar/examples/user-example.xml",
+                "summary": "User Example in XML"
+              }
+            },
+            "schema": {
+              "$ref": "#/components/schemas/User"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/parameter_object_without_schema/test/negative3.yaml
+++ b/assets/queries/openAPI/parameter_object_without_schema/test/negative3.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      parameters:
+        - name: id
+          in: path
+          description: ID of the API version
+          required: true
+          schema:
+            type: integer
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/User"
+              examples:
+                user:
+                  summary: User Example
+                  externalValue: "http://foo.bar/examples/user-example.json"
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+  /user/{id}:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the API version
+        required: true
+        schema:
+          type: integer
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/User"
+            examples:
+              user:
+                summary: User Example
+                externalValue: "http://foo.bar/examples/user-example.json"

--- a/assets/queries/openAPI/parameter_object_without_schema/test/negative4.yaml
+++ b/assets/queries/openAPI/parameter_object_without_schema/test/negative4.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  parameters:
+    idParam:
+      name: id
+      in: path
+      description: ID of the API version
+      required: true
+      schema:
+        type: int
+      content:
+        "application/json":
+          schema:
+            $ref: "#/components/schemas/User"
+          examples:
+            user:
+              summary: User Example
+              externalValue: "http://foo.bar/examples/user-example.json"

--- a/assets/queries/openAPI/parameter_object_without_schema/test/positive1.json
+++ b/assets/queries/openAPI/parameter_object_without_schema/test/positive1.json
@@ -1,0 +1,87 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "List API versions",
+        "parameters": [
+          {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "user": {
+                    "summary": "User Example",
+                    "externalValue": "http://foo.bar/examples/user-example.json"
+                  }
+                }
+              }
+            },
+            "name": "id",
+            "in": "path",
+            "description": "ID of the API version",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "rel": "self",
+                              "href": "http://127.0.0.1:8774/v2/"
+                            }
+                          ],
+                          "status": "CURRENT"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "description": "200 response"
+          }
+        },
+        "operationId": "listVersionsv2"
+      }
+    },
+    "/user/": {
+      "parameters": [
+        {
+          "description": "ID of the API version",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              },
+              "examples": {
+                "user": {
+                  "summary": "User Example",
+                  "externalValue": "http://foo.bar/examples/user-example.json"
+                }
+              }
+            }
+          },
+          "name": "id",
+          "in": "path"
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/parameter_object_without_schema/test/positive2.json
+++ b/assets/queries/openAPI/parameter_object_without_schema/test/positive2.json
@@ -1,0 +1,66 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "idParam": {
+        "name": "id",
+        "in": "path",
+        "description": "ID of the API version",
+        "required": true,
+        "content": {
+          "application/xml": {
+            "examples": {
+              "user": {
+                "externalValue": "http://foo.bar/examples/user-example.xml",
+                "summary": "User Example in XML"
+              }
+            },
+            "schema": {
+              "$ref": "#/components/schemas/User"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/parameter_object_without_schema/test/positive3.yaml
+++ b/assets/queries/openAPI/parameter_object_without_schema/test/positive3.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      parameters:
+        - name: id
+          in: path
+          description: ID of the API version
+          required: true
+          content:
+            "application/json":
+              schema:
+                $ref: "#/components/schemas/User"
+              examples:
+                user:
+                  summary: User Example
+                  externalValue: "http://foo.bar/examples/user-example.json"
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+  /user/:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the API version
+        required: true
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/User"
+            examples:
+              user:
+                summary: User Example
+                externalValue: "http://foo.bar/examples/user-example.json"

--- a/assets/queries/openAPI/parameter_object_without_schema/test/positive4.yaml
+++ b/assets/queries/openAPI/parameter_object_without_schema/test/positive4.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  parameters:
+    idParam:
+      name: id
+      in: path
+      description: ID of the API version
+      required: true
+      content:
+        "application/json":
+          schema:
+            $ref: "#/components/schemas/User"
+          examples:
+            user:
+              summary: User Example
+              externalValue: "http://foo.bar/examples/user-example.json"

--- a/assets/queries/openAPI/parameter_object_without_schema/test/positive_expected_result.json
+++ b/assets/queries/openAPI/parameter_object_without_schema/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "Parameter Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 11,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameter Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 64,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameter Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 44,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Parameter Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 10,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Parameter Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 39,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Parameter Object Without Schema",
+    "severity": "MEDIUM",
+    "line": 26,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Parameter Object Without Schema" query for OpenAPI. It checks if the Parameter Object does not have 'schema' defined

I submit this contribution under the Apache-2.0 license.
