### PR TITLE
feat(query): Added IAM Role Policy passRole Allows All query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/metadata.json
+++ b/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "e39bee8c-fe54-4a3f-824d-e5e2d1cca40a",
+  "queryName": "IAM Role Policy passRole Allows All",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Using the iam:passrole action with wildcards (*) in the resource can be overly permissive because it allows iam:passrole permissions on multiple resources",
+  "descriptionUrl": "https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-reference-policy-checks.html#access-analyzer-reference-policy-checks-security-warning-pass-role-with-star-in-resource",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/query.rego
+++ b/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+import data.generic.common as commonLib
+
+CxPolicy[result] {
+	policy := input.document[i].resource.aws_iam_role_policy[name].policy
+
+	out := commonLib.json_unmarshal(policy)
+	check_passrole(out.Statement[idx])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_iam_role_policy[%s].policy.Statement.Action.{{iam:passrole}}", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'aws_iam_role_policy.policy.Statement.Action' iam:passrole doesn't have Resource '*'",
+		"keyActualValue": "'aws_iam_role_policy.policy.Statement.Action' iam:passrole has Resource '*'",
+	}
+}
+
+check_passrole(statement) {
+	is_string(statement.Action)
+	statement.Action == "iam:passrole"
+	statement.Resource == "*"
+} else {
+	is_array(statement.Action)
+	statement.Action[n] == "iam:passrole"
+	statement.Resource == "*"
+}

--- a/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/negative1.tf
+++ b/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/negative1.tf
@@ -1,0 +1,20 @@
+resource "aws_iam_role_policy" "test_policy" {
+  name = "test_policy"
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "iam:passrole"
+        ],
+        "Effect": "Allow",
+        "Resource": "arn:aws:sqs:us-east-2:account-ID-without-hyphens:queue1"
+      }
+    ]
+  }
+  EOF
+}
+

--- a/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/positive1.tf
+++ b/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/positive1.tf
@@ -1,0 +1,22 @@
+resource "aws_iam_role_policy" "test_policy" {
+  name = "test_policy"
+  role = aws_iam_role.test_role.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "iam:passrole"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
+}
+
+
+

--- a/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_role_policy_passrole_allows_all/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "IAM Role Policy passRole Allows All",
+    "severity": "MEDIUM",
+    "line": 11
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added IAM Role Policy passRole Allows All query for Terraform

Using the iam:passrole action with wildcards (*) in the resource can be overly permissive because it allows iam:passrole permissions on multiple resources

I submit this contribution under the Apache-2.0 license.
