### PR TITLE
feat(query): add "Secretsmanager Secret Encrypted With AWS Managed Key" for Terraform

### DIFF
--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -464,7 +464,6 @@ uses_aws_managed_key(key, awsManagedKey) {
 	key == awsManagedKey
 } else {
 	keyName := split(key, ".")[2]
-	kms := input.document[z].data.aws_kms_key[kmsName]
-	keyName == kmsName
+	kms := input.document[z].data.aws_kms_key[keyName]
 	kms.key_id == awsManagedKey
 }

--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -459,3 +459,12 @@ has_wildcard(statement, typeAction) {
 } else {
 	check_actions(statement, typeAction)
 }
+
+uses_aws_managed_key(key, awsManagedKey) {
+	key == awsManagedKey
+} else {
+	keyName := split(key, ".")[2]
+	kms := input.document[z].data.aws_kms_key[kmsName]
+	keyName == kmsName
+	kms.key_id == awsManagedKey
+}

--- a/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/metadata.json
+++ b/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b0d3ef3f-845d-4b1b-83d6-63a5a380375f",
+  "queryName": "Secretsmanager Secret Encrypted With AWS Managed Key",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "Secrets Manager secret should be encrypted with customer-managed KMS keys instead of AWS managed keys",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret#kms_key_id",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/query.rego
+++ b/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+import data.generic.terraform as terraLib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_secretsmanager_secret[name]
+
+	terraLib.uses_aws_managed_key(resource.kms_key_id, "alias/aws/secretsmanager")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_secretsmanager_secret[%s].kms_key_id", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Secrets Manager secret is not encrypted with AWS managed key",
+		"keyActualValue": "Secrets Manager secret is encrypted with AWS managed key",
+	}
+}

--- a/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/test/negative.tf
+++ b/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/test/negative.tf
@@ -1,0 +1,5 @@
+resource "aws_secretsmanager_secret" "test222" {
+  name       = "test-cloudrail-1"
+  kms_key_id = "alias/MyAlias"
+}
+

--- a/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/test/positive1.tf
+++ b/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/test/positive1.tf
@@ -1,0 +1,4 @@
+resource "aws_secretsmanager_secret" "test2" {
+  name       = "test-cloudrail-1"
+  kms_key_id = "alias/aws/secretsmanager"
+}

--- a/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/test/positive2.tf
+++ b/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/test/positive2.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_kms_key" "by_alias" {
+  key_id = "alias/aws/secretsmanager"
+}
+
+resource "aws_secretsmanager_secret" "test" {
+  name       = "test-cloudrail-1"
+  kms_key_id = data.aws_kms_key.by_alias.arn
+}

--- a/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/secretsmanager_secret_encrypted_with_aws_managed_key/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Secretsmanager Secret Encrypted With AWS Managed Key",
+    "severity": "MEDIUM",
+    "line": 3,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "Secretsmanager Secret Encrypted With AWS Managed Key",
+    "severity": "MEDIUM",
+    "line": 11,
+    "fileName": "positive2.tf"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Secretsmanager Secret Encrypted With AWS Managed Key" query for Terraform. It checks if the Secrets Manager Secret is encrypted with AWS managed key (`alias/aws/secretsmanager`)

I submit this contribution under the Apache-2.0 license.
