### PR TITLE
feat(query): Added Schema Object Using Enum With Keyword query to OpenAPI

### DIFF
--- a/assets/queries/openAPI/schema_object_using_enum_with_keyword/metadata.json
+++ b/assets/queries/openAPI/schema_object_using_enum_with_keyword/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "2e9b6612-8f69-42e0-a5b8-ed17739c2f3a",
+  "queryName": "Schema Object Using Enum With Keyword",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "Schema Object properties should not contain 'enum' and schema keywords",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/schema_object_using_enum_with_keyword/query.rego
+++ b/assets/queries/openAPI/schema_object_using_enum_with_keyword/query.rego
@@ -1,0 +1,33 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	keywords := ["multipleOf", "maximum", "minimum", "exclusiveMaximum", "exclusiveMinimum", "pattern", "minLength", "maxLength", "maxItems", "minItems", "uniqueItems", "items", "required", "maxProperties", "minProperties"]
+
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	properties := value.properties[name]
+	object.get(properties, "enum", "undefined") != "undefined"
+	object.get(properties, keywords[x], "undefined") != "undefined"
+
+	path_c := {x | obj := clean_path(path[n]); obj != ""; x := obj}
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s.properties.%s does not contain 'enum' and schema keyword", [concat(".", path_c), name]),
+		"keyActualValue": sprintf("%s.properties.%s contains 'enum' and schema keyword '%s'", [concat(".", path_c), name, keywords[x]]),
+	}
+}
+
+clean_path(path) = cleaned_path {
+	is_number(path)
+	cleaned_path := ""
+} else = cleaned_path {
+	cleaned_path := path
+}

--- a/assets/queries/openAPI/schema_object_using_enum_with_keyword/query.rego
+++ b/assets/queries/openAPI/schema_object_using_enum_with_keyword/query.rego
@@ -4,7 +4,7 @@ import data.generic.common as common_lib
 import data.generic.openapi as openapi_lib
 
 CxPolicy[result] {
-	keywords := ["multipleOf", "maximum", "minimum", "exclusiveMaximum", "exclusiveMinimum", "pattern", "minLength", "maxLength", "maxItems", "minItems", "uniqueItems", "items", "required", "maxProperties", "minProperties"]
+	keywords := ["multipleOf", "maximum", "minimum", "exclusiveMaximum", "exclusiveMinimum", "pattern", "minLength", "maxLength", "maxItems", "minItems", "uniqueItems", "required", "maxProperties", "minProperties"]
 
 	doc := input.document[i]
 	openapi_lib.check_openapi(doc) != "undefined"

--- a/assets/queries/openAPI/schema_object_using_enum_with_keyword/test/negative1.json
+++ b/assets/queries/openAPI/schema_object_using_enum_with_keyword/test/negative1.json
@@ -1,0 +1,85 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "petType": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "petType"
+        ]
+      },
+      "Cat": {
+        "description": "A representation of a cat. Note that `Cat` will be used as the discriminator value.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "huntingSkill": {
+                "type": "string",
+                "description": "The measured skill for hunting",
+                "default": "lazy",
+                "enum": [
+                  "clueless",
+                  "lazy",
+                  "adventurous",
+                  "aggressive"
+                ]
+              }
+            },
+            "required": [
+              "huntingSkill"
+            ]
+          }
+        ]
+      },
+      "Dog": {
+        "description": "A representation of a dog. Note that `Dog` will be used as the discriminator value.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "packSize": {
+                "type": "integer",
+                "format": "int32",
+                "description": "the size of the pack the dog is from",
+                "default": 0,
+                "minimum": 0
+              }
+            },
+            "required": [
+              "packSize"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_using_enum_with_keyword/test/negative2.yaml
+++ b/assets/queries/openAPI/schema_object_using_enum_with_keyword/test/negative2.yaml
@@ -1,0 +1,58 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.c
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        name:
+          type: string
+        petType:
+          type: string
+      required:
+        - name
+        - petType
+    Cat:
+      description:
+        A representation of a cat. Note that `Cat` will be used as the
+        discriminator value.
+      allOf:
+        - "$ref": "#/components/schemas/Pet"
+        - type: object
+          properties:
+            huntingSkill:
+              type: string
+              description: The measured skill for hunting
+              default: lazy
+              enum:
+                - clueless
+                - lazy
+                - adventurous
+                - aggressive
+          required:
+            - huntingSkill
+    Dog:
+      description:
+        A representation of a dog. Note that `Dog` will be used as the
+        discriminator value.
+      allOf:
+        - "$ref": "#/components/schemas/Pet"
+        - type: object
+          properties:
+            packSize:
+              type: integer
+              format: int32
+              description: the size of the pack the dog is from
+              default: 0
+              minimum: 0
+          required:
+            - packSize

--- a/assets/queries/openAPI/schema_object_using_enum_with_keyword/test/positive1.json
+++ b/assets/queries/openAPI/schema_object_using_enum_with_keyword/test/positive1.json
@@ -1,0 +1,86 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "petType": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "petType"
+        ]
+      },
+      "Cat": {
+        "description": "A representation of a cat. Note that `Cat` will be used as the discriminator value.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "huntingSkill": {
+                "type": "string",
+                "description": "The measured skill for hunting",
+                "default": "lazy",
+                "enum": [
+                  "clueless",
+                  "lazy",
+                  "adventurous",
+                  "aggressive"
+                ],
+                "minLength": 4
+              }
+            },
+            "required": [
+              "huntingSkill"
+            ]
+          }
+        ]
+      },
+      "Dog": {
+        "description": "A representation of a dog. Note that `Dog` will be used as the discriminator value.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "packSize": {
+                "type": "integer",
+                "format": "int32",
+                "description": "the size of the pack the dog is from",
+                "default": 0,
+                "minimum": 0
+              }
+            },
+            "required": [
+              "packSize"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_using_enum_with_keyword/test/positive2.yaml
+++ b/assets/queries/openAPI/schema_object_using_enum_with_keyword/test/positive2.yaml
@@ -1,0 +1,59 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.c
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        name:
+          type: string
+        petType:
+          type: string
+      required:
+        - name
+        - petType
+    Cat:
+      description:
+        A representation of a cat. Note that `Cat` will be used as the
+        discriminator value.
+      allOf:
+        - "$ref": "#/components/schemas/Pet"
+        - type: object
+          properties:
+            huntingSkill:
+              type: string
+              description: The measured skill for hunting
+              default: lazy
+              enum:
+                - clueless
+                - lazy
+                - adventurous
+                - aggressive
+              minLength: 4
+          required:
+            - huntingSkill
+    Dog:
+      description:
+        A representation of a dog. Note that `Dog` will be used as the
+        discriminator value.
+      allOf:
+        - "$ref": "#/components/schemas/Pet"
+        - type: object
+          properties:
+            packSize:
+              type: integer
+              format: int32
+              description: the size of the pack the dog is from
+              default: 0
+              minimum: 0
+          required:
+            - packSize

--- a/assets/queries/openAPI/schema_object_using_enum_with_keyword/test/positive_expected_result.json
+++ b/assets/queries/openAPI/schema_object_using_enum_with_keyword/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Schema Object Using Enum With Keyword",
+    "severity": "INFO",
+    "line": 42,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema Object Using Enum With Keyword",
+    "severity": "INFO",
+    "line": 32,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added Schema Object Using Enum With Keyword query to OpenAPI

Schema Object properties should not contain 'enum' and schema keywords

I submit this contribution under the Apache-2.0 license.
