### PR TITLE
feat(query): "Policy Without Principal" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/policy_without_principal/metadata.json
+++ b/assets/queries/terraform/aws/policy_without_principal/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "bbe3dd3d-fea9-4b68-a785-cfabe2bbbc54",
   "queryName": "Policy Without Principal",
-  "severity": "LOW",
+  "severity": "MEDIUM",
   "category": "Access Control",
   "descriptionText": "All policies, except IAM identity-based policies, should have the 'Principal' element defined",
   "descriptionUrl": "https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html",

--- a/assets/queries/terraform/aws/policy_without_principal/metadata.json
+++ b/assets/queries/terraform/aws/policy_without_principal/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "bbe3dd3d-fea9-4b68-a785-cfabe2bbbc54",
+  "queryName": "Policy Without Principal",
+  "severity": "LOW",
+  "category": "Access Control",
+  "descriptionText": "All policies, except IAM identity-based policies, should have the 'Principal' element defined",
+  "descriptionUrl": "https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/policy_without_principal/query.rego
+++ b/assets/queries/terraform/aws/policy_without_principal/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+import data.generic.common as commonLib
+
+CxPolicy[result] {
+	doc := input.document[i].resource
+	[path, value] := walk(doc)
+
+	policy := commonLib.json_unmarshal(value.policy)
+
+	object.get(policy.Statement[idx], "Principal", "undefined") == "undefined"
+
+	not is_iam_identity_based_policy(path[0])
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[%s].policy.Statement", [path[0], path[1]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'Principal' is set",
+		"keyActualValue": "'Principal' is undefined",
+	}
+}
+
+is_iam_identity_based_policy(resource) {
+	iam_identity_based_policy := {"aws_iam_group_policy", "aws_iam_policy", "aws_iam_role_policy", "aws_iam_user_policy"}
+	resource == iam_identity_based_policy[_]
+}

--- a/assets/queries/terraform/aws/policy_without_principal/test/negative1.tf
+++ b/assets/queries/terraform/aws/policy_without_principal/test/negative1.tf
@@ -1,0 +1,41 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_kms_key" "secure_policy" {
+  description             = "KMS key + secure_policy"
+  deletion_window_in_days = 7
+
+  policy = <<EOF
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "Secure Policy",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Action": [
+            "kms:Create*",
+            "kms:Describe*",
+            "kms:Enable*",
+            "kms:List*",
+            "kms:Put*",
+            "kms:Update*",
+            "kms:Revoke*",
+            "kms:Disable*",
+            "kms:Get*",
+            "kms:Delete*",
+            "kms:TagResource",
+            "kms:UntagResource",
+            "kms:ScheduleKeyDeletion",
+            "kms:CancelKeyDeletion"
+            ],
+            "Principal": "AWS": [
+              "arn:aws:iam::AWS-account-ID:user/user-name-1",
+              "arn:aws:iam::AWS-account-ID:user/UserName2"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/policy_without_principal/test/negative2.tf
+++ b/assets/queries/terraform/aws/policy_without_principal/test/negative2.tf
@@ -1,0 +1,55 @@
+resource "aws_iam_user" "user" {
+  name = "test-user"
+}
+
+resource "aws_iam_role" "role" {
+  name = "test-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_group" "group" {
+  name = "test-group"
+}
+
+resource "aws_iam_policy" "policy" {
+  name        = "test-policy"
+  description = "A test policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "test-attach" {
+  name       = "test-attachment"
+  users      = [aws_iam_user.user.name]
+  roles      = [aws_iam_role.role.name]
+  groups     = [aws_iam_group.group.name]
+  policy_arn = aws_iam_policy.policy.arn
+}

--- a/assets/queries/terraform/aws/policy_without_principal/test/positive.tf
+++ b/assets/queries/terraform/aws/policy_without_principal/test/positive.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_kms_key" "secure_policy" {
+  description             = "KMS key + secure_policy"
+  deletion_window_in_days = 7
+
+  policy = <<EOF
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "Secure Policy",
+            "Effect": "Allow",
+            "Resource": "*",
+            "Action": [
+            "kms:Create*",
+            "kms:Describe*",
+            "kms:Enable*",
+            "kms:List*",
+            "kms:Put*",
+            "kms:Update*",
+            "kms:Revoke*",
+            "kms:Disable*",
+            "kms:Get*",
+            "kms:Delete*",
+            "kms:TagResource",
+            "kms:UntagResource",
+            "kms:ScheduleKeyDeletion",
+            "kms:CancelKeyDeletion"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/policy_without_principal/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/policy_without_principal/test/positive_expected_result.json
@@ -1,7 +1,7 @@
 [
   {
     "queryName": "Policy Without Principal",
-    "severity": "LOW",
+    "severity": "MEDIUM",
     "line": 12
   }
 ]

--- a/assets/queries/terraform/aws/policy_without_principal/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/policy_without_principal/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Policy Without Principal",
+    "severity": "LOW",
+    "line": 12
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Policy Without Principal" query for Terraform. It checks if a policy, except IAM identity-based policy, does not have the 'Principal' element defined

I submit this contribution under the Apache-2.0 license.
