### PR TITLE
fix(analyzer): Removed spec property from K8s file Analyzer #3461

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -28,7 +28,6 @@ var (
 	k8sRegex         = regexp.MustCompile("(\\s*\"apiVersion\":)|(\\s*apiVersion:)")
 	k8sRegexKind     = regexp.MustCompile("(\\s*\"kind\":)|(\\s*kind:)")
 	k8sRegexMetadata = regexp.MustCompile("(\\s*\"metadata\":)|(\\s*metadata:)")
-	k8sRegexSpec     = regexp.MustCompile("(\\s*\"spec\":)|(\\s*spec:)")
 )
 
 const (
@@ -129,7 +128,6 @@ var types = map[string]regexSlice{
 			k8sRegex,
 			k8sRegexKind,
 			k8sRegexMetadata,
-			k8sRegexSpec,
 		},
 	},
 	"cloudformation": {


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3461

**Proposed Changes**
- Removed `spec` property from K8s file Analyzer

I submit this contribution under the Apache-2.0 license.
