### PR TITLE
feat(query): add "S3 Bucket Public ACL Overridden By Public Access Block" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "bf878b1a-7418-4de3-b13c-3a86cf894920",
+  "queryName": "S3 Bucket Public ACL Overridden By Public Access Block",
+  "severity": "LOW",
+  "category": "Access Control",
+  "descriptionText": "S3 bucket public access is overridden by S3 bucket Public Access Block when the following attributes are set to true - 'block_public_acls', 'block_public_policy', 'ignore_public_acls', and 'restrict_public_buckets'",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block#bucket",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_s3_bucket[name]
+	publicAccessACL(resource.acl)
+
+	publicBlockACL := input.document[j].resource.aws_s3_bucket_public_access_block[blockName]
+
+	split(publicBlockACL.bucket, ".")[1] == name
+
+	publicBlockACL.block_public_acls == true
+	publicBlockACL.block_public_policy == true
+	publicBlockACL.ignore_public_acls == true
+	publicBlockACL.restrict_public_buckets == true
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_s3_bucket[%s].acl", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "S3 Bucket public ACL is not overridden by S3 bucket Public Access Block",
+		"keyActualValue": "S3 Bucket public ACL is overridden by S3 bucket Public Access Block",
+	}
+}
+
+publicAccessACL("public-read") = true
+
+publicAccessACL("public-read-write") = true

--- a/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/test/negative.tf
+++ b/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/test/negative.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "public-bucket2" {
+  bucket = "bucket-with-public-acl-32"
+  acl = "public-read-write"
+}
+
+resource "aws_s3_bucket_public_access_block" "block_public_bucket_32" {
+  bucket = aws_s3_bucket.public-bucket2.id
+  block_public_acls = false
+  block_public_policy = true
+  ignore_public_acls = false
+  restrict_public_buckets = true
+}

--- a/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/test/positive.tf
+++ b/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/test/positive.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "public-bucket" {
+  bucket = "bucket-with-public-acl-3"
+  acl = "public-read-write"
+}
+
+resource "aws_s3_bucket_public_access_block" "block_public_bucket_3" {
+  bucket = aws_s3_bucket.public-bucket.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}

--- a/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_public_acl_overridden_by_public_access_block/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "S3 Bucket Public ACL Overridden By Public Access Block",
+    "severity": "LOW",
+    "line": 7
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "S3 Bucket Public ACL Overridden By Public Access Block" query for Terraform. It checks if the S3 bucket public access is overridden by S3 bucket Public Access Block when the following attributes are set to true - 'block_public_acls', 'block_public_policy', 'ignore_public_acls', and 'restrict_public_buckets'"

I submit this contribution under the Apache-2.0 license.
