### PR TITLE
fix(query): removed openapi from openapi.paths search keys

### DIFF
--- a/assets/queries/openAPI/default_response_undefined_operations/query.rego
+++ b/assets/queries/openAPI/default_response_undefined_operations/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Default field should be defined on responses",
 		"keyActualValue": "Default field is not defined on responses",

--- a/assets/queries/openAPI/header_parameter_named_as_accept/query.rego
+++ b/assets/queries/openAPI/header_parameter_named_as_accept/query.rego
@@ -11,10 +11,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
+		"searchKey": sprintf("paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} is not 'Accept'", [name, params.name]),
-		"keyActualValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} is 'Accept'", [name, params.name]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.parameters.name={{%s}} is not 'Accept'", [name, params.name]),
+		"keyActualValue": sprintf("paths.{{%s}}.parameters.name={{%s}} is 'Accept'", [name, params.name]),
 	}
 }
 
@@ -27,10 +27,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
+		"searchKey": sprintf("paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} is not 'Accept'", [name, oper, params.name]),
-		"keyActualValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} is 'Accept'", [name, oper, params.name]),
+		"keyExpectedValue": sprintf("paths.%s.%s.parameters.name={{%s}} is not 'Accept'", [name, oper, params.name]),
+		"keyActualValue": sprintf("paths.%s.%s.parameters.name={{%s}} is 'Accept'", [name, oper, params.name]),
 	}
 }
 

--- a/assets/queries/openAPI/header_parameter_named_as_authorization/query.rego
+++ b/assets/queries/openAPI/header_parameter_named_as_authorization/query.rego
@@ -11,10 +11,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
+		"searchKey": sprintf("paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} is not 'Authorization'", [name, params.name]),
-		"keyActualValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} is 'Authorization'", [name, params.name]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.parameters.name={{%s}} is not 'Authorization'", [name, params.name]),
+		"keyActualValue": sprintf("paths.{{%s}}.parameters.name={{%s}} is 'Authorization'", [name, params.name]),
 	}
 }
 
@@ -27,10 +27,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
+		"searchKey": sprintf("paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} is not 'Authorization'", [name, oper, params.name]),
-		"keyActualValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} is 'Authorization'", [name, oper, params.name]),
+		"keyExpectedValue": sprintf("paths.%s.%s.parameters.name={{%s}} is not 'Authorization'", [name, oper, params.name]),
+		"keyActualValue": sprintf("paths.%s.%s.parameters.name={{%s}} is 'Authorization'", [name, oper, params.name]),
 	}
 }
 

--- a/assets/queries/openAPI/header_parameter_named_as_content_type/query.rego
+++ b/assets/queries/openAPI/header_parameter_named_as_content_type/query.rego
@@ -11,10 +11,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
+		"searchKey": sprintf("paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} is not 'Content-Type'", [name, params.name]),
-		"keyActualValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} is 'Content-Type'", [name, params.name]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.parameters.name={{%s}} is not 'Content-Type'", [name, params.name]),
+		"keyActualValue": sprintf("paths.{{%s}}.parameters.name={{%s}} is 'Content-Type'", [name, params.name]),
 	}
 }
 
@@ -27,10 +27,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
+		"searchKey": sprintf("paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} is not 'Content-Type'", [name, oper, params.name]),
-		"keyActualValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} is 'Content-Type'", [name, oper, params.name]),
+		"keyExpectedValue": sprintf("paths.%s.%s.parameters.name={{%s}} is not 'Content-Type'", [name, oper, params.name]),
+		"keyActualValue": sprintf("paths.%s.%s.parameters.name={{%s}} is 'Content-Type'", [name, oper, params.name]),
 	}
 }
 

--- a/assets/queries/openAPI/header_response_named_as_content_type/query.rego
+++ b/assets/queries/openAPI/header_response_named_as_content_type/query.rego
@@ -11,10 +11,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}}", [n, oper, r, h]),
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}}", [n, oper, r, h]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}} is not 'Content-Type'", [n, oper, r, h]),
-		"keyActualValue": sprintf("openapi.paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}} is 'Content-Type'", [n, oper, r, h]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}} is not 'Content-Type'", [n, oper, r, h]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}.headers.{{%s}} is 'Content-Type'", [n, oper, r, h]),
 	}
 }
 

--- a/assets/queries/openAPI/operation_without_successful_http_status_code/query.rego
+++ b/assets/queries/openAPI/operation_without_successful_http_status_code/query.rego
@@ -11,9 +11,9 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses", [n, oper]),
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses", [n, oper]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.{{%s}}.responses has at least one successful HTTP status code defined", [n, oper]),
-		"keyActualValue": sprintf("openapi.paths.{{%s}}.{{%s}}.responses does not have at least one successful HTTP status code defined", [n, oper]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.responses has at least one successful HTTP status code defined", [n, oper]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.responses does not have at least one successful HTTP status code defined", [n, oper]),
 	}
 }

--- a/assets/queries/openAPI/parameter_object_content_with_multiple_entries/query.rego
+++ b/assets/queries/openAPI/parameter_object_content_with_multiple_entries/query.rego
@@ -29,8 +29,8 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("paths.%s.%s.parameters", [name, oper]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.%s.%s.parameters.%d.content has one entry", [name, oper, n]),
-		"keyActualValue": sprintf("openapi.paths.%s.%s.parameters.%d.content has multiple entries", [name, oper, n]),
+		"keyExpectedValue": sprintf("paths.%s.%s.parameters.%d.content has one entry", [name, oper, n]),
+		"keyActualValue": sprintf("paths.%s.%s.parameters.%d.content has multiple entries", [name, oper, n]),
 	}
 }
 

--- a/assets/queries/openAPI/parameter_object_schema_content/query.rego
+++ b/assets/queries/openAPI/parameter_object_schema_content/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
+		"searchKey": sprintf("paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Parameter Object doesn't have both 'schema' and 'content' defined",
 		"keyActualValue": "Parameter Object has both 'schema' and 'content' defined",
@@ -29,7 +29,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
+		"searchKey": sprintf("paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Parameter Object doesn't have both 'schema' and 'content' defined",
 		"keyActualValue": "Parameter Object has both 'schema' and 'content' defined",

--- a/assets/queries/openAPI/parameter_object_undefined_type/query.rego
+++ b/assets/queries/openAPI/parameter_object_undefined_type/query.rego
@@ -12,10 +12,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
+		"searchKey": sprintf("paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.parameters type should be defined", [name, params.name]),
-		"keyActualValue": sprintf("openapi.paths.{{%s}}.parameters type is not defined", [name, params.name]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.parameters type should be defined", [name, params.name]),
+		"keyActualValue": sprintf("paths.{{%s}}.parameters type is not defined", [name, params.name]),
 	}
 }
 
@@ -46,10 +46,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.parameters.name={{%s}}", [name, oper, params.name]),
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.parameters.name={{%s}}", [name, oper, params.name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.{{%s}}.parameters type should be defined", [name, oper, params.name]),
-		"keyActualValue": sprintf("openapi.paths.{{%s}}.{{%s}}.parameters type is not defined", [name, oper, params.name]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.{{%s}}.parameters type should be defined", [name, oper, params.name]),
+		"keyActualValue": sprintf("paths.{{%s}}.{{%s}}.parameters type is not defined", [name, oper, params.name]),
 	}
 }
 

--- a/assets/queries/openAPI/parameter_objects_headers_dup_name/query.rego
+++ b/assets/queries/openAPI/parameter_objects_headers_dup_name/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.parameters.name=%s", [n, duplicate[_]]),
+		"searchKey": sprintf("paths.%s.parameters.name=%s", [n, duplicate[_]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Parameter Object with location 'header' doesn't have duplicate names",
 		"keyActualValue": "Parameter Object with location 'header' has duplicate names",
@@ -29,7 +29,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.%s.parameters.name=%s", [n, oper, duplicate[_]]),
+		"searchKey": sprintf("paths.%s.%s.parameters.name=%s", [n, oper, duplicate[_]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Parameter Object with location 'header' doesn't have duplicate names",
 		"keyActualValue": "Parameter Object with location 'header' has duplicate names",

--- a/assets/queries/openAPI/path_parameter_not_required/query.rego
+++ b/assets/queries/openAPI/path_parameter_not_required/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}", [name, param.name]),
+		"searchKey": sprintf("paths.{{%s}}.parameters.name={{%s}}", [name, param.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Path parameter has the field 'required' and set to 'true' for location 'path'",
 		"keyActualValue": "Path parameter field 'required' is missing for location 'path'",
@@ -33,7 +33,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}.required", [name, param.name]),
+		"searchKey": sprintf("paths.{{%s}}.parameters.name={{%s}}.required", [name, param.name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Path parameter field 'required' is set to 'true' for location 'path'",
 		"keyActualValue": "Path parameter field 'required' is set to 'false' for location 'path'",

--- a/assets/queries/openAPI/path_server_uses_http/query.rego
+++ b/assets/queries/openAPI/path_server_uses_http/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.servers.url={{%s}}", [path, oper, paths.url]),
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.servers.url={{%s}}", [path, oper, paths.url]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Path Server Object url uses 'HTTPS' protocol",
 		"keyActualValue": "Path Server Object url uses 'HTTP' protocol",

--- a/assets/queries/openAPI/path_without_operation/query.rego
+++ b/assets/queries/openAPI/path_without_operation/query.rego
@@ -13,9 +13,9 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}", [path]),
+		"searchKey": sprintf("paths.{{%s}}", [path]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("openapi.paths.{{%s}} has at least one operation object defined", [path]),
-		"keyActualValue": sprintf("openapi.paths.{{%s}} does not have at least one operation object defined", [path]),
+		"keyExpectedValue": sprintf("paths.{{%s}} has at least one operation object defined", [path]),
+		"keyActualValue": sprintf("paths.{{%s}} does not have at least one operation object defined", [path]),
 	}
 }

--- a/assets/queries/openAPI/paths_object_empty/query.rego
+++ b/assets/queries/openAPI/paths_object_empty/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": "openapi.paths",
+		"searchKey": "paths",
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "The Paths Object should should not be empty",
 		"keyActualValue": "The Paths Object is empty",

--- a/assets/queries/openAPI/property_allow_empty_value_improperly_defined/query.rego
+++ b/assets/queries/openAPI/property_allow_empty_value_improperly_defined/query.rego
@@ -11,10 +11,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
+		"searchKey": sprintf("paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} has 'in' set to 'query' when 'allowEmptyValue' is set", [name, params.name]),
-		"keyActualValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowEmptyValue' is set", [name, params.name]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.parameters.name={{%s}} has 'in' set to 'query' when 'allowEmptyValue' is set", [name, params.name]),
+		"keyActualValue": sprintf("paths.{{%s}}.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowEmptyValue' is set", [name, params.name]),
 	}
 }
 
@@ -27,10 +27,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
+		"searchKey": sprintf("paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} has 'in' set to 'query' when 'allowEmptyValue' is set", [name, oper, params.name]),
-		"keyActualValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowEmptyValue' is set", [name, oper, params.name]),
+		"keyExpectedValue": sprintf("paths.%s.%s.parameters.name={{%s}} has 'in' set to 'query' when 'allowEmptyValue' is set", [name, oper, params.name]),
+		"keyActualValue": sprintf("paths.%s.%s.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowEmptyValue' is set", [name, oper, params.name]),
 	}
 }
 

--- a/assets/queries/openAPI/property_allow_reserved_improperly_defined/query.rego
+++ b/assets/queries/openAPI/property_allow_reserved_improperly_defined/query.rego
@@ -11,10 +11,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
+		"searchKey": sprintf("paths.{{%s}}.parameters.name={{%s}}", [name, params.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} has 'in' set to 'query' when 'allowReserved' is set", [name, params.name]),
-		"keyActualValue": sprintf("openapi.paths.{{%s}}.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowReserved' is set", [name, params.name]),
+		"keyExpectedValue": sprintf("paths.{{%s}}.parameters.name={{%s}} has 'in' set to 'query' when 'allowReserved' is set", [name, params.name]),
+		"keyActualValue": sprintf("paths.{{%s}}.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowReserved' is set", [name, params.name]),
 	}
 }
 
@@ -27,10 +27,10 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
+		"searchKey": sprintf("paths.%s.%s.parameters.name={{%s}}", [name, oper, params.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} has 'in' set to 'query' when 'allowReserved' is set", [name, oper, params.name]),
-		"keyActualValue": sprintf("openapi.paths.%s.%s.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowReserved' is set", [name, oper, params.name]),
+		"keyExpectedValue": sprintf("paths.%s.%s.parameters.name={{%s}} has 'in' set to 'query' when 'allowReserved' is set", [name, oper, params.name]),
+		"keyActualValue": sprintf("paths.%s.%s.parameters.name={{%s}} does not have 'in' set to 'query' when 'allowReserved' is set", [name, oper, params.name]),
 	}
 }
 

--- a/assets/queries/openAPI/responses_wrong_http_status_code/query.rego
+++ b/assets/queries/openAPI/responses_wrong_http_status_code/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.{{%s}}.responses.{{%s}}", [n, oper, code]),
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.responses.{{%s}}", [n, oper, code]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "HTTP responses status codes are in range of [200-599]",
 		"keyActualValue": "HTTP responses status codes are not in range of [200-599]",

--- a/assets/queries/openAPI/success_response_code_undefined_delete_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_undefined_delete_operation/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.delete.responses", [n]),
+		"searchKey": sprintf("paths.{{%s}}.delete.responses", [n]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Delete should have at least one successful code (200, 201, 202 or 204)",
 		"keyActualValue": "Delete does not have any successful code",

--- a/assets/queries/openAPI/success_response_code_undefined_patch_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_undefined_patch_operation/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.patch.responses", [n]),
+		"searchKey": sprintf("paths.{{%s}}.patch.responses", [n]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Patch should have at least one successful code (200, 201, 202 or 204)",
 		"keyActualValue": "Patch does not have any successful code",

--- a/assets/queries/openAPI/success_response_code_undefined_post_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_undefined_post_operation/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.post.responses", [n]),
+		"searchKey": sprintf("paths.{{%s}}.post.responses", [n]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Post should have at least one successful code (200, 201, 202 or 204)",
 		"keyActualValue": "Post does not have any successful code",

--- a/assets/queries/openAPI/success_response_code_undefined_put_operation/query.rego
+++ b/assets/queries/openAPI/success_response_code_undefined_put_operation/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("openapi.paths.{{%s}}.put.responses", [n]),
+		"searchKey": sprintf("paths.{{%s}}.put.responses", [n]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Put should have at least one successful code (200, 201, 202 or 204)",
 		"keyActualValue": "Put does not have any successful code",


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Removed `openapi` from seach keys that it is wrong and, also, not useful

I submit this contribution under the Apache-2.0 license.
