### PR TITLE
feat(query): added 'Security Definitions Undefined or Empty' to openAPI 2.0

### DIFF
--- a/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/metadata.json
+++ b/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "e3f026e8-fdb4-4d5a-bcfd-bd94452073fe",
+  "queryName": "Security Definitions Undefined or Empty",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "Security Definitions Object should be set and not empty",
+  "descriptionUrl": "https://swagger.io/specification/v2/#securityDefinitionsObject",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/query.rego
+++ b/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/query.rego
@@ -1,0 +1,26 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) == "2.0"
+
+	issueType := undefined_or_empty(doc)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": "swagger",
+		"issueType": issueType,
+		"keyExpectedValue": "'securityDefinitions' is set and not empty",
+		"keyActualValue": "'securityDefinitions' is undefined or empty",
+	}
+}
+
+undefined_or_empty(doc) = issueType {
+	object.get(doc, "securityDefinitions", "undefined") == "undefined"
+	issueType = "MissingAttribute"
+} else = issueType {
+	count(doc.securityDefinitions) == 0
+	issueType = "IncorrectValue"
+}

--- a/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/negative1.json
+++ b/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/negative1.json
@@ -1,0 +1,41 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "BasicAuth": {
+      "type": "basic"
+    },
+    "ApiKeyAuth": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "X-API-Key"
+    },
+    "OAuth2": {
+      "type": "oauth2",
+      "flow": "accessCode",
+      "authorizationUrl": "https://example.com/oauth/authorize",
+      "tokenUrl": "https://example.com/oauth/token",
+      "scopes": {
+        "read": "Grants read access",
+        "write": "Grants write access",
+        "admin": "Grants read and write access to administrative information"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/negative2.yaml
+++ b/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/negative2.yaml
@@ -1,0 +1,28 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+securityDefinitions:
+  BasicAuth:
+    type: basic
+  ApiKeyAuth:
+    type: apiKey
+    in: header
+    name: X-API-Key
+  OAuth2:
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: https://example.com/oauth/authorize
+    tokenUrl: https://example.com/oauth/token
+    scopes:
+      read: Grants read access
+      write: Grants write access
+      admin: Grants read and write access to administrative information

--- a/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/positive1.json
+++ b/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/positive1.json
@@ -1,0 +1,21 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {}
+}

--- a/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/positive2.yaml
+++ b/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/positive2.yaml
@@ -1,0 +1,13 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+securityDefinitions: {}

--- a/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/positive3.json
+++ b/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/positive3.json
@@ -1,0 +1,20 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/positive4.yaml
+++ b/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/positive4.yaml
@@ -1,0 +1,12 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response

--- a/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/security_definitions_undefined_or_empty/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Security Definitions Undefined or Empty",
+    "severity": "HIGH",
+    "line": 2,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Security Definitions Undefined or Empty",
+    "severity": "HIGH",
+    "line": 1,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Security Definitions Undefined or Empty",
+    "severity": "HIGH",
+    "line": 2,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Security Definitions Undefined or Empty",
+    "severity": "HIGH",
+    "line": 1,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares <rafaela.soares@checkmarx.com>

**Proposed Changes**
- Added 'Security Definitions Undefined or Empty' query to openAPI 2.0

I submit this contribution under the Apache-2.0 license.
