### PR TITLE
feat(query): "Unknown Schema String Format" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/unknown_schema_string_format/metadata.json
+++ b/assets/queries/openAPI/unknown_schema_string_format/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a767f960-0489-4532-a6a0-3f0b43da7dab",
+  "queryName": "Unknown Schema String Format",
+  "severity": "LOW",
+  "category": "Insecure Configurations",
+  "descriptionText": "String schema should have the format field set as 'date', 'date-time', 'password', 'byte', 'binary', 'email', 'uuid', 'uri', 'hostname', 'ipv4' or 'ipv6'",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/unknown_schema_string_format/metadata.json
+++ b/assets/queries/openAPI/unknown_schema_string_format/metadata.json
@@ -4,6 +4,6 @@
   "severity": "LOW",
   "category": "Insecure Configurations",
   "descriptionText": "String schema should have the format field set as 'date', 'date-time', 'password', 'byte', 'binary', 'email', 'uuid', 'uri', 'hostname', 'ipv4' or 'ipv6'",
-  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "descriptionUrl": "https://swagger.io/docs/specification/data-models/data-types/#string",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/unknown_schema_string_format/query.rego
+++ b/assets/queries/openAPI/unknown_schema_string_format/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+
+	value.type == "string"
+	not known_format(value.format)
+
+	formats := "'date', 'date-time', 'password', 'byte', 'binary', 'email', 'uuid', 'uri', 'hostname', 'ipv4' or 'ipv6'"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.format", [openapi_lib.concat_path(path)]),
+		"issueType": "IncorrectValue",
+		"keyActualValue": sprintf("String schema has 'format' set as %s", [formats]),
+		"keyExpectedValue": sprintf("String schema does not have 'format' set as %s", [formats]),
+	}
+}
+
+known_format(format) {
+	known_formats := {"date", "date-time", "password", "byte", "binary", "email", "uuid", "uri", "hostname", "ipv4", "ipv6"}
+	format == known_formats[x]
+}

--- a/assets/queries/openAPI/unknown_schema_string_format/test/negative1.json
+++ b/assets/queries/openAPI/unknown_schema_string_format/test/negative1.json
@@ -1,0 +1,91 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "maxLength": "15",
+            "format": "binary"
+          },
+          "message": {
+            "type": "string",
+            "format": "binary"
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/unknown_schema_string_format/test/negative2.json
+++ b/assets/queries/openAPI/unknown_schema_string_format/test/negative2.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "maxLength": "15",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/unknown_schema_string_format/test/negative3.yaml
+++ b/assets/queries/openAPI/unknown_schema_string_format/test/negative3.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          maxLength: 15
+          format: binary
+        message:
+          type: string
+          format: binary
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/unknown_schema_string_format/test/negative4.yaml
+++ b/assets/queries/openAPI/unknown_schema_string_format/test/negative4.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: string
+                    maxLength: 15
+                    format: binary
+                  message:
+                    type: string
+                    format: binary
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/unknown_schema_string_format/test/positive1.json
+++ b/assets/queries/openAPI/unknown_schema_string_format/test/positive1.json
@@ -1,0 +1,89 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "format": "binar"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/unknown_schema_string_format/test/positive2.json
+++ b/assets/queries/openAPI/unknown_schema_string_format/test/positive2.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binar"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "petType"
+                  ],
+                  "type": "object"
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/unknown_schema_string_format/test/positive3.yaml
+++ b/assets/queries/openAPI/unknown_schema_string_format/test/positive3.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          maxLength: 15
+          format: binar
+        message:
+          type: string
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/unknown_schema_string_format/test/positive4.yaml
+++ b/assets/queries/openAPI/unknown_schema_string_format/test/positive4.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: string
+                    maxLength: 15
+                    format: binar
+                  message:
+                    type: string
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/unknown_schema_string_format/test/positive_expected_result.json
+++ b/assets/queries/openAPI/unknown_schema_string_format/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Unknown Schema String Format",
+    "severity": "LOW",
+    "line": 59,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Unknown Schema String Format",
+    "severity": "LOW",
+    "line": 28,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Unknown Schema String Format",
+    "severity": "LOW",
+    "line": 36,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Unknown Schema String Format",
+    "severity": "LOW",
+    "line": 24,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Unknown Schema String Format" query for OpenAPI. It checks if the schema string format is not set to 'date', 'date-time', 'password', 'byte', 'binary', 'email', 'uuid', 'uri', 'hostname', 'ipv4' or 'ipv6'

I submit this contribution under the Apache-2.0 license.
