### PR TITLE
feat(query): "API Key Exposed In Global Security Scheme" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/metadata.json
+++ b/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "40e1d1bf-11a9-4f63-a3a2-a8b84c602839",
+  "queryName": "API Key Exposed In Global Security Scheme",
+  "severity": "LOW",
+  "category": "Access Control",
+  "descriptionText": "API Keys should not be transported over network in a header, cookie or query parameters",
+  "descriptionUrl": "https://swagger.io/specification/#security-scheme-object",
+  "platform": "OpenAPI",
+  "aggregation": 3
+}

--- a/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/query.rego
+++ b/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/query.rego
@@ -1,0 +1,19 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	ins := {"cookie", "header", "query"}
+	doc.components.securitySchemes[s].in == ins[z]
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.securitySchemes.%s", [s]),
+		"issueType": "IncorretValue",
+		"keyExpectedValue": sprintf("The API Key is not transported over network in a %s", [ins[z]]),
+		"keyActualValue": sprintf("The API Key is transported over network in a %s", [ins[z]]),
+	}
+}

--- a/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/test/negative1.json
+++ b/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/test/negative1.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "exampleSecurity": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "exampleSecurity": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/test/negative2.yaml
+++ b/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/test/negative2.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          scopes:
+            write: modify objects in your account
+            read: read objects in your account
+          authorizationUrl: https://example.com/oauth/authorize
+          tokenUrl: https://example.com/oauth/token
+security:
+  - OAuth2:
+      - write
+      - read

--- a/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/test/positive1.json
+++ b/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/test/positive1.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "apiKey2": [],
+      "apiKey3": [],
+      "apiKey1": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "apiKey1": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "header"
+      },
+      "apiKey2": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "cookie"
+      },
+      "apiKey3": {
+        "name": "X-API-Key",
+        "in": "query",
+        "type": "apiKey"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/test/positive2.yaml
+++ b/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/test/positive2.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - apiKey1: []
+    apiKey2: []
+    apiKey3: []
+components:
+  securitySchemes:
+    apiKey1:
+      type: apiKey
+      name: X-API-Key
+      in: header
+    apiKey2:
+      type: apiKey
+      name: X-API-Key
+      in: cookie
+    apiKey3:
+      type: apiKey
+      name: X-API-Key
+      in: query

--- a/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/test/positive_expected_result.json
+++ b/assets/queries/openAPI/api_key_exposed_in_global_security_scheme/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "API Key Exposed In Global Security Scheme",
+    "severity": "LOW",
+    "line": 52,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "API Key Exposed In Global Security Scheme",
+    "severity": "LOW",
+    "line": 57,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "API Key Exposed In Global Security Scheme",
+    "severity": "LOW",
+    "line": 62,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "API Key Exposed In Global Security Scheme",
+    "severity": "LOW",
+    "line": 31,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "API Key Exposed In Global Security Scheme",
+    "severity": "LOW",
+    "line": 35,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "API Key Exposed In Global Security Scheme",
+    "severity": "LOW",
+    "line": 39,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "API Key Exposed In Global Security Scheme" query for OpenAPI. It checks if the API Key is transported over the network header, cookie or query parameters

**Considerations**
The code below was not defined in the OpenAPI library in order to explicit in 'keyExpectedValue' and 'keyExpectedValue' what type of 'in' is set
```
ins := {"cookie", "header", "query"}
doc.components.securitySchemes[s].in == ins[z]
```

I submit this contribution under Apache-2.0 license.