### PR TITLE
feat(query): added "Path Is Ambiguous" query for OpenAPI

### DIFF
--- a/assets/queries/openAPI/path_ambiguous/metadata.json
+++ b/assets/queries/openAPI/path_ambiguous/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "237402e2-c2f0-46c9-9cf5-286160cf7bfc",
+  "queryName": "Path Is Ambiguous",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "All path should be unique, if has more than one operation, all operations should be part of same Path Object",
+  "descriptionUrl": "https://swagger.io/specification/#path-item-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/path_ambiguous/query.rego
+++ b/assets/queries/openAPI/path_ambiguous/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+	doc.paths[name]
+	doc.paths[compareName]
+	name != compareName
+
+	firstName := clean_name(name)
+	secondName := clean_name(compareName)
+
+	firstName == secondName
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.%s", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "There is no ambiguous path",
+		"keyActualValue": "There is ambiguous path",
+	}
+}
+
+clean_name(name) = result {
+	templates := regex.find_n("\\{.*\\}", name, -1)
+	result := replace(name, templates[_], "")
+}

--- a/assets/queries/openAPI/path_ambiguous/test/negative1.yaml
+++ b/assets/queries/openAPI/path_ambiguous/test/negative1.yaml
@@ -1,0 +1,26 @@
+---
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/users/{id}":
+    get:
+      parameters:
+      - in: path
+        name: id
+        required: true
+        description: The user ID
+        schema:
+          type: integer
+          minimum: 1
+  "/user/{id}":
+    get:
+      parameters:
+      - in: path
+        name: id
+        required: true
+        description: The user ID
+        schema:
+          type: integer
+          minimum: 1

--- a/assets/queries/openAPI/path_ambiguous/test/negative2.json
+++ b/assets/queries/openAPI/path_ambiguous/test/negative2.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "The user ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ]
+      }
+    },
+    "/user/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "The user ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/path_ambiguous/test/positive1.yaml
+++ b/assets/queries/openAPI/path_ambiguous/test/positive1.yaml
@@ -1,0 +1,26 @@
+---
+openapi: 3.0.0
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/users/{id}":
+    get:
+      parameters:
+      - in: path
+        name: id
+        required: true
+        description: The user ID
+        schema:
+          type: integer
+          minimum: 1
+  "/users/{ids}":
+    get:
+      parameters:
+      - in: path
+        name: id
+        required: true
+        description: The user ID
+        schema:
+          type: integer
+          minimum: 1

--- a/assets/queries/openAPI/path_ambiguous/test/positive2.json
+++ b/assets/queries/openAPI/path_ambiguous/test/positive2.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "The user ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ]
+      }
+    },
+    "/users/{ids}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "description": "The user ID",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/path_ambiguous/test/positive_expected_result.json
+++ b/assets/queries/openAPI/path_ambiguous/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Path Is Ambiguous",
+    "severity": "INFO",
+    "line": 7,
+    "filename": "positive1.yaml"
+  },
+  {
+    "queryName": "Path Is Ambiguous",
+    "severity": "INFO",
+    "line": 17,
+    "filename": "positive1.yaml"
+  },
+  {
+    "queryName": "Path Is Ambiguous",
+    "severity": "INFO",
+    "line": 8,
+    "filename": "positive2.json"
+  },
+  {
+    "queryName": "Path Is Ambiguous",
+    "severity": "INFO",
+    "line": 24,
+    "filename": "positive2.json"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- This query checks if there is a path that, without template, is equal, so it will generate two occurrences when this happens, one for each path

I submit this contribution under the Apache-2.0 license.
