### PR TITLE
feat(query): added 'Path Scheme Accepts HTTP' to openAPI 2.0

### DIFF
--- a/assets/queries/openAPI/2.0/path_scheme_accepts_http/metadata.json
+++ b/assets/queries/openAPI/2.0/path_scheme_accepts_http/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a6847dc6-f4ea-45ac-a81f-93291ae6c573",
+  "queryName": "Path Scheme Accepts HTTP",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "The Scheme list of Operation Object should only allow 'HTTPS' protocol to ensure an encrypted connection",
+  "descriptionUrl": "https://swagger.io/specification/v2/#operationObject",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/2.0/path_scheme_accepts_http/metadata.json
+++ b/assets/queries/openAPI/2.0/path_scheme_accepts_http/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "a6847dc6-f4ea-45ac-a81f-93291ae6c573",
-  "queryName": "Path Scheme Accepts HTTP",
+  "queryName": "Path Scheme Accepts HTTP (v2)",
   "severity": "MEDIUM",
   "category": "Encryption",
   "descriptionText": "The Scheme list of Operation Object should only allow 'HTTPS' protocol to ensure an encrypted connection",

--- a/assets/queries/openAPI/2.0/path_scheme_accepts_http/query.rego
+++ b/assets/queries/openAPI/2.0/path_scheme_accepts_http/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) == "2.0"
+
+	doc.paths[path][oper].schemes[s] == "http"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.{{%s}}.schemes.http", [path, oper]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The Scheme list uses only 'HTTPS' protocol",
+		"keyActualValue": "The Scheme list uses 'HTTP' protocol",
+	}
+}

--- a/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/negative1.json
+++ b/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/negative1.json
@@ -1,0 +1,23 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "schemes": [
+          "https"
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/negative2.yaml
+++ b/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/negative2.yaml
@@ -1,0 +1,14 @@
+swagger: "2.0"
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      schemes:
+        - https
+      responses:
+        "200":
+          description: 200 response

--- a/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/positive1.json
+++ b/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/positive1.json
@@ -1,0 +1,23 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "schemes": [
+          "http"
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/positive2.yaml
+++ b/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/positive2.yaml
@@ -1,0 +1,14 @@
+swagger: "2.0"
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      schemes:
+        - http
+      responses:
+        "200":
+          description: 200 response

--- a/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
   {
-    "queryName": "Path Scheme Accepts HTTP",
+    "queryName": "Path Scheme Accepts HTTP (v2)",
     "severity": "MEDIUM",
     "line": 13,
     "filename": "positive1.json"
   },
   {
-    "queryName": "Path Scheme Accepts HTTP",
+    "queryName": "Path Scheme Accepts HTTP (v2)",
     "severity": "MEDIUM",
     "line": 11,
     "filename": "positive2.yaml"

--- a/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/path_scheme_accepts_http/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Path Scheme Accepts HTTP",
+    "severity": "MEDIUM",
+    "line": 13,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Path Scheme Accepts HTTP",
+    "severity": "MEDIUM",
+    "line": 11,
+    "filename": "positive2.yaml"
+  }
+]

--- a/assets/queries/openAPI/3.0/path_server_uses_http/metadata.json
+++ b/assets/queries/openAPI/3.0/path_server_uses_http/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "9670f240-7b4d-4955-bd93-edaa9fa38b58",
-  "queryName": "Path Server Object Uses HTTP",
+  "queryName": "Path Server Object Uses HTTP (v3)",
   "severity": "MEDIUM",
   "category": "Encryption",
   "descriptionText": "The property 'url' in the Path Server Object should only allow 'HTTPS' protocols to ensure an encrypted connection",

--- a/assets/queries/openAPI/3.0/path_server_uses_http/query.rego
+++ b/assets/queries/openAPI/3.0/path_server_uses_http/query.rego
@@ -4,7 +4,7 @@ import data.generic.openapi as openapi_lib
 
 CxPolicy[result] {
 	doc := input.document[i]
-	openapi_lib.check_openapi(doc) != "undefined"
+	openapi_lib.check_openapi(doc) == "3.0"
 	paths := doc.paths[path][oper].servers[n]
 
 	regex.match("^(http:)", paths.url)

--- a/assets/queries/openAPI/3.0/path_server_uses_http/test/positive_expected_result.json
+++ b/assets/queries/openAPI/3.0/path_server_uses_http/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
   {
-    "queryName": "Path Server Object Uses HTTP",
+    "queryName": "Path Server Object Uses HTTP (v3)",
     "severity": "MEDIUM",
     "line": 18,
     "filename": "positive1.json"
   },
   {
-    "queryName": "Path Server Object Uses HTTP",
+    "queryName": "Path Server Object Uses HTTP (v3)",
     "severity": "MEDIUM",
     "line": 15,
     "filename": "positive2.yaml"


### PR DESCRIPTION
Signed-off-by: Rafaela Soares <rafaela.soares@checkmarx.com>

**Proposed Changes**
- Added "Path Scheme Accepts HTTP" query to openAPI 2.0

I submit this contribution under the Apache-2.0 license.
