### PR TITLE
feat(query): add "Unknown Property" for OpenAPI

### DIFF
--- a/assets/queries/openAPI/unknown_property/metadata.json
+++ b/assets/queries/openAPI/unknown_property/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "fb7d81e7-4150-48c4-b914-92fc05da6a2f",
+  "queryName": "Unknown Property",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "All properties defined in OpenAPI objects should be known",
+  "descriptionUrl": "https://swagger.io/specification/",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/unknown_property/query.rego
+++ b/assets/queries/openAPI/unknown_property/query.rego
@@ -1,0 +1,366 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+
+	field := path[0]
+	all([field != "id", field != "file"])
+	not known_openapi_object_field(field)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s", [field]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("The field '%s' is known in the openapi object", [field]),
+		"keyActualValue": sprintf("The field '%s' is unknown in the openapi object", [field]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+
+	object := simple_objects[o]
+	path[minus(count(path), 1)] == o
+
+	v := value[x]
+	not known_field(object, x)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("The field '%s' is known in the %s object", [x, o]),
+		"keyActualValue": sprintf("The field '%s' is unknown in the %s object", [x, o]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+
+	object := array_objects[o]
+	path[minus(count(path), 1)] == o
+	is_array(value)
+
+	field := value[x][v]
+	not known_field(object, v)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), v]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("The field '%s' is known in the %s object", [v, o]),
+		"keyActualValue": sprintf("The field '%s' is unknown in the %s object", [v, o]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+
+	object := map_objects[o]
+	path[minus(count(path), 2)] == o
+
+	v := value[x]
+	not known_field(object, x)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("The field '%s' is known in the %s object", [x, o]),
+		"keyActualValue": sprintf("The field '%s' is unknown in the %s object", [x, o]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+
+	path[minus(count(path), 3)] == "callbacks"
+
+	v := value[x]
+	not known_field(map_objects.paths, x)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.%s", [openapi_lib.concat_path(path), x]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("The field '%s' is known in the callbacks object", [x]),
+		"keyActualValue": sprintf("The field '%s' is unknown in the callbacks object", [x]),
+	}
+}
+
+openapi := {
+	"openapi",
+	"info",
+	"paths",
+	"servers",
+	"components",
+	"security",
+	"tags",
+	"externalDocs",
+}
+
+known_openapi_object_field(field) {
+	field == openapi[_]
+}
+
+known_field(object, value) {
+	object[_] == value
+}
+
+flow := {
+	"authorizationUrl",
+	"tokenUrl",
+	"refreshUrl",
+	"scopes",
+}
+
+parameters_properties := {
+	"$ref",
+	"name",
+	"in",
+	"description",
+	"required",
+	"deprecated",
+	"allowEmptyValue",
+	"style",
+	"explode",
+	"allowReserved",
+	"schema",
+	"example",
+	"examples",
+	"content",
+}
+
+request_body_properties := {
+	"$ref",
+	"description",
+	"content",
+	"required",
+}
+
+schema_properties := {
+	"$ref",
+	"title",
+	"multipleOf",
+	"maximum",
+	"exclusiveMaximum",
+	"minimum",
+	"exclusiveMinimum",
+	"maxLength",
+	"minLength",
+	"pattern",
+	"maxItems",
+	"minItems",
+	"uniqueItems",
+	"maxProperties",
+	"minProperties",
+	"required",
+	"enum",
+	"type",
+	"allOf",
+	"oneOf",
+	"not",
+	"items",
+	"properties",
+	"description",
+	"format",
+	"default",
+	"nullable",
+	"discriminator",
+	"readOnly",
+	"writeOnly",
+	"xml",
+	"externalDocs",
+	"example",
+	"deprecated",
+}
+
+array_objects := {
+	"tags": {
+		"name",
+		"description",
+		"externalDocs",
+	},
+	"servers": {
+		"url",
+		"description",
+		"variables",
+	},
+	"parameters": parameters_properties,
+}
+
+map_objects := {
+	"encoding": {
+		"contentType",
+		"headers",
+		"style",
+		"explode",
+		"allowReserved",
+	},
+	"variables": {
+		"enum",
+		"default",
+		"description",
+	},
+	"schemas": schema_properties,
+	"links": {
+		"$ref",
+		"operationRef",
+		"operationId",
+		"parameters",
+		"requestBody",
+		"description",
+		"server",
+	},
+	"headers": {
+		"$ref",
+		"description",
+		"required",
+		"deprecated",
+		"allowEmptyValue",
+		"style",
+		"explode",
+		"allowReserved",
+		"schema",
+		"example",
+		"examples",
+		"content",
+	},
+	"securitySchemes": {
+		"$ref",
+		"type",
+		"description",
+		"name",
+		"in",
+		"scheme",
+		"bearerFormat",
+		"flows",
+		"openIdConnectUrl",
+	},
+	"requestBodies": request_body_properties,
+	"parameters": parameters_properties,
+	"examples": {
+		"$ref",
+		"summary",
+		"description",
+		"value",
+		"externalValue",
+	},
+	"responses": {
+		"$ref",
+		"description",
+		"headers",
+		"content",
+		"links",
+	},
+	"content": {
+		"schema",
+		"example",
+		"examples",
+		"encoding",
+	},
+	"paths": {
+		"$ref",
+		"sumarry",
+		"description",
+		"get",
+		"post",
+		"put",
+		"delete",
+		"options",
+		"head",
+		"patch",
+		"trace",
+		"servers",
+		"parameters",
+	},
+}
+
+simple_objects := {
+	"info": {
+		"title",
+		"description",
+		"termsOfService",
+		"contact",
+		"license",
+		"version",
+	},
+	"contact": {
+		"name",
+		"url",
+		"email",
+	},
+	"license": {
+		"name",
+		"url",
+	},
+	"components": {
+		"schemas",
+		"responses",
+		"parameters",
+		"examples",
+		"requestBodies",
+		"headers",
+		"securitySchemes",
+		"links",
+		"callbacks",
+	},
+	"operation": {
+		"tags",
+		"summary",
+		"description",
+		"externalDocs",
+		"operationId",
+		"parameters",
+		"requestBody",
+		"responses",
+		"callbacks",
+		"deprecated",
+		"security",
+		"servers",
+	},
+	"externalDocs": {
+		"description",
+		"url",
+	},
+	"requestBody": request_body_properties,
+	"discriminator": {
+		"propertyName",
+		"mapping",
+	},
+	"xml": {
+		"name",
+		"namespace",
+		"prefix",
+		"attribute",
+		"wrapped",
+	},
+	"flows": {
+		"implicit",
+		"password",
+		"clientCredentials",
+		"authorizationCode",
+	},
+	"implicit": flow,
+	"password": flow,
+	"clientCredentials": flow,
+	"authorizationCode": flow,
+	"schema": schema_properties,
+}

--- a/assets/queries/openAPI/unknown_property/test/negative1.json
+++ b/assets/queries/openAPI/unknown_property/test/negative1.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "exampleSecurity": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "pets",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "url": "http://docs.my-api.com/pet-operations.htm"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "url": "http://docs.my-api.com/store-orders.htm"
+      }
+    }
+  ]
+}

--- a/assets/queries/openAPI/unknown_property/test/negative2.json
+++ b/assets/queries/openAPI/unknown_property/test/negative2.json
@@ -1,0 +1,44 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/unknown_property/test/negative3.json
+++ b/assets/queries/openAPI/unknown_property/test/negative3.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "callbacks": {
+          "inProgress": {
+            "{$request.body#/inProgressUrl}": {
+              "post": {
+                "requestBody": {
+                  "$ref": "#/components/requestBodies/callbackMessage1"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/unknown_property/test/negative4.yaml
+++ b/assets/queries/openAPI/unknown_property/test/negative4.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+security:
+  - exampleSecurity: []
+tags:
+  - name: pets
+    description: Everything about your Pets
+    externalDocs:
+      url: http://docs.my-api.com/pet-operations.htm
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      url: http://docs.my-api.com/store-orders.htm

--- a/assets/queries/openAPI/unknown_property/test/negative5.yaml
+++ b/assets/queries/openAPI/unknown_property/test/negative5.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/unknown_property/test/negative6.yaml
+++ b/assets/queries/openAPI/unknown_property/test/negative6.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: OK
+      callbacks:
+        inProgress:
+          "{$request.body#/inProgressUrl}":
+            post:
+              requestBody:
+                $ref: "#/components/requestBodies/callbackMessage1"
+              responses:
+                "200":
+                  description: OK

--- a/assets/queries/openAPI/unknown_property/test/positive1.json
+++ b/assets/queries/openAPI/unknown_property/test/positive1.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "descrinnption": "200 response"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "exampleSecurity": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "pets",
+      "desdddcription": "Everything about your Pets",
+      "externalDocs": {
+        "url": "http://docs.my-api.com/pet-operations.htm"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "url": "http://docs.my-api.com/store-orders.htm"
+      }
+    }
+  ]
+}

--- a/assets/queries/openAPI/unknown_property/test/positive2.json
+++ b/assets/queries/openAPI/unknown_property/test/positive2.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.0.0",
+  "infjnjnjno": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "tybhbhbpe:": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "encoding": {
+                  "code": {
+                    "contentType": "image/png, image/jpeg"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "listVersionsv2",
+        "summary": "List API versions"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/unknown_property/test/positive3.json
+++ b/assets/queries/openAPI/unknown_property/test/positive3.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "callbacks": {
+          "inProgress": {
+            "{$request.body#/inProgressUrl}": {
+              "pbhbhbost": {
+                "requestBody": {
+                  "$ref": "#/components/requestBodies/callbackMessage1"
+                },
+                "responses": {
+                  "200": {
+                    "description": "OK"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/unknown_property/test/positive4.yaml
+++ b/assets/queries/openAPI/unknown_property/test/positive4.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          descrinnption: 200 response
+security:
+  - exampleSecurity: []
+tags:
+  - name: pets
+    desdddcription: Everything about your Pets
+    externalDocs:
+      url: http://docs.my-api.com/pet-operations.htm
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      url: http://docs.my-api.com/store-orders.htm

--- a/assets/queries/openAPI/unknown_property/test/positive5.yaml
+++ b/assets/queries/openAPI/unknown_property/test/positive5.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.0
+infjnjnjno:
+  title: Simple API Overview
+  version: 1.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                tybhbhbpe: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  code:
+                    type: string
+                    format: binary
+                  message:
+                    type: string
+              encoding:
+                code:
+                  contentType: image/png, image/jpeg

--- a/assets/queries/openAPI/unknown_property/test/positive6.yaml
+++ b/assets/queries/openAPI/unknown_property/test/positive6.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: OK
+      callbacks:
+        inProgress:
+          "{$request.body#/inProgressUrl}":
+            pbhbhbost:
+              requestBody:
+                $ref: "#/components/requestBodies/callbackMessage1"
+              responses:
+                "200":
+                  description: OK

--- a/assets/queries/openAPI/unknown_property/test/positive_expected_result.json
+++ b/assets/queries/openAPI/unknown_property/test/positive_expected_result.json
@@ -1,0 +1,62 @@
+[
+  {
+    "queryName": "Unknown Property",
+    "severity": "INFO",
+    "line": 14,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Unknown Property",
+    "severity": "INFO",
+    "line": 28,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Unknown Property",
+    "severity": "INFO",
+    "line": 3,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Unknown Property",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Unknown Property",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Unknown Property",
+    "severity": "INFO",
+    "line": 12,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Unknown Property",
+    "severity": "INFO",
+    "line": 17,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Unknown Property",
+    "severity": "INFO",
+    "line": 2,
+    "filename": "positive5.yaml"
+  },
+  {
+    "queryName": "Unknown Property",
+    "severity": "INFO",
+    "line": 19,
+    "filename": "positive5.yaml"
+  },
+  {
+    "queryName": "Unknown Property",
+    "severity": "INFO",
+    "line": 16,
+    "filename": "positive6.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Unknown Property" query for OpenAPI. It checks if the object in question has unknown properties. The objects were grouped as:
    -  **Simple objects**: objects that have direct access to the fields, e.g., info, contact, license, etc.
  ```
       "info": {
          "title": "Simple API Overview",
          "version": "1.0.0"
      }
  ``` 
    - **Map objects**: objects that are defined as a map, e.g., links, headers, responses, etc.
   ```
       "responses": {
            "200": {
              "description": "OK"
            }
        }
   ``` 
  - **Array objects**: objects that are defined as an array, e.g., tags, servers, etc.
   ```
       "tags": [
            {
              "name": "pets",
              "description": "Everything about your Pets",
              "externalDocs": {
                "url": "http://docs.my-api.com/pet-operations.htm"
              }
       ]
   ``` 

  **NOTE**:  It was needed to add two special cases since the previous ones could not cover it:
     - **OpenAPI object**( "openapi", "info", "paths", "servers", "components", "security", "tags", and "externalDocs").
     - **Callback object**


I submit this contribution under the Apache-2.0 license.
