### PR TITLE
feat(query): added Parameter File Type Not In 'formData' query for swagger

### DIFF
--- a/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/metadata.json
+++ b/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "c3cab8c4-6c52-47a9-942b-c27f26fbd7d2",
+  "queryName": "Parameter File Type Not In 'formData'",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "The In field of Parameter Object must be 'formData' when type is 'file'",
+  "descriptionUrl": "https://swagger.io/specification/v2/#parameterObject",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/query.rego
+++ b/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/query.rego
@@ -1,0 +1,23 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) == "2.0"
+
+	[path, value] := walk(doc)
+	param := value.parameters[n]
+	param.type == "file"
+	param.in != "formData"
+
+	searchKey := openapi_lib.concat_default_value(openapi_lib.concat_path(path), "parameters")
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.name=%s", [searchKey, param.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'schema' is set",
+		"keyActualValue": "'schema' is undefined",
+	}
+}

--- a/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/test/negative1.json
+++ b/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/test/negative1.json
@@ -1,0 +1,38 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "parameters": [
+          {
+            "name": "limit2",
+            "in": "formData",
+            "description": "return a file with limit info",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "operationId": "listVersionsV2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "limitParam": {
+      "name": "limit",
+      "in": "formData",
+      "description": "return a file with limit info",
+      "required": true,
+      "type": "file"
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/test/negative2.yaml
+++ b/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/test/negative2.yaml
@@ -1,0 +1,25 @@
+swagger: '2.0'
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      parameters:
+      - name: limit2
+        in: formData
+        description: return a file with limit info
+        required: true
+        type: file
+      operationId: listVersionsV2
+      summary: List API versions
+      responses:
+        '200':
+          description: 200 response
+parameters:
+  limitParam:
+    name: limit
+    in: formData
+    description: return a file with limit info
+    required: true
+    type: file

--- a/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/test/positive1.json
+++ b/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/test/positive1.json
@@ -1,0 +1,38 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "parameters": [
+          {
+            "name": "limit2",
+            "in": "query",
+            "description": "return a file with limit info",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "operationId": "listVersionsV2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "limitParam": {
+      "name": "limit",
+      "in": "query",
+      "description": "return a file with limit info",
+      "required": true,
+      "type": "file"
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/test/positive2.yaml
+++ b/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/test/positive2.yaml
@@ -1,0 +1,26 @@
+---
+swagger: '2.0'
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      parameters:
+      - name: limit2
+        in: query
+        description: return a file with limit info
+        required: true
+        type: file
+      operationId: listVersionsV2
+      summary: List API versions
+      responses:
+        '200':
+          description: 200 response
+parameters:
+  limitParam:
+    name: limit
+    in: query
+    description: return a file with limit info
+    required: true
+    type: file

--- a/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/parameter_file_type_not_in_formdata/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Parameter File Type Not In 'formData'",
+    "severity": "INFO",
+    "line": 12,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameter File Type Not In 'formData'",
+    "severity": "INFO",
+    "line": 10,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Parameter File Type Not In 'formData'",
+    "severity": "INFO",
+    "line": 31,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Parameter File Type Not In 'formData'",
+    "severity": "INFO",
+    "line": 22,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Added Parameter File Type Not In 'formData' query for swagger

I submit this contribution under the Apache-2.0 license.
