### PR TITLE
fix(parser): Fixed MarshalJSON Error on YAML Extend #3414

### DIFF
--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -48,7 +48,42 @@ func (p *Parser) Parse(filePath string, fileContent []byte) ([]model.Document, e
 		}
 	}
 
-	return documents, nil
+	return convertKeysToString(documents), nil
+}
+
+// convertKeysToString goes through every document to convert map[interface{}]interface{}
+// to map[string]interface{}
+func convertKeysToString(docs []model.Document) []model.Document {
+	documents := make([]model.Document, 0, len(docs))
+	for _, doc := range docs {
+		for key, value := range doc {
+			doc[key] = convert(value)
+		}
+		documents = append(documents, doc)
+	}
+	return documents
+}
+
+// convert goes recursively through the keys in the given value and converts nested maps type of map[interface{}]interface{}
+// to map[string]interface{}
+func convert(value interface{}) interface{} {
+	switch t := value.(type) {
+	case map[interface{}]interface{}:
+		mapStr := map[string]interface{}{}
+		for key, val := range t {
+			mapStr[key.(string)] = convert(val)
+		}
+		return mapStr
+	case []interface{}:
+		for key, val := range t {
+			t[key] = convert(val)
+		}
+	case model.Document:
+		for key, val := range t {
+			t[key] = convert(val)
+		}
+	}
+	return value
 }
 
 // SupportedExtensions returns extensions supported by this parser, which are yaml and yml extension

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -42,8 +42,13 @@ martin2:
     mode: create
     permission: authenticated-read
 `, `
--name: test
--name: test2
+test:
+  - &test_anchor
+    group:
+      name: "cx"
+test_2:
+  perm:
+    - <<: *test_anchor
 `,
 	}
 
@@ -57,6 +62,13 @@ martin2:
 	require.NoError(t, err)
 	require.Len(t, playbook, 1)
 	require.Contains(t, playbook[0]["playbooks"].([]interface{})[0].(map[string]interface{})["name"], "bucket2")
+
+	nestedMap, err := p.Parse("test.yaml", []byte(have[2]))
+	require.NoError(t, err)
+	require.Len(t, nestedMap, 1)
+	require.Contains(t, nestedMap[0], "test_2")
+	require.Contains(t,
+		nestedMap[0]["test_2"].(model.Document)["perm"].([]interface{})[0].(map[string]interface{})["group"].(model.Document)["name"], "cx")
 }
 
 // Test_Resolve tests the functions [Resolve()] and all the methods called by them


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3414

Since nested maps were being converted to type `map[interface{}]interface{}` json marshal was reporting an error

**Proposed Changes**
- Added converter to convert `map[interface{}]interface{}` values to `map[string]interface{}`

I submit this contribution under the Apache-2.0 license.
