### PR TITLE
feat(query): "API Key Exposed In Operation Security" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/api_key_exposed_in_operation_security/metadata.json
+++ b/assets/queries/openAPI/api_key_exposed_in_operation_security/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "281b8071-6226-4a43-911d-fec246d422c2",
+  "queryName": "API Key Exposed In Operation Security",
+  "severity": "LOW",
+  "category": "Access Control",
+  "descriptionText": "API Keys should not be transported over network in a header, cookie or query parameters",
+  "descriptionUrl": "https://swagger.io/specification/#security-scheme-object",
+  "platform": "OpenAPI",
+  "aggregation": 3
+}

--- a/assets/queries/openAPI/api_key_exposed_in_operation_security/query.rego
+++ b/assets/queries/openAPI/api_key_exposed_in_operation_security/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	security := doc.paths[path][operation].security[x][s]
+	ins := {"cookie", "header", "query"}
+	doc.components.securitySchemes[s].in == ins[z]
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.%s.%s.security.%s", [path, operation, s]),
+		"issueType": "IncorretValue",
+		"keyExpectedValue": sprintf("The API Key is not transported over network in a %s", [ins[z]]),
+		"keyActualValue": sprintf("The API Key is transported over network in a %s", [ins[z]]),
+	}
+}

--- a/assets/queries/openAPI/api_key_exposed_in_operation_security/test/negative1.json
+++ b/assets/queries/openAPI/api_key_exposed_in_operation_security/test/negative1.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Simple API overview"
+  },
+  "paths": {
+    "/pets": {
+      "post": {
+        "description": "Creates a new pet in the store",
+        "operationId": "addPet",
+        "security": [
+          {
+            "OAuth2": [
+              "write",
+              "read"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "scopes": {
+              "write": "modify objects in your account",
+              "read": "read objects in your account"
+            },
+            "authorizationUrl": "https://example.com/oauth/authorize",
+            "tokenUrl": "https://example.com/oauth/token"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/api_key_exposed_in_operation_security/test/negative2.yaml
+++ b/assets/queries/openAPI/api_key_exposed_in_operation_security/test/negative2.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      description: Creates a new pet in the store
+      operationId: addPet
+      security:
+        - OAuth2:
+            - write
+            - read
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          scopes:
+            write: modify objects in your account
+            read: read objects in your account
+          authorizationUrl: https://example.com/oauth/authorize
+          tokenUrl: https://example.com/oauth/token

--- a/assets/queries/openAPI/api_key_exposed_in_operation_security/test/positive1.json
+++ b/assets/queries/openAPI/api_key_exposed_in_operation_security/test/positive1.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "post": {
+        "description": "Creates a new pet in the store",
+        "operationId": "addPet",
+        "security": [
+          {
+            "apiKey1": [],
+            "apiKey2": [],
+            "apiKey3": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey1": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "header"
+      },
+      "apiKey2": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "cookie"
+      },
+      "apiKey3": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "query"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/api_key_exposed_in_operation_security/test/positive2.yaml
+++ b/assets/queries/openAPI/api_key_exposed_in_operation_security/test/positive2.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      description: Creates a new pet in the store
+      operationId: addPet
+      security:
+        - apiKey1: []
+          apiKey2: []
+          apiKey3: []
+components:
+  securitySchemes:
+    apiKey1:
+      type: apiKey
+      name: X-API-Key
+      in: header
+    apiKey2:
+      type: apiKey
+      name: X-API-Key
+      in: cookie
+    apiKey3:
+      type: apiKey
+      name: X-API-Key
+      in: query

--- a/assets/queries/openAPI/api_key_exposed_in_operation_security/test/positive_expected_result.json
+++ b/assets/queries/openAPI/api_key_exposed_in_operation_security/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "API Key Exposed In Operation Security",
+    "severity": "LOW",
+    "line": 14,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "API Key Exposed In Operation Security",
+    "severity": "LOW",
+    "line": 15,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "API Key Exposed In Operation Security",
+    "severity": "LOW",
+    "line": 16,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "API Key Exposed In Operation Security",
+    "severity": "LOW",
+    "line": 11,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "API Key Exposed In Operation Security",
+    "severity": "LOW",
+    "line": 12,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "API Key Exposed In Operation Security",
+    "severity": "LOW",
+    "line": 13,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "API Key Exposed In Operation Security" query for OpenAPI. It checks if the API Key is transported over the network header, cookie or query parameters

**Considerations**
The code below was not defined in the OpenAPI library in order to explicit in 'keyExpectedValue' and 'keyExpectedValue' what type of 'in' is set
```
ins := {"cookie", "header", "query"}
doc.components.securitySchemes[s].in == ins[z]
```

I submit this contribution under Apache-2.0 license.

