### PR TITLE
feat(query): added 'Schema with 'additionalProperties' set as Boolean' for swagger

### DIFF
--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/metadata.json
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Schema with 'additionalProperties' set as Boolean",
   "severity": "INFO",
   "category": "Best Practices",
-  "descriptionText": "The value of 'additionalProperties' should be set as object instead of boolean since openAPI 2.0 does not support boolean value for it",
+  "descriptionText": "The value of 'additionalProperties' should be set as object instead of boolean, since swagger 2.0 does not support boolean value for it",
   "descriptionUrl": "https://swagger.io/specification/v2/#schema-object",
   "platform": "OpenAPI"
 }

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/metadata.json
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "3a01790c-ebee-4da6-8fd3-e78657383b75",
+  "queryName": "Schema with 'additionalProperties' set as Boolean",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "The value of 'additionalProperties' should be set as object instead of boolean since openAPI 2.0 does not support boolean value for it",
+  "descriptionUrl": "https://swagger.io/specification/v2/#schema-object",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/query.rego
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/query.rego
@@ -1,0 +1,35 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) == "2.0"
+
+	[path, value] := walk(doc)
+	is_boolean(value.schema.additionalProperties)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.schema.additionalProperties", [openapi_lib.concat_path(path)]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'additionalProperties' is not set as a boolean value",
+		"keyActualValue": "'additionalProperties' is set as a boolean value",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) == "2.0"
+
+	schema := doc.definitions[s]
+	is_boolean(schema.additionalProperties)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("definitions.{{%s}}.additionalProperties", [s]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'additionalProperties' is not set as a boolean value",
+		"keyActualValue": "'additionalProperties' is set as a boolean value",
+	}
+}

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/query.rego
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/query.rego
@@ -7,13 +7,13 @@ CxPolicy[result] {
 	openapi_lib.check_openapi(doc) == "2.0"
 
 	[path, value] := walk(doc)
-	is_boolean(value.schema.additionalProperties)
+	is_boolean(value.additionalProperties)
 
 	result := {
 		"documentId": doc.id,
-		"searchKey": sprintf("%s.schema.additionalProperties", [openapi_lib.concat_path(path)]),
+		"searchKey": sprintf("%s.additionalProperties", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "'additionalProperties' is not set as a boolean value",
-		"keyActualValue": "'additionalProperties' is set as a boolean value",
+		"keyActualValue": "'additionalProperties' is set as an object value",
 	}
 }

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/query.rego
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("%s.additionalProperties", [openapi_lib.concat_path(path)]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'additionalProperties' is not set as a boolean value",
-		"keyActualValue": "'additionalProperties' is set as an object value",
+		"keyExpectedValue": "'additionalProperties' is set as an object value",
+		"keyActualValue": "'additionalProperties' is set as a boolean value",
 	}
 }

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/query.rego
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/query.rego
@@ -17,19 +17,3 @@ CxPolicy[result] {
 		"keyActualValue": "'additionalProperties' is set as a boolean value",
 	}
 }
-
-CxPolicy[result] {
-	doc := input.document[i]
-	openapi_lib.check_openapi(doc) == "2.0"
-
-	schema := doc.definitions[s]
-	is_boolean(schema.additionalProperties)
-
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("definitions.{{%s}}.additionalProperties", [s]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'additionalProperties' is not set as a boolean value",
-		"keyActualValue": "'additionalProperties' is set as a boolean value",
-	}
-}

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/negative1.json
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/negative1.json
@@ -1,0 +1,53 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "User": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/negative2.yaml
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/negative2.yaml
@@ -1,0 +1,33 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              tag:
+                type: string
+            required:
+              - name
+            additionalProperties:
+              $ref: "#/definitions/User"
+definitions:
+  User:
+    type: object
+    properties:
+      name:
+        type: string
+      tag:
+        type: string
+    required:
+      - name

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/negative3.json
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/negative3.json
@@ -1,0 +1,56 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "User": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/negative4.yaml
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/negative4.yaml
@@ -1,0 +1,35 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              tag:
+                type: string
+            required:
+              - name
+            additionalProperties:
+              $ref: "#/definitions/User"
+definitions:
+  User:
+    type: object
+    properties:
+      name:
+        type: string
+      tag:
+        type: string
+    required:
+      - name
+    additionalProperties:
+      type: string

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive1.json
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive1.json
@@ -1,0 +1,35 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive2.yaml
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive2.yaml
@@ -1,0 +1,32 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              tag:
+                type: string
+            required:
+              - name
+            additionalProperties: false
+definitions:
+  User:
+    type: object
+    properties:
+      name:
+        type: string
+      tag:
+        type: string
+    required:
+      - name

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive3.json
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive3.json
@@ -1,0 +1,54 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "tag": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "User": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive4.yaml
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive4.yaml
@@ -1,0 +1,34 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              tag:
+                type: string
+            required:
+              - name
+            additionalProperties:
+              $ref: "#/definitions/User"
+definitions:
+  User:
+    type: object
+    properties:
+      name:
+        type: string
+      tag:
+        type: string
+    required:
+      - name
+    additionalProperties: false

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Schema with 'additionalProperties' set as Boolean",
+    "severity": "INFO",
+    "line": 28,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schema with 'additionalProperties' set as Boolean",
+    "severity": "INFO",
+    "line": 22,
+    "filename": "positive2.yaml"
+  }
+]

--- a/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/schema_with_additional_properties_set_as_boolean/test/positive_expected_result.json
@@ -10,5 +10,17 @@
     "severity": "INFO",
     "line": 22,
     "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Schema with 'additionalProperties' set as Boolean",
+    "severity": "INFO",
+    "line": 51,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "Schema with 'additionalProperties' set as Boolean",
+    "severity": "INFO",
+    "line": 34,
+    "filename": "positive4.yaml"
   }
 ]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares <rafaela.soares@checkmarx.com>

**Proposed Changes**
- Added 'Schema with 'additionalProperties' set as Boolean' for openAPI 2.0

I submit this contribution under the Apache-2.0 license.
