### PR TITLE
feat(query): add "Public and Private EC2 Share Role" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/public_and_private_ec2_share_role/metadata.json
+++ b/assets/queries/terraform/aws/public_and_private_ec2_share_role/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "c53c7a89-f9d7-4c7b-8b66-8a555be99593",
+  "queryName": "Public and Private EC2 Share Role",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Public and private EC2 istances should not share the same role.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#iam_instance_profile",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/public_and_private_ec2_share_role/query.rego
+++ b/assets/queries/terraform/aws/public_and_private_ec2_share_role/query.rego
@@ -1,0 +1,26 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_instance[name]
+	contains(resource.subnet_id, "public_subnets")
+
+	instanceProfileName := split(resource.iam_instance_profile, ".")[1]
+
+	check_private_instance(instanceProfileName)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_instance[%s].iam_instance_profile", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Public and private istances do not share the same role",
+		"keyActualValue": "Public and private istances share the same role",
+	}
+}
+
+check_private_instance(instanceProfileName) {
+	instance := input.document[z].resource.aws_instance[name]
+
+	contains(instance.subnet_id, "private_subnets")
+
+	split(instance.iam_instance_profile, ".")[1] == instanceProfileName
+}

--- a/assets/queries/terraform/aws/public_and_private_ec2_share_role/test/negative.tf
+++ b/assets/queries/terraform/aws/public_and_private_ec2_share_role/test/negative.tf
@@ -70,13 +70,13 @@ EOF
 
 resource "aws_iam_instance_profile" "test_profile2" {
   name = "test_profile"
-  role = "${aws_iam_role.test_role2.name}"
+  role = "aws_iam_role.test_role2.name"
 }
 
 
 resource "aws_iam_role_policy" "test_policy2" {
   name = "test_policy"
-  role = "${aws_iam_role.test_role2.id}"
+  role = "aws_iam_role.test_role2.id"
 
   policy = <<EOF
 {
@@ -96,7 +96,7 @@ EOF
 
 
 resource "aws_instance" "pub_ins2" {
-  ami           = "${data.aws_ami.ubuntu.id}"
+  ami           = "data.aws_ami.ubuntu.id"
   instance_type = "t2.micro"
   subnet_id = module.vpc.public_subnets[0]
   iam_instance_profile = aws_iam_instance_profile.test_profile2.name
@@ -104,7 +104,7 @@ resource "aws_instance" "pub_ins2" {
 }
 
 resource "aws_instance" "priv_ins2" {
-  ami           = "${data.aws_ami.ubuntu.id}"
+  ami           = "data.aws_ami.ubuntu.id"
   instance_type = "t2.micro"
   subnet_id = module.vpc.private_subnets[0]
   iam_instance_profile = aws_iam_instance_profile.test_profile3.name

--- a/assets/queries/terraform/aws/public_and_private_ec2_share_role/test/negative.tf
+++ b/assets/queries/terraform/aws/public_and_private_ec2_share_role/test/negative.tf
@@ -1,0 +1,111 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+locals {
+  test_description = "two EC2s, one public, one private"
+  test_name        = "Ec2RoleShareRule test - use case 1"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+
+  name = "Ec2RoleShareRule1"
+  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_nat_gateway = true
+  enable_vpn_gateway = true
+
+  cidr = "10.0.0.0/16"
+  manage_default_security_group= true
+  default_security_group_ingress = [
+          {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      description = "ssh"
+      cidr_blocks = "0.0.0.0/0"
+    }]
+  default_security_group_egress =[]
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_iam_role" "test_role2" {
+  name = "test_role2"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_instance_profile" "test_profile2" {
+  name = "test_profile"
+  role = "${aws_iam_role.test_role2.name}"
+}
+
+
+resource "aws_iam_role_policy" "test_policy2" {
+  name = "test_policy"
+  role = "${aws_iam_role.test_role2.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_instance" "pub_ins2" {
+  ami           = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t2.micro"
+  subnet_id = module.vpc.public_subnets[0]
+  iam_instance_profile = aws_iam_instance_profile.test_profile2.name
+
+}
+
+resource "aws_instance" "priv_ins2" {
+  ami           = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t2.micro"
+  subnet_id = module.vpc.private_subnets[0]
+  iam_instance_profile = aws_iam_instance_profile.test_profile3.name
+}

--- a/assets/queries/terraform/aws/public_and_private_ec2_share_role/test/positive.tf
+++ b/assets/queries/terraform/aws/public_and_private_ec2_share_role/test/positive.tf
@@ -1,0 +1,111 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+locals {
+  test_description = "two EC2s, one public, one private"
+  test_name        = "Ec2RoleShareRule test - use case 1"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+
+  name = "Ec2RoleShareRule1"
+  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_nat_gateway = true
+  enable_vpn_gateway = true
+
+  cidr = "10.0.0.0/16"
+  manage_default_security_group= true
+  default_security_group_ingress = [
+          {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      description = "ssh"
+      cidr_blocks = "0.0.0.0/0"
+    }]
+  default_security_group_egress =[]
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "test_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_instance_profile" "test_profile" {
+  name = "test_profile"
+  role = "${aws_iam_role.test_role.name}"
+}
+
+
+resource "aws_iam_role_policy" "test_policy" {
+  name = "test_policy"
+  role = "${aws_iam_role.test_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_instance" "pub_ins" {
+  ami           = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t2.micro"
+  subnet_id = module.vpc.public_subnets[0]
+  iam_instance_profile = aws_iam_instance_profile.test_profile.name
+
+}
+
+resource "aws_instance" "priv_ins" {
+  ami           = "${data.aws_ami.ubuntu.id}"
+  instance_type = "t2.micro"
+  subnet_id = module.vpc.private_subnets[0]
+  iam_instance_profile = aws_iam_instance_profile.test_profile.name
+}

--- a/assets/queries/terraform/aws/public_and_private_ec2_share_role/test/positive.tf
+++ b/assets/queries/terraform/aws/public_and_private_ec2_share_role/test/positive.tf
@@ -70,13 +70,13 @@ EOF
 
 resource "aws_iam_instance_profile" "test_profile" {
   name = "test_profile"
-  role = "${aws_iam_role.test_role.name}"
+  role = "aws_iam_role.test_role.name"
 }
 
 
 resource "aws_iam_role_policy" "test_policy" {
   name = "test_policy"
-  role = "${aws_iam_role.test_role.id}"
+  role = "aws_iam_role.test_role.id"
 
   policy = <<EOF
 {
@@ -96,7 +96,7 @@ EOF
 
 
 resource "aws_instance" "pub_ins" {
-  ami           = "${data.aws_ami.ubuntu.id}"
+  ami           = "data.aws_ami.ubuntu.id"
   instance_type = "t2.micro"
   subnet_id = module.vpc.public_subnets[0]
   iam_instance_profile = aws_iam_instance_profile.test_profile.name
@@ -104,7 +104,7 @@ resource "aws_instance" "pub_ins" {
 }
 
 resource "aws_instance" "priv_ins" {
-  ami           = "${data.aws_ami.ubuntu.id}"
+  ami           = "data.aws_ami.ubuntu.id"
   instance_type = "t2.micro"
   subnet_id = module.vpc.private_subnets[0]
   iam_instance_profile = aws_iam_instance_profile.test_profile.name

--- a/assets/queries/terraform/aws/public_and_private_ec2_share_role/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/public_and_private_ec2_share_role/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Public and Private EC2 Share Role",
+    "severity": "MEDIUM",
+    "line": 102
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Public and Private EC2 Share Role" query for Terraform. It checks if a public and a private EC2 instances shares the same role through the same `iam_instance_profile`

I submit this contribution under the Apache-2.0 license.
