### PR TITLE
feat(query): Added Security Scheme Using Oauth 1.0 query for OpenAPI

### DIFF
--- a/assets/queries/openAPI/security_schemes_using_oauth/metadata.json
+++ b/assets/queries/openAPI/security_schemes_using_oauth/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "1bc3205c-0d60-44e6-84f3-44fbf4dac5b3",
+  "queryName": "Security Scheme Using Oauth 1.0",
+  "severity": "LOW",
+  "category": "Access Control",
+  "descriptionText": "Oauth 1.0 is deprecated, OAuth2 should be used instead",
+  "descriptionUrl": "https://swagger.io/specification/#security-scheme-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/security_schemes_using_oauth/query.rego
+++ b/assets/queries/openAPI/security_schemes_using_oauth/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	security_scheme := doc.components.securitySchemes[name]
+	security_scheme.type == "http"
+	security_scheme.scheme == "oauth"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.securitySchemes.{{%s}}", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.securitySchemes.{{%s}} does not use oauth 1.0 security scheme", [name]),
+		"keyActualValue": sprintf("components.securitySchemes.{{%s}} uses oauth 1.0 security scheme", [name]),
+	}
+}

--- a/assets/queries/openAPI/security_schemes_using_oauth/test/negative1.json
+++ b/assets/queries/openAPI/security_schemes_using_oauth/test/negative1.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "tokenUrl": "https://example.com/api/oauth/token",
+            "authorizationUrl": "http://example.org/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_schemes_using_oauth/test/negative2.yaml
+++ b/assets/queries/openAPI/security_schemes_using_oauth/test/negative2.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          tokenUrl: https://example.com/api/oauth/token
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets

--- a/assets/queries/openAPI/security_schemes_using_oauth/test/positive1.json
+++ b/assets/queries/openAPI/security_schemes_using_oauth/test/positive1.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "http",
+        "scheme": "oauth"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_schemes_using_oauth/test/positive2.yaml
+++ b/assets/queries/openAPI/security_schemes_using_oauth/test/positive2.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: http
+      scheme: oauth

--- a/assets/queries/openAPI/security_schemes_using_oauth/test/positive_expected_result.json
+++ b/assets/queries/openAPI/security_schemes_using_oauth/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Security Scheme Using Oauth 1.0",
+    "severity": "LOW",
+    "line": 55,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Security Scheme Using Oauth 1.0",
+    "severity": "LOW",
+    "line": 31,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Security Scheme Using Oauth 1.0

Oauth 1.0 is deprecated, OAuth2 should be used instead

I submit this contribution under the Apache-2.0 license.
