### PR TITLE
feat(query): Added ECR Repository Without Policy query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/ecr_repository_without_policy/metadata.json
+++ b/assets/queries/terraform/aws/ecr_repository_without_policy/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "69e7c320-b65d-41bb-be02-d63ecc0bcc9d",
+  "queryName": "ECR Repository Without Policy",
+  "severity": "LOW",
+  "category": "Best Practices",
+  "descriptionText": "ECR Repository should have Policies attached to it",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/ecr_repository_without_policy/query.rego
+++ b/assets/queries/terraform/aws/ecr_repository_without_policy/query.rego
@@ -1,0 +1,22 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource
+	ecr_repo := resource.aws_ecr_repository[name]
+	check_policy(resource, name)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ecr_repository[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_ecr_repository[%s] has policies attached", [name]),
+		"keyActualValue": sprintf("aws_ecr_repository[%s] doesn't have policies attached", [name]),
+	}
+}
+
+check_policy(resource, name) {
+	object.get(resource, "aws_ecr_repository_policy", "undefined") == "undefined"
+} else {
+	res_pol := {x | resource.aws_ecr_repository_policy[name_poly].repository == sprintf("${aws_ecr_repository.%s.name}", [name]); x := name_poly}
+	count(res_pol) == 0
+}

--- a/assets/queries/terraform/aws/ecr_repository_without_policy/test/negative1.tf
+++ b/assets/queries/terraform/aws/ecr_repository_without_policy/test/negative1.tf
@@ -1,0 +1,36 @@
+resource "aws_ecr_repository" "foo" {
+  name = "bar"
+}
+
+resource "aws_ecr_repository_policy" "foopolicy" {
+  repository = aws_ecr_repository.foo.name
+
+  policy = <<EOF
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "new policy",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:DescribeRepositories",
+                "ecr:GetRepositoryPolicy",
+                "ecr:ListImages",
+                "ecr:DeleteRepository",
+                "ecr:BatchDeleteImage",
+                "ecr:SetRepositoryPolicy",
+                "ecr:DeleteRepositoryPolicy"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/ecr_repository_without_policy/test/positive1.tf
+++ b/assets/queries/terraform/aws/ecr_repository_without_policy/test/positive1.tf
@@ -1,0 +1,4 @@
+resource "aws_ecr_repository" "foo" {
+  name = "bar"
+}
+

--- a/assets/queries/terraform/aws/ecr_repository_without_policy/test/positive2.tf
+++ b/assets/queries/terraform/aws/ecr_repository_without_policy/test/positive2.tf
@@ -1,0 +1,37 @@
+resource "aws_ecr_repository" "foo2" {
+  name = "bar"
+}
+
+
+resource "aws_ecr_repository_policy" "foopolicy" {
+  repository = aws_ecr_repository.foo.name
+
+  policy = <<EOF
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "new policy",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:DescribeRepositories",
+                "ecr:GetRepositoryPolicy",
+                "ecr:ListImages",
+                "ecr:DeleteRepository",
+                "ecr:BatchDeleteImage",
+                "ecr:SetRepositoryPolicy",
+                "ecr:DeleteRepositoryPolicy"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/ecr_repository_without_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ecr_repository_without_policy/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "ECR Repository Without Policy",
+    "severity": "LOW",
+    "line": 1,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "ECR Repository Without Policy",
+    "severity": "LOW",
+    "line": 1,
+    "filename": "positive2.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added ECR Repository Without Policy query for Terraform

ECR Repository should have Policies attached to it

I submit this contribution under the Apache-2.0 license.
