### PR TITLE
feat(query): add "Example JSON Reference Does Not Exists" query for OpenAPI

### DIFF
--- a/assets/queries/openAPI/json_reference_does_not_exists_example/metadata.json
+++ b/assets/queries/openAPI/json_reference_does_not_exists_example/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "6a2c219f-da5e-4745-941e-5ea8cde23356",
+  "queryName": "Example JSON Reference Does Not Exists",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Example reference should exists on components field",
+  "descriptionUrl": "https://swagger.io/specification/#components-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/json_reference_does_not_exists_example/query.rego
+++ b/assets/queries/openAPI/json_reference_does_not_exists_example/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	ref := value["$ref"]
+	checkComponents := openapi_lib.check_reference_unexisting(doc, ref, "examples")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.$ref", [openapi_lib.concat_path(path)]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("%s from %s is declared on components.examples", [checkComponents, ref]),
+		"keyActualValue": sprintf("%s from %s is not declared on components.examples", [checkComponents, ref]),
+	}
+}

--- a/assets/queries/openAPI/json_reference_does_not_exists_example/test/negative1.json
+++ b/assets/queries/openAPI/json_reference_does_not_exists_example/test/negative1.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyObject"
+                },
+                "examples": {
+                  "objectExample": {
+                    "$ref": "#/components/examples/objectExample"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "MyObject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "examples": {
+      "objectExample": {
+        "value": {
+          "id": "1",
+          "name": "new object"
+        },
+        "summary": "A sample object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/json_reference_does_not_exists_example/test/negative2.yaml
+++ b/assets/queries/openAPI/json_reference_does_not_exists_example/test/negative2.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MyObject"
+              examples:
+                objectExample:
+                  "$ref": "#/components/examples/objectExample"
+components:
+  schemas:
+    MyObject:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+  examples:
+    objectExample:
+      value:
+        id: '1'
+        name: new object
+      summary: A sample object

--- a/assets/queries/openAPI/json_reference_does_not_exists_example/test/positive1.json
+++ b/assets/queries/openAPI/json_reference_does_not_exists_example/test/positive1.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyObject"
+                },
+                "examples": {
+                  "objectExample": {
+                    "$ref": "#/components/examples/wrongExample"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "MyObject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "examples": {
+      "objectExample": {
+        "value": {
+          "id": "1",
+          "name": "new object"
+        },
+        "summary": "A sample object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/json_reference_does_not_exists_example/test/positive2.yaml
+++ b/assets/queries/openAPI/json_reference_does_not_exists_example/test/positive2.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MyObject"
+              examples:
+                objectExample:
+                  "$ref": "#/components/examples/wrongExample"
+components:
+  schemas:
+    MyObject:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+  examples:
+    objectExample:
+      value:
+        id: '1'
+        name: new object
+      summary: A sample object

--- a/assets/queries/openAPI/json_reference_does_not_exists_example/test/positive_expected_result.json
+++ b/assets/queries/openAPI/json_reference_does_not_exists_example/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Example JSON Reference Does Not Exists",
+    "severity": "INFO",
+    "line": 22,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Example JSON Reference Does Not Exists",
+    "severity": "INFO",
+    "line": 19,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Added "Example JSON Reference Does Not Exists" query for OpenAPI

I submit this contribution under the Apache-2.0 license.
