### PR TITLE
feat(query): update "APT-GET Missing '-y' To Avoid Manual Input" for Dockerfile (#3391)

### DIFF
--- a/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
+++ b/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
@@ -28,7 +28,7 @@ CxPolicy[result] {
 
 	count(resource.Value) > 1
 
-    dockerLib.arrayContains(resource.Value, {"apt-get", "install"})
+	dockerLib.arrayContains(resource.Value, {"apt-get", "install"})
 
 	not avoidManualInputInList(resource.Value)
 
@@ -46,7 +46,7 @@ isAptGet(command) {
 }
 
 avoidManualInputInList(command) {
-	flags := ["-y", "yes", "--assumeyes"]
+	flags := ["-y", "yes", "--assumeyes", "-qy"]
 
 	contains(command[j], flags[x])
 }
@@ -56,13 +56,13 @@ isAptGet(command) {
 }
 
 avoidManualInput(command) {
-	regex.match("apt-get (-(-)?[a-zA-Z]+ *)*(-y|-yes|--assumeyes) (-(-)?[a-zA-Z]+ *)*install", command)
+	regex.match("apt-get (-(-)?[a-zA-Z]+ *)*(-(q)?y|-yes|--assumeyes) (-(-)?[a-zA-Z]+ *)*install", command)
 }
 
 avoidManualInput(command) {
-	regex.match("apt-get (-(-)?[a-zA-Z]+ *)*install (-(-)?[a-zA-Z]+ *)*(-y|-yes|--assumeyes)", command)
+	regex.match("apt-get (-(-)?[a-zA-Z]+ *)*install (-(-)?[a-zA-Z]+ *)*(-(q)?y|-yes|--assumeyes)", command)
 }
 
 avoidManualInput(command) {
-	regex.match("apt-get (-(-)?[a-zA-Z]+ *)*install ([A-Za-z0-9-:=.$_]+ *)*(-y|-yes|--assumeyes)", command)
+	regex.match("apt-get (-(-)?[a-zA-Z]+ *)*install ([A-Za-z0-9-:=.$_]+ *)*(-(q)?y|-yes|--assumeyes)", command)
 }

--- a/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/test/negative.dockerfile
+++ b/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/test/negative.dockerfile
@@ -1,3 +1,4 @@
 FROM node:12
 RUN apt-get -y install apt-utils
+RUN apt-get -qy install git gcc
 RUN ["apt-get", "-y", "install", "apt-utils"]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

Closes #3391

**Proposed Changes**
- Updated "APT-GET Missing '-y' To Avoid Manual Input" query for Docker. It supports now the flag "-qy"

I submit this contribution under the Apache-2.0 license.
