### PR TITLE
feat(query): add "DOCDB Cluster Encrypted With AWS Managed Key" for Terraform

### DIFF
--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -464,7 +464,6 @@ uses_aws_managed_key(key, awsManagedKey) {
 	key == awsManagedKey
 } else {
 	keyName := split(key, ".")[2]
-	kms := input.document[z].data.aws_kms_key[kmsName]
-	keyName == kmsName
+	kms := input.document[z].data.aws_kms_key[keyName]
 	kms.key_id == awsManagedKey
 }

--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -459,3 +459,12 @@ has_wildcard(statement, typeAction) {
 } else {
 	check_actions(statement, typeAction)
 }
+
+uses_aws_managed_key(key, awsManagedKey) {
+	key == awsManagedKey
+} else {
+	keyName := split(key, ".")[2]
+	kms := input.document[z].data.aws_kms_key[kmsName]
+	keyName == kmsName
+	kms.key_id == awsManagedKey
+}

--- a/assets/queries/terraform/aws/docdb_cluster_encrypted_with_aws_managed_key/metadata.json
+++ b/assets/queries/terraform/aws/docdb_cluster_encrypted_with_aws_managed_key/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "2134641d-30a4-4b16-8ffc-2cd4c4ffd15d",
+  "queryName": "DOCDB Cluster Encrypted With AWS Managed Key",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "DOCDB Cluster should be encrypted with customer-managed KMS keys instead of AWS managed keys",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster#kms_key_id",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/docdb_cluster_encrypted_with_aws_managed_key/query.rego
+++ b/assets/queries/terraform/aws/docdb_cluster_encrypted_with_aws_managed_key/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+import data.generic.terraform as terraLib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_docdb_cluster[name]
+
+	terraLib.uses_aws_managed_key(resource.kms_key_id, "alias/aws/rds")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_docdb_cluster[%s].kms_key_id", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "DOCDB Cluster is not encrypted with AWS managed key",
+		"keyActualValue": "DOCDB Cluster is encrypted with AWS managed key",
+	}
+}

--- a/assets/queries/terraform/aws/docdb_cluster_encrypted_with_aws_managed_key/test/negative.tf
+++ b/assets/queries/terraform/aws/docdb_cluster_encrypted_with_aws_managed_key/test/negative.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_kms_key" "test2" {
+  key_id = "alias/myAlias"
+}
+
+resource "aws_docdb_cluster" "test22" {
+  cluster_identifier  = "my-docdb-cluster-test2"
+  engine              = "docdb"
+  master_username     = "foo"
+  master_password     = "mustbeeightchars"
+  skip_final_snapshot = true
+  storage_encrypted   = true
+  kms_key_id          = data.aws_kms_key.test2.arn
+}

--- a/assets/queries/terraform/aws/docdb_cluster_encrypted_with_aws_managed_key/test/positive.tf
+++ b/assets/queries/terraform/aws/docdb_cluster_encrypted_with_aws_managed_key/test/positive.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_kms_key" "test" {
+  key_id = "alias/aws/rds"
+}
+
+resource "aws_docdb_cluster" "test2" {
+  cluster_identifier  = "my-docdb-cluster-test2"
+  engine              = "docdb"
+  master_username     = "foo"
+  master_password     = "mustbeeightchars"
+  skip_final_snapshot = true
+  storage_encrypted   = true
+  kms_key_id          = data.aws_kms_key.test.arn
+}

--- a/assets/queries/terraform/aws/docdb_cluster_encrypted_with_aws_managed_key/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/docdb_cluster_encrypted_with_aws_managed_key/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "DOCDB Cluster Encrypted With AWS Managed Key",
+    "severity": "MEDIUM",
+    "line": 16
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "DOCDB Cluster Encrypted With AWS Managed Key" query for Terraform. It checks if the DOCDB Cluster is encrypted with AWS managed key (`alias/aws/rds`)

I submit this contribution under the Apache-2.0 license.
