### PR TITLE
fix(parser): yaml parser panics on templated files #3529

### DIFF
--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -71,7 +71,9 @@ func convert(value interface{}) interface{} {
 	case map[interface{}]interface{}:
 		mapStr := map[string]interface{}{}
 		for key, val := range t {
-			mapStr[key.(string)] = convert(val)
+			if t, ok := key.(string); ok {
+				mapStr[t] = convert(val)
+			}
 		}
 		return mapStr
 	case []interface{}:

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -49,6 +49,21 @@ test:
 test_2:
   perm:
     - <<: *test_anchor
+`, `
+kube_node_ready_controller_memory: "200Mi"
+{{if eq .Cluster.Environment "test"}}
+downscaler_default_uptime: "Mon-Fri 07:30-20:30 Europe/Berlin"
+downscaler_default_downtime: "never"
+downscaler_enabled: "true"
+{{else if eq .Cluster.Environment "e2e"}}
+downscaler_default_uptime: "always"
+downscaler_default_downtime: "never"
+downscaler_enabled: "true"
+{{else}}
+downscaler_default_uptime: "always"
+downscaler_default_downtime: "never"
+downscaler_enabled: "false"
+{{end}}
 `,
 	}
 
@@ -69,6 +84,9 @@ test_2:
 	require.Contains(t, nestedMap[0], "test_2")
 	require.Contains(t,
 		nestedMap[0]["test_2"].(model.Document)["perm"].([]interface{})[0].(map[string]interface{})["group"].(model.Document)["name"], "cx")
+
+	_, err = p.Parse("test.yaml", []byte(have[3]))
+	require.Error(t, err)
 }
 
 // Test_Resolve tests the functions [Resolve()] and all the methods called by them


### PR DESCRIPTION
Closes #3529

**Proposed Changes**
- Fix yaml parser panics on templated files due to unchecked type assertion

I submit this contribution under the Apache-2.0 license.
