### PR TITLE
feat(query): add "CloudWatch Logs Destination With Vulnerable Policy" for Terraform

### DIFF
--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -440,9 +440,22 @@ check_action(action, typeAction) {
 	any([action[_] == typeAction, action == "*"])
 }
 
+check_principals(statement) {
+	statement.principals.identifiers[_] == "*"
+	statement.principals.type == "AWS"
+}
+
+check_actions(statement, typeAction) {
+	any([statement.actions[_] == typeAction, statement.actions[_] == "*"])
+}
+
 # it verifies if 'Principal' or 'Actions' has wildcard
 has_wildcard(statement, typeAction) {
 	check_principal(statement.Principal)
 } else {
+	check_principals(statement)
+} else {
 	check_action(statement.Action, typeAction)
+} else {
+	check_actions(statement, typeAction)
 }

--- a/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "db0ec4c4-852c-46a2-b4f3-7ec13cdb12a8",
+  "queryName": "CloudWatch Logs Destination With Vulnerable Policy",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "CloudWatch Logs destination policy should avoid wildcard in 'principals' and 'actions'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_destination_policy#access_policy",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.terraform as terraLib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_cloudwatch_log_destination_policy[name]
+
+	policyName := split(resource.access_policy, ".")[2]
+
+	policy := input.document[j].data.aws_iam_policy_document[policyName]
+
+	terraLib.has_wildcard(policy.statement, "logs:*")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("ws_cloudwatch_log_destination_policy[%s].access_policy", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("ws_cloudwatch_log_destination_policy[%s].access_policy does not have wildcard in 'principals' and 'actions'", [name]),
+		"keyActualValue": sprintf("ws_cloudwatch_log_destination_policy[%s].access_policy has wildcard in 'principals' or 'actions'", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/negative.tf
+++ b/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/negative.tf
@@ -1,0 +1,26 @@
+data "aws_iam_policy_document" "test_destination_policy2" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "123456789012",
+      ]
+    }
+
+    actions = [
+      "logs:PutSubscriptionFilter",
+    ]
+
+    resources = [
+      aws_cloudwatch_log_destination.test_destination.arn,
+    ]
+  }
+}
+
+resource "aws_cloudwatch_log_destination_policy" "test_destination_policy2" {
+  destination_name = aws_cloudwatch_log_destination.test_destination.name
+  access_policy    = data.aws_iam_policy_document.test_destination_policy2.json
+}

--- a/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive.tf
+++ b/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive.tf
@@ -1,0 +1,23 @@
+data "aws_iam_policy_document" "test_destination_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        data.aws_caller_identity.current.id,
+      ]
+    }
+
+    actions = [
+      "logs:*",
+    ]
+
+  }
+}
+
+resource "aws_cloudwatch_log_destination_policy" "test_destination_policy" {
+  destination_name = aws_cloudwatch_log_destination.test_destination.name
+  access_policy    = data.aws_iam_policy_document.test_destination_policy.json
+}

--- a/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_logs_destination_with_vulnerable_policy/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "CloudWatch Logs Destination With Vulnerable Policy",
+    "severity": "MEDIUM",
+    "line": 22,
+    "fileName": "positive.tf"
+  }
+]

--- a/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/metadata.json
@@ -1,9 +1,9 @@
 {
   "id": "b161c11b-a59b-4431-9a29-4e19f63e6b27",
-  "queryName": "Rest API With Vulnerable Policy",
+  "queryName": "REST API With Vulnerable Policy",
   "severity": "MEDIUM",
   "category": "Access Control",
-  "descriptionText": "Rest API policy should avoid wildcard in 'Action' or 'Principal'",
+  "descriptionText": "REST API policy should avoid wildcard in 'Action' and 'Principal'",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_rest_api_policy#policy",
   "platform": "Terraform"
 }

--- a/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_api_gateway_rest_api_policy[%s].policy", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_api_gateway_rest_api_policy[%s].policy does not have wildcard in 'Action' or 'Principal'", [name]),
+		"keyExpectedValue": sprintf("aws_api_gateway_rest_api_policy[%s].policy does not have wildcard in 'Action' and 'Principal'", [name]),
 		"keyActualValue": sprintf("aws_api_gateway_rest_api_policy[%s].policy has wildcard in 'Action' or 'Principal'", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/rest_api_with_vulnerable_policy/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
   {
-    "queryName": "Rest API With Vulnerable Policy",
+    "queryName": "REST API With Vulnerable Policy",
     "severity": "MEDIUM",
     "line": 15,
     "fileName": "positive.tf"


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "CloudWatch Logs Destination With Vulnerable Policy" query for Terraform. It checks if the CloudWatch Logs Destination policy defines wildcards in 'principals' or 'actions'

I submit this contribution under the Apache-2.0 license.
