### PR TITLE
feat(query): "Array Schema Without Maximum Number of Items" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/metadata.json
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "6998389e-66b2-473d-8d05-c8d71ac4d04d",
+  "queryName": "Array Schema Without Maximum Number of Items",
+  "severity": "HIGH",
+  "category": "Insecure Configurations",
+  "descriptionText": "Array schema should have the field 'maxItems' set",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/query.rego
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/query.rego
@@ -1,0 +1,43 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	info := openapi_lib.is_operation(path)
+	openapi_lib.content_allowed(info.operation, info.code)
+	undefined_maximum_number(value)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
+		"issueType": "MissingAttribute",
+		"keyActualValue": "Array schema has 'maxItems' set",
+		"keyExpectedValue": "Array schema has 'maxItems' undefined",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	openapi_lib.is_operation(path) == {}
+	undefined_maximum_number(value)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
+		"issueType": "MissingAttribute",
+		"keyActualValue": "Array schema has 'maxItems' set",
+		"keyExpectedValue": "Array schema has 'maxItems' undefined",
+	}
+}
+
+undefined_maximum_number(value) {
+	value.type == "array"
+	object.get(value, "maxItems", "undefined") == "undefined"
+}

--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/test/negative1.json
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/test/negative1.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "format": "int32"
+          },
+          "message": {
+            "type": "array",
+            "maxItems": 5,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/test/negative2.json
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/test/negative2.json
@@ -1,0 +1,63 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "array",
+                      "maxItems": 5,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/test/negative3.yaml
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/test/negative3.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      schema:
+        properties:
+          code:
+            type: string
+            format: int32
+          message:
+            type: array
+            maxItems: 5
+            items:
+              type: string

--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/test/negative4.yaml
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/test/negative4.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                properties:
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: array
+                    maxItems: 5
+                    items:
+                      type: string
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/test/positive1.json
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/test/positive1.json
@@ -1,0 +1,66 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "format": "int32"
+          },
+          "message": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/test/positive2.json
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/test/positive2.json
@@ -1,0 +1,62 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/test/positive3.yaml
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/test/positive3.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      schema:
+        properties:
+          code:
+            type: string
+            format: int32
+          message:
+            type: array
+            items:
+              type: string

--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/test/positive4.yaml
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/test/positive4.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                properties:
+                  code:
+                    type: string
+                    format: int32
+                  message:
+                    type: array
+                    items:
+                      type: string
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/array_schema_without_maximum_number_items/test/positive_expected_result.json
+++ b/assets/queries/openAPI/array_schema_without_maximum_number_items/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Array Schema Without Maximum Number of Items",
+    "severity": "HIGH",
+    "line": 57,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Array Schema Without Maximum Number of Items",
+    "severity": "HIGH",
+    "line": 29,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Array Schema Without Maximum Number of Items",
+    "severity": "HIGH",
+    "line": 34,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Array Schema Without Maximum Number of Items",
+    "severity": "HIGH",
+    "line": 21,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Array Schema Without Maximum Number of Items" query for OpenAPI. It checks if the array schema does not have 'maxItems' set

I submit this contribution under the Apache-2.0 license.
