### PR TITLE
feat(query): add "Invalid Media Type Value" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/invalid_media_type_value/metadata.json
+++ b/assets/queries/openAPI/invalid_media_type_value/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "cf4a5f45-a27b-49df-843a-9911dbfe71d4",
+  "queryName": "Invalid Media Type Value",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "The Media Type value should match the following format: <type>/<subtype>[+suffix][;parameters]",
+  "descriptionUrl": "https://swagger.io/specification/#media-type-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/invalid_media_type_value/query.rego
+++ b/assets/queries/openAPI/invalid_media_type_value/query.rego
@@ -1,0 +1,30 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+	content = value.content[mime]
+
+	type := "[A-Za-z0-9][A-Za-z0-9!#$&\\-^_]{0,126}"
+	subtype := "[A-Za-z0-9][A-Za-z0-9!#$&\\-^_.+]{0,126}"
+	token := "([!#$%&'*+.^_`|~0-9A-Za-z-]+)"
+	space := "[ \t]*"
+	quotedString := "\"(?:[^\"\\\\]|\\.)*\""
+	parameter := concat("", [";", space, token, space, "=", space, "(", token, "|", quotedString, ")"])
+
+	mimeRegex := concat("", ["^", type, "/", "(", subtype, ")", "(", parameter, ")*", "$"])
+
+	regex.match(mimeRegex, mime) == false
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.content.%s", [openapi_lib.concat_path(path), mime]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The Media Type is a valid value",
+		"keyActualValue": "The Media Type is a invalid value",
+	}
+}

--- a/assets/queries/openAPI/invalid_media_type_value/test/negative1.json
+++ b/assets/queries/openAPI/invalid_media_type_value/test/negative1.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "string",
+                "format": "binary",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "code": {
+                  "contentType": "image/png, image/jpeg"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/invalid_media_type_value/test/negative2.yaml
+++ b/assets/queries/openAPI/invalid_media_type_value/test/negative2.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: string
+              format: binary
+              properties:
+                code:
+                  type: string
+                  format: binary
+            encoding:
+              code:
+                contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/invalid_media_type_value/test/positive1.json
+++ b/assets/queries/openAPI/invalid_media_type_value/test/positive1.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "multipart/form- data": {
+              "encoding": {
+                "code": {
+                  "contentType": "image/png, image/jpeg"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/invalid_media_type_value/test/positive2.yaml
+++ b/assets/queries/openAPI/invalid_media_type_value/test/positive2.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg
+      requestBody:
+        content:
+          multipart/form- data:
+            encoding:
+              code:
+                contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/invalid_media_type_value/test/positive_expected_result.json
+++ b/assets/queries/openAPI/invalid_media_type_value/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Invalid Media Type Value",
+    "severity": "INFO",
+    "line": 28,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Invalid Media Type Value",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Invalid Media Type Value" query for OpenAPI. It checks if the media type value does not match the following format: `<type>/<subtype>[+suffix][;parameters]`

I submit this contribution under the Apache-2.0 license.
