### PR TITLE
feature(metrics): Metrics default to 'ms' and 'b' for 'ci' flag 

### DIFF
--- a/internal/metrics/cpu_metric.go
+++ b/internal/metrics/cpu_metric.go
@@ -23,6 +23,10 @@ var cpuMap = map[string]float64{
 	"hrs": float64(time.Hour),
 }
 
+func (c *cpuMetric) getDefault() string {
+	return "ms"
+}
+
 // Start - start gathering metrics for CPU usage
 func (c *cpuMetric) start() {
 	c.idx = 1

--- a/internal/metrics/mem_metric.go
+++ b/internal/metrics/mem_metric.go
@@ -51,6 +51,10 @@ func (c *memMetric) start() {
 	}
 }
 
+func (c *memMetric) getDefault() string {
+	return "B"
+}
+
 // Stop - stop gathering metrics for Memory usage
 func (c *memMetric) stop() {
 	c.close()


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #3477 #3476

**Proposed Changes**
- Metrics and scanning time will now return formatted as `ms` for time and 'B' for memory for `--ci` flag

I submit this contribution under the Apache-2.0 license.
