### PR TITLE
feat(query): Added Example Not Compliant With Schema Type query for OpenAPI

### DIFF
--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/metadata.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Example Not Compliant With Schema Type",
   "severity": "INFO",
   "category": "Best Practices",
-  "descriptionText": "Examples value and feilds should be compliant to the schema type",
+  "descriptionText": "Examples values and fields should be compliant with the schema type",
   "descriptionUrl": "https://swagger.io/specification/#example-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/metadata.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "881a6e71-c2a7-4fe2-b9c3-dfcf08895331",
+  "queryName": "Example Not Compliant With Schema Type",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "Examples value and feilds should be compliant to the schema type",
+  "descriptionUrl": "https://swagger.io/specification/#example-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/query.rego
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/query.rego
@@ -1,0 +1,97 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+# policy for examples
+CxPolicy[result] {
+	docs := input.document[i]
+	openapi_lib.check_openapi(docs) != "undefined"
+
+	[path, value] = walk(docs)
+	path[n] != "components"
+
+	ex_obj := get_ref(value.examples[name], docs, "examples")
+	schema_obj := get_ref(value.schema, docs, "schemas")
+	properties := get_properties(schema_obj)
+	items := compare_prop(ex_obj.value, properties)
+	count(items) > 0
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s.examples.%s", [openapi_lib.concat_path(path), name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s.examples.%s' is not compliant with the schema type", [concat(".", path)]),
+		"keyActualValue": sprintf("%s.examples.%s is not compliant with the schema type", [concat(".", path)]),
+	}
+}
+
+# policy for example
+CxPolicy[result] {
+	docs := input.document[i]
+	openapi_lib.check_openapi(docs) != "undefined"
+
+	[path, value] = walk(docs)
+	path[n] != "components"
+
+	schema_obj := get_ref(value.schema, docs, "schemas")
+	properties := get_properties(schema_obj)
+	items := compare_prop(value.example, properties)
+	count(items) > 0
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s.example", [openapi_lib.concat_path(path)]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s.example is not compliant with the schema type", [concat(".", path)]),
+		"keyActualValue": sprintf("%s.example is not compliant with the schema type", [concat(".", path)]),
+	}
+}
+
+# compare_prop() - checks if the example is complient with schema type, returns a set with all feilds that are not valid
+compare_prop(ex_obj, prop) = items {
+	prop.object == true
+	items := {x | prop_item := prop.properties[n]; not check_prop(prop_item, ex_obj, n); x := {"name": n}}
+} else = items {
+	prop.array == true
+	items := {x | prop_item := ex_obj[z]; get_type(prop_item) != prop.item_type; x := {"name": ex_obj[z]}}
+} else = items {
+	items := {x | get_type(ex_obj) != prop.type; x := {"name": ex_obj}}
+}
+
+# check_prop() - checks if all object properties are present in the example and if they have the correct type
+check_prop(prop, ex_obj, name) {
+	object.get(ex_obj, name, "undefined") != "undefined"
+	get_type(ex_obj[name]) == prop.type
+}
+
+# get_type() - get the type of the value present in the example
+get_type(obj_feild) = type {
+	is_number(obj_feild)
+	type := "integer"
+} else = type {
+	is_string(obj_feild)
+	type := "string"
+} else = type {
+	is_boolean(obj_feild)
+	type := "bool"
+}
+
+# get_ref() - returns the object based on the type (schema, examples). If the object is a ref gets the object from the ref
+get_ref(obj, docs, type) = example {
+	object.get(obj, "$ref", "undefined") == "undefined"
+	example := obj
+} else = example {
+	path := split(substring(obj["$ref"], 2, -1), "/")
+	example := docs.components[type][path[minus(count(path), 1)]]
+}
+
+# get_properties() - returns properties, type, and feilds to compare
+get_properties(schema) = properties {
+	schema.type == "object"
+	properties := {"object": true, "type": schema.type, "properties": schema.properties}
+} else = properties {
+	schema.type == "array"
+	properties := {"array": true, "type": schema.type, "item_type": schema.items.type}
+} else = properties {
+	properties := {"type": schema.type}
+}

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative1.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative1.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyObject"
+                },
+                "examples": {
+                  "object": {
+                    "$ref": "#/components/examples/objectExample"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "MyObject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "examples": {
+      "objectExample": {
+        "value": {
+          "id": "1",
+          "name": "new object"
+        },
+        "summary": "A sample object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative2.yaml
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative2.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MyObject"
+              examples:
+                object:
+                  "$ref": "#/components/examples/objectExample"
+components:
+  schemas:
+    MyObject:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+  examples:
+    objectExample:
+      value:
+        id: "1"
+        name: new object
+      summary: A sample object

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative3.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative3.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/my_schema"
+                },
+                "examples": {
+                  "foo": {
+                    "value": "this is a string"
+                  },
+                  "foo_2": {
+                    "value": "true"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "my_schema": {
+        "type": "string"
+      }
+    }
+  },
+  "security": [
+    {
+      "exampleSecurity": []
+    }
+  ]
+}

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative4.yaml
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative4.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/my_schema"
+              examples:
+                foo:
+                  value: "this is a string"
+                foo_2:
+                  value: "true"
+components:
+  schemas:
+    my_schema:
+      type: string
+security:
+  - exampleSecurity: []

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative5.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative5.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/my_schema"
+                },
+                "example": "true"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "my_schema": {
+        "type": "string"
+      }
+    }
+  },
+  "security": [
+    {
+      "exampleSecurity": []
+    }
+  ]
+}

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative6.yaml
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative6.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/my_schema"
+              example: "true"
+components:
+  schemas:
+    my_schema:
+      type: string
+security:
+  - exampleSecurity: []

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative7.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative7.json
@@ -1,0 +1,44 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": [
+                      "true",
+                      "test2",
+                      "test3"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "exampleSecurity": []
+    }
+  ]
+}

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative8.yaml
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/negative8.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              examples:
+                foo:
+                  value:
+                    - "true"
+                    - "test2"
+                    - "test3"
+security:
+  - exampleSecurity: []

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive1.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive1.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MyObject"
+                },
+                "examples": {
+                  "object": {
+                    "$ref": "#/components/examples/objectExample"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "MyObject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "examples": {
+      "objectExample": {
+        "value": {
+          "id": 1,
+          "name": "new object"
+        },
+        "summary": "A sample object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive2.yaml
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive2.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MyObject"
+              examples:
+                object:
+                  "$ref": "#/components/examples/objectExample"
+components:
+  schemas:
+    MyObject:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+  examples:
+    objectExample:
+      value:
+        id: 1
+        name: new object
+      summary: A sample object

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive3.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive3.json
@@ -1,0 +1,47 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/my_schema"
+                },
+                "examples": {
+                  "foo": {
+                    "value": "this is a string"
+                  },
+                  "foo_2": {
+                    "value": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "my_schema": {
+        "type": "string"
+      }
+    }
+  },
+  "security": [
+    {
+      "exampleSecurity": []
+    }
+  ]
+}

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive4.yaml
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive4.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/my_schema"
+              examples:
+                foo:
+                  value: "this is a string"
+                foo_2:
+                  value: true
+components:
+  schemas:
+    my_schema:
+      type: string
+security:
+  - exampleSecurity: []

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive5.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive5.json
@@ -1,0 +1,59 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/my_schema"
+                },
+                "example": true
+              }
+            }
+          },
+          "400": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                },
+                "example": [
+                  1,
+                  2,
+                  "3",
+                  4
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "my_schema": {
+        "type": "string"
+      }
+    }
+  },
+  "security": [
+    {
+      "exampleSecurity": []
+    }
+  ]
+}

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive6.yaml
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive6.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/my_schema"
+              example: true
+        "400":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+              example:
+                - 1
+                - 2
+                - "3"
+                - 4
+components:
+  schemas:
+    my_schema:
+      type: string
+security:
+  - exampleSecurity: []

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive7.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive7.json
@@ -1,0 +1,44 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "examples": {
+                  "foo": {
+                    "value": [
+                      true,
+                      "test2",
+                      "test3"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "exampleSecurity": []
+    }
+  ]
+}

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive8.yaml
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive8.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              examples:
+                foo:
+                  value:
+                    - true
+                    - "test2"
+                    - "test3"
+security:
+  - exampleSecurity: []

--- a/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive_expected_result.json
+++ b/assets/queries/openAPI/example_not_compliant_with_schema_type/test/positive_expected_result.json
@@ -1,0 +1,62 @@
+[
+  {
+    "queryName": "Example Not Compliant With Schema Type",
+    "severity": "INFO",
+    "line": 21,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Example Not Compliant With Schema Type",
+    "severity": "INFO",
+    "line": 18,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Example Not Compliant With Schema Type",
+    "severity": "INFO",
+    "line": 24,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Example Not Compliant With Schema Type",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Example Not Compliant With Schema Type",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive5.json"
+  },
+  {
+    "queryName": "Example Not Compliant With Schema Type",
+    "severity": "INFO",
+    "line": 17,
+    "filename": "positive6.yaml"
+  },
+  {
+    "queryName": "Example Not Compliant With Schema Type",
+    "severity": "INFO",
+    "line": 34,
+    "filename": "positive5.json"
+  },
+  {
+    "queryName": "Example Not Compliant With Schema Type",
+    "severity": "INFO",
+    "line": 26,
+    "filename": "positive6.yaml"
+  },
+  {
+    "queryName": "Example Not Compliant With Schema Type",
+    "severity": "INFO",
+    "line": 24,
+    "filename": "positive7.json"
+  },
+  {
+    "queryName": "Example Not Compliant With Schema Type",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive8.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added Example Not Compliant With Schema Type query for OpenAPI

Examples values and fields should be compliant with the schema type

I submit this contribution under the Apache-2.0 license.
