### PR TITLE
feat(query): Added Security Requirement Object With Wrong Scopes query for OpenAPI

### DIFF
--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/metadata.json
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "37140f7f-724a-4c87-a536-e9cee1d61533",
+  "queryName": "Security Requirement Object With Wrong Scopes",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Security Requirement Object should only have scopes defined for security schemes of type 'oauth2' and 'openIdConnect'",
+  "descriptionUrl": "https://swagger.io/specification/#security-requirement-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/query.rego
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/query.rego
@@ -1,0 +1,24 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	[path, value] := walk(doc)
+	sec := value.security[idx][name]
+	count(sec) > 0
+	type := doc.components.securitySchemes[name].type
+	auth_no_scopes := {"apiKey", "http"}
+	type == auth_no_scopes[t]
+
+	path_t = array.concat(path, ["security", name])
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s", [openapi_lib.concat_path(path_t)]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'security.%s' has no scopes defined for security scheme of type '%s'", [name, auth_no_scopes[t]]),
+		"keyActualValue": sprintf("'security.%s' has no scopes defined for security scheme of type '%s'", [name, auth_no_scopes[t]]),
+	}
+}

--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/negative1.json
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/negative1.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "security": [
+    {
+      "api_key": []
+    },
+    {
+      "petstore_auth": [
+        "write:pets",
+        "read:pets"
+      ]
+    }
+  ],
+  "paths": {},
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://example.org/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/negative2.yaml
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/negative2.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+security:
+  - api_key: []
+  - petstore_auth:
+      - write:pets
+      - read:pets
+paths: {}
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets

--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/negative3.json
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/negative3.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "responses": {
+          "200": {
+            "description": "A list of pets.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/pet"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://example.org/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/negative4.yaml
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/negative4.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/pets":
+    get:
+      description: Returns all pets from the system that the user has access to
+      responses:
+        "200":
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/pet"
+      security:
+        - api_key: []
+        - petstore_auth:
+            - write:pets
+            - read:pets
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets

--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/positive1.json
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/positive1.json
@@ -1,0 +1,43 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "security": [
+    {
+      "api_key": [
+        "write:api",
+        "read:api"
+      ]
+    },
+    {
+      "petstore_auth": [
+        "write:pets",
+        "read:pets"
+      ]
+    }
+  ],
+  "paths": {},
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://example.org/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/positive2.yaml
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/positive2.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+security:
+  - api_key:
+      - write:pets
+      - read:pets
+  - petstore_auth:
+      - write:pets
+      - read:pets
+paths: {}
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets

--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/positive3.json
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/positive3.json
@@ -1,0 +1,64 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to",
+        "responses": {
+          "200": {
+            "description": "A list of pets.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/pet"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+              "write:pets",
+              "read:pets"
+            ]
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      },
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://example.org/api/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/positive4.yaml
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/positive4.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/pets":
+    get:
+      description: Returns all pets from the system that the user has access to
+      responses:
+        "200":
+          description: A list of pets.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/pet"
+      security:
+        - api_key:
+            - write:pets
+            - read:pets
+        - petstore_auth:
+            - write:pets
+            - read:pets
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets

--- a/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/positive_expected_result.json
+++ b/assets/queries/openAPI/security_requirement_object_with_wrong_scopes/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Security Requirement Object With Wrong Scopes",
+    "severity": "INFO",
+    "line": 9,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Security Requirement Object With Wrong Scopes",
+    "severity": "INFO",
+    "line": 6,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Security Requirement Object With Wrong Scopes",
+    "severity": "INFO",
+    "line": 28,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Security Requirement Object With Wrong Scopes",
+    "severity": "INFO",
+    "line": 19,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added Security Requirement Object With Wrong Scopes query for OpenAPI

Security Requirement Object should only have scopes defined for security schemes of type 'oauth2' and 'openIdConnect'

I submit this contribution under the Apache-2.0 license.
