### PR TITLE
feat(query): add "Secrets Manager With Vulnerable Policy" for Terraform

### DIFF
--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -440,9 +440,22 @@ check_action(action, typeAction) {
 	any([action[_] == typeAction, action == "*"])
 }
 
+check_principals(statement) {
+	statement.principals.identifiers[_] == "*"
+	statement.principals.type == "AWS"
+}
+
+check_actions(statement, typeAction) {
+	any([statement.actions[_] == typeAction, statement.actions[_] == "*"])
+}
+
 # it verifies if 'Principal' or 'Actions' has wildcard
 has_wildcard(statement, typeAction) {
 	check_principal(statement.Principal)
 } else {
+	check_principals(statement)
+} else {
 	check_action(statement.Action, typeAction)
+} else {
+	check_actions(statement, typeAction)
 }

--- a/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/metadata.json
+++ b/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "fa00ce45-386d-4718-8392-fb485e1f3c5b",
+  "queryName": "Secrets Manager With Vulnerable Policy",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Secrets Manager policy should avoid wildcard in 'Principal' and 'Action'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy#policy",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/query.rego
+++ b/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.common as commonLib
+import data.generic.terraform as terraLib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_secretsmanager_secret_policy[name]
+
+	policy := commonLib.json_unmarshal(resource.policy)
+	statement := policy.Statement[_]
+
+	terraLib.has_wildcard(statement, "secretsmanager:*")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_secretsmanager_secret_policy[%s].policy", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_secretsmanager_secret_policy[%s].policy does not have wildcard in 'Principal' and 'Action'", [name]),
+		"keyActualValue": sprintf("aws_secretsmanager_secret_policy[%s].policy has wildcard in 'Principal' and 'Action'", [name]),
+	}
+}

--- a/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/negative.tf
+++ b/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/negative.tf
@@ -1,0 +1,24 @@
+resource "aws_secretsmanager_secret" "example2" {
+  name = "example"
+}
+
+resource "aws_secretsmanager_secret_policy" "example2" {
+  secret_arn = aws_secretsmanager_secret.example2.arn
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EnableAllPermissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::var.account_id:saml-provider/var.provider_name"
+      },
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive.tf
+++ b/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_secretsmanager_secret" "not_secure_policy" {
+  name = "not_secure_secret"
+}
+
+resource "aws_secretsmanager_secret_policy" "example" {
+  secret_arn = aws_secretsmanager_secret.not_secure_policy.arn
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EnableAllPermissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "secretsmanager:*",
+      "Resource": "*"
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/secrets_manager_with_vulnerable_policy/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Secrets Manager With Vulnerable Policy",
+    "severity": "MEDIUM",
+    "line": 12,
+    "fileName": "positive.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Secrets Manager With Vulnerable Policy" query for Terraform. It checks if the Secrets Manager policy defines wildcards in 'Principal' or 'Action'

I submit this contribution under the Apache-2.0 license.
