### PR TITLE
update(query): Updated Unrestricted SQL Server Access query 

### DIFF
--- a/assets/queries/ansible/azure/unrestricted_sql_server_acess/query.rego
+++ b/assets/queries/ansible/azure/unrestricted_sql_server_acess/query.rego
@@ -10,23 +10,6 @@ CxPolicy[result] {
 	rule := task[modules[m]]
 	ansLib.checkState(rule)
 
-	rule.start_ip_address == "0.0.0.0"
-	rule.end_ip_address == "0.0.0.0"
-
-	result := {
-		"documentId": id,
-		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "azure_rm_sqlfirewallrule.start_ip_address is different from '0.0.0.0' and azure_rm_sqlfirewallrule.end_ip_address is different from '0.0.0.0'",
-		"keyActualValue": "azure_rm_sqlfirewallrule.start_ip_address is '0.0.0.0' and azure_rm_sqlfirewallrule.end_ip_address is '0.0.0.0'",
-	}
-}
-
-CxPolicy[result] {
-	task := ansLib.tasks[id][t]
-	rule := task[modules[m]]
-	ansLib.checkState(rule)
-
 	startIP_value := commonLib.calc_IP_value(rule.start_ip_address)
 	endIP_value := commonLib.calc_IP_value(rule.end_ip_address)
 

--- a/assets/queries/ansible/azure/unrestricted_sql_server_acess/test/positive.yaml
+++ b/assets/queries/ansible/azure/unrestricted_sql_server_acess/test/positive.yaml
@@ -5,7 +5,7 @@
     server_name: firewallrulecrudtest-6285
     name: firewallrulecrudtest-5370
     start_ip_address: 0.0.0.0
-    end_ip_address: 0.0.0.0
+    end_ip_address: 172.28.11.138
 - name: Create (or update) Firewall Rule2
   azure_rm_sqlfirewallrule:
     resource_group: myResourceGroup2

--- a/assets/queries/terraform/azure/unrestricted_sql_server_acess/query.rego
+++ b/assets/queries/terraform/azure/unrestricted_sql_server_acess/query.rego
@@ -4,20 +4,6 @@ import data.generic.common as lib
 
 CxPolicy[result] {
 	resource := input.document[i].resource.azurerm_sql_firewall_rule[name]
-	resource.start_ip_address == "0.0.0.0"
-	resource.end_ip_address == "0.0.0.0"
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("azurerm_sql_firewall_rule[%s].start_ip_address", [name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'azurerm_sql_firewall_rule[%s].start_ip_address' is different from '0.0.0.0'", [name]),
-		"keyActualValue": sprintf("'azurerm_sql_firewall_rule[%s].start_ip_address' is equal to '0.0.0.0'", [name]),
-	}
-}
-
-CxPolicy[result] {
-	resource := input.document[i].resource.azurerm_sql_firewall_rule[name]
 	startIP_value := lib.calc_IP_value(resource.start_ip_address)
 	endIP_value := lib.calc_IP_value(resource.end_ip_address)
 	abs(endIP_value - startIP_value) >= 256

--- a/assets/queries/terraform/azure/unrestricted_sql_server_acess/test/positive.tf
+++ b/assets/queries/terraform/azure/unrestricted_sql_server_acess/test/positive.tf
@@ -17,7 +17,7 @@ resource "azurerm_sql_firewall_rule" "positive3" {
   resource_group_name = azurerm_resource_group.example.name
   server_name         = azurerm_sql_server.example.name
   start_ip_address    = "0.0.0.0"
-  end_ip_address      = "0.0.0.0"
+  end_ip_address      = "10.0.27.62"
 }
 
 resource "azurerm_sql_firewall_rule" "positive4" {


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3444

**Proposed Changes**
- Updated Unrestricted SQL Server Access query for Terraform and Ansible 

The Azure feature Allow access to Azure services can be enabled by setting start_ip_address and end_ip_address to 0.0.0.0.
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sql_firewall_rule#end_ip_address

I submit this contribution under the Apache-2.0 license.
