### PR TITLE
fix(ci): release dkr image debian digest

### DIFF
--- a/.github/workflows/release-dkr-image.yml
+++ b/.github/workflows/release-dkr-image.yml
@@ -93,7 +93,7 @@ jobs:
 
           echo "${VERSION},${DIGEST}" >> docs/docker/digests.csv
           echo "${VERSION}-alpine,${ALPINE_DIGEST}" >> docs/docker/digests.csv
-          echo "${VERSION}-alpine,${DEBIAN_DIGEST}" >> docs/docker/digests.csv
+          echo "${VERSION}-debian,${DEBIAN_DIGEST}" >> docs/docker/digests.csv
       - uses: actions/setup-python@v2.2.2
         with:
           python-version: 3.x


### PR DESCRIPTION
**Proposed Changes**
- fixing typo in saving debian docker image sha256 digest in the repo

I submit this contribution under the Apache-2.0 license.
