### PR TITLE
feat(query): Added Security Scheme HTTP Unknown Scheme query for OpenAPI

### DIFF
--- a/assets/queries/openAPI/security_schemes_http_unknown_scheme/metadata.json
+++ b/assets/queries/openAPI/security_schemes_http_unknown_scheme/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "06764426-3c56-407e-981f-caa25db1c149",
+  "queryName": "Security Scheme HTTP Unknown Scheme",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Security Scheme HTTP scheme should be registered in the IANA Authentication Scheme registry",
+  "descriptionUrl": "https://swagger.io/specification/#security-scheme-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/security_schemes_http_unknown_scheme/query.rego
+++ b/assets/queries/openAPI/security_schemes_http_unknown_scheme/query.rego
@@ -1,0 +1,23 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	types := {"basic", "bearer", "digest", "hoba", "mutual", "negotiate", "oauth", "scram-sha-1", "scram-sha-256", "vapid"}
+
+	security_scheme := doc.components.securitySchemes[name]
+	security_scheme.type == "http"
+	not common_lib.inArray(types, lower(security_scheme.scheme))
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.securitySchemes.{{%s}}.scheme", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.securitySchemes.{{%s}}.scheme is registered in the IANA Authentication Scheme registry", [name]),
+		"keyActualValue": sprintf("components.securitySchemes.{{%s}}.scheme is not registered in the IANA Authentication Scheme registry", [name]),
+	}
+}

--- a/assets/queries/openAPI/security_schemes_http_unknown_scheme/test/negative1.json
+++ b/assets/queries/openAPI/security_schemes_http_unknown_scheme/test/negative1.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_schemes_http_unknown_scheme/test/negative2.yaml
+++ b/assets/queries/openAPI/security_schemes_http_unknown_scheme/test/negative2.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: http
+      scheme: basic

--- a/assets/queries/openAPI/security_schemes_http_unknown_scheme/test/positive1.json
+++ b/assets/queries/openAPI/security_schemes_http_unknown_scheme/test/positive1.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "http",
+        "scheme": "test"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_schemes_http_unknown_scheme/test/positive2.yaml
+++ b/assets/queries/openAPI/security_schemes_http_unknown_scheme/test/positive2.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: http
+      scheme: test

--- a/assets/queries/openAPI/security_schemes_http_unknown_scheme/test/positive_expected_result.json
+++ b/assets/queries/openAPI/security_schemes_http_unknown_scheme/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Security Scheme HTTP Unknown Scheme",
+    "severity": "MEDIUM",
+    "line": 57,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Security Scheme HTTP Unknown Scheme",
+    "severity": "MEDIUM",
+    "line": 33,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
-  Added Security Scheme HTTP Unknown Scheme query for OpenAPI

Security Scheme HTTP scheme should be registered in the IANA Authentication Scheme registry

I submit this contribution under the Apache-2.0 license.
