### PR TITLE
feat(query): "Header Object With Incorrect Ref" for OpenAPI

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -19,9 +19,9 @@ improperly_defined(params, value) {
 
 incorrect_ref(ref, object) {
 	references := {
-		"schema": "#/components/schemas/",
+		"schemas": "#/components/schemas/",
 		"responses": "#/components/responses/",
-		"requestBody": "#/components/requestBodies/",
+		"requestBodies": "#/components/requestBodies/",
 		"links": "#/components/links/",
 		"callbacks": "#/components/callbacks/",
 		"headers": "#/components/headers/",

--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -24,6 +24,8 @@ incorrect_ref(ref, object) {
 		"requestBody": "#/components/requestBodies/",
 		"links": "#/components/links/",
 		"callbacks": "#/components/callbacks/",
+		"headers": "#/components/headers/",
+		"parameters": "#/components/parameters/",
 	}
 
 	regex.match(references[object], ref) == false

--- a/assets/queries/openAPI/callback_object_incorrect_ref/metadata.json
+++ b/assets/queries/openAPI/callback_object_incorrect_ref/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Callback Object With Incorrect Ref",
   "severity": "INFO",
   "category": "Structure and Semantics",
-  "descriptionText": "Callback Object reference must always point to '#components/callbacks'",
+  "descriptionText": "Callback Object reference must always point to '#/components/callbacks'",
   "descriptionUrl": "https://swagger.io/specification/#callback-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/callback_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/callback_object_incorrect_ref/query.rego
@@ -5,13 +5,15 @@ import data.generic.openapi as openapi_lib
 CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
-	call_back := doc.paths[n][oper].callbacks[c]
 
-	openapi_lib.incorrect_ref(call_back["$ref"], "callbacks")
+	[path, value] := walk(doc)
+
+	ref := value.callbacks[c]["$ref"]
+	openapi_lib.incorrect_ref(ref, "callbacks")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("paths.%s.%s.responses.%s.$ref", [n, oper, c]),
+		"searchKey": sprintf("%s.callbacks.$ref", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Callback ref points to '#/components/callbacks'",
 		"keyActualValue": "Callback ref does not point to '#/components/callbacks'",

--- a/assets/queries/openAPI/callback_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/callback_object_incorrect_ref/query.rego
@@ -9,11 +9,12 @@ CxPolicy[result] {
 	[path, value] := walk(doc)
 
 	ref := value.callbacks[c]["$ref"]
+	path[minus(count(path), 1)] != "components"
 	openapi_lib.incorrect_ref(ref, "callbacks")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.callbacks.$ref", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.callbacks.{{%s}}.$ref", [openapi_lib.concat_path(path), c]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Callback ref points to '#/components/callbacks'",
 		"keyActualValue": "Callback ref does not point to '#/components/callbacks'",

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/metadata.json
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "2d6646f4-2946-420f-8c14-3232d49ae0cb",
+  "queryName": "Header Object With Incorrect Ref",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Header Object reference must always point to '#/components/headers'",
+  "descriptionUrl": "https://swagger.io/specification/#responses-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/query.rego
@@ -9,11 +9,12 @@ CxPolicy[result] {
 	[path, value] := walk(doc)
 
 	ref := value.headers[h]["$ref"]
+	path[minus(count(path), 1)] != "components"
 	openapi_lib.incorrect_ref(ref, "headers")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.headers.$ref", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.headers.{{%s}}.$ref", [openapi_lib.concat_path(path), h]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Response ref points to '#/components/headers'",
 		"keyActualValue": "Response ref does not point to '#/components/headers'",

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+
+	ref := value.headers[h]["$ref"]
+	openapi_lib.incorrect_ref(ref, "headers")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.headers.$ref", [openapi_lib.concat_path(path)]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Response ref points to '#/components/headers'",
+		"keyActualValue": "Response ref does not point to '#/components/headers'",
+	}
+}

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/test/negative1.json
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/test/negative1.json
@@ -1,20 +1,12 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Simple API overview",
-    "version": "1.0.0"
-  },
-  "components": {
-    "parameters": {
-      "idParam": {
-        "name": "id",
-        "in": "path",
-        "description": "ID of the API the version",
-        "required": true,
-        "schema": {
-          "type": "int"
-        }
-      }
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
     }
   },
   "paths": {
@@ -50,12 +42,42 @@
             }
           }
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/idParam"
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ResponseExample": {
+        "description": "200 response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "discriminator": {
+                "propertyName": "petType"
+              },
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "encoding": {
+              "code": {
+                "headers": {
+                  "X-Rate-Limit-Limit": {
+                    "$ref": "#/components/headers/"
+                  }
+                }
+              }
+            }
+          }
         }
-      ]
+      }
     }
   }
 }

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/test/negative2.json
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/test/negative2.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "50": {
+            "description": "500 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "6xx": {
+            "description": "[600-699] response",
+            "headers": {
+              "X-Rate-Limit-Limit": {
+                "$ref": "#/components/headers/"
+              }
+            },
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/test/negative3.yaml
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/test/negative3.yaml
@@ -1,22 +1,7 @@
 openapi: 3.0.0
 info:
-  title: Simple API overview
+  title: Simple API Overview
   version: 1.0.0
-components:
-  parameters:
-    idParam:
-      name: id
-      in: path
-      description: ID of the API version
-      required: true
-      schema:
-        type: int
-    nameParam:
-      in: path
-      description: Name of the API version
-      required: true
-      schema:
-        type: string
 paths:
   "/":
     get:
@@ -37,5 +22,24 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-    parameters:
-      - $ref: "#/components/parameters/idParam"
+components:
+  responses:
+    ResponseExample:
+      description: 200 response
+      content:
+        application/json:
+          schema:
+            type: object
+            discriminator:
+              propertyName: petType
+            properties:
+              code:
+                type: string
+                format: binary
+              message:
+                type: string
+          encoding:
+            code:
+              headers:
+                X-Rate-Limit-Limit:
+                  $ref: "#/components/headers/"

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/test/negative4.yaml
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/test/negative4.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "50":
+          description: Server error response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+        "6xx":
+          description: "[600-699] response"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#/components/headers/"
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/test/positive1.json
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/test/positive1.json
@@ -1,20 +1,12 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Simple API overview",
-    "version": "1.0.0"
-  },
-  "components": {
-    "parameters": {
-      "idParam": {
-        "name": "id",
-        "in": "path",
-        "description": "ID of the API the version",
-        "required": true,
-        "schema": {
-          "type": "int"
-        }
-      }
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
     }
   },
   "paths": {
@@ -50,12 +42,42 @@
             }
           }
         }
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/idParam"
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "ResponseExample": {
+        "description": "200 response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "discriminator": {
+                "propertyName": "petType"
+              },
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "message": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "encoding": {
+              "code": {
+                "headers": {
+                  "X-Rate-Limit-Limit": {
+                    "$ref": "#components/h"
+                  }
+                }
+              }
+            }
+          }
         }
-      ]
+      }
     }
   }
 }

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/test/positive2.json
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/test/positive2.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "50": {
+            "description": "500 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "6xx": {
+            "description": "[600-699] response",
+            "headers": {
+              "X-Rate-Limit-Limit": {
+                "$ref": "#components/h"
+              }
+            },
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/test/positive3.yaml
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/test/positive3.yaml
@@ -1,22 +1,7 @@
 openapi: 3.0.0
 info:
-  title: Simple API overview
+  title: Simple API Overview
   version: 1.0.0
-components:
-  parameters:
-    idParam:
-      name: id
-      in: path
-      description: ID of the API version
-      required: true
-      schema:
-        type: int
-    nameParam:
-      in: path
-      description: Name of the API version
-      required: true
-      schema:
-        type: string
 paths:
   "/":
     get:
@@ -37,5 +22,24 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
-    parameters:
-      - $ref: "#/components/parameters/idParam"
+components:
+  responses:
+    ResponseExample:
+      description: 200 response
+      content:
+        application/json:
+          schema:
+            type: object
+            discriminator:
+              propertyName: petType
+            properties:
+              code:
+                type: string
+                format: binary
+              message:
+                type: string
+          encoding:
+            code:
+              headers:
+                X-Rate-Limit-Limit:
+                  $ref: "#components/h"

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/test/positive4.yaml
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/test/positive4.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "50":
+          description: Server error response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+        "6xx":
+          description: "[600-699] response"
+          headers:
+            X-Rate-Limit-Limit:
+              $ref: "#components/h"
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/header_object_with_incorrect_ref/test/positive_expected_result.json
+++ b/assets/queries/openAPI/header_object_with_incorrect_ref/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Header Object With Incorrect Ref",
+    "severity": "INFO",
+    "line": 73,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Header Object With Incorrect Ref",
+    "severity": "INFO",
+    "line": 43,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Header Object With Incorrect Ref",
+    "severity": "INFO",
+    "line": 45,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Header Object With Incorrect Ref",
+    "severity": "INFO",
+    "line": 29,
+    "filename": "positive4.yaml"
+  }
+]

--- a/assets/queries/openAPI/link_object_incorrect_ref/metadata.json
+++ b/assets/queries/openAPI/link_object_incorrect_ref/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Link Object Incorrect Ref",
   "severity": "INFO",
   "category": "Structure and Semantics",
-  "descriptionText": "Link object reference must always point to '#components/links'",
+  "descriptionText": "Link object reference must always point to '#/components/links'",
   "descriptionUrl": "https://swagger.io/specification/#link-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/link_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/link_object_incorrect_ref/query.rego
@@ -6,29 +6,14 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	link := doc.components.responses[r].links[l]
-	openapi_lib.incorrect_ref(link["$ref"], "links")
+	[path, value] := walk(doc)
+
+	ref := value.links[l]["$ref"]
+	openapi_lib.incorrect_ref(ref, "links")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("components.responses.{{%s}}.links.{{%s}}.$ref={{%s}}", [r, l, link["$ref"]]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Link ref points to '#/components/links'",
-		"keyActualValue": "Link ref does not point to '#/components/links'",
-	}
-}
-
-CxPolicy[result] {
-	doc := input.document[i]
-	openapi_lib.check_openapi(doc) != "undefined"
-
-	link := doc.paths[path][operation].responses[r].links[l]
-	openapi_lib.content_allowed(operation, r)
-	openapi_lib.incorrect_ref(link["$ref"], "links")
-
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.links.{{%s}}.$ref={{%s}}", [path, operation, r, l, link["$ref"]]),
+		"searchKey": sprintf("%s.links.$ref", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Link ref points to '#/components/links'",
 		"keyActualValue": "Link ref does not point to '#/components/links'",

--- a/assets/queries/openAPI/link_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/link_object_incorrect_ref/query.rego
@@ -9,11 +9,12 @@ CxPolicy[result] {
 	[path, value] := walk(doc)
 
 	ref := value.links[l]["$ref"]
+	path[minus(count(path), 1)] != "components"
 	openapi_lib.incorrect_ref(ref, "links")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.links.$ref", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.links.{{%s}}.$ref", [openapi_lib.concat_path(path), l]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Link ref points to '#/components/links'",
 		"keyActualValue": "Link ref does not point to '#/components/links'",

--- a/assets/queries/openAPI/parameter_object_incorrect_ref/metadata.json
+++ b/assets/queries/openAPI/parameter_object_incorrect_ref/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Parameter Object With Incorrect Ref",
   "severity": "INFO",
   "category": "Structure and Semantics",
-  "descriptionText": "Parameter Object reference must always point to '#components/parameters'",
+  "descriptionText": "Parameter Object reference must always point to '#/components/parameters'",
   "descriptionUrl": "https://swagger.io/specification/#parameter-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/parameter_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/parameter_object_incorrect_ref/query.rego
@@ -9,11 +9,12 @@ CxPolicy[result] {
 	[path, value] := walk(doc)
 
 	ref := value.parameters[n]["$ref"]
+	path[minus(count(path), 1)] != "components"
 	openapi_lib.incorrect_ref(ref, "parameters")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.parameters.$ref", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.parameters.$ref=%s", [openapi_lib.concat_path(path), ref]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Parameter Object ref points to '#/components/parameters'",
 		"keyActualValue": "Parameter Object ref doesn't point to '#/components/parameters'",

--- a/assets/queries/openAPI/parameter_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/parameter_object_incorrect_ref/query.rego
@@ -5,29 +5,17 @@ import data.generic.openapi as openapi_lib
 CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
-	params := doc.paths[name].parameters[n]
-	not startswith(params["$ref"], "#components/parameters/")
+
+	[path, value] := walk(doc)
+
+	ref := value.parameters[n]["$ref"]
+	openapi_lib.incorrect_ref(ref, "parameters")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.parameters", [name]),
+		"searchKey": sprintf("%s.parameters.$ref", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Parameter Object ref points to '#components/parameters'",
-		"keyActualValue": "Parameter Object ref doesn't point to '#components/parameters'",
-	}
-}
-
-CxPolicy[result] {
-	doc := input.document[i]
-	openapi_lib.check_openapi(doc) != "undefined"
-	params := doc.paths[name][oper].parameters[n]
-	not startswith(params["$ref"], "#components/parameters/")
-
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.%s.parameters", [name, oper]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Parameter Object ref points to '#components/parameters'",
-		"keyActualValue": "Parameter Object ref doesn't point to '#components/parameters'",
+		"keyExpectedValue": "Parameter Object ref points to '#/components/parameters'",
+		"keyActualValue": "Parameter Object ref doesn't point to '#/components/parameters'",
 	}
 }

--- a/assets/queries/openAPI/parameter_object_incorrect_ref/test/positive1.json
+++ b/assets/queries/openAPI/parameter_object_incorrect_ref/test/positive1.json
@@ -60,7 +60,7 @@
         }
       ]
     },
-    "/user/{id}": {
+    "/user/id": {
       "get": {
         "parameters": [
           {

--- a/assets/queries/openAPI/parameter_object_incorrect_ref/test/positive_expected_result.json
+++ b/assets/queries/openAPI/parameter_object_incorrect_ref/test/positive_expected_result.json
@@ -2,8 +2,26 @@
   {
     "queryName": "Parameter Object With Incorrect Ref",
     "severity": "INFO",
-    "line": 20,
+    "line": 56,
     "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameter Object With Incorrect Ref",
+    "severity": "INFO",
+    "line": 59,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameter Object With Incorrect Ref",
+    "severity": "INFO",
+    "line": 67,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameter Object With Incorrect Ref",
+    "severity": "INFO",
+    "line": 46,
+    "filename": "positive2.yaml"
   },
   {
     "queryName": "Parameter Object With Incorrect Ref",
@@ -14,13 +32,7 @@
   {
     "queryName": "Parameter Object With Incorrect Ref",
     "severity": "INFO",
-    "line": 56,
-    "filename": "positive1.json"
-  },
-  {
-    "queryName": "Parameter Object With Incorrect Ref",
-    "severity": "INFO",
-    "line": 46,
+    "line": 42,
     "filename": "positive2.yaml"
   }
 ]

--- a/assets/queries/openAPI/parameter_object_incorrect_ref/test/positive_expected_result.json
+++ b/assets/queries/openAPI/parameter_object_incorrect_ref/test/positive_expected_result.json
@@ -2,25 +2,25 @@
   {
     "queryName": "Parameter Object With Incorrect Ref",
     "severity": "INFO",
-    "line": 54,
+    "line": 20,
     "filename": "positive1.json"
   },
   {
     "queryName": "Parameter Object With Incorrect Ref",
     "severity": "INFO",
-    "line": 40,
+    "line": 41,
     "filename": "positive2.yaml"
   },
   {
     "queryName": "Parameter Object With Incorrect Ref",
     "severity": "INFO",
-    "line": 65,
+    "line": 56,
     "filename": "positive1.json"
   },
   {
     "queryName": "Parameter Object With Incorrect Ref",
     "severity": "INFO",
-    "line": 45,
+    "line": 46,
     "filename": "positive2.yaml"
   }
 ]

--- a/assets/queries/openAPI/request_body_incorrect_ref/metadata.json
+++ b/assets/queries/openAPI/request_body_incorrect_ref/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Request Body With Incorrect Ref",
   "severity": "INFO",
   "category": "Structure and Semantics",
-  "descriptionText": "Request Body reference must always point to '#components/RequestBodies'",
+  "descriptionText": "Request Body reference must always point to '#/components/RequestBodies'",
   "descriptionUrl": "https://swagger.io/specification/#request-body-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/request_body_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/request_body_incorrect_ref/query.rego
@@ -5,15 +5,17 @@ import data.generic.openapi as openapi_lib
 CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
-	req := doc.paths[n][oper].requestBody
 
-	openapi_lib.incorrect_ref(req["$ref"], "requestBody")
+	[path, value] := walk(doc)
+
+	ref := value.requestBody["$ref"]
+	openapi_lib.incorrect_ref(ref, "requestBody")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.%s.requestBody.$ref={{%s}}", [n, oper, req["$ref"]]),
+		"searchKey": sprintf("%s.requestBody.$ref", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Request body ref points to '#components/requestBodies'",
-		"keyActualValue": "Request body ref doesn't point to '#components/requestBodies'",
+		"keyExpectedValue": "Request body ref points to '#/components/requestBodies'",
+		"keyActualValue": "Request body ref doesn't point to '#/components/requestBodies'",
 	}
 }

--- a/assets/queries/openAPI/request_body_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/request_body_incorrect_ref/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 	[path, value] := walk(doc)
 
 	ref := value.requestBody["$ref"]
-	openapi_lib.incorrect_ref(ref, "requestBody")
+	openapi_lib.incorrect_ref(ref, "requestBodies")
 
 	result := {
 		"documentId": doc.id,

--- a/assets/queries/openAPI/response_object_incorrect_ref/metadata.json
+++ b/assets/queries/openAPI/response_object_incorrect_ref/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Response Object With Incorrect Ref",
   "severity": "INFO",
   "category": "Structure and Semantics",
-  "descriptionText": "Response Object reference must always point to '#components/responses'",
+  "descriptionText": "Response Object reference must always point to '#/components/responses'",
   "descriptionUrl": "https://swagger.io/specification/#responses-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/response_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/response_object_incorrect_ref/query.rego
@@ -5,13 +5,15 @@ import data.generic.openapi as openapi_lib
 CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
-	response := doc.paths[n][oper].responses[code]
-	openapi_lib.content_allowed(oper, code)
-	openapi_lib.incorrect_ref(response["$ref"], "responses")
+
+	[path, value] := walk(doc)
+
+	ref := value.responses[code]["$ref"]
+	openapi_lib.incorrect_ref(ref, "responses")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.%s.responses.%s.$ref={{%s}}", [n, oper, code, response["$ref"]]),
+		"searchKey": sprintf("%s.responses.$ref", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Response ref points to '#/components/responses'",
 		"keyActualValue": "Response ref does not point to '#/components/responses'",

--- a/assets/queries/openAPI/response_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/response_object_incorrect_ref/query.rego
@@ -9,11 +9,12 @@ CxPolicy[result] {
 	[path, value] := walk(doc)
 
 	ref := value.responses[code]["$ref"]
+	path[minus(count(path), 1)] != "components"
 	openapi_lib.incorrect_ref(ref, "responses")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.responses.$ref", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.responses.{{%s}}.$ref", [openapi_lib.concat_path(path), code]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Response ref points to '#/components/responses'",
 		"keyActualValue": "Response ref does not point to '#/components/responses'",

--- a/assets/queries/openAPI/schema_object_incorrect_ref/metadata.json
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Schema Object Incorrect Ref",
   "severity": "INFO",
   "category": "Structure and Semantics",
-  "descriptionText": "Schema Object reference must always point to '#components/schemas'",
+  "descriptionText": "Schema Object reference must always point to '#/components/schemas'",
   "descriptionUrl": "https://swagger.io/specification/#schema-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/schema_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/query.rego
@@ -6,109 +6,14 @@ CxPolicy[result] {
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"
 
-	schema_ref := doc.paths[path][operation].responses[r].content[c].schema["$ref"]
-	openapi_lib.content_allowed(operation, r)
-	openapi_lib.incorrect_ref(schema_ref, "schema")
+	[path, value] := walk(doc)
+
+	ref := value.schema["$ref"]
+	openapi_lib.incorrect_ref(ref, "schema")
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.content.{{%s}}.schema.$ref={{%s}}", [path, operation, r, c, schema_ref]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Schema reference points to '#components/schemas'",
-		"keyActualValue": "Schema reference does not point to '#components/schemas'",
-	}
-}
-
-CxPolicy[result] {
-	doc := input.document[i]
-	openapi_lib.check_openapi(doc) != "undefined"
-
-	schema_ref := doc.paths[path].parameters[parameter].schema["$ref"]
-	openapi_lib.incorrect_ref(schema_ref, "schema")
-
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.parameters.{{%s}}.schema.$ref={{%s}}", [path, parameter, schema_ref]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Schema reference points to '#components/schemas'",
-		"keyActualValue": "Schema reference does not point to '#components/schemas'",
-	}
-}
-
-CxPolicy[result] {
-	doc := input.document[i]
-	openapi_lib.check_openapi(doc) != "undefined"
-
-	schema_ref := doc.paths[path][operation].parameters[parameter].schema["$ref"]
-	openapi_lib.incorrect_ref(schema_ref, "schema")
-
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.{{%s}}.parameters.{{%s}}.schema.$ref={{%s}}", [path, operation, parameter, schema_ref]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Schema reference points to '#components/schemas'",
-		"keyActualValue": "Schema reference does not point to '#components/schemas'",
-	}
-}
-
-CxPolicy[result] {
-	doc := input.document[i]
-	openapi_lib.check_openapi(doc) != "undefined"
-
-	schema_ref := doc.paths[path][operation].requestBody.content[c].schema["$ref"]
-	openapi_lib.incorrect_ref(schema_ref, "schema")
-
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("paths.{{%s}}.{{%s}}.requestBody.content.{{%s}}.schema.$ref={{%s}}", [path, operation, c, schema_ref]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Schema reference points to '#components/schemas'",
-		"keyActualValue": "Schema reference does not point to '#components/schemas'",
-	}
-}
-
-CxPolicy[result] {
-	doc := input.document[i]
-	openapi_lib.check_openapi(doc) != "undefined"
-
-	schema_ref := doc.components.requestBodies[r].content[c].schema["$ref"]
-	openapi_lib.incorrect_ref(schema_ref, "schema")
-
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("components.requestBodies.{{%s}}.content.{{%s}}.schema.$ref={{%s}}", [r, c, schema_ref]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Schema reference points to '#components/schemas'",
-		"keyActualValue": "Schema reference does not point to '#components/schemas'",
-	}
-}
-
-CxPolicy[result] {
-	doc := input.document[i]
-	openapi_lib.check_openapi(doc) != "undefined"
-
-	schema_ref := doc.components.parameters[parameter].schema["$ref"]
-	openapi_lib.incorrect_ref(schema_ref, "schema")
-
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("components.parameters.{{%s}}.schema.$ref={{%s}}", [parameter, schema_ref]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Schema reference points to '#components/schemas'",
-		"keyActualValue": "Schema reference does not point to '#components/schemas'",
-	}
-}
-
-CxPolicy[result] {
-	doc := input.document[i]
-	openapi_lib.check_openapi(doc) != "undefined"
-
-	schema_ref := doc.components.responses[r].content[c].schema["$ref"]
-	openapi_lib.incorrect_ref(schema_ref, "schema")
-
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("components.responses.{{%s}}.content.{{%s}}.schema.$ref={{%s}}", [r, c, schema_ref]),
+		"searchKey": sprintf("%s.schema.$ref", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Schema reference points to '#components/schemas'",
 		"keyActualValue": "Schema reference does not point to '#components/schemas'",

--- a/assets/queries/openAPI/schema_object_incorrect_ref/query.rego
+++ b/assets/queries/openAPI/schema_object_incorrect_ref/query.rego
@@ -9,7 +9,7 @@ CxPolicy[result] {
 	[path, value] := walk(doc)
 
 	ref := value.schema["$ref"]
-	openapi_lib.incorrect_ref(ref, "schema")
+	openapi_lib.incorrect_ref(ref, "schemas")
 
 	result := {
 		"documentId": doc.id,


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Proposed Changes
- Added "Header Object With Incorrect Ref" query for OpenAPI. It checks if header object reference does not point to '#/components/headers'
- Improving similar queries with the 'walk' function

I submit this contribution under the Apache-2.0 license.