### PR TITLE
feat(query): add "Dynamodb VPC Endpoint Without Route Table Association" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/dynamodb_vpc_endpoint_wihout_route_table_association/metadata.json
+++ b/assets/queries/terraform/aws/dynamodb_vpc_endpoint_wihout_route_table_association/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "0bc534c5-13d1-4353-a7fe-b8665d5c1d7d",
+  "queryName": "Dynamodb VPC Endpoint Without Route Table Association",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Dynamodb VPC Endpoint should be associated with Route Table Association",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint#vpc_id",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/dynamodb_vpc_endpoint_wihout_route_table_association/query.rego
+++ b/assets/queries/terraform/aws/dynamodb_vpc_endpoint_wihout_route_table_association/query.rego
@@ -1,0 +1,31 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_vpc_endpoint[name]
+
+	serviceNameSplit := split(resource.service_name, ".")
+	serviceNameSplit[minus(count(serviceNameSplit), 1)] == "dynamodb"
+	vpcNameRef := split(resource.vpc_id, ".")[1]
+
+	not has_route_association(vpcNameRef)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_vpc_endpoint[%s].vpc_id", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Dynamodb VPC Endpoint is associated with Route Table Association",
+		"keyActualValue": "Dynamodb VPC Endpoint is not associated with Route Table Association",
+	}
+}
+
+has_route_association(vpcNameRef) {
+	route := input.document[j].resource.aws_route_table[routeName]
+	split(route.vpc_id, ".")[1] == vpcNameRef
+
+	subnet := input.document[k].resource.aws_subnet[subnetName]
+	split(subnet.vpc_id, ".")[1] == vpcNameRef
+
+	routeAssociation := input.document[z].resource.aws_route_table_association[routeAssociationName]
+	split(routeAssociation.route_table_id, ".")[1] == routeName
+	split(routeAssociation.subnet_id, ".")[1] == subnetName
+}

--- a/assets/queries/terraform/aws/dynamodb_vpc_endpoint_wihout_route_table_association/test/negative.tf
+++ b/assets/queries/terraform/aws/dynamodb_vpc_endpoint_wihout_route_table_association/test/negative.tf
@@ -1,0 +1,112 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+locals {
+  s3_prefix_list_cidr_block = "3.218.183.128/25"
+}
+resource "aws_vpc" "main2" {
+  cidr_block = "192.168.100.0/24"
+  enable_dns_support = true
+}
+
+resource "aws_subnet" "private-subnet2" {
+  vpc_id     = aws_vpc.main2.id
+  cidr_block = "192.168.100.128/25"
+
+  tags = {
+    Name = "private-subnet"
+  }
+}
+
+resource "aws_route_table" "private-rtb2" {
+  vpc_id = aws_vpc.main2.id
+
+  tags = {
+    Name = "private-rtb"
+  }
+}
+
+resource "aws_route_table_association" "private-rtb-assoc2" {
+  subnet_id      = aws_subnet.private-subnet2.id
+  route_table_id = aws_route_table.private-rtb2.id
+}
+
+resource "aws_vpc_endpoint" "dynamodb-vpce-gw2" {
+  vpc_id       = aws_vpc.main2.id
+  service_name = "com.amazonaws.us-east-1.dynamodb"
+}
+
+resource "aws_network_acl" "allow-public-outbound-nacl2" {
+  vpc_id = aws_vpc.main.id
+  subnet_ids = [aws_subnet.private-subnet2.id]
+
+  egress {
+    protocol   = "tcp"
+    rule_no    = 200
+    action     = "allow"
+    cidr_block = local.s3_prefix_list_cidr_block
+    from_port  = 443
+    to_port    = 443
+  }
+
+  tags = {
+    Name = "allow-public-outbound-nacl"
+  }
+}
+
+resource "aws_security_group" "allow-public-outbound-sg2" {
+  name        = "allow-public-outbound-sg"
+  description = "Allow HTTPS outbound traffic"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [local.s3_prefix_list_cidr_block]
+  }
+
+}
+
+data "aws_ami" "ubuntu2" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "test2" {
+  ami = data.aws_ami.ubuntu2.id
+  instance_type = "t2.micro"
+  vpc_security_group_ids = [aws_security_group.allow-public-outbound-sg2.id]
+  subnet_id = aws_subnet.private-subnet2.id
+}
+
+resource "aws_dynamodb_table" "basic-dynamodb-table2" {
+  name           = "GameScores"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 5
+  write_capacity = 5
+  hash_key       = "UserId"
+  range_key      = "GameTitle"
+
+  attribute {
+    name = "UserId"
+    type = "S"
+  }
+
+  attribute {
+    name = "GameTitle"
+    type = "S"
+  }
+}

--- a/assets/queries/terraform/aws/dynamodb_vpc_endpoint_wihout_route_table_association/test/positive.tf
+++ b/assets/queries/terraform/aws/dynamodb_vpc_endpoint_wihout_route_table_association/test/positive.tf
@@ -1,0 +1,107 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+locals {
+  s3_prefix_list_cidr_block = "3.218.183.128/25"
+}
+resource "aws_vpc" "main" {
+  cidr_block = "192.168.100.0/24"
+  enable_dns_support = true
+}
+
+resource "aws_subnet" "private-subnet" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = "192.168.100.128/25"
+
+  tags = {
+    Name = "private-subnet"
+  }
+}
+
+resource "aws_route_table" "private-rtb" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "private-rtb"
+  }
+}
+
+resource "aws_vpc_endpoint" "dynamodb-vpce-gw" {
+  vpc_id       = aws_vpc.main.id
+  service_name = "com.amazonaws.us-east-1.dynamodb"
+}
+
+resource "aws_network_acl" "allow-public-outbound-nacl" {
+  vpc_id = aws_vpc.main.id
+  subnet_ids = [aws_subnet.private-subnet.id]
+
+  egress {
+    protocol   = "tcp"
+    rule_no    = 200
+    action     = "allow"
+    cidr_block = local.s3_prefix_list_cidr_block
+    from_port  = 443
+    to_port    = 443
+  }
+
+  tags = {
+    Name = "allow-public-outbound-nacl"
+  }
+}
+
+resource "aws_security_group" "allow-public-outbound-sg" {
+  name        = "allow-public-outbound-sg"
+  description = "Allow HTTPS outbound traffic"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [local.s3_prefix_list_cidr_block]
+  }
+
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "test" {
+  ami = data.aws_ami.ubuntu.id
+  instance_type = "t2.micro"
+  vpc_security_group_ids = [aws_security_group.allow-public-outbound-sg.id]
+  subnet_id = aws_subnet.private-subnet.id
+}
+
+resource "aws_dynamodb_table" "basic-dynamodb-table" {
+  name           = "GameScores"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 5
+  write_capacity = 5
+  hash_key       = "UserId"
+  range_key      = "GameTitle"
+
+  attribute {
+    name = "UserId"
+    type = "S"
+  }
+
+  attribute {
+    name = "GameTitle"
+    type = "S"
+  }
+}

--- a/assets/queries/terraform/aws/dynamodb_vpc_endpoint_wihout_route_table_association/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/dynamodb_vpc_endpoint_wihout_route_table_association/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "Dynamodb VPC Endpoint Without Route Table Association",
+    "severity": "MEDIUM",
+    "line": 31
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added "Dynamodb VPC Endpoint Without Route Association" query for Terraform. It checks if the Dynamodb VPC Endpoint is not associated with Route Table Association

I submit this contribution under the Apache-2.0 license.
