### PR TITLE
feat(query): Added Schema Object Properties With Duplicated Keys query for OpenAPI

### DIFF
--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/metadata.json
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "10c61e4b-eed5-49cf-9c7d-d4bf02e9edfa",
+  "queryName": "Schema Object Properties With Duplicated Keys",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Schema Object Property key should be unique through out the fields 'properties', 'allOf', 'additionalProperties'",
+  "descriptionUrl": "https://swagger.io/specification/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/query.rego
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/query.rego
@@ -1,0 +1,87 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+# components schemas map
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	schemas := doc.components.schemas[name]
+
+	porperties := get_properties(schemas)
+	val := porperties[m].value
+	check_properties(val, porperties, m)
+	search_key := create_searchkey(name, porperties[m].path, val)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": search_key,
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s' is unique through out the fields 'properties', 'allOf' and 'additionalProperties'", [val]),
+		"keyActualValue": sprintf("'%s' is not unique through out the fields 'properties', 'allOf' and 'additionalProperties'", [val]),
+	}
+}
+
+# schema object
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) != "undefined"
+
+	[path, value] := walk(doc)
+
+	porperties := get_properties(value.schema)
+	val := porperties[m].value
+	check_properties(val, porperties, m)
+	search_key := create_searchkey(path, porperties[m].path, val)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": search_key,
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s' is unique through out the fields 'properties', 'allOf' and 'additionalProperties'", [val]),
+		"keyActualValue": sprintf("'%s' is not unique through out the fields 'properties', 'allOf' and 'additionalProperties'", [val]),
+	}
+}
+
+create_searchkey(name, path, val) = search_key {
+	is_array(name)
+	count(path) != 0
+	search_key := sprintf("%s.%s.%s", [openapi_lib.concat_path(name), openapi_lib.concat_path(path), val])
+} else = search_key {
+	is_array(name)
+	count(path) == 0
+	search_key := sprintf("%s.%s", [openapi_lib.concat_path(name), val])
+} else = search_key {
+	count(path) == 0
+	search_key := sprintf("components.schemas.%s.%s", [name, val])
+} else = search_key {
+	search_key := sprintf("components.schemas.%s.%s.%s", [name, openapi_lib.concat_path(path), val])
+}
+
+check_properties(value, properties, m) {
+	set := {x |
+		tt := properties[z].value
+		z != m
+		tt == value
+		x := value
+	}
+
+	count(set) > 0
+}
+
+get_properties(schema) = properties {
+	properties := {x |
+		[path, value] := walk(schema)
+		prop := value.properties
+		filter_paths(path)
+		prop[name]
+		x := {"path": path, "value": name}
+	}
+}
+
+filter_paths(path) {
+	count(path) == 0
+} else {
+	any([contains(path[_], "allOf"), contains(path[_], "additionalProperties")])
+}

--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/negative1.json
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/negative1.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "ErrorModel": {
+        "type": "object",
+        "required": [
+          "message",
+          "code"
+        ],
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 600
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorModel"
+          },
+          {
+            "type": "object",
+            "required": [
+              "rootCause"
+            ],
+            "properties": {
+              "rootCause": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "ErrorModel_2": {
+        "type": "object",
+        "required": [
+          "message2",
+          "code2"
+        ],
+        "properties": {
+          "message2": {
+            "type": "string"
+          },
+          "code2": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 600
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorModel"
+          },
+          {
+            "type": "object",
+            "required": [
+              "rootCause2"
+            ],
+            "properties": {
+              "rootCause2": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/negative2.yaml
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/negative2.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.c
+paths: {}
+components:
+  schemas:
+    ErrorModel:
+      type: object
+      required:
+        - message
+        - code
+      properties:
+        message:
+          type: string
+        code:
+          type: integer
+          minimum: 100
+          maximum: 600
+      allOf:
+        - "$ref": "#/components/schemas/ErrorModel"
+        - type: object
+          required:
+            - rootCause
+          properties:
+            rootCause:
+              type: string
+    ErrorModel_2:
+      type: object
+      required:
+        - message2
+        - code2
+      properties:
+        message2:
+          type: string
+        code2:
+          type: integer
+          minimum: 100
+          maximum: 600
+      allOf:
+        - "$ref": "#/components/schemas/ErrorModel"
+        - type: object
+          required:
+            - rootCause2
+          properties:
+            rootCause2:
+              type: string

--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/negative3.json
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/negative3.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "minimum": 100,
+                      "maximum": 600
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ErrorModel"
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "rootCause"
+                      ],
+                      "properties": {
+                        "rootCause": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/negative4.yaml
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/negative4.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.c
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: integer
+                    minimum: 100
+                    maximum: 600
+                allOf:
+                  - "$ref": "#/components/schemas/ErrorModel"
+                  - type: object
+                    required:
+                      - rootCause
+                    properties:
+                      rootCause:
+                        type: string

--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/positive1.json
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/positive1.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "ErrorModel": {
+        "type": "object",
+        "required": [
+          "message",
+          "code"
+        ],
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 600
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorModel"
+          },
+          {
+            "type": "object",
+            "required": [
+              "code"
+            ],
+            "properties": {
+              "code": {
+                "type": "integer",
+                "minimum": 100,
+                "maximum": 600
+              }
+            }
+          }
+        ],
+        "additionalProperties": [
+          {
+            "type": "object",
+            "required": [
+              "code"
+            ],
+            "properties": {
+              "code": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/positive2.yaml
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/positive2.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.c
+paths: {}
+components:
+  schemas:
+    ErrorModel:
+      type: object
+      required:
+        - message
+        - code
+      properties:
+        message:
+          type: string
+        code:
+          type: integer
+          minimum: 100
+          maximum: 600
+      allOf:
+        - "$ref": "#/components/schemas/ErrorModel"
+        - type: object
+          required:
+            - code
+          properties:
+            code:
+              type: integer
+              minimum: 100
+              maximum: 600
+      additionalProperties:
+        - type: object
+          required:
+            - code
+          properties:
+            code:
+              type: string

--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/positive3.json
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/positive3.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.c"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "discriminator": {
+                    "propertyName": "petType"
+                  },
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "integer",
+                      "minimum": 100,
+                      "maximum": 600
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ErrorModel"
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "message"
+                      ],
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ],
+                  "additionalProperties": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "message"
+                      ],
+                      "properties": {
+                        "message": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/positive4.yaml
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/positive4.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.c
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+                discriminator:
+                  propertyName: petType
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: integer
+                    minimum: 100
+                    maximum: 600
+                allOf:
+                  - "$ref": "#/components/schemas/ErrorModel"
+                  - type: object
+                    required:
+                      - message
+                    properties:
+                      message:
+                        type: string
+                additionalProperties:
+                  - type: object
+                    required:
+                      - message
+                    properties:
+                      message:
+                        type: string

--- a/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/positive_expected_result.json
+++ b/assets/queries/openAPI/schema_object_properties_with_duplicated_keys/test/positive_expected_result.json
@@ -1,0 +1,74 @@
+[
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 19,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 38,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 53,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 16,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 28,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 37,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 28,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 44,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 57,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 24,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 34,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Schema Object Properties With Duplicated Keys",
+    "severity": "INFO",
+    "line": 41,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added Schema Object Properties With Duplicated Keys query for OpenAPI

Schema Object Property key should be unique through out the fields 'properties', 'allOf', 'additionalProperties'

I submit this contribution under the Apache-2.0 license.
