### PR TITLE
fix(detector): Added the possibility to use /" inside '[]' #2010

### DIFF
--- a/pkg/detector/helper.go
+++ b/pkg/detector/helper.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	nameRegex       = regexp.MustCompile(`^([A-Za-z0-9-_]+)\[([A-Za-z0-9-_{}]+)]$`)
+	nameRegex       = regexp.MustCompile(`^(["A-Za-z0-9-_]+)\[(["A-Za-z0-9-_{}]+)]$`)
 	nameRegexDocker = regexp.MustCompile(`{{(.*?)}}`)
 )
 


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #2010

Added the possibility to add \" to '[]' in the search key
ex: 
```
searchKey: sprintf("aws_resource[\"%s\"]", [name])
```

**Proposed Changes**
- Added the possibility to use \" inside '[]' 


I submit this contribution under the Apache-2.0 license.
