### PR TITLE
feat(query): "Cleartext Credentials with Basic Authentication" for OpenAPI

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -113,3 +113,15 @@ is_operation(path) = info {
 } else = info {
 	info := {}
 }
+
+# checks if an URL uses unsecure HTTP protocol
+is_unsecure_http(url){
+    startswith(url, "http://")
+}
+
+# checks if security schemes contains basic authentication
+is_basic_authentication(securitySchemes) {
+    scheme := securitySchemes[x]
+	lower(scheme.type) == "http"
+	lower(scheme.scheme) == "basic"
+}

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth/metadata.json
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "3c37e786-fb98-40d5-b704-ceedfe6131b9",
+  "queryName": "Cleartext Credentials With Basic Authentication",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "Cleartext credentials over unencrypted channel should not be accepted",
+  "descriptionUrl": "https://swagger.io/specification/#server-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth/query.rego
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth/query.rego
@@ -1,0 +1,25 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	openapi_lib.is_basic_authentication(doc.components.securitySchemes)
+
+	server := doc.servers[j]
+	openapi_lib.is_unsecure_http(server.url)
+
+	sec := doc.security[k][schemeName]
+	is_array(sec)
+	sec == []
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("security.{{%s}}", [schemeName]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("security.{{%s}} should not allow cleartext credentials over unencrypted channel", [schemeName]),
+		"keyActualValue": sprintf("security.{{%s}} allows cleartext credentials over unencrypted channel", [schemeName]),
+	}
+}

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth/test/negative1.json
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth/test/negative1.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple KICS API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersions",
+        "summary": "List versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://kicsapi.server.com/",
+      "description": "API server"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "scopes": {
+              "write": "modify objects",
+              "read": "read objects"
+            },
+            "authorizationUrl": "https://kicsapi.com/oauth/authorize",
+            "tokenUrl": "https://kicsapi.com/oauth/token"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "OAuth2": [
+        "write",
+        "read"
+      ]
+    }
+  ]
+}

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth/test/negative2.yaml
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth/test/negative2.yaml
@@ -1,22 +1,12 @@
 openapi: 3.0.0
 info:
-  title: Simple API overview
+  title: Simple KICS API
   version: 1.0.0
-components:
-  securitySchemes:
-    regularSecurity:
-      type: http
-      scheme: basic
 paths:
   "/":
     get:
       operationId: listVersions
       summary: List versions
-      servers:
-        - url: http://kicsapi.com/
-          description: server URL
-      security:
-        - regularSecurity: []
       responses:
         "200":
           description: 200 response
@@ -32,3 +22,21 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
+servers:
+  - url: https://kicsapi.server.com/
+    description: API server
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          scopes:
+            write: modify objects in your account
+            read: read objects in your account
+          authorizationUrl: https://kicsauthenticator.com/oauth/authorize
+          tokenUrl: https://kicsauthenticator.com/oauth/token
+security:
+  - OAuth2:
+      - write
+      - read

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth/test/positive1.json
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth/test/positive1.json
@@ -1,0 +1,63 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple KICS API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersions",
+        "summary": "List versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "http://kicsapi.server.com/",
+      "description": "API server"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "regularSecurity": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  },
+  "security": [
+    {
+      "regularSecurity": []
+    }
+  ]
+
+}

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth/test/positive2.yaml
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth/test/positive2.yaml
@@ -2,21 +2,11 @@ openapi: 3.0.0
 info:
   title: Simple API overview
   version: 1.0.0
-components:
-  securitySchemes:
-    regularSecurity:
-      type: http
-      scheme: basic
 paths:
   "/":
     get:
       operationId: listVersions
       summary: List versions
-      servers:
-        - url: http://kicsapi.com/
-          description: server URL
-      security:
-        - regularSecurity: []
       responses:
         "200":
           description: 200 response
@@ -32,3 +22,13 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
+servers:
+  - url: http://kicsapi.server.com/
+    description: API server
+components:
+  securitySchemes:
+    regularSecurity:
+      type: http
+      scheme: basic
+security:
+  - regularSecurity: []

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth/test/positive_expected_result.json
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Cleartext Credentials With Basic Authentication",
+    "severity": "HIGH",
+    "line": 59,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Cleartext Credentials With Basic Authentication",
+    "severity": "HIGH",
+    "line": 34,
+    "filename": "positive2.yaml"
+  }
+]

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_operation/query.rego
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_operation/query.rego
@@ -6,9 +6,9 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	scheme := doc.components.securitySchemes[x]
-	lower(scheme.type) == "http"
-	lower(scheme.scheme) == "basic"
+    scheme := doc.components.securitySchemes[x]
+    lower(scheme.type) == "http"
+    lower(scheme.scheme) == "basic"
 
 	op := doc.paths[path][operation]
 	object.get(op.security[sec], x, "undefined") == []


### PR DESCRIPTION


**Proposed Changes**
- Add "Cleartext Credentials With Basic Authentication for OpenAPI"
- Checks if servers URL uses HTTPS
- Checks if securityScheme is set as basic authentication
- Checks if global security is empty

I submit this contribution under the Apache-2.0 license.
