### PR TITLE
feat(query): add "Property Defining Maximum Not Greater Than Minimum" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/metadata.json
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "ab2af219-cd08-4233-b5a1-a788aac88b51",
-  "queryName": "Property Defining Maximum Not Greater Than Minimum",
+  "queryName": "Property Defining Minimum Greater Than Maximum",
   "severity": "INFO",
   "category": "Structure and Semantics",
   "descriptionText": "Property defining maximum has a value not greater than the minimum defined",

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/metadata.json
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "ab2af219-cd08-4233-b5a1-a788aac88b51",
+  "queryName": "Property Defining Maximum Not Greater Than Minimum",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Property defining maximum has a value not greater than the minimum defined",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/metadata.json
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Property Defining Minimum Greater Than Maximum",
   "severity": "INFO",
   "category": "Structure and Semantics",
-  "descriptionText": "Property defining maximum has a value not greater than the minimum defined",
+  "descriptionText": "Property defining minimum has greater value than maximum defined",
   "descriptionUrl": "https://swagger.io/specification/#schema-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
@@ -55,6 +55,6 @@ CxPolicy[result] {
 		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Array schema value should not have 'minItems' larger than 'maxItems'",
-		"keyActualValue": "Array schame value has 'minItems' larger than 'maxItems'",
+		"keyActualValue": "Array schema value has 'minItems' larger than 'maxItems'",
 	}
 }

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
@@ -52,7 +52,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Array schema value should not have 'minItems' larger than 'maxItems'",
 		"keyActualValue": "Array schema value has 'minItems' larger than 'maxItems'",

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Numeric schema value should not have 'minimum' larger than 'maximum'",
 		"keyActualValue": "Numeric schema value has 'minimum' larger than 'maximum'",

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
@@ -36,7 +36,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "String schema value should not have 'minLength' larger than 'maxLength'",
-		"keyActualValue": "String schame value has 'minLength' larger than 'maxLength'",
+		"keyActualValue": "String schema value has 'minLength' larger than 'maxLength'",
 	}
 }
 

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
@@ -1,0 +1,60 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	openapi_lib.is_numeric_type(value.type)
+	minimum := value.minimum
+	maximum := value.maximum
+	minimum > maximum
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Numeric schema value should not have 'minimum' larger than 'maximum'",
+		"keyActualValue": "Numeric schema value has 'minimum' larger than 'maximum'",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	value.type == "string"
+	minimum := value.minLength
+	maximum := value.maxLength
+	minimum > maximum
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "String schema value should not have 'minLength' larger than 'maxLength'",
+		"keyActualValue": "String schame value has 'minLength' larger than 'maxLength'",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	value.type == "array"
+	minimum := value.minItems
+	maximum := value.maxItems
+	minimum > maximum
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Array schema value should not have 'minItems' larger than 'maxItems'",
+		"keyActualValue": "Array schame value has 'minItems' larger than 'maxItems'",
+	}
+}

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/query.rego
@@ -33,7 +33,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "String schema value should not have 'minLength' larger than 'maxLength'",
 		"keyActualValue": "String schema value has 'minLength' larger than 'maxLength'",

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative1.json
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative1.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 50
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative2.json
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative2.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 10
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative3.yaml
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative3.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 3
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative4.yaml
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative4.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 10
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative5.json
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative5.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 10
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative6.yaml
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative6.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          minLength: 1
+          maxLength: 15
+          format: int32
+        message:
+          type: string
+          maxLength: 15
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative7.yaml
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/negative7.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      schema:
+        properties:
+          code:
+            type: string
+            format: int32
+          message:
+            type: array
+            minItems: 10
+            maxItems: 300
+            items:
+              type: string

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive1.json
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive1.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 3,
+            "maximum": 1
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            },
+            "examples": {
+              "tshirt": {
+                "$ref": "#/components/examples/tshirt"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive2.json
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive2.json
@@ -1,0 +1,58 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "additionalProperties": false,
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32",
+                      "minimum": 10,
+                      "maximum": 2
+                    }
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive3.yaml
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive3.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: integer
+          format: int32
+          minimum: 3
+          maximum: 1
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive4.yaml
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive4.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                additionalProperties: false
+                properties:
+                  code:
+                    type: integer
+                    format: int32
+                    minimum: 10
+                    maximum: 2
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive5.yaml
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive5.yaml
@@ -1,0 +1,53 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          minLength: 20
+          maxLength: 15
+          format: int32
+        message:
+          type: string
+          maxLength: 15
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"
+          examples:
+            tshirt:
+              $ref: "#/components/examples/tshirt"

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive6.yaml
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive6.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      schema:
+        properties:
+          code:
+            type: string
+            format: int32
+          message:
+            type: array
+            minItems: 10
+            maxItems: 5
+            items:
+              type: string

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive_expected_result.json
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "severity": "INFO",
+    "line": 53,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "severity": "INFO",
+    "line": 25,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "severity": "INFO",
+    "line": 34,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "severity": "INFO",
+    "line": 22,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "severity": "INFO",
+    "line": 34,
+    "filename": "positive5.yaml"
+  },
+  {
+    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "severity": "INFO",
+    "line": 34,
+    "filename": "positive6.yaml"
+  }
+]

--- a/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive_expected_result.json
+++ b/assets/queries/openAPI/property_defining_maximum_not_greater_than_minimum/test/positive_expected_result.json
@@ -1,38 +1,38 @@
 [
   {
-    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "queryName": "Property Defining Minimum Greater Than Maximum",
     "severity": "INFO",
-    "line": 53,
+    "line": 52,
     "filename": "positive1.json"
   },
   {
-    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "queryName": "Property Defining Minimum Greater Than Maximum",
     "severity": "INFO",
-    "line": 25,
+    "line": 24,
     "filename": "positive2.json"
   },
   {
-    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "queryName": "Property Defining Minimum Greater Than Maximum",
     "severity": "INFO",
-    "line": 34,
+    "line": 33,
     "filename": "positive3.yaml"
   },
   {
-    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "queryName": "Property Defining Minimum Greater Than Maximum",
     "severity": "INFO",
-    "line": 22,
+    "line": 21,
     "filename": "positive4.yaml"
   },
   {
-    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "queryName": "Property Defining Minimum Greater Than Maximum",
     "severity": "INFO",
-    "line": 34,
+    "line": 33,
     "filename": "positive5.yaml"
   },
   {
-    "queryName": "Property Defining Maximum Not Greater Than Minimum",
+    "queryName": "Property Defining Minimum Greater Than Maximum",
     "severity": "INFO",
-    "line": 34,
+    "line": 33,
     "filename": "positive6.yaml"
   }
 ]


### PR DESCRIPTION
Signed-off-by: Rogério Peixoto <rogerio.peixoto@checkmarx.com>

**Proposed Changes**
- Check if schema numeric types has `minimum` larger than `maximum`
- Check if schema array types has `minItems` larger than `maxItems`
- Check if schema string types has `minLength` larger than `maxLength`

I submit this contribution under the Apache-2.0 license.
