### PR TITLE
feat(query): add "Cleartext Credentials With Basic Authentication For Global Security" for OpenAPI

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -113,3 +113,15 @@ is_operation(path) = info {
 } else = info {
 	info := {}
 }
+
+# checks if an URL uses unsecure HTTP protocol
+is_unsecure_http(url){
+    startswith(url, "http://")
+}
+
+# checks if security schemes contains basic authentication
+is_basic_authentication(securitySchemes) {
+    scheme := securitySchemes[x]
+	lower(scheme.type) == "http"
+	lower(scheme.scheme) == "basic"
+}

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/metadata.json
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "77276d82-4f45-4cf1-8e2b-4d345b936228",
+  "queryName": "Cleartext Credentials With Basic Authentication For Global Security",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "Cleartext credentials over unencrypted channel should not be accepted",
+  "descriptionUrl": "https://swagger.io/specification/#security-scheme-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/query.rego
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+    openapi_lib.is_basic_authentication(doc.components.securitySchemes)
+
+    server := doc.servers[j]
+    openapi_lib.is_unsecure_http(server.url)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("servers.url={{%s}}", [server.url]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("servers.url=%s global security should not allow cleartext credentials over unencrypted channel", [server.url]),
+		"keyActualValue": sprintf("servers.url=%s global security allows cleartext credentials over unencrypted channel", [server.url]),
+	}
+}

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/test/negative1.json
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/test/negative1.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple KICS API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersions",
+        "summary": "List versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://kicsapi.server.com/",
+      "description": "API server"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "scopes": {
+              "write": "modify objects",
+              "read": "read objects"
+            },
+            "authorizationUrl": "https://kicsapi.com/oauth/authorize",
+            "tokenUrl": "https://kicsapi.com/oauth/token"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "OAuth2": [
+        "write",
+        "read"
+      ]
+    }
+  ]
+}

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/test/negative2.yaml
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/test/negative2.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: Simple KICS API
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersions
+      summary: List versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+servers:
+  - url: https://kicsapi.server.com/
+    description: API server
+components:
+  securitySchemes:
+    OAuth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          scopes:
+            write: modify objects in your account
+            read: read objects in your account
+          authorizationUrl: https://kicsauthenticator.com/oauth/authorize
+          tokenUrl: https://kicsauthenticator.com/oauth/token
+security:
+  - OAuth2:
+      - write
+      - read

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/test/positive1.json
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/test/positive1.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple KICS API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersions",
+        "summary": "List versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "http://kicsapi.server.com/",
+      "description": "API server"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "regularSecurity": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/test/positive2.yaml
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/test/positive2.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersions
+      summary: List versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+servers:
+  - url: http://kicsapi.server.com/
+    description: API server
+components:
+  securitySchemes:
+    regularSecurity:
+      type: http
+      scheme: basic

--- a/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/test/positive_expected_result.json
+++ b/assets/queries/openAPI/cleartext_credentials_with_basic_auth_for_global_security/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Cleartext Credentials With Basic Authentication For Global Security",
+    "severity": "HIGH",
+    "line": 45,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Cleartext Credentials With Basic Authentication For Global Security",
+    "severity": "HIGH",
+    "line": 26,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
**Proposed Changes**
- Add "Cleartext Credentials With Basic Authentication for OpenAPI"
- Checks if servers URL uses HTTPS
- Checks if securityScheme is set as basic authentication

I submit this contribution under the Apache-2.0 license.
