### PR TITLE
Add "Neptune Cluster With IAM Database Authentication Disabled" query for Terraform and CloudFormation (Closes #3653)

### DIFF
--- a/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/metadata.json
+++ b/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a3aa0087-8228-4e7e-b202-dc9036972d02",
+  "queryName": "Neptune Cluster With IAM Database Authentication Disabled",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Neptune Cluster should have IAM Database Authentication enabled",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-neptune-dbcluster.html#cfn-neptune-dbcluster-iamauthenabled",
+  "platform": "CloudFormation"
+}

--- a/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/query.rego
+++ b/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/query.rego
@@ -1,0 +1,32 @@
+package Cx
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::Neptune::DBCluster"
+	properties := resource.Properties
+	properties.IamAuthEnabled == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.IamAuthEnabled", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.IamAuthEnabled is set to true", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.IamAuthEnabled is set to false", [name]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::Neptune::DBCluster"
+	properties := resource.Properties
+
+	object.get(properties, "IamAuthEnabled", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.IamAuthEnabled is set to true", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.IamAuthEnabled is undefined", [name]),
+	}
+}

--- a/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/test/negative1.yaml
+++ b/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/test/negative1.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: A sample template
+Resources:
+  NeptuneDBCluster3:
+    Type: AWS::Neptune::DBCluster
+    Properties:
+      IamAuthEnabled: true
+      StorageEncrypted: true

--- a/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/test/negative2.json
+++ b/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/test/negative2.json
@@ -1,0 +1,13 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
+  "Description": "A sample template",
+  "Resources": {
+    "NeptuneDBCluster3": {
+      "Type": "AWS::Neptune::DBCluster",
+      "Properties": {
+        "IamAuthEnabled": true,
+        "StorageEncrypted": true
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/test/positive1.yaml
+++ b/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/test/positive1.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: A sample template
+Resources:
+  NeptuneDBCluster:
+    Type: AWS::Neptune::DBCluster
+    Properties:
+      IamAuthEnabled: false
+      StorageEncrypted: true
+  NeptuneDBCluster2:
+    Type: AWS::Neptune::DBCluster
+    Properties:
+      IamAuthEnabled: false
+      StorageEncrypted: true

--- a/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/test/positive2.json
+++ b/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/test/positive2.json
@@ -1,0 +1,20 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
+  "Description": "A sample template",
+  "Resources": {
+    "NeptuneDBCluster": {
+      "Type": "AWS::Neptune::DBCluster",
+      "Properties": {
+        "IamAuthEnabled": false,
+        "StorageEncrypted": true
+      }
+    },
+    "NeptuneDBCluster2": {
+      "Type": "AWS::Neptune::DBCluster",
+      "Properties": {
+        "IamAuthEnabled": false,
+        "StorageEncrypted": true
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive1.yaml",
+    "queryName": "Neptune Cluster With IAM Database Authentication Disabled"
+  },
+  {
+    "severity": "MEDIUM",
+    "line": 12,
+    "fileName": "positive1.yaml",
+    "queryName": "Neptune Cluster With IAM Database Authentication Disabled"
+  },
+  {
+    "line": 8,
+    "fileName": "positive2.json",
+    "queryName": "Neptune Cluster With IAM Database Authentication Disabled",
+    "severity": "MEDIUM"
+  },
+  {
+    "line": 15,
+    "fileName": "positive2.json",
+    "queryName": "Neptune Cluster With IAM Database Authentication Disabled",
+    "severity": "MEDIUM"
+  }
+]

--- a/assets/queries/terraform/aws/neptune_cluster_with_iam_database_authentication_disabled/metadata.json
+++ b/assets/queries/terraform/aws/neptune_cluster_with_iam_database_authentication_disabled/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "c91d7ea0-d4d1-403b-8fe1-c9961ac082c5",
+  "queryName": "Neptune Cluster With IAM Database Authentication Disabled",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Neptune Cluster should have IAM Database Authentication enabled",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/neptune_cluster#storage_encrypted",
+  "platform": "Terraform"
+}

--- a/assets/queries/terraform/aws/neptune_cluster_with_iam_database_authentication_disabled/query.rego
+++ b/assets/queries/terraform/aws/neptune_cluster_with_iam_database_authentication_disabled/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+CxPolicy[result] {
+	password_policy := input.document[i].resource.aws_neptune_cluster[name]
+	object.get(password_policy, "iam_database_authentication_enabled", "undefined") == "undefined"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_neptune_cluster[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'iam_database_authentication_enabled' is set to true",
+		"keyActualValue": "'iam_database_authentication_enabled' is undefined",
+	}
+}
+
+CxPolicy[result] {
+	password_policy := input.document[i].resource.aws_neptune_cluster[name]
+	password_policy.iam_database_authentication_enabled == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_neptune_cluster[%s].iam_database_authentication_enabled", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'iam_database_authentication_enabled' is set to true",
+		"keyActualValue": "'iam_database_authentication_enabled' is set to false",
+	}
+}

--- a/assets/queries/terraform/aws/neptune_cluster_with_iam_database_authentication_disabled/test/negative.tf
+++ b/assets/queries/terraform/aws/neptune_cluster_with_iam_database_authentication_disabled/test/negative.tf
@@ -1,0 +1,10 @@
+resource "aws_neptune_cluster" "negative1" {
+  cluster_identifier                  = "neptune-cluster-demo"
+  engine                              = "neptune"
+  backup_retention_period             = 5
+  preferred_backup_window             = "07:00-09:00"
+  skip_final_snapshot                 = true
+  iam_database_authentication_enabled = true
+  apply_immediately                   = true
+  storage_encrypted                   = true
+}

--- a/assets/queries/terraform/aws/neptune_cluster_with_iam_database_authentication_disabled/test/positive.tf
+++ b/assets/queries/terraform/aws/neptune_cluster_with_iam_database_authentication_disabled/test/positive.tf
@@ -1,0 +1,20 @@
+resource "aws_neptune_cluster" "positive1" {
+  cluster_identifier                  = "neptune-cluster-demo"
+  engine                              = "neptune"
+  backup_retention_period             = 5
+  preferred_backup_window             = "07:00-09:00"
+  skip_final_snapshot                 = true
+  apply_immediately                   = true
+  storage_encrypted                   = true
+}
+
+resource "aws_neptune_cluster" "positive2" {
+  cluster_identifier                  = "neptune-cluster-demo"
+  engine                              = "neptune"
+  backup_retention_period             = 5
+  preferred_backup_window             = "07:00-09:00"
+  skip_final_snapshot                 = true
+  iam_database_authentication_enabled = false
+  apply_immediately                   = true
+  storage_encrypted                   = true
+}

--- a/assets/queries/terraform/aws/neptune_cluster_with_iam_database_authentication_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/neptune_cluster_with_iam_database_authentication_disabled/test/positive_expected_result.json
@@ -1,0 +1,12 @@
+[
+  {
+    "queryName": "Neptune Cluster With IAM Database Authentication Disabled",
+    "severity": "MEDIUM",
+    "line": 1
+  },
+  {
+    "queryName": "Neptune Cluster With IAM Database Authentication Disabled",
+    "severity": "MEDIUM",
+    "line": 17
+  }
+]


### PR DESCRIPTION
Closes #3653

**Proposed Changes**
- Added "Neptune Cluster With IAM Database Authentication Disabled" query for Terraform and CloudFormation (This query is relevant to ensure the use of the IAM service in database access)


I submit this contribution under the Apache-2.0 license.
