### PR TITLE
fix(report): Update gitlab report fields to match proper formatting

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -332,8 +332,8 @@ Gitlab SAST reports are sorted by severity (from high to info), following [Gitla
 	"vulnerabilities": [
 		{
 			"id": "32e763ac363dfee1ea972d951fb3de00f5f7a8d3f9f57b93e55e2d51957794a6",
-			"category": "Insecure Configurations",
-			"severity": "high",
+			"category": "sast",
+			"severity": "High",
 			"cve": "32e763ac363dfee1ea972d951fb3de00f5f7a8d3f9f57b93e55e2d51957794a6",
 			"scanner": {
 				"id": "keeping_infrastructure_as_code_secure",
@@ -362,8 +362,8 @@ Gitlab SAST reports are sorted by severity (from high to info), following [Gitla
 		},
 		{
 			"id": "32e763ac363dfee1ea972d951fb3de00f5f7a8d3f9f57b93e55e2d51957794a6",
-			"category": "Insecure Configurations",
-			"severity": "high",
+			"category": "sast",
+			"severity": "High",
 			"cve": "32e763ac363dfee1ea972d951fb3de00f5f7a8d3f9f57b93e55e2d51957794a6",
 			"scanner": {
 				"id": "keeping_infrastructure_as_code_secure",
@@ -392,8 +392,8 @@ Gitlab SAST reports are sorted by severity (from high to info), following [Gitla
 		},
 		{
 			"id": "3d4f14f3ac2ebc0d2cb1710eec4f61fae359fe78ab244cb716485cb6c90846f6",
-			"category": "Insecure Configurations",
-			"severity": "high",
+			"category": "sast",
+			"severity": "High",
 			"cve": "3d4f14f3ac2ebc0d2cb1710eec4f61fae359fe78ab244cb716485cb6c90846f6",
 			"scanner": {
 				"id": "keeping_infrastructure_as_code_secure",

--- a/pkg/report/model/gitlab_sast.go
+++ b/pkg/report/model/gitlab_sast.go
@@ -123,8 +123,8 @@ func (glsr *gitlabSASTReport) BuildGitlabSASTVulnerability(issue *model.Vulnerab
 
 		vulnerability := gitlabSASTVulnerability{
 			ID:       file.SimilarityID,
-			Category: issue.Category,
-			Severity: strings.ToLower(string(issue.Severity)),
+			Category: "sast",
+			Severity: strings.Title(strings.ToLower(string(issue.Severity))),
 			CVE:      file.SimilarityID,
 			Scanner: gitlabSASTVulnerabilityScanner{
 				ID:   "keeping_infrastructure_as_code_secure",

--- a/pkg/report/model/gitlab_sast_test.go
+++ b/pkg/report/model/gitlab_sast_test.go
@@ -57,7 +57,7 @@ var tests = []gitlabSASTTest{
 			Description: "test description",
 			QueryURI:    "https://www.test.com",
 			Severity:    model.SeverityHigh,
-			Category:    "test category",
+			Category:    "sast",
 			Files: []model.VulnerableFile{
 				{KeyActualValue: "test", FileName: "test.json", Line: 1, SimilarityID: "similarity"},
 			},
@@ -72,8 +72,8 @@ var tests = []gitlabSASTTest{
 			Vulnerabilities: []gitlabSASTVulnerability{
 				{
 					ID:       "similarity",
-					Category: "test category",
-					Severity: "high",
+					Category: "sast",
+					Severity: "High",
 					CVE:      "similarity",
 					Scanner: gitlabSASTVulnerabilityScanner{
 						ID:   "keeping_infrastructure_as_code_secure",


### PR DESCRIPTION
**Proposed Changes**

Fixes a few issues in the GitLab SAST output format to conform with v13.1.0 of our SAST schema

- `Severity` should be titlecase
- `Category` is an enum of the report type

Relates to https://github.com/Checkmarx/kics/issues/1986

See discussion in https://github.com/Checkmarx/kics/pull/3432#issuecomment-849764618


I submit this contribution under the Apache-2.0 license.
