### PR TITLE
feat(query): add "Parameters Name In Combination Should Be Unique" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/parameters_name_in_should_be_unique/metadata.json
+++ b/assets/queries/openAPI/parameters_name_in_should_be_unique/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "f5b2e6af-76f5-496d-8482-8f898c5fdb4a",
+  "queryName": "Parameters Name In Combination Should Be Unique",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Parameters properties 'name' and 'in' should have unique combinations",
+  "descriptionUrl": "https://swagger.io/specification/#parameters-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/parameters_name_in_should_be_unique/query.rego
+++ b/assets/queries/openAPI/parameters_name_in_should_be_unique/query.rego
@@ -1,0 +1,23 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	parameters := doc.components.parameters
+	paramOne := parameters[keyOne]
+	paramTwo := parameters[keyTwo]
+	keyOne != keyTwo
+	paramOne.name == paramTwo.name
+	paramOne.in == paramTwo.in
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("components.parameters.{{%s}}", [keyOne]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Parameters should have unique 'name' and 'in' combinations",
+		"keyActualValue": sprintf("components.parameters.{{%s}} parameters does not have unique 'name' and 'in' combinations", [keyOne]),
+	}
+}

--- a/assets/queries/openAPI/parameters_name_in_should_be_unique/test/negative1.json
+++ b/assets/queries/openAPI/parameters_name_in_should_be_unique/test/negative1.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "$ref": "#/components/schemas/Success"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/limitParam"
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "negativeLimitParam": {
+        "name": "limit",
+        "in": "query",
+        "description": "max records to return",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "negativeOtherParam": {
+        "name": "other",
+        "in": "query",
+        "description": "max records to return",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/parameters_name_in_should_be_unique/test/negative2.yaml
+++ b/assets/queries/openAPI/parameters_name_in_should_be_unique/test/negative2.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          "$ref": "#/components/schemas/Success"
+      parameters:
+      - "$ref": "#/components/parameters/limitParam"
+components:
+  parameters:
+    negativeLimitParam:
+      name: limit
+      in: query
+      description: max records to return
+      required: true
+      schema:
+        type: integer
+    negativeOtherParam:
+      name: other
+      in: header
+      description: max records to return
+      required: true
+      schema:
+        type: integer

--- a/assets/queries/openAPI/parameters_name_in_should_be_unique/test/positive1.json
+++ b/assets/queries/openAPI/parameters_name_in_should_be_unique/test/positive1.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "$ref": "#/components/schemas/Success"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "limitJSONParam": {
+        "name": "limit",
+        "in": "query",
+        "description": "max records to return",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "otherJSONParam": {
+        "name": "limit",
+        "in": "query",
+        "description": "max records to return",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/parameters_name_in_should_be_unique/test/positive2.yaml
+++ b/assets/queries/openAPI/parameters_name_in_should_be_unique/test/positive2.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          "$ref": "#/components/schemas/Success"
+components:
+  parameters:
+    limitParam:
+      name: limit
+      in: query
+      description: max records to return
+      required: true
+      schema:
+        type: integer
+    otherParam:
+      name: limit
+      in: query
+      description: max records to return
+      required: true
+      schema:
+        type: integer

--- a/assets/queries/openAPI/parameters_name_in_should_be_unique/test/positive_expected_result.json
+++ b/assets/queries/openAPI/parameters_name_in_should_be_unique/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Parameters Name In Combination Should Be Unique",
+    "severity": "INFO",
+    "line": 22,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameters Name In Combination Should Be Unique",
+    "severity": "INFO",
+    "line": 15,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Parameters Name In Combination Should Be Unique",
+    "severity": "INFO",
+    "line": 31,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameters Name In Combination Should Be Unique",
+    "severity": "INFO",
+    "line": 22,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
**Proposed Changes**
- Parameters fields 'name' and 'in' should have unique combinations

I submit this contribution under the Apache-2.0 license.
