### PR TITLE
feat(query): "Cleartext API Key In Global Security" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/cleartext_api_key_in_global_security/metadata.json
+++ b/assets/queries/openAPI/cleartext_api_key_in_global_security/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "9c238c97-1991-4c0b-9c7d-6c7912e1dc7c",
+  "queryName": "Cleartext API Key In Global Security",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "API Keys should not be sent as cleartext in a header, cookie or query parameters over an unencrypted channel",
+  "descriptionUrl": "https://swagger.io/specification/#security-scheme-object",
+  "platform": "OpenAPI",
+  "aggregation": 3
+}

--- a/assets/queries/openAPI/cleartext_api_key_in_global_security/query.rego
+++ b/assets/queries/openAPI/cleartext_api_key_in_global_security/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	security := doc.security[x][s]
+	ins := {"cookie", "header", "query"}
+	doc.components.securitySchemes[s].in == ins[z]
+	count(security) == 0
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("security.%s", [s]),
+		"issueType": "IncorretValue",
+		"keyExpectedValue": sprintf("The API Key is not sent as cleartext in a %s over an unencrypted channel", [ins[z]]),
+		"keyActualValue": sprintf("The API Key is sent as cleartext in a %s over an unencrypted channel", [ins[z]]),
+	}
+}

--- a/assets/queries/openAPI/cleartext_api_key_in_global_security/test/negative1.json
+++ b/assets/queries/openAPI/cleartext_api_key_in_global_security/test/negative1.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "exampleSecurity": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "exampleSecurity": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/cleartext_api_key_in_global_security/test/negative2.yaml
+++ b/assets/queries/openAPI/cleartext_api_key_in_global_security/test/negative2.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          scopes:
+            write: modify objects in your account
+            read: read objects in your account
+          authorizationUrl: https://example.com/oauth/authorize
+          tokenUrl: https://example.com/oauth/token
+security:
+  - OAuth2:
+      - write
+      - read

--- a/assets/queries/openAPI/cleartext_api_key_in_global_security/test/positive1.json
+++ b/assets/queries/openAPI/cleartext_api_key_in_global_security/test/positive1.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "apiKey2": [],
+      "apiKey3": [],
+      "apiKey1": []
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "apiKey1": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "header"
+      },
+      "apiKey2": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "cookie"
+      },
+      "apiKey3": {
+        "name": "X-API-Key",
+        "in": "query",
+        "type": "apiKey"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/cleartext_api_key_in_global_security/test/positive2.yaml
+++ b/assets/queries/openAPI/cleartext_api_key_in_global_security/test/positive2.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+security:
+  - apiKey1: []
+    apiKey2: []
+    apiKey3: []
+components:
+  securitySchemes:
+    apiKey1:
+      type: apiKey
+      name: X-API-Key
+      in: header
+    apiKey2:
+      type: apiKey
+      name: X-API-Key
+      in: cookie
+    apiKey3:
+      type: apiKey
+      name: X-API-Key
+      in: query

--- a/assets/queries/openAPI/cleartext_api_key_in_global_security/test/positive_expected_result.json
+++ b/assets/queries/openAPI/cleartext_api_key_in_global_security/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "Cleartext API Key In Global Security",
+    "severity": "MEDIUM",
+    "line": 45,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Cleartext API Key In Global Security",
+    "severity": "MEDIUM",
+    "line": 46,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Cleartext API Key In Global Security",
+    "severity": "MEDIUM",
+    "line": 47,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Cleartext API Key In Global Security",
+    "severity": "MEDIUM",
+    "line": 26,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Cleartext API Key In Global Security",
+    "severity": "MEDIUM",
+    "line": 27,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Cleartext API Key In Global Security",
+    "severity": "MEDIUM",
+    "line": 28,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Cleartext API Key In Global Security" query for OpenAPI. It checks if the API Key is not sent as cleartext in a header, cookie or query parameters over an unencrypted channel

**Considerations**
The code below was not defined in the OpenAPI library in order to explicit in 'keyExpectedValue' and 'keyExpectedValue' what type of 'in' is set
```
ins := {"cookie", "header", "query"}
doc.components.securitySchemes[s].in == ins[z]
```

I submit this contribution under Apache-2.0 license.