### PR TITLE
feat(query): Added Operation Object Without 'produces' (v2) query to OpenAPI 2.0

### DIFF
--- a/assets/queries/openAPI/2.0/operation_object_without_produces/metadata.json
+++ b/assets/queries/openAPI/2.0/operation_object_without_produces/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "be3e170e-1572-461e-a8b6-d963def581ec",
+  "queryName": "Operation Object Without 'produces' (v2)",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "Operation Object should have 'produces' feild defined for 'GET'operation",
+  "descriptionUrl": "https://swagger.io/specification/v2/#operation-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/2.0/operation_object_without_produces/metadata.json
+++ b/assets/queries/openAPI/2.0/operation_object_without_produces/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "be3e170e-1572-461e-a8b6-d963def581ec",
-  "queryName": "Operation Object Without 'produces' (v2)",
+  "queryName": "Operation Object Without 'produces'",
   "severity": "MEDIUM",
   "category": "Insecure Configurations",
   "descriptionText": "Operation Object should have 'produces' feild defined for 'GET'operation",

--- a/assets/queries/openAPI/2.0/operation_object_without_produces/query.rego
+++ b/assets/queries/openAPI/2.0/operation_object_without_produces/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) == "2.0"
+
+	op := doc.paths[path][operation]
+	operation == "get"
+	object.get(doc, "produces", "undefined") == "undefined"
+	object.get(op, "produces", "undefined") == "undefined"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.%s", [path, operation]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("paths.{{%s}}.%s 'produces' is defined", [path, operation]),
+		"keyActualValue": sprintf("paths.{{%s}}.%s 'produces' is missing", [path, operation]),
+	}
+}

--- a/assets/queries/openAPI/2.0/operation_object_without_produces/test/negative1.json
+++ b/assets/queries/openAPI/2.0/operation_object_without_produces/test/negative1.json
@@ -1,0 +1,57 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/definitions/User"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/limitParam"
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "limitParam": {
+      "name": "limit",
+      "in": "query",
+      "description": "max records to return",
+      "required": true,
+      "schema": {
+        "type": "integer"
+      }
+    }
+  },
+  "definitions": {
+    "User": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/operation_object_without_produces/test/negative2.yaml
+++ b/assets/queries/openAPI/2.0/operation_object_without_produces/test/negative2.yaml
@@ -1,0 +1,36 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      produces:
+        - application/json
+      responses:
+        "200":
+          "$ref": "#/definitions/User"
+      parameters:
+        - "$ref": "#/parameters/limitParam"
+parameters:
+  limitParam:
+    name: limit
+    in: query
+    description: max records to return
+    required: true
+    schema:
+      type: integer
+definitions:
+  User:
+    type: object
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string

--- a/assets/queries/openAPI/2.0/operation_object_without_produces/test/positive1.json
+++ b/assets/queries/openAPI/2.0/operation_object_without_produces/test/positive1.json
@@ -1,0 +1,54 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "$ref": "#/definitions/User"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/limitParam"
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "limitParam": {
+      "name": "limit",
+      "in": "query",
+      "description": "max records to return",
+      "required": true,
+      "schema": {
+        "type": "integer"
+      }
+    }
+  },
+  "definitions": {
+    "User": {
+      "type": "object",
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/operation_object_without_produces/test/positive2.yaml
+++ b/assets/queries/openAPI/2.0/operation_object_without_produces/test/positive2.yaml
@@ -1,0 +1,34 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          "$ref": "#/definitions/User"
+      parameters:
+        - "$ref": "#/parameters/limitParam"
+parameters:
+  limitParam:
+    name: limit
+    in: query
+    description: max records to return
+    required: true
+    schema:
+      type: integer
+definitions:
+  User:
+    type: object
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string

--- a/assets/queries/openAPI/2.0/operation_object_without_produces/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/operation_object_without_produces/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
   {
-    "queryName": "Operation Object Without 'produces' (v2)",
+    "queryName": "Operation Object Without 'produces'",
     "severity": "MEDIUM",
     "line": 9,
     "filename": "positive1.json"
   },
   {
-    "queryName": "Operation Object Without 'produces' (v2)",
+    "queryName": "Operation Object Without 'produces'",
     "severity": "MEDIUM",
     "line": 7,
     "filename": "positive2.yaml"

--- a/assets/queries/openAPI/2.0/operation_object_without_produces/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/operation_object_without_produces/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Operation Object Without 'produces' (v2)",
+    "severity": "MEDIUM",
+    "line": 9,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Operation Object Without 'produces' (v2)",
+    "severity": "MEDIUM",
+    "line": 7,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added Operation Object Without 'produces' (v2) query to OpenAPI 2.0

I submit this contribution under the Apache-2.0 license.
