### PR TITLE
fix(ci): adding python3 environment to metrics workflow

### DIFF
--- a/.github/workflows/go-ci-metrics.yaml
+++ b/.github/workflows/go-ci-metrics.yaml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v2.3.4
+      - uses: actions/setup-python@v2.2.2
+        with:
+          python-version: "3.x"
       - name: Run test metrics script
         id: metrics
         run: |


### PR DESCRIPTION

I submit this contribution under the Apache-2.0 license.
