### PR TITLE
fix(docs): corrected docs to match KICS behavior

### DIFF
--- a/docs/dockerhub.md
+++ b/docs/dockerhub.md
@@ -50,7 +50,7 @@ Flags:
   -h, --help                help for kics
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)
@@ -105,7 +105,7 @@ Global Flags:
       --ci                  display only log messages to CLI output (mutually exclusive with silent)
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -24,7 +24,7 @@ Flags:
   -h, --help                help for kics
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)
@@ -79,7 +79,7 @@ Global Flags:
       --ci                  display only log messages to CLI output (mutually exclusive with silent)
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)

--- a/e2e/fixtures/E2E_CLI_001
+++ b/e2e/fixtures/E2E_CLI_001
@@ -15,7 +15,7 @@ Flags:
   -h, --help                help for kics
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)

--- a/e2e/fixtures/E2E_CLI_002
+++ b/e2e/fixtures/E2E_CLI_002
@@ -41,7 +41,7 @@ Global Flags:
       --ci                  display only log messages to CLI output (mutually exclusive with silent)
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)

--- a/e2e/fixtures/E2E_CLI_003
+++ b/e2e/fixtures/E2E_CLI_003
@@ -40,7 +40,7 @@ Global Flags:
       --ci                  display only log messages to CLI output (mutually exclusive with silent)
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)

--- a/e2e/fixtures/E2E_CLI_004
+++ b/e2e/fixtures/E2E_CLI_004
@@ -40,7 +40,7 @@ Global Flags:
       --ci                  display only log messages to CLI output (mutually exclusive with silent)
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)

--- a/e2e/fixtures/E2E_CLI_010
+++ b/e2e/fixtures/E2E_CLI_010
@@ -47,7 +47,7 @@ Global Flags:
       --ci                  display only log messages to CLI output (mutually exclusive with silent)
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)

--- a/e2e/fixtures/E2E_CLI_016_INVALID_FLAG
+++ b/e2e/fixtures/E2E_CLI_016_INVALID_FLAG
@@ -14,7 +14,7 @@ Flags:
   -h, --help                help for kics
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)

--- a/e2e/fixtures/E2E_CLI_016_INVALID_SCAN_FLAG
+++ b/e2e/fixtures/E2E_CLI_016_INVALID_SCAN_FLAG
@@ -40,7 +40,7 @@ Global Flags:
       --ci                  display only log messages to CLI output (mutually exclusive with silent)
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)

--- a/e2e/fixtures/E2E_CLI_016_INVALID_SHOTHAND
+++ b/e2e/fixtures/E2E_CLI_016_INVALID_SHOTHAND
@@ -14,7 +14,7 @@ Flags:
   -h, --help                help for kics
   -f, --log-format string   determines log format (pretty,json) (default "pretty")
       --log-level string    determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL) (default "INFO")
-      --log-path string     path to log files, (defaults to ${PWD}/info.log)
+      --log-path string     path to generate log file (info.log)
       --no-color            disable CLI color output
       --profiling string    enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)
   -s, --silent              silence stdout messages (mutually exclusive with verbose and ci)

--- a/internal/console/kics.go
+++ b/internal/console/kics.go
@@ -55,14 +55,12 @@ func initialize(rootCmd *cobra.Command) error {
 		printer.LogFileShorthand,
 		false,
 		"writes log messages to log file")
-	rootCmd.PersistentFlags().StringVarP(&logPath,
+	rootCmd.PersistentFlags().StringVar(&logPath,
 		printer.LogPathFlag,
 		"",
-		"",
-		fmt.Sprintf("path to log files, (defaults to ${PWD}/%s)", constants.DefaultLogFile))
-	rootCmd.PersistentFlags().StringVarP(&logLevel,
+		fmt.Sprintf("path to generate log file (%s)", constants.DefaultLogFile))
+	rootCmd.PersistentFlags().StringVar(&logLevel,
 		printer.LogLevelFlag,
-		"",
 		"INFO",
 		"determines log level (TRACE,DEBUG,INFO,WARN,ERROR,FATAL)")
 	rootCmd.PersistentFlags().StringVarP(&logFormat,
@@ -80,19 +78,16 @@ func initialize(rootCmd *cobra.Command) error {
 		printer.SilentShorthand,
 		false,
 		"silence stdout messages (mutually exclusive with verbose and ci)")
-	rootCmd.PersistentFlags().BoolVarP(&noColor,
+	rootCmd.PersistentFlags().BoolVar(&noColor,
 		printer.NoColorFlag,
-		"",
 		false,
 		"disable CLI color output")
-	rootCmd.PersistentFlags().BoolVarP(&ci,
+	rootCmd.PersistentFlags().BoolVar(&ci,
 		printer.CIFlag,
-		"",
 		false,
 		"display only log messages to CLI output (mutually exclusive with silent)")
-	rootCmd.PersistentFlags().StringVarP(&profiling,
+	rootCmd.PersistentFlags().StringVar(&profiling,
 		"profiling",
-		"",
 		"",
 		"enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)")
 


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #3141 

**Proposed Changes**
- Now --log-path does not contains a text with default behavior
- Also refactored kics.go to use "P functions" only when there is a shorthand

I submit this contribution under the Apache-2.0 license.
