### PR TITLE
feat(query): add "EFS With Vulnerable Policy" for Terraform

### DIFF
--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -419,3 +419,23 @@ empty_array(arr) {
 } else {
 	false
 }
+
+check_principal(principal) {
+	is_string(principal) == true
+	principal == "*"
+}
+
+check_principal(principal) {
+	is_object(principal) == true
+	principal.AWS == "*"
+}
+
+check_action(action, typeAction) {
+	is_string(action) == true
+	action == typeAction
+}
+
+check_action(action, typeAction) {
+	is_array(action) == true
+	action[_] == typeAction
+}

--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -432,10 +432,17 @@ check_principal(principal) {
 
 check_action(action, typeAction) {
 	is_string(action) == true
-	action == typeAction
+	any([action == typeAction, action == "*"])
 }
 
 check_action(action, typeAction) {
 	is_array(action) == true
-	action[_] == typeAction
+	any([action[_] == typeAction, action == "*"])
+}
+
+# it verifies if 'Principal' or 'Actions' has wildcard
+has_wildcard(statement, typeAction) {
+	check_principal(statement.Principal)
+} else {
+	check_action(statement.Action, typeAction)
 }

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "EFS With Vulnerable Policy",
   "severity": "HIGH",
   "category": "Access Control",
-  "descriptionText": "EFS (Elastic File System) policy should avoid wildcard in 'Action' and 'Principal'",
+  "descriptionText": "EFS (Elastic File System) policy should avoid wildcard in 'Action' and 'Principal'.",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system_policy#policy",
   "platform": "Terraform"
 }

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "EFS With Vulnerable Policy",
   "severity": "HIGH",
   "category": "Access Control",
-  "descriptionText": "EFS (Elastic File System) policy should avoid wildcard in 'Action' or 'Principal'",
+  "descriptionText": "EFS (Elastic File System) policy should avoid wildcard in 'Action' and 'Principal'",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system_policy#policy",
   "platform": "Terraform"
 }

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "EFS With Vulnerable Policy",
   "severity": "HIGH",
   "category": "Access Control",
-  "descriptionText": "EFS (Elastic File System) policy should avoid wildcards in both 'Principal' and 'Actions'",
+  "descriptionText": "EFS (Elastic File System) policy should avoid wildcard in 'Action' or 'Principal'",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system_policy#policy",
   "platform": "Terraform"
 }

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "fae52418-bb8b-4ac2-b287-0b9082d6a3fd",
+  "queryName": "EFS With Vulnerable Policy",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "EFS (Elastic File System) policy should avoid wildcards in both 'Principal' and 'Actions'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system_policy#policy",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/query.rego
@@ -9,14 +9,13 @@ CxPolicy[result] {
 	policy := commonLib.json_unmarshal(resource.policy)
 	statement := policy.Statement[_]
 
-	terraLib.check_principal(statement.Principal)
-	terraLib.check_action(statement.Action, "elasticfilesystem:*")
+	terraLib.has_wildcard(statement, "elasticfilesystem:*")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_efs_file_system_policy[%s].policy", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_efs_file_system_policy[%s].policy definition is correct", [name]),
-		"keyActualValue": sprintf("aws_efs_file_system_policy[%s].policy definition is incorrect", [name]),
+		"keyExpectedValue": sprintf("aws_efs_file_system_policy[%s].policy does not have wildcard in 'Action' or 'Principal'", [name]),
+		"keyActualValue": sprintf("aws_efs_file_system_policy[%s].policy has wildcard in 'Action' or 'Principal'", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.common as commonLib
+import data.generic.terraform as terraLib
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_efs_file_system_policy[name]
@@ -8,8 +9,8 @@ CxPolicy[result] {
 	policy := commonLib.json_unmarshal(resource.policy)
 	statement := policy.Statement[_]
 
-	check_principal(statement.Principal)
-	statement.Action[_] == "elasticfilesystem:*"
+	terraLib.check_principal(statement.Principal)
+	terraLib.check_action(statement.Action, "elasticfilesystem:*")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -18,14 +19,4 @@ CxPolicy[result] {
 		"keyExpectedValue": sprintf("aws_efs_file_system_policy[%s].policy definition is correct", [name]),
 		"keyActualValue": sprintf("aws_efs_file_system_policy[%s].policy definition is incorrect", [name]),
 	}
-}
-
-check_principal(principal) {
-	is_string(principal) == true
-	principal == "*"
-}
-
-check_principal(principal) {
-	is_object(principal) == true
-	principal.AWS == "*"
 }

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_efs_file_system_policy[%s].policy", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_efs_file_system_policy[%s].policy does not have wildcard in 'Action' or 'Principal'", [name]),
+		"keyExpectedValue": sprintf("aws_efs_file_system_policy[%s].policy does not have wildcard in 'Action' and 'Principal'", [name]),
 		"keyActualValue": sprintf("aws_efs_file_system_policy[%s].policy has wildcard in 'Action' or 'Principal'", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/query.rego
@@ -1,0 +1,31 @@
+package Cx
+
+import data.generic.common as commonLib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_efs_file_system_policy[name]
+
+	policy := commonLib.json_unmarshal(resource.policy)
+	statement := policy.Statement[_]
+
+	check_principal(statement.Principal)
+	statement.Action[_] == "elasticfilesystem:*"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_efs_file_system_policy[%s].policy", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_efs_file_system_policy[%s].policy definition is correct", [name]),
+		"keyActualValue": sprintf("aws_efs_file_system_policy[%s].policy definition is incorrect", [name]),
+	}
+}
+
+check_principal(principal) {
+	is_string(principal) == true
+	principal == "*"
+}
+
+check_principal(principal) {
+	is_object(principal) == true
+	principal.AWS == "*"
+}

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/negative.tf
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/negative.tf
@@ -1,0 +1,33 @@
+resource "aws_efs_file_system" "fs" {
+  creation_token = "my-product"
+}
+
+resource "aws_efs_file_system_policy" "policy" {
+  file_system_id = aws_efs_file_system.fs.id
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Id": "ExamplePolicy01",
+    "Statement": [
+        {
+            "Sid": "ExampleStatement01",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Resource": "aws_efs_file_system.test.arn",
+            "Action": [
+                "elasticfilesystem:ClientMount",
+                "elasticfilesystem:ClientWrite"
+            ],
+            "Condition": {
+                "Bool": {
+                    "aws:SecureTransport": "true"
+                }
+            }
+        }
+    ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/negative.tf
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/negative.tf
@@ -14,8 +14,8 @@ resource "aws_efs_file_system_policy" "policy" {
             "Sid": "ExampleStatement01",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "*"
-            },
+                "AWS": "arn:aws:iam::111122223333:user/Carlos"
+            }
             "Resource": "aws_efs_file_system.test.arn",
             "Action": [
                 "elasticfilesystem:ClientMount",

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive.tf
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive.tf
@@ -1,0 +1,34 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_efs_file_system" "not_secure" {
+  creation_token = "efs-not-secure"
+
+  tags = {
+    Name = "NotSecure"
+  }
+}
+
+resource "aws_efs_file_system_policy" "not_secure_policy" {
+  file_system_id = aws_efs_file_system.not_secure.id
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Id": "ExamplePolicy01",
+    "Statement": [
+        {
+            "Sid": "ExampleStatement01",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": [
+                "elasticfilesystem:*"
+            ]
+        }
+    ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/efs_with_vulnerable_policy/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "EFS With Vulnerable Policy",
+    "severity": "HIGH",
+    "line": 16,
+    "fileName": "positive.tf"
+  }
+]

--- a/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/query.rego
@@ -9,15 +9,13 @@ CxPolicy[result] {
 	policy := commonLib.json_unmarshal(resource.policy)
 	statement := policy.Statement[_]
 
-	terraLib.check_principal(statement.Principal)
-	terraLib.check_action(statement.Action, "kms:*")
-	statement.Resource == "*"
+	terraLib.has_wildcard(statement, "kms:*")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_kms_key[%s].policy", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_kms_key[%s].policy definition is correct", [name]),
-		"keyActualValue": sprintf("aws_kms_key[%s].policy definition is incorrect", [name]),
+		"keyExpectedValue": sprintf("aws_kms_key[%s].policy does not have wildcard in 'Action' or 'Principal'", [name]),
+		"keyActualValue": sprintf("aws_kms_key[%s].policy has wildcard in 'Action' or 'Principal'", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.common as commonLib
+import data.generic.terraform as terraLib
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_kms_key[name]
@@ -8,8 +9,8 @@ CxPolicy[result] {
 	policy := commonLib.json_unmarshal(resource.policy)
 	statement := policy.Statement[_]
 
-	check_principal(statement.Principal)
-	statement.Action[_] == "kms:*"
+	terraLib.check_principal(statement.Principal)
+	terraLib.check_action(statement.Action, "kms:*")
 	statement.Resource == "*"
 
 	result := {
@@ -19,14 +20,4 @@ CxPolicy[result] {
 		"keyExpectedValue": sprintf("aws_kms_key[%s].policy definition is correct", [name]),
 		"keyActualValue": sprintf("aws_kms_key[%s].policy definition is incorrect", [name]),
 	}
-}
-
-check_principal(principal) {
-	is_string(principal) == true
-	principal == "*"
-}
-
-check_principal(principal) {
-	is_object(principal) == true
-	principal.AWS == "*"
 }

--- a/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/test/negative.tf
+++ b/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/test/negative.tf
@@ -8,9 +8,17 @@ resource "aws_kms_key" "negative1" {
     "Statement":[
       {
         "Sid":"AddCannedAcl",
-        "Effect":"Allow",
-        "Principal": { "AWS": "123456789012" },
-        "Action":["kms:*"],
+        "Effect":"Deny",
+        "Principal": {"AWS": [
+          "arn:aws:iam::111122223333:user/CMKUser"
+        ]},
+        "Action": [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ],
         "Resource":"*"
       }
     ]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "EFS With Vulnerable Policy" query for Terraform. It checks if the EFS (Elastic File System) policy defines wildcards in  'Principal' or 'Action'

I submit this contribution under the Apache-2.0 license.
