### PR TITLE
feat(query): Added Schema Object With Circular Ref query for OpenAPI

### DIFF
--- a/assets/queries/openAPI/schema_object_with_circular_ref/metadata.json
+++ b/assets/queries/openAPI/schema_object_with_circular_ref/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Schema Object With Circular Ref",
   "severity": "INFO",
   "category": "Structure and Semantics",
-  "descriptionText": "Schema Object should not reference it self for 'allOf', 'oneOf', 'anyOf' and 'not' properties",
+  "descriptionText": "Schema Object should not reference it self in 'allOf', 'oneOf', 'anyOf' and 'not' properties",
   "descriptionUrl": "https://swagger.io/specification/#schema-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/schema_object_with_circular_ref/metadata.json
+++ b/assets/queries/openAPI/schema_object_with_circular_ref/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "1a1aea94-745b-40a7-b860-0702ea6ee636",
+  "queryName": "Schema Object With Circular Ref",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Schema Object should not reference it self for 'allOf', 'oneOf', 'anyOf' and 'not' properties",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/schema_object_with_circular_ref/query.rego
+++ b/assets/queries/openAPI/schema_object_with_circular_ref/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("%s.%s.$ref=%s", [openapi_lib.concat_path(path), types[prop], properties["$ref"]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s.%s does not referances own schema", [concat(".", path), types[prop]]),
-		"keyActualValue": sprintf("%s.%s referances own schema", [concat(".", path), types[prop]]),
+		"keyExpectedValue": sprintf("%s.%s does not reference own schema", [concat(".", path), types[prop]]),
+		"keyActualValue": sprintf("%s.%s reference own schema", [concat(".", path), types[prop]]),
 	}
 }

--- a/assets/queries/openAPI/schema_object_with_circular_ref/query.rego
+++ b/assets/queries/openAPI/schema_object_with_circular_ref/query.rego
@@ -1,0 +1,22 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	types := {"allOf", "oneOf", "anyOf", "not"}
+	object.get(value[types[prop]][n], "$ref", "undefined") != "undefined"
+	properties := value[types[prop]][n]
+	trim_prefix(properties["$ref"], "#/components/schemas/") == path[minus(count(path), 1)]
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.%s.$ref=%s", [openapi_lib.concat_path(path), types[prop], properties["$ref"]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s.%s does not referances own schema", [concat(".", path), types[prop]]),
+		"keyActualValue": sprintf("%s.%s referances own schema", [concat(".", path), types[prop]]),
+	}
+}

--- a/assets/queries/openAPI/schema_object_with_circular_ref/test/negative1.json
+++ b/assets/queries/openAPI/schema_object_with_circular_ref/test/negative1.json
@@ -1,0 +1,87 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ErrorModel": {
+        "type": "object",
+        "required": [
+          "message",
+          "code"
+        ],
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 600
+          }
+        }
+      },
+      "ExtendedErrorModel": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorModel"
+          },
+          {
+            "type": "object",
+            "required": [
+              "rootCause"
+            ],
+            "properties": {
+              "rootCause": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_with_circular_ref/test/negative2.yaml
+++ b/assets/queries/openAPI/schema_object_with_circular_ref/test/negative2.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.c
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    ErrorModel:
+      type: object
+      required:
+        - message
+        - code
+      properties:
+        message:
+          type: string
+        code:
+          type: integer
+          minimum: 100
+          maximum: 600
+    ExtendedErrorModel:
+      allOf:
+        - "$ref": "#/components/schemas/ErrorModel"
+        - type: object
+          required:
+            - rootCause
+          properties:
+            rootCause:
+              type: string

--- a/assets/queries/openAPI/schema_object_with_circular_ref/test/positive1.json
+++ b/assets/queries/openAPI/schema_object_with_circular_ref/test/positive1.json
@@ -1,0 +1,87 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ErrorModel": {
+        "type": "object",
+        "required": [
+          "message",
+          "code"
+        ],
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 600
+          }
+        }
+      },
+      "ExtendedErrorModel": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ExtendedErrorModel"
+          },
+          {
+            "type": "object",
+            "required": [
+              "rootCause"
+            ],
+            "properties": {
+              "rootCause": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_with_circular_ref/test/positive2.yaml
+++ b/assets/queries/openAPI/schema_object_with_circular_ref/test/positive2.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.c
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    ErrorModel:
+      type: object
+      required:
+        - message
+        - code
+      properties:
+        message:
+          type: string
+        code:
+          type: integer
+          minimum: 100
+          maximum: 600
+    ExtendedErrorModel:
+      allOf:
+        - $ref: "#/components/schemas/ExtendedErrorModel"
+        - type: object
+          required:
+            - rootCause
+          properties:
+            rootCause:
+              type: string

--- a/assets/queries/openAPI/schema_object_with_circular_ref/test/positive_expected_result.json
+++ b/assets/queries/openAPI/schema_object_with_circular_ref/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Schema Object With Circular Ref",
+    "severity": "INFO",
+    "line": 70,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema Object With Circular Ref",
+    "severity": "INFO",
+    "line": 45,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added Schema Object With Circular Ref query for OpenAPI

Schema Object should not reference it self in 'allOf', 'oneOf', 'anyOf' and 'not' properties

I submit this contribution under the Apache-2.0 license.
