### PR TITLE
fix(CI): removing automated trigger to update install script workflow

### DIFF
--- a/.github/workflows/update-install-script.yaml
+++ b/.github/workflows/update-install-script.yaml
@@ -2,8 +2,6 @@ name: update-install-script
 
 on:
   workflow_dispatch:
-  release:
-    type: [created]
 
 jobs:
   update-install:


### PR DESCRIPTION
I submit this contribution under the Apache-2.0 license.
