### PR TITLE
feat(query): Added Security Scheme Using HTTP Negotiate query for OpenAPI

### DIFF
--- a/assets/queries/openAPI/security_scheme_using_http_negotiate/metadata.json
+++ b/assets/queries/openAPI/security_scheme_using_http_negotiate/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "f525cc92-9050-4c41-a75c-890dc6f64449",
+  "queryName": "Security Scheme Using HTTP Negotiate",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Security Scheme HTTP should not be using negotiate authentication",
+  "descriptionUrl": "https://swagger.io/specification/#security-scheme-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/security_scheme_using_http_negotiate/query.rego
+++ b/assets/queries/openAPI/security_scheme_using_http_negotiate/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	security_scheme := doc.components.securitySchemes[name]
+	security_scheme.type == "http"
+	security_scheme.scheme == "negotiate"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.securitySchemes.{{%s}}.scheme", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("components.securitySchemes.{{%s}} does not use 'negotiate' authentication", [name]),
+		"keyActualValue": sprintf("components.securitySchemes.{{%s}} uses 'negotiate' authentication", [name]),
+	}
+}

--- a/assets/queries/openAPI/security_scheme_using_http_negotiate/test/negative1.json
+++ b/assets/queries/openAPI/security_scheme_using_http_negotiate/test/negative1.json
@@ -1,0 +1,70 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://example.com/api/oauth/dialog",
+            "tokenUrl": "https://example.com/api/oauth/token",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_scheme_using_http_negotiate/test/negative1.yaml
+++ b/assets/queries/openAPI/security_scheme_using_http_negotiate/test/negative1.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          tokenUrl: https://example.com/api/oauth/token
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets

--- a/assets/queries/openAPI/security_scheme_using_http_negotiate/test/positive1.json
+++ b/assets/queries/openAPI/security_scheme_using_http_negotiate/test/positive1.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "http",
+        "scheme": "negotiate"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_scheme_using_http_negotiate/test/positive2.yaml
+++ b/assets/queries/openAPI/security_scheme_using_http_negotiate/test/positive2.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: http
+      scheme: negotiate

--- a/assets/queries/openAPI/security_scheme_using_http_negotiate/test/positive_expected_result.json
+++ b/assets/queries/openAPI/security_scheme_using_http_negotiate/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Security Scheme Using HTTP Negotiate",
+    "severity": "MEDIUM",
+    "line": 57,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Security Scheme Using HTTP Negotiate",
+    "severity": "MEDIUM",
+    "line": 33,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added Security Scheme Using HTTP Negotiate query for OpenAPI

Security Scheme HTTP should not be using negotiate authentication

I submit this contribution under the Apache-2.0 license.
