### PR TITLE
feat(query): add "Lambda With Vulnerable Policy" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/lambda_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/lambda_with_vulnerable_policy/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "ad9dabc7-7839-4bae-a957-aa9120013f39",
+  "queryName": "Lambda With Vulnerable Policy",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "The attribute 'action' should not have wildcard",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission#action",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/lambda_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/lambda_with_vulnerable_policy/query.rego
@@ -1,0 +1,15 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_lambda_permission[name]
+
+	resource.action == "lambda:*"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_lambda_permission[%s].action", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_lambda_permission[%s].action does not have wildcard", [name]),
+		"keyActualValue": sprintf("aws_lambda_permission[%s].action has wildcard", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/lambda_with_vulnerable_policy/test/negative.tf
+++ b/assets/queries/terraform/aws/lambda_with_vulnerable_policy/test/negative.tf
@@ -1,0 +1,43 @@
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.test_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = "arn:aws:events:eu-west-1:111122223333:rule/RunDaily"
+  qualifier     = aws_lambda_alias.test_alias.name
+}
+
+resource "aws_lambda_alias" "test_alias" {
+  name             = "testalias"
+  description      = "a sample description"
+  function_name    = aws_lambda_function.test_lambda.function_name
+  function_version = "$LATEST"
+}
+
+resource "aws_lambda_function" "test_lambda" {
+  filename      = "lambdatest.zip"
+  function_name = "lambda_function_name"
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.handler"
+  runtime       = "nodejs12.x"
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda"
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      },
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/lambda_with_vulnerable_policy/test/positive.tf
+++ b/assets/queries/terraform/aws/lambda_with_vulnerable_policy/test/positive.tf
@@ -1,0 +1,49 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_lambda_function" "my-lambda" {
+  filename = "~/Downloads/lambda.json.zip"
+  function_name = "my-lambda"
+  role          = aws_iam_role.lambda-role.arn
+  handler       = "lambda_function.lambda_handler"
+  runtime = "python3.8"
+}
+
+resource "aws_iam_role" "lambda-role" {
+  name = "lambda-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_permission" "all" {
+  statement_id  = "AllowAllResources"
+  action        = "lambda:*"
+  function_name = aws_lambda_function.my-lambda.function_name
+  principal     = "s3.amazonaws.com"
+  source_arn    = "arn:aws:s3:::delete-me-us-east-1-permissions-tests"
+  source_account = "111111111111"
+  qualifier     = aws_lambda_alias.my-lambda-alias.name
+}
+
+
+resource "aws_lambda_alias" "my-lambda-alias" {
+  name             = "v1"
+  description      = "a sample description"
+  function_name    = aws_lambda_function.my-lambda.function_name
+  function_version = "$LATEST"
+}

--- a/assets/queries/terraform/aws/lambda_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/lambda_with_vulnerable_policy/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Lambda With Vulnerable Policy",
+    "severity": "MEDIUM",
+    "line": 35,
+    "fileName": "positive.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Lambda With Vulnerable Policy" query for Terraform. It checks if the Lambda policy defines wildcard in the attribute 'action'. It is not necessary to check the attribute 'principal' since Terraform does not support it as you can see [here](https://github.com/hashicorp/terraform-provider-aws/issues/2776)

I submit this contribution under the Apache-2.0 license.
