### PR TITLE
feat(query): add "Schema Enum Invalid" for OpenAPI

### DIFF
--- a/assets/libraries/openapi/library.rego
+++ b/assets/libraries/openapi/library.rego
@@ -105,3 +105,22 @@ undefined_field_in_numeric_schema(value, field) {
 	is_numeric_type(value.type)
 	object.get(value, field, "undefined") == "undefined"
 }
+
+# It verifies if the 'field' is consistent with the 'type'
+invalid_field(field, type) {
+	numeric := {"integer", "number"}
+	type == numeric[_]
+	not is_number(field)
+} else {
+	type == "string"
+	not is_string(field)
+} else {
+	type == "boolean"
+	not is_boolean(field)
+} else {
+	type == "object"
+	not is_object(field)
+} else {
+	type == "array"
+	not is_array(field)
+}

--- a/assets/queries/openAPI/schema_enum_invalid/metadata.json
+++ b/assets/queries/openAPI/schema_enum_invalid/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "03856cb2-e46c-4daf-bfbf-214ec93c882b",
+  "queryName": "Schema Enum Invalid",
+  "severity": "INFO",
+  "category": "Insecure Configurations",
+  "descriptionText": "The field 'enum' of Schema Object should be consistent with the schema's type",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/schema_enum_invalid/metadata.json
+++ b/assets/queries/openAPI/schema_enum_invalid/metadata.json
@@ -2,7 +2,7 @@
   "id": "03856cb2-e46c-4daf-bfbf-214ec93c882b",
   "queryName": "Schema Enum Invalid",
   "severity": "INFO",
-  "category": "Insecure Configurations",
+  "category": "Structure and Semantics",
   "descriptionText": "The field 'enum' of Schema Object should be consistent with the schema's type",
   "descriptionUrl": "https://swagger.io/specification/#schema-object",
   "platform": "OpenAPI"

--- a/assets/queries/openAPI/schema_enum_invalid/query.rego
+++ b/assets/queries/openAPI/schema_enum_invalid/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+
+	openapi_lib.invalid_field(value.enum[x], value.type)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.enum.%s", [openapi_lib.concat_path(path), value.enum[x]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The field 'enum' is consistent with the schema's type",
+		"keyActualValue": "The field 'enum' is not consistent with the schema's type",
+	}
+}

--- a/assets/queries/openAPI/schema_enum_invalid/test/negative1.json
+++ b/assets/queries/openAPI/schema_enum_invalid/test/negative1.json
@@ -1,0 +1,32 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "$ref": "#/components/schemas/MyObject"
+          },
+          "201": {
+            "schema": {
+              "type": "number",
+              "enum": [
+                1,
+                2,
+                3,
+                4,
+                5
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_enum_invalid/test/negative2.json
+++ b/assets/queries/openAPI/schema_enum_invalid/test/negative2.json
@@ -1,0 +1,32 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "$ref": "#/components/schemas/MyObject"
+          },
+          "201": {
+            "schema": {
+              "type": "integer",
+              "enum": [
+                1,
+                2,
+                3,
+                4,
+                5
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_enum_invalid/test/negative3.yaml
+++ b/assets/queries/openAPI/schema_enum_invalid/test/negative3.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          "$ref": "#/components/schemas/MyObject"
+        "201":
+          schema:
+            type: number
+            enum:
+              - 1
+              - 2
+              - 3
+              - 4
+              - 5

--- a/assets/queries/openAPI/schema_enum_invalid/test/negative4.yaml
+++ b/assets/queries/openAPI/schema_enum_invalid/test/negative4.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          "$ref": "#/components/schemas/MyObject"
+        "201":
+          schema:
+            type: integer
+            enum:
+              - 1
+              - 2
+              - 3
+              - 4
+              - 5

--- a/assets/queries/openAPI/schema_enum_invalid/test/positive1.json
+++ b/assets/queries/openAPI/schema_enum_invalid/test/positive1.json
@@ -1,0 +1,28 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "$ref": "#/components/schemas/MyObject"
+          },
+          "201": {
+            "schema": {
+              "type": "number",
+              "enum": [
+                "black"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_enum_invalid/test/positive2.json
+++ b/assets/queries/openAPI/schema_enum_invalid/test/positive2.json
@@ -1,0 +1,28 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "$ref": "#/components/schemas/MyObject"
+          },
+          "201": {
+            "schema": {
+              "type": "integer",
+              "enum": [
+                "black"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_enum_invalid/test/positive3.yaml
+++ b/assets/queries/openAPI/schema_enum_invalid/test/positive3.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          "$ref": "#/components/schemas/MyObject"
+        "201":
+          schema:
+            type: number
+            enum:
+              - black

--- a/assets/queries/openAPI/schema_enum_invalid/test/positive4.yaml
+++ b/assets/queries/openAPI/schema_enum_invalid/test/positive4.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          "$ref": "#/components/schemas/MyObject"
+        "201":
+          schema:
+            type: integer
+            enum:
+              - black

--- a/assets/queries/openAPI/schema_enum_invalid/test/positive_expected_result.json
+++ b/assets/queries/openAPI/schema_enum_invalid/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Schema Enum Invalid",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema Enum Invalid",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Schema Enum Invalid",
+    "severity": "INFO",
+    "line": 17,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Schema Enum Invalid",
+    "severity": "INFO",
+    "line": 17,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Schema Enum Invalid" query for OpenAPI. It checks if the 'enum' field is not consistent with the schema's type


I submit this contribution under Apache-2.0 license.

