### PR TITLE
feat(query): added Multiple Body Parameters In The Same Operation query for swagger

### DIFF
--- a/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/metadata.json
+++ b/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b90033cf-ad9f-4fb9-acd1-1b9d6d278c87",
+  "queryName": "Multiple Body Parameters In The Same Operation",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "Only one body parameter is allowed on operation's parameters type field",
+  "descriptionUrl": "https://swagger.io/specification/v2/#parameterObject",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/query.rego
+++ b/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) == "2.0"
+
+	op := doc.paths[path][operation]
+	bodyParameters := [x | p := op.parameters[_]; p.in == "body"; x := p]
+	count(bodyParameters) > 1
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("paths.{{%s}}.%s.parameters", [path, operation]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Operation's parameters should have just one body type parameter",
+		"keyActualValue": "Operation's parameters has more than one body type parameter",
+	}
+}

--- a/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/negative1.json
+++ b/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/negative1.json
@@ -9,9 +9,18 @@
       "get": {
         "parameters": [
           {
-            "name": "limit2",
+            "name": "limit",
             "in": "body",
             "description": "max records to return",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageCount",
+            "in": "query",
+            "description": "records per page",
             "required": true,
             "schema": {
               "type": "integer"

--- a/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/negative1.json
+++ b/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/negative1.json
@@ -1,0 +1,31 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "parameters": [
+          {
+            "name": "limit2",
+            "in": "body",
+            "description": "max records to return",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/negative2.yaml
+++ b/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/negative2.yaml
@@ -6,9 +6,15 @@ paths:
   "/":
     get:
       parameters:
-      - name: limit2
+      - name: limit
         in: body
         description: max records to return
+        required: true
+        schema:
+          type: integer
+      - name: pageCount
+        in: query
+        description: records per page
         required: true
         schema:
           type: integer

--- a/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/negative2.yaml
+++ b/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/negative2.yaml
@@ -1,0 +1,19 @@
+swagger: '2.0'
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      parameters:
+      - name: limit2
+        in: body
+        description: max records to return
+        required: true
+        schema:
+          type: integer
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: 200 response

--- a/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/positive1.json
+++ b/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/positive1.json
@@ -1,0 +1,40 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "body",
+            "description": "max records to return",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit2",
+            "in": "body",
+            "description": "max records to return",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/positive2.yaml
+++ b/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/positive2.yaml
@@ -1,0 +1,25 @@
+swagger: '2.0'
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      parameters:
+      - name: limit
+        in: body
+        description: max records to return
+        required: true
+        schema:
+          type: integer
+      - name: limit2
+        in: body
+        description: max records to return
+        required: true
+        schema:
+          type: string
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: 200 response

--- a/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/multi_body_parameters_same_operation/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Multiple Body Parameters In The Same Operation",
+    "severity": "INFO",
+    "line": 10,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Multiple Body Parameters In The Same Operation",
+    "severity": "INFO",
+    "line": 8,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Added Multiple Body Parameters In The Same Operation query for swagger

I submit this contribution under the Apache-2.0 license.
