### PR TITLE
feat(query): add "CodeBuild Project Encrypted With AWS Managed Key" for Terraform

### DIFF
--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -464,7 +464,6 @@ uses_aws_managed_key(key, awsManagedKey) {
 	key == awsManagedKey
 } else {
 	keyName := split(key, ".")[2]
-	kms := input.document[z].data.aws_kms_key[kmsName]
-	keyName == kmsName
+	kms := input.document[z].data.aws_kms_key[keyName]
 	kms.key_id == awsManagedKey
 }

--- a/assets/libraries/terraform/library.rego
+++ b/assets/libraries/terraform/library.rego
@@ -459,3 +459,12 @@ has_wildcard(statement, typeAction) {
 } else {
 	check_actions(statement, typeAction)
 }
+
+uses_aws_managed_key(key, awsManagedKey) {
+	key == awsManagedKey
+} else {
+	keyName := split(key, ".")[2]
+	kms := input.document[z].data.aws_kms_key[kmsName]
+	keyName == kmsName
+	kms.key_id == awsManagedKey
+}

--- a/assets/queries/terraform/aws/codebuild_project_encrypted_with_aws_managed_key/metadata.json
+++ b/assets/queries/terraform/aws/codebuild_project_encrypted_with_aws_managed_key/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "3deec14b-03d2-4d27-9670-7d79322e3340",
+  "queryName": "CodeBuild Project Encrypted With AWS Managed Key",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "CodeBuild Project should be encrypted with customer-managed KMS keys instead of AWS managed keys",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project#encryption_key",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/codebuild_project_encrypted_with_aws_managed_key/query.rego
+++ b/assets/queries/terraform/aws/codebuild_project_encrypted_with_aws_managed_key/query.rego
@@ -1,0 +1,17 @@
+package Cx
+
+import data.generic.terraform as terraLib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_codebuild_project[name]
+
+	terraLib.uses_aws_managed_key(resource.encryption_key, "alias/aws/s3")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_codebuild_project[%s].encryption_key", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "CodeBuild Project is not encrypted with AWS managed key",
+		"keyActualValue": "CodeBuild Project is encrypted with AWS managed key",
+	}
+}

--- a/assets/queries/terraform/aws/codebuild_project_encrypted_with_aws_managed_key/test/negative.tf
+++ b/assets/queries/terraform/aws/codebuild_project_encrypted_with_aws_managed_key/test/negative.tf
@@ -1,0 +1,63 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_kms_key" "by_alias2" {
+  key_id = "alias/myAlias"
+}
+
+# No policy attached to this role because it is for testing purposes
+resource "aws_iam_role" "codebuild2" {
+  name = "codebuild-cloudrail-test"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codebuild_project" "project-cloudrail-test2" {
+  name           = "project-cloudrail-test"
+  description    = "project-cloudrail-test"
+  build_timeout  = "5"
+  queued_timeout = "5"
+  service_role   = aws_iam_role.codebuild2.arn
+  encryption_key = data.aws_kms_key.by_alias2.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  cache {
+    type  = "LOCAL"
+    modes = ["LOCAL_DOCKER_LAYER_CACHE", "LOCAL_SOURCE_CACHE"]
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:1.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+
+    environment_variable {
+      name  = "SOME_KEY1"
+      value = "SOME_VALUE1"
+    }
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/mitchellh/packer.git"
+    git_clone_depth = 1
+  }
+}

--- a/assets/queries/terraform/aws/codebuild_project_encrypted_with_aws_managed_key/test/positive.tf
+++ b/assets/queries/terraform/aws/codebuild_project_encrypted_with_aws_managed_key/test/positive.tf
@@ -1,0 +1,63 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_kms_key" "by_alias" {
+  key_id = "alias/aws/s3"
+}
+
+# No policy attached to this role because it is for testing purposes
+resource "aws_iam_role" "codebuild" {
+  name = "codebuild-cloudrail-test"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codebuild_project" "project-cloudrail-test" {
+  name           = "project-cloudrail-test"
+  description    = "project-cloudrail-test"
+  build_timeout  = "5"
+  queued_timeout = "5"
+  service_role   = aws_iam_role.codebuild.arn
+  encryption_key = data.aws_kms_key.by_alias.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  cache {
+    type  = "LOCAL"
+    modes = ["LOCAL_DOCKER_LAYER_CACHE", "LOCAL_SOURCE_CACHE"]
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:1.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+
+    environment_variable {
+      name  = "SOME_KEY1"
+      value = "SOME_VALUE1"
+    }
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/mitchellh/packer.git"
+    git_clone_depth = 1
+  }
+}

--- a/assets/queries/terraform/aws/codebuild_project_encrypted_with_aws_managed_key/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/codebuild_project_encrypted_with_aws_managed_key/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "CodeBuild Project Encrypted With AWS Managed Key",
+    "severity": "HIGH",
+    "line": 35
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "CodeBuild Project Encrypted With AWS Managed Key" query for Terraform. It checks if the CodeBuild Project is encrypted with AWS managed key (`alias/aws/s3`)

I submit this contribution under the Apache-2.0 license.
