### PR TITLE
feat(query): add "Elasticsearch Domain With Vulnerable Policy" for Terraform

### DIFF
--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -432,10 +432,16 @@ check_principal(principal) {
 
 check_action(action, typeAction) {
 	is_string(action) == true
-	action == typeAction
+	any([action == typeAction, action == "*"])
 }
 
 check_action(action, typeAction) {
 	is_array(action) == true
-	action[_] == typeAction
+	any([action[_] == typeAction, action == "*"])
+}
+
+has_wildcard(statement, typeAction) {
+	check_principal(statement.Principal)
+} else {
+	check_action(statement.Action, typeAction)
 }

--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -440,6 +440,7 @@ check_action(action, typeAction) {
 	any([action[_] == typeAction, action == "*"])
 }
 
+# it verifies if 'Principal' or 'Actions' has wildcard
 has_wildcard(statement, typeAction) {
 	check_principal(statement.Principal)
 } else {

--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -419,3 +419,23 @@ empty_array(arr) {
 } else {
 	false
 }
+
+check_principal(principal) {
+	is_string(principal) == true
+	principal == "*"
+}
+
+check_principal(principal) {
+	is_object(principal) == true
+	principal.AWS == "*"
+}
+
+check_action(action, typeAction) {
+	is_string(action) == true
+	action == typeAction
+}
+
+check_action(action, typeAction) {
+	is_array(action) == true
+	action[_] == typeAction
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "16c4216a-50d3-4785-bfb2-4adb5144a8ba",
+  "queryName": "Elasticsearch Domain With Vulnerable Policy",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Elasticsearch Domain policy should avoid wildcards in both 'Principal' and 'Actions'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain_policy#access_policies",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Elasticsearch Domain With Vulnerable Policy",
   "severity": "MEDIUM",
   "category": "Access Control",
-  "descriptionText": "Elasticsearch Domain policy should avoid wildcard in 'Action' and 'Principal'",
+  "descriptionText": "Elasticsearch Domain policy should avoid wildcard in 'Action' and 'Principal'.",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain_policy#access_policies",
   "platform": "Terraform"
 }

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Elasticsearch Domain With Vulnerable Policy",
   "severity": "MEDIUM",
   "category": "Access Control",
-  "descriptionText": "Elasticsearch Domain policy should avoid wildcard in 'Action' or 'Principal'",
+  "descriptionText": "Elasticsearch Domain policy should avoid wildcard in 'Action' and 'Principal'",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain_policy#access_policies",
   "platform": "Terraform"
 }

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Elasticsearch Domain With Vulnerable Policy",
   "severity": "MEDIUM",
   "category": "Access Control",
-  "descriptionText": "Elasticsearch Domain policy should avoid wildcards in both 'Principal' and 'Actions'",
+  "descriptionText": "Elasticsearch Domain policy should avoid wildcard in 'Action' or 'Principal'",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain_policy#access_policies",
   "platform": "Terraform"
 }

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_elasticsearch_domain_policy[%s].access_policies", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies does not have wildcard in 'Action' or 'Principal'", [name]),
+		"keyExpectedValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies does not have wildcard in 'Action' and 'Principal'", [name]),
 		"keyActualValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies has wildcard in 'Action' or 'Principal'", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/query.rego
@@ -9,14 +9,13 @@ CxPolicy[result] {
 	policy := commonLib.json_unmarshal(resource.access_policies)
 	statement := policy.Statement[_]
 
-	terraLib.check_principal(statement.Principal)
-	terraLib.check_action(statement.Action, "es:*")
+	terraLib.has_wildcard(statement, "es:*")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_elasticsearch_domain_policy[%s].access_policies", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies definition is correct", [name]),
-		"keyActualValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies definition is incorrect", [name]),
+		"keyExpectedValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies does not have wildcard in 'Action' or 'Principal'", [name]),
+		"keyActualValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies has wildcard in 'Action' or 'Principal'", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/query.rego
@@ -1,0 +1,22 @@
+package Cx
+
+import data.generic.common as commonLib
+import data.generic.terraform as terraLib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_elasticsearch_domain_policy[name]
+
+	policy := commonLib.json_unmarshal(resource.access_policies)
+	statement := policy.Statement[_]
+
+	terraLib.check_principal(statement.Principal)
+	terraLib.check_action(statement.Action, "es:*")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticsearch_domain_policy[%s].access_policies", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies definition is correct", [name]),
+		"keyActualValue": sprintf("aws_elasticsearch_domain_policy[%s].access_policies definition is incorrect", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/negative.tf
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/negative.tf
@@ -10,19 +10,19 @@ resource "aws_elasticsearch_domain_policy" "main2" {
 {
     "Version": "2012-10-17",
     "Statement": [
-        {
-            "Action": [
-              "es:ESHttpGet",
-              "es:ESHttpPut"
-            ],
-            "Principal": "*",
-            "Effect": "Allow",
-            "Condition": {
-                "IpAddress": {"aws:SourceIp": "127.0.0.1/32"}
-            },
-            "Resource": "aws_elasticsearch_domain.example2.arn/*"
-        }
-    ]
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::123456789012:user/test-user"
+        ]
+      },
+      "Action": [
+        "es:ESHttpGet"
+      ],
+      "Resource": "arn:aws:es:us-west-1:987654321098:domain/test-domain/test-index/_search"
+    }
+  ]
 }
 POLICIES
 }

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/negative.tf
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/negative.tf
@@ -1,0 +1,28 @@
+resource "aws_elasticsearch_domain" "example2" {
+  domain_name           = "tf-test"
+  elasticsearch_version = "2.3"
+}
+
+resource "aws_elasticsearch_domain_policy" "main2" {
+  domain_name = aws_elasticsearch_domain.example2.domain_name
+
+  access_policies = <<POLICIES
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+              "es:ESHttpGet",
+              "es:ESHttpPut"
+            ],
+            "Principal": "*",
+            "Effect": "Allow",
+            "Condition": {
+                "IpAddress": {"aws:SourceIp": "127.0.0.1/32"}
+            },
+            "Resource": "aws_elasticsearch_domain.example2.arn/*"
+        }
+    ]
+}
+POLICIES
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive.tf
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_elasticsearch_domain" "es-not-secure-policy" {
+  domain_name = "es-not-secure-policy"
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+    volume_type = "gp2"
+  }
+}
+
+resource "aws_elasticsearch_domain_policy" "main" {
+  domain_name = aws_elasticsearch_domain.es-not-secure-policy.domain_name
+
+  access_policies = <<POLICIES
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "es:*",
+            "Principal": "*",
+            "Effect": "Allow"
+        }
+    ]
+}
+POLICIES
+}

--- a/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticsearch_domain_with_vulnerable_policy/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Elasticsearch Domain With Vulnerable Policy",
+    "severity": "MEDIUM",
+    "line": 18,
+    "fileName": "positive.tf"
+  }
+]

--- a/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/query.rego
@@ -9,15 +9,13 @@ CxPolicy[result] {
 	policy := commonLib.json_unmarshal(resource.policy)
 	statement := policy.Statement[_]
 
-	terraLib.check_principal(statement.Principal)
-	terraLib.check_action(statement.Action, "kms:*")
-	statement.Resource == "*"
+	terraLib.has_wildcard(statement, "kms:*")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_kms_key[%s].policy", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_kms_key[%s].policy definition is correct", [name]),
-		"keyActualValue": sprintf("aws_kms_key[%s].policy definition is incorrect", [name]),
+		"keyExpectedValue": sprintf("aws_kms_key[%s].policy does not have wildcard in 'Action' or 'Principal'", [name]),
+		"keyActualValue": sprintf("aws_kms_key[%s].policy has wildcard in 'Action' or 'Principal'", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.common as commonLib
+import data.generic.terraform as terraLib
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_kms_key[name]
@@ -8,8 +9,8 @@ CxPolicy[result] {
 	policy := commonLib.json_unmarshal(resource.policy)
 	statement := policy.Statement[_]
 
-	check_principal(statement.Principal)
-	statement.Action[_] == "kms:*"
+	terraLib.check_principal(statement.Principal)
+	terraLib.check_action(statement.Action, "kms:*")
 	statement.Resource == "*"
 
 	result := {
@@ -19,14 +20,4 @@ CxPolicy[result] {
 		"keyExpectedValue": sprintf("aws_kms_key[%s].policy definition is correct", [name]),
 		"keyActualValue": sprintf("aws_kms_key[%s].policy definition is incorrect", [name]),
 	}
-}
-
-check_principal(principal) {
-	is_string(principal) == true
-	principal == "*"
-}
-
-check_principal(principal) {
-	is_object(principal) == true
-	principal.AWS == "*"
 }

--- a/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/test/negative.tf
+++ b/assets/queries/terraform/aws/kms_key_with_vulnerable_policy/test/negative.tf
@@ -8,9 +8,17 @@ resource "aws_kms_key" "negative1" {
     "Statement":[
       {
         "Sid":"AddCannedAcl",
-        "Effect":"Allow",
-        "Principal": { "AWS": "123456789012" },
-        "Action":["kms:*"],
+        "Effect":"Deny",
+        "Principal": {"AWS": [
+          "arn:aws:iam::111122223333:user/CMKUser"
+        ]},
+        "Action": [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ],
         "Resource":"*"
       }
     ]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Elasticsearch Domain With Vulnerable Policy" query for Terraform. It checks if the Elasticsearch Domain policy defines wildcards in 'Principal' or 'Action'
- Added 'check_principal' function to Terraform library

I submit this contribution under the Apache-2.0 license.
