### PR TITLE
feat(query): "Cleartext API Key In Operation Security" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/cleartext_api_key_in_operation_security/metadata.json
+++ b/assets/queries/openAPI/cleartext_api_key_in_operation_security/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "d90d4e40-44c1-4125-87a0-e072c3e195b5",
+  "queryName": "Cleartext API Key In Operation Security",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "API Keys should not be sent as cleartext in a header, cookie or query parameters over an unencrypted channel",
+  "descriptionUrl": "https://swagger.io/specification/#security-scheme-object",
+  "platform": "OpenAPI",
+  "aggregation": 3
+}

--- a/assets/queries/openAPI/cleartext_api_key_in_operation_security/query.rego
+++ b/assets/queries/openAPI/cleartext_api_key_in_operation_security/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	security := doc.paths[path][operation].security[x][s]
+	ins := {"cookie", "header", "query"}
+	doc.components.securitySchemes[s].in == ins[z]
+	count(security) == 0
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.%s.%s.security.%s", [path, operation, s]),
+		"issueType": "IncorretValue",
+		"keyExpectedValue": sprintf("The API Key is not sent as cleartext in a %s over an unencrypted channel", [ins[z]]),
+		"keyActualValue": sprintf("The API Key is sent as cleartext in a %s over an unencrypted channel", [ins[z]]),
+	}
+}

--- a/assets/queries/openAPI/cleartext_api_key_in_operation_security/test/negative1.json
+++ b/assets/queries/openAPI/cleartext_api_key_in_operation_security/test/negative1.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Simple API overview"
+  },
+  "paths": {
+    "/pets": {
+      "post": {
+        "description": "Creates a new pet in the store",
+        "operationId": "addPet",
+        "security": [
+          {
+            "OAuth2": [
+              "write",
+              "read"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "scopes": {
+              "write": "modify objects in your account",
+              "read": "read objects in your account"
+            },
+            "authorizationUrl": "https://example.com/oauth/authorize",
+            "tokenUrl": "https://example.com/oauth/token"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/cleartext_api_key_in_operation_security/test/negative2.yaml
+++ b/assets/queries/openAPI/cleartext_api_key_in_operation_security/test/negative2.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      description: Creates a new pet in the store
+      operationId: addPet
+      security:
+        - OAuth2:
+            - write
+            - read
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          scopes:
+            write: modify objects in your account
+            read: read objects in your account
+          authorizationUrl: https://example.com/oauth/authorize
+          tokenUrl: https://example.com/oauth/token

--- a/assets/queries/openAPI/cleartext_api_key_in_operation_security/test/positive1.json
+++ b/assets/queries/openAPI/cleartext_api_key_in_operation_security/test/positive1.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "post": {
+        "description": "Creates a new pet in the store",
+        "operationId": "addPet",
+        "security": [
+          {
+            "apiKey1": [],
+            "apiKey2": [],
+            "apiKey3": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey1": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "header"
+      },
+      "apiKey2": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "cookie"
+      },
+      "apiKey3": {
+        "type": "apiKey",
+        "name": "X-API-Key",
+        "in": "query"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/cleartext_api_key_in_operation_security/test/positive2.yaml
+++ b/assets/queries/openAPI/cleartext_api_key_in_operation_security/test/positive2.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  /pets:
+    post:
+      description: Creates a new pet in the store
+      operationId: addPet
+      security:
+        - apiKey1: []
+          apiKey2: []
+          apiKey3: []
+components:
+  securitySchemes:
+    apiKey1:
+      type: apiKey
+      name: X-API-Key
+      in: header
+    apiKey2:
+      type: apiKey
+      name: X-API-Key
+      in: cookie
+    apiKey3:
+      type: apiKey
+      name: X-API-Key
+      in: query

--- a/assets/queries/openAPI/cleartext_api_key_in_operation_security/test/positive_expected_result.json
+++ b/assets/queries/openAPI/cleartext_api_key_in_operation_security/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "Cleartext API Key In Operation Security",
+    "severity": "HIGH",
+    "line": 14,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Cleartext API Key In Operation Security",
+    "severity": "HIGH",
+    "line": 15,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Cleartext API Key In Operation Security",
+    "severity": "HIGH",
+    "line": 16,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Cleartext API Key In Operation Security",
+    "severity": "HIGH",
+    "line": 11,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Cleartext API Key In Operation Security",
+    "severity": "HIGH",
+    "line": 12,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Cleartext API Key In Operation Security",
+    "severity": "HIGH",
+    "line": 13,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Cleartext API Key In Operation Security" query for OpenAPI. It checks if the API Key is not sent as cleartext in a header, cookie or query parameters over an unencrypted channel

**Considerations**
The code below was not defined in the OpenAPI library in order to explicit in 'keyExpectedValue' and 'keyExpectedValue' what type of 'in' is set
```
ins := {"cookie", "header", "query"}
doc.components.securitySchemes[s].in == ins[z]
```

I submit this contribution under Apache-2.0 license.
