### PR TITLE
docs(roadmap): redesign roadmap page

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,56 +1,47 @@
 ## KICS Roadmap
 
-| Status | Milestone | ETA | Target Release |
-| :--- | :--- | :--- | :--- |
-| Not-Started | **Milestone 8** | Jun 2021 | |
-|  | Google Deployment Manager support |  | TBA |
-| Not-Started | **Milestone 7** | May 2021 | |
-|  | Schemas support OpenAPI 3.0|  | TBA |
-|  | Schemas support OpenAPI 2.0 (Swagger) |  | TBA |
-|  | Schemas support gRPC |  | TBA |
-|  | Azure Resource Manager support |  | TBA |
-
-
----
-<br/>
-
-## Closed Milestones
-
-| Status | Milestone | ETA | Release |
-| :--- | :--- | :--- | :--- |
-| Completed | **Milestone 6** | Apr 2021 | |
-|  | Terraform - Parameters files support |  | v.1.2.3|
-|  | Distribution platforms: Homebrew|  | v1.3.0|
-| Completed | **Milestone 5** | Mar 2021 | |
-|  | Helm support |  | v1.2.1 |
-|  | Reporting - add HTML format |  | v1.2.1|
-|  | Documentation - Queries catalog |  | v1.2.0|
-| Completed | **Milestone 4** | Feb 2021 | |
-|  | Reporting - add SARIF format |  | v1.2.0|
-|  | Improved CLI outputs (progess, coloring, logo) |  | v1.2.0|
-|  | Engineering and performance improvements |  | 1.2.0|
-|  | CI/CD improved documentation |  | v1.1.4|
-|  | Mac support |  | v1.1.3 |
-|  | Hard-coded secret keys detection |  | v1.1.3|
-| Completed | **Milestone 3** | January 2021 | |
-|  | Adding more queries and extending coverage |  | v1.1.1|
-|  | Adding more CI/CD integrations |  | v1.1.1|
-|  | Engineering and performance improvements |  | v1.1.1|
-| Completed | **Milestone 2** | December 2020 | |
-|   | Adding support for K8S |  | v1.1.0|
-|   | Adding support for Docker |  | v1.1.0|
-|   | Adding support for Ansible |  | v1.1.0|
-|   | Adding support for AWS CloudFormation |  | v1.1.0|
-|   | Designing official logo for KICS | | |
-| Completed | **Milestone 1** | November 2020 | |
-|  | First version of KICS engine |  | v1.0.0|
-|  | Terraform support, 50 queries |  | v1.0.0|
-|  | Delivery: CLI & Docker |  | v1.0.0|
-
----
-
-
+These are our upcoming features:
+- Schemas support OpenAPI 3.0
+- Schemas support OpenAPI 2.0 (Swagger)
+- Schemas support gRPC
+- Azure Resource Manager support
+- Google Deployment Manager support
 
 Have an idea?
-Join the chat <a href="https://gitter.im/kics-io/community" target="_blank">on Gitter</a>.
-Or contact KICS core team at [kics@checkmarx.com](mailto:kics@checkmarx.com)
+Join the chat <a href="https://gitter.im/kics-io/community" target="_blank">on Gitter</a> or contact KICS core team at [kics@checkmarx.com](mailto:kics@checkmarx.com)
+
+---
+
+## Completed Feautres
+
+| Release | Feature |
+| --- | --- |
+| **April 2021** |
+| v1.2.4 | Added Open API 3.0 support |
+| v1.2.4 | Distribution platforms: Homebrew |
+| v1.2.2 | Terraform - Parameters files support |
+| **March 2021** | |
+| v1.2.1 | Helm support |
+| v1.2.1 | Reporting - add HTML format |
+| v1.2.0 | Documentation - Queries catalog |
+| v1.2.0 | Reporting - add SARIF format |
+| v1.2.0 | Improved CLI outputs (progess, coloring, logo) |
+| v1.2.0 | Engineering and performance improvements |
+| **February 2021** | |
+| v1.1.4 | CI/CD improved documentation |
+| v1.1.3 | Mac support |
+| v1.1.3 | Hard-coded secret keys detection |
+| **January 2021** | |
+| v1.1.1 | Adding more queries and extending coverage |
+| v1.1.1 | Adding more CI/CD integrations |
+| v1.1.1 | Engineering and performance improvements |
+| **December 2020** | |
+| v1.1.0 | Adding support for K8S |
+| v1.1.0 | Adding support for Docker |
+| v1.1.0 | Adding support for Ansible |
+| v1.1.0 | Adding support for AWS CloudFormation |
+| **November 2020** | |
+| v1.0.0 | First version of KICS engine |
+| v1.0.0 | Terraform support, 50 queries |
+| v1.0.0 | Delivery: CLI & Docker |
+


### PR DESCRIPTION
Remove sprint/milestone concepts, they are internal
Remove ETA, community help is welcomed

I submit this contribution under the Apache-2.0 license.
