### PR TITLE
feat(query): add "SNS Topic Encrypted With AWS Managed Key" for Terraform

### DIFF
--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -464,7 +464,6 @@ uses_aws_managed_key(key, awsManagedKey) {
 	key == awsManagedKey
 } else {
 	keyName := split(key, ".")[2]
-	kms := input.document[z].data.aws_kms_key[kmsName]
-	keyName == kmsName
+	kms := input.document[z].data.aws_kms_key[keyName]
 	kms.key_id == awsManagedKey
 }

--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -459,3 +459,12 @@ has_wildcard(statement, typeAction) {
 } else {
 	check_actions(statement, typeAction)
 }
+
+uses_aws_managed_key(key, awsManagedKey) {
+	key == awsManagedKey
+} else {
+	keyName := split(key, ".")[2]
+	kms := input.document[z].data.aws_kms_key[kmsName]
+	keyName == kmsName
+	kms.key_id == awsManagedKey
+}

--- a/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/metadata.json
+++ b/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b1a72f66-2236-4f3b-87ba-0da1b366956f",
+  "queryName": "SNS Topic Encrypted With AWS Managed Key",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "SNS (Simple Notification Service) Topic should be encrypted with customer-managed KMS keys instead of AWS managed keys",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic#kms_master_key_id",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/query.rego
+++ b/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/query.rego
@@ -1,9 +1,11 @@
 package Cx
 
+import data.generic.terraform as terraLib
+
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_sns_topic[name]
 
-	uses_aws_maneged_key(resource.kms_master_key_id)
+	terraLib.uses_aws_managed_key(resource.kms_master_key_id, "alias/aws/sns")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -12,13 +14,4 @@ CxPolicy[result] {
 		"keyExpectedValue": "SNS Topic is not encrypted with AWS managed key",
 		"keyActualValue": "SNS Topic is encrypted with AWS managed key",
 	}
-}
-
-uses_aws_maneged_key(key) {
-	key == "alias/aws/sns"
-} else {
-	keyName := split(key, ".")[2]
-	kms := input.document[z].data.aws_kms_key[kmsName]
-	keyName == kmsName
-	kms.key_id == "alias/aws/sns"
 }

--- a/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/query.rego
+++ b/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/query.rego
@@ -1,0 +1,24 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_sns_topic[name]
+
+	uses_aws_maneged_key(resource.kms_master_key_id)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_sns_topic[%s].kms_master_key_id", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "SNS Topic is not encrypted with AWS managed key",
+		"keyActualValue": "SNS Topic is encrypted with AWS managed key",
+	}
+}
+
+uses_aws_maneged_key(key) {
+	key == "alias/aws/sns"
+} else {
+	keyName := split(key, ".")[2]
+	kms := input.document[z].data.aws_kms_key[kmsName]
+	keyName == kmsName
+	kms.key_id == "alias/aws/sns"
+}

--- a/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/test/negative.tf
+++ b/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/test/negative.tf
@@ -1,0 +1,8 @@
+provider "aws2" {
+  region = "us-east-1"
+}
+
+resource "aws_sns_topic" "test2" {
+  name              = "sns_ecnrypted"
+  kms_master_key_id = "alias/MyAlias"
+}

--- a/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/test/positive1.tf
+++ b/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/test/positive1.tf
@@ -1,0 +1,4 @@
+resource "aws_sns_topic" "user_updates" {
+  name              = "user-updates-topic"
+  kms_master_key_id = "alias/aws/sns"
+}

--- a/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/test/positive2.tf
+++ b/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/test/positive2.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_kms_key" "by_alias" {
+  key_id = "alias/aws/sns"
+}
+
+resource "aws_sns_topic" "test" {
+  name              = "sns_ecnrypted"
+  kms_master_key_id = data.aws_kms_key.by_alias.arn
+}

--- a/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sns_topic_encrypted_with_aws_managed_key/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "SNS Topic Encrypted With AWS Managed Key",
+    "severity": "MEDIUM",
+    "line": 3,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "SNS Topic Encrypted With AWS Managed Key",
+    "severity": "MEDIUM",
+    "line": 11,
+    "fileName": "positive2.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "SNS Topic Encrypted With AWS Managed Key" query for Terraform. It checks if the SNS Topic is encrypted with AWS managed key (`alias/aws/sns`)

I submit this contribution under the Apache-2.0 license.
