### PR TITLE
refactor(query): Updated SQLServer Ingress From Any IP query for Terraform and Ansible

### DIFF
--- a/assets/queries/ansible/azure/sql_server_ingress_from_any_ip/query.rego
+++ b/assets/queries/ansible/azure/sql_server_ingress_from_any_ip/query.rego
@@ -20,6 +20,4 @@ CxPolicy[result] {
 	}
 }
 
-isUnsafeEndIpAddress("0.0.0.0") = true
-
 isUnsafeEndIpAddress("255.255.255.255") = true

--- a/assets/queries/ansible/azure/sql_server_ingress_from_any_ip/test/positive.yaml
+++ b/assets/queries/ansible/azure/sql_server_ingress_from_any_ip/test/positive.yaml
@@ -6,10 +6,3 @@
     name: firewallrulecrudtest-5370
     start_ip_address: 0.0.0.0
     end_ip_address: 255.255.255.255
-- name: Create (or update) Firewall Rule2
-  azure.azcollection.azure_rm_sqlfirewallrule:
-    resource_group: myResourceGroup
-    server_name: firewallrulecrudtest-6285
-    name: firewallrulecrudtest-5370
-    start_ip_address: 0.0.0.0
-    end_ip_address: 0.0.0.0

--- a/assets/queries/ansible/azure/sql_server_ingress_from_any_ip/test/positive_expected_result.json
+++ b/assets/queries/ansible/azure/sql_server_ingress_from_any_ip/test/positive_expected_result.json
@@ -3,10 +3,5 @@
     "queryName": "SQLServer Ingress From Any IP",
     "severity": "HIGH",
     "line": 8
-  },
-  {
-    "queryName": "SQLServer Ingress From Any IP",
-    "severity": "HIGH",
-    "line": 15
   }
 ]

--- a/assets/queries/terraform/azure/sql_server_ingress_from_any_ip/query.rego
+++ b/assets/queries/terraform/azure/sql_server_ingress_from_any_ip/query.rego
@@ -14,6 +14,4 @@ CxPolicy[result] {
 	}
 }
 
-checkEndIP("0.0.0.0") = true
-
 checkEndIP("255.255.255.255") = true


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3443

**Proposed Changes**
-Updated SQLServer Ingress From Any IP query for Terraform and Ansible

The Azure feature Allow access to Azure services can be enabled by setting start_ip_address and end_ip_address to 0.0.0.0
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/sql_firewall_rule#end_ip_address

I submit this contribution under the Apache-2.0 license.
