### PR TITLE
feat(query): "String Schema with Broad Pattern" for OpenAPI

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -34,12 +34,14 @@ content_allowed(operation, code) {
 	all([code != "204", code != "304"])
 }
 
+# It verifies if there is some schema in 'components.schemas' equal to the input with the 'field' undefined
 check_content(doc, s, field) {
 	component_schema := doc.components.schemas[sc]
 	sc == s
 	object.get(component_schema, field, "undefined") == "undefined"
 }
 
+# It verifies if the 'schema_ref' refers to a schema with the 'field' undefined
 undefined_field_in_json_object(doc, schema_ref, field) {
 	r := split(schema_ref, "/")
 	count(r) == 4
@@ -52,6 +54,7 @@ is_ref(schema) {
 	object.get(schema, "$ref", "undefined") != "undefined"
 }
 
+# It verifies if there is some schema of 'type' in 'components.schemas' equal to the input with the 'field' undefined
 check_schema(doc, s, type, field) {
 	component_schema := doc.components.schemas[sc]
 	sc == s
@@ -59,6 +62,7 @@ check_schema(doc, s, type, field) {
 	object.get(component_schema.properties[p], field, "undefined") == "undefined"
 }
 
+# It verifies if a schema of 'type' has the 'field' undefined. In the case of being a reference, it is necessary to check the referenced schema
 undefined_properties_in_schema(doc, value, sc_kind, type, field) {
 	sc_kind == "schema"
 	schema := value[sc_kind]
@@ -69,6 +73,7 @@ undefined_properties_in_schema(doc, value, sc_kind, type, field) {
 	check_schema(doc, s, type, field)
 }
 
+# It verifies if a schema of 'type' has the 'field' undefined
 undefined_properties_in_schema(doc, value, sc_kind, type, field) {
 	sc_kind == "schema"
 	schema := value[sc_kind]
@@ -77,6 +82,7 @@ undefined_properties_in_schema(doc, value, sc_kind, type, field) {
 	object.get(schema.properties[p], field, "undefined") == "undefined"
 }
 
+# It verifies if schemas element of 'type' has the 'field' undefined
 undefined_properties_in_schema(doc, value, sc_kind, type, field) {
 	sc_kind == "schemas"
 	schema := value[sc_kind][s]
@@ -123,6 +129,7 @@ is_operation(path) = info {
 	info := {}
 }
 
+# It verifies what kind of schema is set in the 'value'
 get_schema(value) = schema_kind {
 	object.get(value, "schemas", "undefined") != "undefined"
 	schema_kind := "schemas"

--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -36,8 +36,7 @@ content_allowed(operation, code) {
 
 # It verifies if there is some schema in 'components.schemas' equal to the input with the 'field' undefined
 check_content(doc, s, field) {
-	component_schema := doc.components.schemas[sc]
-	sc == s
+	component_schema := doc.components.schemas[s]
 	object.get(component_schema, field, "undefined") == "undefined"
 }
 
@@ -47,48 +46,6 @@ undefined_field_in_json_object(doc, schema_ref, field) {
 	count(r) == 4
 	s := r[3]
 	check_content(doc, s, field)
-}
-
-is_ref(schema) {
-	count(schema) == 1
-	object.get(schema, "$ref", "undefined") != "undefined"
-}
-
-# It verifies if there is some schema of 'type' in 'components.schemas' equal to the input with the 'field' undefined
-check_schema(doc, s, type, field) {
-	component_schema := doc.components.schemas[sc]
-	sc == s
-	component_schema.properties[p].type == type
-	object.get(component_schema.properties[p], field, "undefined") == "undefined"
-}
-
-# It verifies if a schema of 'type' has the 'field' undefined. In the case of being a reference, it is necessary to check the referenced schema
-undefined_properties_in_schema(doc, value, sc_kind, type, field) {
-	sc_kind == "schema"
-	schema := value[sc_kind]
-	is_ref(schema)
-	r := split(schema["$ref"], "/")
-	count(r) == 4
-	s := r[3]
-	check_schema(doc, s, type, field)
-}
-
-# It verifies if a schema of 'type' has the 'field' undefined
-undefined_properties_in_schema(doc, value, sc_kind, type, field) {
-	sc_kind == "schema"
-	schema := value[sc_kind]
-	not is_ref(schema)
-	schema.properties[p].type == type
-	object.get(schema.properties[p], field, "undefined") == "undefined"
-}
-
-# It verifies if schemas element of 'type' has the 'field' undefined
-undefined_properties_in_schema(doc, value, sc_kind, type, field) {
-	sc_kind == "schemas"
-	schema := value[sc_kind][s]
-	not is_ref(schema)
-	schema.properties[p].type == type
-	object.get(schema.properties[p], field, "undefined") == "undefined"
 }
 
 check_unused_reference(doc, referenceName, type) {
@@ -129,11 +86,19 @@ is_operation(path) = info {
 	info := {}
 }
 
-# It verifies what kind of schema is set in the 'value'
-get_schema(value) = schema_kind {
-	object.get(value, "schemas", "undefined") != "undefined"
-	schema_kind := "schemas"
-} else = schema_kind {
-	object.get(value, "schema", "undefined") != "undefined"
-	schema_kind := "schema"
+is_numeric_type(type) {
+	numeric := {"integer", "number"}
+	type == numeric[x]
+}
+
+# It verifies if the string schema does not have the 'field' defined
+undefined_field_in_string_schema(value, field) {
+	value.type == "string"
+	object.get(value, field, "undefined") == "undefined"
+}
+
+# It verifies if the numeric schema does not have the 'field' defined
+undefined_field_in_numeric_schema(value, field) {
+	is_numeric_type(value.type)
+	object.get(value, field, "undefined") == "undefined"
 }

--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -52,7 +52,7 @@ is_ref(schema) {
 	object.get(schema, "$ref", "undefined") != "undefined"
 }
 
-check_string_schema(doc, s, type, field) {
+check_schema(doc, s, type, field) {
 	component_schema := doc.components.schemas[sc]
 	sc == s
 	component_schema.properties[p].type == type
@@ -64,13 +64,13 @@ undefined_properties_in_schema(doc, schema, type, field) {
 	r := split(schema["$ref"], "/")
 	count(r) == 4
 	s := r[3]
-	check_string_schema(doc, s, type, field)
+	check_schema(doc, s, type, field)
 }
 
 undefined_properties_in_schema(doc, schema, type, field) {
 	not is_ref(schema)
-	schema.type == type
-	object.get(schema, field, "undefined") == "undefined"
+	schema.properties[p].type == type
+	object.get(schema.properties[p], field, "undefined") == "undefined"
 }
 
 check_unused_reference(doc, referenceName, type) {
@@ -109,4 +109,10 @@ is_operation(path) = info {
 	info := {"code": code, "operation": op}
 } else = info {
 	info := {}
+}
+
+get_schema(value) = schema {
+	schema := {"kind": "schemas", "content": value.schemas[s]}
+} else = schema {
+	schema := {"kind": "schema", "content": value.schema}
 }

--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -59,7 +59,9 @@ check_schema(doc, s, type, field) {
 	object.get(component_schema.properties[p], field, "undefined") == "undefined"
 }
 
-undefined_properties_in_schema(doc, schema, type, field) {
+undefined_properties_in_schema(doc, value, sc_kind, type, field) {
+	sc_kind == "schema"
+	schema := value[sc_kind]
 	is_ref(schema)
 	r := split(schema["$ref"], "/")
 	count(r) == 4
@@ -67,7 +69,17 @@ undefined_properties_in_schema(doc, schema, type, field) {
 	check_schema(doc, s, type, field)
 }
 
-undefined_properties_in_schema(doc, schema, type, field) {
+undefined_properties_in_schema(doc, value, sc_kind, type, field) {
+	sc_kind == "schema"
+	schema := value[sc_kind]
+	not is_ref(schema)
+	schema.properties[p].type == type
+	object.get(schema.properties[p], field, "undefined") == "undefined"
+}
+
+undefined_properties_in_schema(doc, value, sc_kind, type, field) {
+	sc_kind == "schemas"
+	schema := value[sc_kind][s]
 	not is_ref(schema)
 	schema.properties[p].type == type
 	object.get(schema.properties[p], field, "undefined") == "undefined"
@@ -111,8 +123,10 @@ is_operation(path) = info {
 	info := {}
 }
 
-get_schema(value) = schema {
-	schema := {"kind": "schemas", "content": value.schemas[s]}
-} else = schema {
-	schema := {"kind": "schema", "content": value.schema}
+get_schema(value) = schema_kind {
+	object.get(value, "schemas", "undefined") != "undefined"
+	schema_kind := "schemas"
+} else = schema_kind {
+	object.get(value, "schema", "undefined") != "undefined"
+	schema_kind := "schema"
 }

--- a/assets/queries/openAPI/numeric_schema_without_format/query.rego
+++ b/assets/queries/openAPI/numeric_schema_without_format/query.rego
@@ -9,14 +9,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "format")
-
+	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "format")
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'format' defined",
 		"keyActualValue": "Numeric schema does not have 'format' defined",
@@ -28,13 +27,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "format")
+	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "format")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'format' defined",
 		"keyActualValue": "Numeric schema does not have 'format' defined",

--- a/assets/queries/openAPI/numeric_schema_without_format/query.rego
+++ b/assets/queries/openAPI/numeric_schema_without_format/query.rego
@@ -9,14 +9,14 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = value.schema
+	schema = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, schema, numeric[x], "format")
+	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "format")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'format' defined",
 		"keyActualValue": "Numeric schema does not have 'format' defined",
@@ -28,13 +28,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = value.schema
+	schema = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, schema, numeric[x], "format")
+	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "format")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'format' defined",
 		"keyActualValue": "Numeric schema does not have 'format' defined",

--- a/assets/queries/openAPI/numeric_schema_without_format/query.rego
+++ b/assets/queries/openAPI/numeric_schema_without_format/query.rego
@@ -2,20 +2,19 @@ package Cx
 
 import data.generic.openapi as openapi_lib
 
-numeric := {"integer", "number"}
-
 CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "format")
+
+	openapi_lib.undefined_field_in_numeric_schema(value, "format")
+
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'format' defined",
 		"keyActualValue": "Numeric schema does not have 'format' defined",
@@ -27,13 +26,14 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "format")
+	openapi_lib.is_numeric_type(value.type)
+
+	openapi_lib.undefined_field_in_numeric_schema(value, "format")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'format' defined",
 		"keyActualValue": "Numeric schema does not have 'format' defined",

--- a/assets/queries/openAPI/numeric_schema_without_format/test/negative2.json
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/negative2.json
@@ -18,7 +18,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 50,
+                      "format": "int32"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,28 +60,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0,
-            "maximum": 50
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/numeric_schema_without_format/test/negative4.yaml
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/negative4.yaml
@@ -13,7 +13,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: integer
+                    minimum: 0
+                    maximum: 50
+                    format: int32
+                required:
+                  - petType
               examples:
                 foo:
                   value:
@@ -24,18 +35,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: integer
-          format: int32
-          minimum: 0
-          maximum: 50
-      required:
-        - petType

--- a/assets/queries/openAPI/numeric_schema_without_format/test/positive2.json
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/positive2.json
@@ -18,7 +18,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 50
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,27 +59,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "integer",
-            "minimum": 0,
-            "maximum": 50
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/numeric_schema_without_format/test/positive4.yaml
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/positive4.yaml
@@ -13,7 +13,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: integer
+                    minimum: 0
+                    maximum: 50
+                required:
+                  - petType
               examples:
                 foo:
                   value:
@@ -24,17 +34,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: integer
-          minimum: 0
-          maximum: 50
-      required:
-        - petType

--- a/assets/queries/openAPI/numeric_schema_without_format/test/positive_expected_result.json
+++ b/assets/queries/openAPI/numeric_schema_without_format/test/positive_expected_result.json
@@ -2,49 +2,25 @@
   {
     "queryName": "Numeric Schema Without Format",
     "severity": "MEDIUM",
-    "line": 49,
+    "line": 58,
     "filename": "positive1.json"
   },
   {
     "queryName": "Numeric Schema Without Format",
     "severity": "MEDIUM",
-    "line": 74,
-    "filename": "positive1.json"
-  },
-  {
-    "queryName": "Numeric Schema Without Format",
-    "severity": "MEDIUM",
-    "line": 20,
+    "line": 27,
     "filename": "positive2.json"
   },
   {
     "queryName": "Numeric Schema Without Format",
     "severity": "MEDIUM",
-    "line": 52,
-    "filename": "positive2.json"
-  },
-  {
-    "queryName": "Numeric Schema Without Format",
-    "severity": "MEDIUM",
-    "line": 26,
+    "line": 34,
     "filename": "positive3.yaml"
   },
   {
     "queryName": "Numeric Schema Without Format",
     "severity": "MEDIUM",
-    "line": 45,
-    "filename": "positive3.yaml"
-  },
-  {
-    "queryName": "Numeric Schema Without Format",
-    "severity": "MEDIUM",
-    "line": 15,
-    "filename": "positive4.yaml"
-  },
-  {
-    "queryName": "Numeric Schema Without Format",
-    "severity": "MEDIUM",
-    "line": 28,
+    "line": 22,
     "filename": "positive4.yaml"
   }
 ]

--- a/assets/queries/openAPI/numeric_schema_without_maximum/query.rego
+++ b/assets/queries/openAPI/numeric_schema_without_maximum/query.rego
@@ -9,14 +9,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "maximum")
-
+	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "maximum")
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'maximum' defined",
 		"keyActualValue": "Numeric schema does not have 'maximum' defined",
@@ -28,13 +27,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "maximum")
+	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "maximum")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'maximum' defined",
 		"keyActualValue": "Numeric schema does not have 'maximum' defined",

--- a/assets/queries/openAPI/numeric_schema_without_maximum/query.rego
+++ b/assets/queries/openAPI/numeric_schema_without_maximum/query.rego
@@ -9,14 +9,14 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = value.schema
+	schema = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, schema, numeric[x], "maximum")
+	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "maximum")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'maximum' defined",
 		"keyActualValue": "Numeric schema does not have 'maximum' defined",
@@ -28,13 +28,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = value.schema
+	schema = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, schema, numeric[x], "maximum")
+	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "maximum")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'maximum' defined",
 		"keyActualValue": "Numeric schema does not have 'maximum' defined",

--- a/assets/queries/openAPI/numeric_schema_without_maximum/query.rego
+++ b/assets/queries/openAPI/numeric_schema_without_maximum/query.rego
@@ -2,20 +2,19 @@ package Cx
 
 import data.generic.openapi as openapi_lib
 
-numeric := {"integer", "number"}
-
 CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "maximum")
+
+	openapi_lib.undefined_field_in_numeric_schema(value, "maximum")
+
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'maximum' defined",
 		"keyActualValue": "Numeric schema does not have 'maximum' defined",
@@ -27,13 +26,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "maximum")
+
+	openapi_lib.undefined_field_in_numeric_schema(value, "maximum")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'maximum' defined",
 		"keyActualValue": "Numeric schema does not have 'maximum' defined",

--- a/assets/queries/openAPI/numeric_schema_without_maximum/test/negative2.json
+++ b/assets/queries/openAPI/numeric_schema_without_maximum/test/negative2.json
@@ -18,7 +18,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32",
+                      "minimum": 0,
+                      "maximum": 50
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,28 +60,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0,
-            "maximum": 50
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/numeric_schema_without_maximum/test/negative4.yaml
+++ b/assets/queries/openAPI/numeric_schema_without_maximum/test/negative4.yaml
@@ -13,7 +13,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: integer
+                    format: int32
+                    minimum: 0
+                    maximum: 50
               examples:
                 foo:
                   value:
@@ -24,18 +33,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: integer
-          format: int32
-          minimum: 0
-          maximum: 50
-      required:
-        - petType

--- a/assets/queries/openAPI/numeric_schema_without_maximum/test/positive2.json
+++ b/assets/queries/openAPI/numeric_schema_without_maximum/test/positive2.json
@@ -18,7 +18,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32",
+                      "minimum": 0
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,27 +59,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/numeric_schema_without_maximum/test/positive4.yaml
+++ b/assets/queries/openAPI/numeric_schema_without_maximum/test/positive4.yaml
@@ -13,7 +13,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: integer
+                    format: int32
+                    minimum: 0
               examples:
                 foo:
                   value:
@@ -24,17 +32,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: integer
-          format: int32
-          minimum: 0
-      required:
-        - petType

--- a/assets/queries/openAPI/numeric_schema_without_maximum/test/positive_expected_result.json
+++ b/assets/queries/openAPI/numeric_schema_without_maximum/test/positive_expected_result.json
@@ -2,6 +2,12 @@
   {
     "queryName": "Numeric Schema Without Maximum",
     "severity": "MEDIUM",
+    "line": 49,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Numeric Schema Without Maximum",
+    "severity": "MEDIUM",
     "line": 74,
     "filename": "positive1.json"
   },
@@ -14,6 +20,18 @@
   {
     "queryName": "Numeric Schema Without Maximum",
     "severity": "MEDIUM",
+    "line": 52,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Numeric Schema Without Maximum",
+    "severity": "MEDIUM",
+    "line": 26,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Numeric Schema Without Maximum",
+    "severity": "MEDIUM",
     "line": 45,
     "filename": "positive3.yaml"
   },
@@ -21,6 +39,12 @@
     "queryName": "Numeric Schema Without Maximum",
     "severity": "MEDIUM",
     "line": 15,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Numeric Schema Without Maximum",
+    "severity": "MEDIUM",
+    "line": 28,
     "filename": "positive4.yaml"
   }
 ]

--- a/assets/queries/openAPI/numeric_schema_without_maximum/test/positive_expected_result.json
+++ b/assets/queries/openAPI/numeric_schema_without_maximum/test/positive_expected_result.json
@@ -2,49 +2,25 @@
   {
     "queryName": "Numeric Schema Without Maximum",
     "severity": "MEDIUM",
-    "line": 49,
+    "line": 58,
     "filename": "positive1.json"
   },
   {
     "queryName": "Numeric Schema Without Maximum",
     "severity": "MEDIUM",
-    "line": 74,
-    "filename": "positive1.json"
-  },
-  {
-    "queryName": "Numeric Schema Without Maximum",
-    "severity": "MEDIUM",
-    "line": 20,
+    "line": 27,
     "filename": "positive2.json"
   },
   {
     "queryName": "Numeric Schema Without Maximum",
     "severity": "MEDIUM",
-    "line": 52,
-    "filename": "positive2.json"
-  },
-  {
-    "queryName": "Numeric Schema Without Maximum",
-    "severity": "MEDIUM",
-    "line": 26,
+    "line": 34,
     "filename": "positive3.yaml"
   },
   {
     "queryName": "Numeric Schema Without Maximum",
     "severity": "MEDIUM",
-    "line": 45,
-    "filename": "positive3.yaml"
-  },
-  {
-    "queryName": "Numeric Schema Without Maximum",
-    "severity": "MEDIUM",
-    "line": 15,
-    "filename": "positive4.yaml"
-  },
-  {
-    "queryName": "Numeric Schema Without Maximum",
-    "severity": "MEDIUM",
-    "line": 28,
+    "line": 22,
     "filename": "positive4.yaml"
   }
 ]

--- a/assets/queries/openAPI/numeric_schema_without_minimum/query.rego
+++ b/assets/queries/openAPI/numeric_schema_without_minimum/query.rego
@@ -2,20 +2,19 @@ package Cx
 
 import data.generic.openapi as openapi_lib
 
-numeric := {"integer", "number"}
-
 CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "minimum")
+
+	openapi_lib.undefined_field_in_numeric_schema(value, "minimum")
+
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'minimum' defined",
 		"keyActualValue": "Numeric schema does not have 'minimum' defined",
@@ -27,13 +26,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "minimum")
+
+	openapi_lib.undefined_field_in_numeric_schema(value, "minimum")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'minimum' defined",
 		"keyActualValue": "Numeric schema does not have 'minimum' defined",

--- a/assets/queries/openAPI/numeric_schema_without_minimum/query.rego
+++ b/assets/queries/openAPI/numeric_schema_without_minimum/query.rego
@@ -9,14 +9,14 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = value.schema
+	schema = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, schema, numeric[x], "minimum")
+	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "minimum")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'minimum' defined",
 		"keyActualValue": "Numeric schema does not have 'minimum' defined",
@@ -28,13 +28,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = value.schema
+	schema = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, schema, numeric[x], "minimum")
+	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "minimum")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'minimum' defined",
 		"keyActualValue": "Numeric schema does not have 'minimum' defined",

--- a/assets/queries/openAPI/numeric_schema_without_minimum/query.rego
+++ b/assets/queries/openAPI/numeric_schema_without_minimum/query.rego
@@ -9,14 +9,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "minimum")
-
+	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "minimum")
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'minimum' defined",
 		"keyActualValue": "Numeric schema does not have 'minimum' defined",
@@ -28,13 +27,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, schema.content, numeric[x], "minimum")
+	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, numeric[x], "minimum")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Numeric schema has 'minimum' defined",
 		"keyActualValue": "Numeric schema does not have 'minimum' defined",

--- a/assets/queries/openAPI/numeric_schema_without_minimum/test/negative2.json
+++ b/assets/queries/openAPI/numeric_schema_without_minimum/test/negative2.json
@@ -18,7 +18,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32",
+                      "minimum": 0
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,27 +59,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/numeric_schema_without_minimum/test/negative4.yaml
+++ b/assets/queries/openAPI/numeric_schema_without_minimum/test/negative4.yaml
@@ -13,7 +13,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: integer
+                    format: int32
+                    minimum: 0
+                required:
+                  - petType
               examples:
                 foo:
                   value:
@@ -24,17 +34,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: integer
-          format: int32
-          minimum: 0
-      required:
-        - petType

--- a/assets/queries/openAPI/numeric_schema_without_minimum/test/positive2.json
+++ b/assets/queries/openAPI/numeric_schema_without_minimum/test/positive2.json
@@ -18,7 +18,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,26 +58,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/numeric_schema_without_minimum/test/positive4.yaml
+++ b/assets/queries/openAPI/numeric_schema_without_minimum/test/positive4.yaml
@@ -13,7 +13,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: integer
+                    format: int32
+                required:
+                  - petType
               examples:
                 foo:
                   value:
@@ -24,16 +33,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: integer
-          format: int32
-      required:
-        - petType

--- a/assets/queries/openAPI/numeric_schema_without_minimum/test/positive_expected_result.json
+++ b/assets/queries/openAPI/numeric_schema_without_minimum/test/positive_expected_result.json
@@ -2,49 +2,25 @@
   {
     "queryName": "Numeric Schema Without Minimum",
     "severity": "MEDIUM",
-    "line": 49,
+    "line": 58,
     "filename": "positive1.json"
   },
   {
     "queryName": "Numeric Schema Without Minimum",
     "severity": "MEDIUM",
-    "line": 73,
-    "filename": "positive1.json"
-  },
-  {
-    "queryName": "Numeric Schema Without Minimum",
-    "severity": "MEDIUM",
-    "line": 20,
+    "line": 27,
     "filename": "positive2.json"
   },
   {
     "queryName": "Numeric Schema Without Minimum",
     "severity": "MEDIUM",
-    "line": 52,
-    "filename": "positive2.json"
-  },
-  {
-    "queryName": "Numeric Schema Without Minimum",
-    "severity": "MEDIUM",
-    "line": 26,
+    "line": 34,
     "filename": "positive3.yaml"
   },
   {
     "queryName": "Numeric Schema Without Minimum",
     "severity": "MEDIUM",
-    "line": 44,
-    "filename": "positive3.yaml"
-  },
-  {
-    "queryName": "Numeric Schema Without Minimum",
-    "severity": "MEDIUM",
-    "line": 15,
-    "filename": "positive4.yaml"
-  },
-  {
-    "queryName": "Numeric Schema Without Minimum",
-    "severity": "MEDIUM",
-    "line": 28,
+    "line": 22,
     "filename": "positive4.yaml"
   }
 ]

--- a/assets/queries/openAPI/numeric_schema_without_minimum/test/positive_expected_result.json
+++ b/assets/queries/openAPI/numeric_schema_without_minimum/test/positive_expected_result.json
@@ -2,6 +2,12 @@
   {
     "queryName": "Numeric Schema Without Minimum",
     "severity": "MEDIUM",
+    "line": 49,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Numeric Schema Without Minimum",
+    "severity": "MEDIUM",
     "line": 73,
     "filename": "positive1.json"
   },
@@ -14,6 +20,18 @@
   {
     "queryName": "Numeric Schema Without Minimum",
     "severity": "MEDIUM",
+    "line": 52,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Numeric Schema Without Minimum",
+    "severity": "MEDIUM",
+    "line": 26,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Numeric Schema Without Minimum",
+    "severity": "MEDIUM",
     "line": 44,
     "filename": "positive3.yaml"
   },
@@ -21,6 +39,12 @@
     "queryName": "Numeric Schema Without Minimum",
     "severity": "MEDIUM",
     "line": 15,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Numeric Schema Without Minimum",
+    "severity": "MEDIUM",
+    "line": 28,
     "filename": "positive4.yaml"
   }
 ]

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/metadata.json
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "8c81d6c0-716b-49ec-afa5-2d62da4e3f3c",
+  "queryName": "String Schema with Broad Pattern",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "String schema should restrict the pattern",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/query.rego
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/query.rego
@@ -7,14 +7,14 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	has_broad_schema(schema.content, doc)
+	has_broad_schema(value, schema_kind, doc)
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "String schema has 'pattern' restricted",
 		"keyActualValue": "String schema does not have 'pattern' restricted",
@@ -26,13 +26,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	has_broad_schema(schema.content, doc)
+	has_broad_schema(value, schema_kind, doc)
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "String schema has 'pattern' restricted",
 		"keyActualValue": "String schema does not have 'pattern' restricted",
@@ -44,14 +44,24 @@ broad_schema(schema) {
 	startswith(schema.properties[p].pattern, "^") == false
 }
 
-has_broad_schema(schema, doc) {
-	not openapi_lib.is_ref(schema)
-	broad_schema(schema)
+has_broad_schema(value, schema_kind, doc) {
+	schema_kind == "schema"
+	sc := value[schema_kind]
+	not openapi_lib.is_ref(sc)
+	broad_schema(sc)
 }
 
-has_broad_schema(schema, doc) {
-	openapi_lib.is_ref(schema)
-	r := split(schema["$ref"], "/")
+has_broad_schema(value, schema_kind, doc) {
+	schema_kind == "schemas"
+	sc := value[schema_kind][s]
+	not openapi_lib.is_ref(sc)
+	broad_schema(sc)
+}
+
+has_broad_schema(value, schema_kind, doc) {
+	schema_kind == "schema"
+	openapi_lib.is_ref(value[schema_kind])
+	r := split(value[schema_kind]["$ref"], "/")
 	count(r) == 4
 	s := r[3]
 	component_schema := doc.components.schemas[sc]

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/query.rego
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/query.rego
@@ -1,0 +1,60 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	schema = openapi_lib.get_schema(value)
+	info := openapi_lib.is_operation(path)
+	openapi_lib.content_allowed(info.operation, info.code)
+	has_broad_schema(schema.content, doc)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "String schema has 'pattern' restricted",
+		"keyActualValue": "String schema does not have 'pattern' restricted",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	schema = openapi_lib.get_schema(value)
+	openapi_lib.is_operation(path) == {}
+	has_broad_schema(schema.content, doc)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "String schema has 'pattern' restricted",
+		"keyActualValue": "String schema does not have 'pattern' restricted",
+	}
+}
+
+broad_schema(schema) {
+	schema.properties[p].type == "string"
+	startswith(schema.properties[p].pattern, "^") == false
+}
+
+has_broad_schema(schema, doc) {
+	not openapi_lib.is_ref(schema)
+	broad_schema(schema)
+}
+
+has_broad_schema(schema, doc) {
+	openapi_lib.is_ref(schema)
+	r := split(schema["$ref"], "/")
+	count(r) == 4
+	s := r[3]
+	component_schema := doc.components.schemas[sc]
+	sc == s
+	broad_schema(component_schema)
+}

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/query.rego
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/query.rego
@@ -7,64 +7,20 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
-	info := openapi_lib.is_operation(path)
-	openapi_lib.content_allowed(info.operation, info.code)
-	has_broad_schema(value, schema_kind, doc)
+	value.type == "string"
+	broad_schema(value.pattern)
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.pattern", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "String schema has 'pattern' restricted",
 		"keyActualValue": "String schema does not have 'pattern' restricted",
 	}
 }
 
-CxPolicy[result] {
-	doc := input.document[i]
-	openapi_lib.check_openapi(doc) != "undefined"
-
-	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
-	openapi_lib.is_operation(path) == {}
-	has_broad_schema(value, schema_kind, doc)
-
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "String schema has 'pattern' restricted",
-		"keyActualValue": "String schema does not have 'pattern' restricted",
-	}
-}
-
-broad_schema(schema) {
-	schema.properties[p].type == "string"
-	startswith(schema.properties[p].pattern, "^") == false
-}
-
-has_broad_schema(value, schema_kind, doc) {
-	schema_kind == "schema"
-	sc := value[schema_kind]
-	not openapi_lib.is_ref(sc)
-	broad_schema(sc)
-}
-
-has_broad_schema(value, schema_kind, doc) {
-	schema_kind == "schemas"
-	sc := value[schema_kind][s]
-	not openapi_lib.is_ref(sc)
-	broad_schema(sc)
-}
-
-has_broad_schema(value, schema_kind, doc) {
-	schema_kind == "schema"
-	openapi_lib.is_ref(value[schema_kind])
-	r := split(value[schema_kind]["$ref"], "/")
-	count(r) == 4
-	s := r[3]
-	component_schema := doc.components.schemas[sc]
-	sc == s
-	broad_schema(component_schema)
+broad_schema(pattern) {
+	startswith(pattern, "^") == false
+} else {
+	endswith(pattern, "$") == false
 }

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative1.json
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative1.json
@@ -1,0 +1,93 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": "15",
+            "format": "int32",
+            "pattern": "^[0-9a-z]{15}$"
+          },
+          "message": {
+            "type": "string",
+            "maxLength": "15",
+            "pattern": "^[0-9a-z]{15}$"
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative2.json
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative2.json
@@ -1,0 +1,78 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": "15",
+            "format": "int32",
+            "pattern": "^[0-9a-z]{15}$"
+          },
+          "message": {
+            "type": "string",
+            "maxLength": "15",
+            "pattern": "^[0-9a-z]{15}$"
+          }
+        },
+        "required": [
+          "petType"
+        ],
+        "type": "object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative2.json
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative2.json
@@ -18,7 +18,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "maxLength": "15",
+                      "format": "int32",
+                      "pattern": "^[0-9a-z]{15}$"
+                    },
+                    "message": {
+                      "type": "string",
+                      "maxLength": "15",
+                      "pattern": "^[0-9a-z]{15}$"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,33 +65,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": "15",
-            "format": "int32",
-            "pattern": "^[0-9a-z]{15}$"
-          },
-          "message": {
-            "type": "string",
-            "maxLength": "15",
-            "pattern": "^[0-9a-z]{15}$"
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative3.yaml
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative3.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          maxLength: 15
+          format: int32
+          pattern: ^[0-9a-z]{15}$
+        message:
+          type: string
+          maxLength: 15
+          pattern: ^[0-9a-z]{15}$
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative4.yaml
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative4.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          maxLength: 15
+          format: int32
+          pattern: ^[0-9a-z]{15}$
+        message:
+          type: string
+          maxLength: 15
+          pattern: ^[0-9a-z]{15}$
+      required:
+        - petType

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative4.yaml
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/negative4.yaml
@@ -13,7 +13,20 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: string
+                    maxLength: 15
+                    format: int32
+                    pattern: ^[0-9a-z]{15}$
+                  message:
+                    type: string
+                    maxLength: 15
+                    pattern: ^[0-9a-z]{15}$
               examples:
                 foo:
                   value:
@@ -24,22 +37,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: string
-          maxLength: 15
-          format: int32
-          pattern: ^[0-9a-z]{15}$
-        message:
-          type: string
-          maxLength: 15
-          pattern: ^[0-9a-z]{15}$
-      required:
-        - petType

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive1.json
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive1.json
@@ -1,0 +1,93 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": "15",
+            "format": "int32",
+            "pattern": ".*"
+          },
+          "message": {
+            "type": "string",
+            "maxLength": "15",
+            "pattern": "^[0-9a-z]{15}$"
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive2.json
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive2.json
@@ -18,7 +18,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "maxLength": "15",
+                      "format": "int32",
+                      "pattern": ".*"
+                    },
+                    "message": {
+                      "type": "string",
+                      "maxLength": "15",
+                      "pattern": "^[0-9a-z]{15}$"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,33 +65,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": "15",
-            "format": "int32",
-            "pattern": ".*"
-          },
-          "message": {
-            "type": "string",
-            "maxLength": "15",
-            "pattern": "^[0-9a-z]{15}$"
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive2.json
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive2.json
@@ -1,0 +1,78 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralError"
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": "15",
+            "format": "int32",
+            "pattern": ".*"
+          },
+          "message": {
+            "type": "string",
+            "maxLength": "15",
+            "pattern": "^[0-9a-z]{15}$"
+          }
+        },
+        "required": [
+          "petType"
+        ],
+        "type": "object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive3.yaml
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive3.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          maxLength: 15
+          format: int32
+          pattern: .*
+        message:
+          type: string
+          maxLength: 15
+          pattern: ^[0-9a-z]{15}$
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive4.yaml
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive4.yaml
@@ -13,7 +13,20 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: string
+                    maxLength: 15
+                    format: int32
+                    pattern: .*
+                  message:
+                    type: string
+                    maxLength: 15
+                    pattern: ^[0-9a-z]{15}$
               examples:
                 foo:
                   value:
@@ -24,22 +37,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: string
-          maxLength: 15
-          format: int32
-          pattern: .*
-        message:
-          type: string
-          maxLength: 15
-          pattern: ^[0-9a-z]{15}$
-      required:
-        - petType

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive4.yaml
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive4.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralError"
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          maxLength: 15
+          format: int32
+          pattern: .*
+        message:
+          type: string
+          maxLength: 15
+          pattern: ^[0-9a-z]{15}$
+      required:
+        - petType

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive_expected_result.json
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive_expected_result.json
@@ -1,48 +1,48 @@
 [
   {
-    "queryName": "Numeric Schema Without Format",
+    "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
     "line": 49,
     "filename": "positive1.json"
   },
   {
-    "queryName": "Numeric Schema Without Format",
+    "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
-    "line": 74,
+    "line": 80,
     "filename": "positive1.json"
   },
   {
-    "queryName": "Numeric Schema Without Format",
+    "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
     "line": 20,
     "filename": "positive2.json"
   },
   {
-    "queryName": "Numeric Schema Without Format",
+    "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
     "line": 52,
     "filename": "positive2.json"
   },
   {
-    "queryName": "Numeric Schema Without Format",
+    "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
     "line": 26,
     "filename": "positive3.yaml"
   },
   {
-    "queryName": "Numeric Schema Without Format",
+    "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
-    "line": 45,
+    "line": 50,
     "filename": "positive3.yaml"
   },
   {
-    "queryName": "Numeric Schema Without Format",
+    "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
     "line": 15,
     "filename": "positive4.yaml"
   },
   {
-    "queryName": "Numeric Schema Without Format",
+    "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
     "line": 28,
     "filename": "positive4.yaml"

--- a/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive_expected_result.json
+++ b/assets/queries/openAPI/string_schema_with_broad_pattern/test/positive_expected_result.json
@@ -2,49 +2,25 @@
   {
     "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
-    "line": 49,
+    "line": 61,
     "filename": "positive1.json"
   },
   {
     "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
-    "line": 80,
-    "filename": "positive1.json"
-  },
-  {
-    "queryName": "String Schema with Broad Pattern",
-    "severity": "MEDIUM",
-    "line": 20,
+    "line": 30,
     "filename": "positive2.json"
   },
   {
     "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
-    "line": 52,
-    "filename": "positive2.json"
-  },
-  {
-    "queryName": "String Schema with Broad Pattern",
-    "severity": "MEDIUM",
-    "line": 26,
+    "line": 37,
     "filename": "positive3.yaml"
   },
   {
     "queryName": "String Schema with Broad Pattern",
     "severity": "MEDIUM",
-    "line": 50,
-    "filename": "positive3.yaml"
-  },
-  {
-    "queryName": "String Schema with Broad Pattern",
-    "severity": "MEDIUM",
-    "line": 15,
-    "filename": "positive4.yaml"
-  },
-  {
-    "queryName": "String Schema with Broad Pattern",
-    "severity": "MEDIUM",
-    "line": 28,
+    "line": 25,
     "filename": "positive4.yaml"
   }
 ]

--- a/assets/queries/openAPI/string_schema_without_maximum_length/query.rego
+++ b/assets/queries/openAPI/string_schema_without_maximum_length/query.rego
@@ -7,14 +7,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, "string", "maxLength")
+	openapi_lib.undefined_field_in_string_schema(value, "maxLength")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'maxLength' defined",
 		"keyActualValue": "String schema does not have 'maxLength' defined",
@@ -26,13 +25,12 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, "string", "maxLength")
+	openapi_lib.undefined_field_in_string_schema(value, "maxLength")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'maxLength' defined",
 		"keyActualValue": "String schema does not have 'maxLength' defined",

--- a/assets/queries/openAPI/string_schema_without_maximum_length/query.rego
+++ b/assets/queries/openAPI/string_schema_without_maximum_length/query.rego
@@ -7,14 +7,14 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, schema.content, "string", "maxLength")
+	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, "string", "maxLength")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'maxLength' defined",
 		"keyActualValue": "String schema does not have 'maxLength' defined",
@@ -26,13 +26,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, schema.content, "string", "maxLength")
+	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, "string", "maxLength")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'maxLength' defined",
 		"keyActualValue": "String schema does not have 'maxLength' defined",

--- a/assets/queries/openAPI/string_schema_without_maximum_length/query.rego
+++ b/assets/queries/openAPI/string_schema_without_maximum_length/query.rego
@@ -7,14 +7,14 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = value.schema
+	schema = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, schema, "string", "maxLength")
+	openapi_lib.undefined_properties_in_schema(doc, schema.content, "string", "maxLength")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'maxLength' defined",
 		"keyActualValue": "String schema does not have 'maxLength' defined",
@@ -26,13 +26,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = value.schema
+	schema = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, schema, "string", "maxLength")
+	openapi_lib.undefined_properties_in_schema(doc, schema.content, "string", "maxLength")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'maxLength' defined",
 		"keyActualValue": "String schema does not have 'maxLength' defined",

--- a/assets/queries/openAPI/string_schema_without_maximum_length/test/negative2.json
+++ b/assets/queries/openAPI/string_schema_without_maximum_length/test/negative2.json
@@ -18,7 +18,25 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "int32",
+                      "maxLength": "15"
+                    },
+                    "message": {
+                      "type": "string",
+                      "maxLength": "15"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -42,34 +60,7 @@
               }
             }
           }
-        },
-        "operationId": "listVersionsv2",
-        "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": "15",
-            "format": "int32"
-          },
-          "message": {
-            "type": "string",
-            "maxLength": "15"
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
+        }
       }
     }
   }

--- a/assets/queries/openAPI/string_schema_without_maximum_length/test/negative4.yaml
+++ b/assets/queries/openAPI/string_schema_without_maximum_length/test/negative4.yaml
@@ -13,7 +13,20 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: string
+                    format: int32
+                    maxLength: 15
+                  message:
+                    type: string
+                    maxLength: 15
+                required:
+                  - petType
               examples:
                 foo:
                   value:
@@ -34,8 +47,8 @@ components:
       properties:
         code:
           type: string
-          maxLength: 15
           format: int32
+          maxLength: 15
         message:
           type: string
           maxLength: 15

--- a/assets/queries/openAPI/string_schema_without_maximum_length/test/positive2.json
+++ b/assets/queries/openAPI/string_schema_without_maximum_length/test/positive2.json
@@ -18,7 +18,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,29 +61,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "string",
-            "format": "int32"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/string_schema_without_maximum_length/test/positive4.yaml
+++ b/assets/queries/openAPI/string_schema_without_maximum_length/test/positive4.yaml
@@ -13,7 +13,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: string
+                required:
+                  - petType
               examples:
                 foo:
                   value:
@@ -24,18 +35,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: string
-          format: int32
-        message:
-          type: string
-      required:
-        - petType

--- a/assets/queries/openAPI/string_schema_without_maximum_length/test/positive_expected_result.json
+++ b/assets/queries/openAPI/string_schema_without_maximum_length/test/positive_expected_result.json
@@ -2,49 +2,49 @@
   {
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
-    "line": 49,
+    "line": 58,
     "filename": "positive1.json"
   },
   {
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
-    "line": 76,
+    "line": 62,
     "filename": "positive1.json"
   },
   {
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
-    "line": 20,
+    "line": 27,
     "filename": "positive2.json"
   },
   {
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
-    "line": 52,
+    "line": 31,
     "filename": "positive2.json"
   },
   {
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
-    "line": 26,
+    "line": 34,
     "filename": "positive3.yaml"
   },
   {
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
-    "line": 46,
+    "line": 37,
     "filename": "positive3.yaml"
   },
   {
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
-    "line": 15,
+    "line": 22,
     "filename": "positive4.yaml"
   },
   {
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
-    "line": 28,
+    "line": 25,
     "filename": "positive4.yaml"
   }
 ]

--- a/assets/queries/openAPI/string_schema_without_maximum_length/test/positive_expected_result.json
+++ b/assets/queries/openAPI/string_schema_without_maximum_length/test/positive_expected_result.json
@@ -2,6 +2,12 @@
   {
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
+    "line": 49,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "String Schema Without Maximum Length",
+    "severity": "MEDIUM",
     "line": 76,
     "filename": "positive1.json"
   },
@@ -14,6 +20,18 @@
   {
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
+    "line": 52,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "String Schema Without Maximum Length",
+    "severity": "MEDIUM",
+    "line": 26,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "String Schema Without Maximum Length",
+    "severity": "MEDIUM",
     "line": 46,
     "filename": "positive3.yaml"
   },
@@ -21,6 +39,12 @@
     "queryName": "String Schema Without Maximum Length",
     "severity": "MEDIUM",
     "line": 15,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "String Schema Without Maximum Length",
+    "severity": "MEDIUM",
+    "line": 28,
     "filename": "positive4.yaml"
   }
 ]

--- a/assets/queries/openAPI/string_schema_without_pattern/query.rego
+++ b/assets/queries/openAPI/string_schema_without_pattern/query.rego
@@ -7,14 +7,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, "string", "pattern")
+	openapi_lib.undefined_field_in_string_schema(value, "pattern")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'pattern' defined",
 		"keyActualValue": "String schema does not have 'pattern' defined",
@@ -26,13 +25,12 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, "string", "pattern")
+	openapi_lib.undefined_field_in_string_schema(value, "pattern")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'pattern' defined",
 		"keyActualValue": "String schema does not have 'pattern' defined",

--- a/assets/queries/openAPI/string_schema_without_pattern/query.rego
+++ b/assets/queries/openAPI/string_schema_without_pattern/query.rego
@@ -7,14 +7,14 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = value.schema
+	schema = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, schema, "string", "pattern")
+	openapi_lib.undefined_properties_in_schema(doc, schema.content, "string", "pattern")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'pattern' defined",
 		"keyActualValue": "String schema does not have 'pattern' defined",
@@ -26,13 +26,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = value.schema
+	schema = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, schema, "string", "pattern")
+	openapi_lib.undefined_properties_in_schema(doc, schema.content, "string", "pattern")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'pattern' defined",
 		"keyActualValue": "String schema does not have 'pattern' defined",

--- a/assets/queries/openAPI/string_schema_without_pattern/query.rego
+++ b/assets/queries/openAPI/string_schema_without_pattern/query.rego
@@ -7,14 +7,14 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
-	openapi_lib.undefined_properties_in_schema(doc, schema.content, "string", "pattern")
+	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, "string", "pattern")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'pattern' defined",
 		"keyActualValue": "String schema does not have 'pattern' defined",
@@ -26,13 +26,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) != "undefined"
 
 	[path, value] := walk(doc)
-	schema = openapi_lib.get_schema(value)
+	schema_kind = openapi_lib.get_schema(value)
 	openapi_lib.is_operation(path) == {}
-	openapi_lib.undefined_properties_in_schema(doc, schema.content, "string", "pattern")
+	openapi_lib.undefined_properties_in_schema(doc, value, schema_kind, "string", "pattern")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema.kind]),
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), schema_kind]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "String schema has 'pattern' defined",
 		"keyActualValue": "String schema does not have 'pattern' defined",

--- a/assets/queries/openAPI/string_schema_without_pattern/test/negative2.json
+++ b/assets/queries/openAPI/string_schema_without_pattern/test/negative2.json
@@ -18,7 +18,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "maxLength": "15",
+                      "format": "int32",
+                      "pattern": "^[0-9a-z]{15}$"
+                    },
+                    "message": {
+                      "type": "string",
+                      "maxLength": "15",
+                      "pattern": "^[0-9a-z]{15}$"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,33 +65,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": "15",
-            "format": "int32",
-            "pattern": "^[0-9a-z]{15}$"
-          },
-          "message": {
-            "type": "string",
-            "maxLength": "15",
-            "pattern": "^[0-9a-z]{15}$"
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/string_schema_without_pattern/test/negative4.yaml
+++ b/assets/queries/openAPI/string_schema_without_pattern/test/negative4.yaml
@@ -13,7 +13,20 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: string
+                    maxLength: 15
+                    format: int32
+                    pattern: ^[0-9a-z]{15}$
+                  message:
+                    type: string
+                    maxLength: 15
+                    pattern: ^[0-9a-z]{15}$
               examples:
                 foo:
                   value:
@@ -24,22 +37,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: string
-          maxLength: 15
-          format: int32
-          pattern: ^[0-9a-z]{15}$
-        message:
-          type: string
-          maxLength: 15
-          pattern: ^[0-9a-z]{15}$
-      required:
-        - petType

--- a/assets/queries/openAPI/string_schema_without_pattern/test/positive2.json
+++ b/assets/queries/openAPI/string_schema_without_pattern/test/positive2.json
@@ -18,7 +18,25 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GeneralError"
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "maxLength": "15",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string",
+                      "maxLength": "15"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
                 },
                 "examples": {
                   "foo": {
@@ -45,31 +63,6 @@
         },
         "operationId": "listVersionsv2",
         "summary": "List API versions"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "GeneralError": {
-        "discriminator": {
-          "propertyName": "petType"
-        },
-        "additionalProperties": false,
-        "properties": {
-          "code": {
-            "type": "string",
-            "maxLength": "15",
-            "format": "int32"
-          },
-          "message": {
-            "type": "string",
-            "maxLength": "15"
-          }
-        },
-        "required": [
-          "petType"
-        ],
-        "type": "object"
       }
     }
   }

--- a/assets/queries/openAPI/string_schema_without_pattern/test/positive4.yaml
+++ b/assets/queries/openAPI/string_schema_without_pattern/test/positive4.yaml
@@ -13,7 +13,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GeneralError"
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: string
+                    maxLength: 15
+                    format: int32
+                  message:
+                    type: string
+                    maxLength: 15
               examples:
                 foo:
                   value:
@@ -24,20 +35,3 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-components:
-  schemas:
-    GeneralError:
-      type: object
-      discriminator:
-        propertyName: petType
-      additionalProperties: false
-      properties:
-        code:
-          type: string
-          maxLength: 15
-          format: int32
-        message:
-          type: string
-          maxLength: 15
-      required:
-        - petType

--- a/assets/queries/openAPI/string_schema_without_pattern/test/positive_expected_result.json
+++ b/assets/queries/openAPI/string_schema_without_pattern/test/positive_expected_result.json
@@ -2,49 +2,49 @@
   {
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
-    "line": 49,
+    "line": 63,
     "filename": "positive1.json"
   },
   {
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
-    "line": 78,
+    "line": 58,
     "filename": "positive1.json"
   },
   {
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
-    "line": 20,
+    "line": 27,
     "filename": "positive2.json"
   },
   {
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
-    "line": 52,
+    "line": 32,
     "filename": "positive2.json"
   },
   {
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
-    "line": 26,
+    "line": 34,
     "filename": "positive3.yaml"
   },
   {
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
-    "line": 48,
+    "line": 38,
     "filename": "positive3.yaml"
   },
   {
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
-    "line": 15,
+    "line": 22,
     "filename": "positive4.yaml"
   },
   {
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
-    "line": 28,
+    "line": 26,
     "filename": "positive4.yaml"
   }
 ]

--- a/assets/queries/openAPI/string_schema_without_pattern/test/positive_expected_result.json
+++ b/assets/queries/openAPI/string_schema_without_pattern/test/positive_expected_result.json
@@ -2,6 +2,12 @@
   {
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
+    "line": 49,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "String Schema Without Pattern",
+    "severity": "MEDIUM",
     "line": 78,
     "filename": "positive1.json"
   },
@@ -14,6 +20,18 @@
   {
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
+    "line": 52,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "String Schema Without Pattern",
+    "severity": "MEDIUM",
+    "line": 26,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "String Schema Without Pattern",
+    "severity": "MEDIUM",
     "line": 48,
     "filename": "positive3.yaml"
   },
@@ -21,6 +39,12 @@
     "queryName": "String Schema Without Pattern",
     "severity": "MEDIUM",
     "line": 15,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "String Schema Without Pattern",
+    "severity": "MEDIUM",
+    "line": 28,
     "filename": "positive4.yaml"
   }
 ]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "String Schema with Broad Pattern" query for OpenAPI. It checks if the string schema does not restrict the pattern (does not start with "^")

**Considerations**
- Added function '`get_schema'` (in \kics\assets\libraries\openapi\library.rego) to cover schemas of the Components Object

I submit this contribution under Apache-2.0 license.
