### PR TITLE
feat(query): add "Property 'allowEmptyValue' Ignored" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/property_allow_empty_value_ignored/metadata.json
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "59c2f769-7cc2-49c8-a3de-4e211135cfab",
+  "queryName": "Property 'allowEmptyValue' Ignored",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "Property 'allowEmptyValue' is ignored in the following cases: {\"sytle\": \"simple\", \"explode\": false}, {\"sytle\": \"simple\", \"explode\": true}, {\"sytle\": \"spaceDelimited\", \"explode\": false}, {\"sytle\": \"pipeDelimited\", \"explode\": false}, and {\"sytle\": \"deepObject\", \"explode\": true}",
+  "descriptionUrl": "https://swagger.io/specification/#parameter-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/query.rego
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/query.rego
@@ -1,0 +1,50 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+
+	value.allowEmptyValue == true
+	allow_empty_value_ignored(value)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.allowEmptyValue", [openapi_lib.concat_path(path)]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Property 'allowEmptyValue' is not ignored",
+		"keyActualValue": "Property 'allowEmptyValue' is ignored (due to one of the following cases: {\"sytle\": \"simple\", \"explode\": false}, {\"sytle\": \"simple\", \"explode\": true}, {\"sytle\": \"spaceDelimited\", \"explode\": false}, {\"sytle\": \"pipeDelimited\", \"explode\": false}, or {\"sytle\": \"deepObject\", \"explode\": true})",
+	}
+}
+
+check_simple(value) {
+	value.style == "simple"
+} else {
+	ins := {"path", "header"}
+	value.in == ins[_]
+	object.get(value, "style", "undefined") == "undefined"
+}
+
+set_to_false(value) {
+	value.explode == false
+} else {
+	object.get(value, "explode", "undefined") == "undefined"
+}
+
+check_delimited(value) {
+	styles := {"spaceDelimited", "pipeDelimited"}
+	value.style == styles[_]
+	set_to_false(value)
+}
+
+allow_empty_value_ignored(value) {
+	check_simple(value)
+} else {
+	check_delimited(value)
+} else {
+	value.style == "deepObject"
+	value.explode == true
+}

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative1.json
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative1.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "style": "label",
+          "description": "ID of the API version",
+          "required": true,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative2.yaml
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative2.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: path
+        style: label
+        description: ID of the API version
+        required: true
+        allowEmptyValue: true
+        schema:
+          type: integer

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative3.json
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative3.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "parameters": [
+        {
+          "required": true,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "integer"
+          },
+          "name": "id",
+          "in": "query",
+          "style": "deepObject",
+          "explode": false,
+          "description": "ID of the API version"
+        }
+      ],
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative4.yaml
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative4.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: query
+        style: deepObject
+        explode: false
+        description: ID of the API version
+        required: true
+        allowEmptyValue: true
+        schema:
+          type: integer

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative5.json
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative5.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "query",
+          "style": "spaceDelimited",
+          "explode": true,
+          "description": "ID of the API version",
+          "required": true,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative5.json
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative5.json
@@ -11,10 +11,10 @@
           "name": "id",
           "in": "query",
           "style": "spaceDelimited",
-          "explode": true,
+          "explode": false,
           "description": "ID of the API version",
           "required": true,
-          "allowEmptyValue": true,
+          "allowEmptyValue": false,
           "schema": {
             "type": "integer"
           }

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative6.yaml
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative6.yaml
@@ -26,9 +26,9 @@ paths:
       - name: id
         in: query
         style: spaceDelimited
-        explode: true
+        explode: false
         description: ID of the API version
         required: true
-        allowEmptyValue: true
+        allowEmptyValue: false
         schema:
           type: integer

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative6.yaml
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/negative6.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: query
+        style: spaceDelimited
+        explode: true
+        description: ID of the API version
+        required: true
+        allowEmptyValue: true
+        schema:
+          type: integer

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive1.json
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive1.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of the API version",
+          "required": true,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive2.yaml
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive2.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: path
+        description: ID of the API version
+        required: true
+        allowEmptyValue: true
+        schema:
+          type: integer

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive3.json
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive3.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "parameters": [
+        {
+          "required": true,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "integer"
+          },
+          "name": "id",
+          "in": "query",
+          "style": "deepObject",
+          "explode": true,
+          "description": "ID of the API version"
+        }
+      ],
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive4.yaml
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive4.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: query
+        style: deepObject
+        explode: true
+        description: ID of the API version
+        required: true
+        allowEmptyValue: true
+        schema:
+          type: integer

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive5.json
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive5.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "query",
+          "style": "spaceDelimited",
+          "description": "ID of the API version",
+          "required": true,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive6.yaml
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive6.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+    parameters:
+      - name: id
+        in: query
+        style: spaceDelimited
+        description: ID of the API version
+        required: true
+        allowEmptyValue: true
+        schema:
+          type: integer

--- a/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive_expected_result.json
+++ b/assets/queries/openAPI/property_allow_empty_value_ignored/test/positive_expected_result.json
@@ -1,0 +1,38 @@
+[
+  {
+    "queryName": "Property 'allowEmptyValue' Ignored",
+    "severity": "INFO",
+    "line": 47,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Property 'allowEmptyValue' Ignored",
+    "severity": "INFO",
+    "line": 30,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Property 'allowEmptyValue' Ignored",
+    "severity": "INFO",
+    "line": 12,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Property 'allowEmptyValue' Ignored",
+    "severity": "INFO",
+    "line": 32,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Property 'allowEmptyValue' Ignored",
+    "severity": "INFO",
+    "line": 16,
+    "filename": "positive5.json"
+  },
+  {
+    "queryName": "Property 'allowEmptyValue' Ignored",
+    "severity": "INFO",
+    "line": 31,
+    "filename": "positive6.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Property 'allowEmptyValue' Ignored" query for OpenAPI.
- Since property 'allowEmptyValue' is ignored in the following cases: {"sytle": "simple", "explode": false}, {"sytle": "simple", "explode": true}, {"sytle": "spaceDelimited", "explode": false}, {"sytle": "pipeDelimited", "explode": false}, and {"sytle": "deepObject", "explode": true}, we need to check:
  - If `style` is set to `simple` or if it is undefined when `in` is set to `path` or `header` (by default, when `in` is set to `path` or `header`, `style` is `simple` (It is not necessary to check `explode` since it is ignored in both cases - explode set to false or explode set to true)
  - If `style` is set to `spaceDelimited` or `pipeDelimited` when 'explode' is `false` (in other words, when it is set to false or it is undefined (by default, explode is set to false, except for form style))
  - If `style` is set to `deepObject` when 'explode' is `true`

I submit this contribution under the Apache-2.0 license.
