### PR TITLE
feat(query): add "SQS VPC Endpoint Without DNS Resolution" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/metadata.json
+++ b/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "e9b7acf9-9ba0-4837-a744-31e7df1e434d",
+  "queryName": "SQS VPC Endpoint Without DNS Resolution",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "SQS VPC Endpoint should have DNS resolution enabled",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc#enable_dns_support",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/query.rego
+++ b/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_vpc_endpoint[name]
+
+	serviceNameSplit := split(resource.service_name, ".")
+	serviceNameSplit[minus(count(serviceNameSplit), 1)] == "sqs"
+	vpcNameRef := split(resource.vpc_id, ".")[1]
+
+	vpc := input.document[j].resource.aws_vpc[vpcNameRef]
+	vpc.enable_dns_support == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_vpc_endpoint[%s].vpc_id", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "SQS VPC Endpoint has DNS resolution enabled",
+		"keyActualValue": "SQS VPC Endpoint has DNS resolution disabled ('enable_dns_support' set to false)",
+	}
+}

--- a/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/test/negative.tf
+++ b/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/test/negative.tf
@@ -1,0 +1,14 @@
+resource "aws_vpc" "main2" {
+  cidr_block = local.cidr_block
+  enable_dns_support = true
+  enable_dns_hostnames = false
+}
+
+resource "aws_vpc_endpoint" "sqs-vpc-endpoint2" {
+  vpc_id            = aws_vpc.main2.id
+  service_name      = "com.amazonaws.${local.region}.sqs"
+  vpc_endpoint_type = "Interface"
+  private_dns_enabled = true
+  subnet_ids = [aws_subnet.public-subnet.id]
+  security_group_ids = [aws_security_group.public-internet-sg.id]
+}

--- a/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/test/positive.tf
+++ b/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/test/positive.tf
@@ -1,0 +1,109 @@
+locals {
+  region = "us-east-1"
+  cidr_block = "172.16.0.0/16"
+  public_subnet_cidr_block = "172.16.100.0/24"
+  quad_zero_cidr_block = "0.0.0.0/0"
+}
+
+provider "aws" {
+  region = local.region
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = local.cidr_block
+  enable_dns_support = false
+  enable_dns_hostnames = false
+}
+
+resource "aws_subnet" "public-subnet" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = local.public_subnet_cidr_block
+
+  tags = {
+    Name = "public-subnet"
+  }
+}
+
+resource "aws_route_table" "public-rtb" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = local.cidr_block
+    vpc_endpoint_id = aws_vpc_endpoint.sqs-vpc-endpoint.id
+  }
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "public-rtb"
+  }
+}
+
+resource "aws_route_table_association" "public-rtb-assoc" {
+  subnet_id      = aws_subnet.public-subnet.id
+  route_table_id = aws_route_table.public-rtb.id
+}
+
+resource "aws_security_group" "public-internet-sg" {
+  name        = "public-internet-sg"
+  description = "Allow all local traffic with internet access"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [local.quad_zero_cidr_block]
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [local.cidr_block]
+  }
+
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "test-ec2-instance" {
+  ami = data.aws_ami.ubuntu.id
+  instance_type = "t2.micro"
+  subnet_id = aws_subnet.public-subnet.id
+  vpc_security_group_ids = [aws_security_group.public-internet-sg.id]
+}
+
+resource "aws_vpc_endpoint" "sqs-vpc-endpoint" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${local.region}.sqs"
+  vpc_endpoint_type = "Interface"
+  private_dns_enabled = true
+  subnet_ids = [aws_subnet.public-subnet.id]
+  security_group_ids = [aws_security_group.public-internet-sg.id]
+}
+
+resource "aws_sqs_queue" "test-queue" {
+  name = "test-queue"
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+}

--- a/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sqs_vpc_endpoint_without_dns_resolution/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "SQS VPC Endpoint Without DNS Resolution",
+    "severity": "MEDIUM",
+    "line": 95
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "SQS VPC Endpoint Without DNS Resolution" query for Terraform. It checks if the SQS VPC Endpoint has DNS resolution disabled ('enable_dns_support' set to false). According to the official AWS documentation, the attribute `enableDnsSupport` "indicates whether the DNS resolution is supported", as you can see [here](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-support)

I submit this contribution under the Apache-2.0 license.
