### PR TITLE
feat(query): Added BasePath With Wrong Format query to Swagger

### DIFF
--- a/assets/queries/openAPI/2.0/basepath_with_wrong_format/metadata.json
+++ b/assets/queries/openAPI/2.0/basepath_with_wrong_format/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "b4803607-ed72-4d60-99e2-3fa6edf471c6",
+  "queryName": "BasePath With Wrong Format",
+  "severity": "INFO",
+  "category": "Structure and Semantics",
+  "descriptionText": "The 'basePath' value format must match the pattern '^/'",
+  "descriptionUrl": "https://swagger.io/specification/v2/#schema",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/2.0/basepath_with_wrong_format/query.rego
+++ b/assets/queries/openAPI/2.0/basepath_with_wrong_format/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) == "2.0"
+
+	not regex.match("^/", doc.basePath)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("basePath={{%s}}", [doc.basePath]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'basePath' value format matches the pattern '^/'",
+		"keyActualValue": "'basePath' value format doesn't match the pattern '^/'",
+	}
+}

--- a/assets/queries/openAPI/2.0/basepath_with_wrong_format/query.rego
+++ b/assets/queries/openAPI/2.0/basepath_with_wrong_format/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("basePath={{%s}}", [doc.basePath]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'basePath' value format matches the pattern '^/'",
-		"keyActualValue": "'basePath' value format doesn't match the pattern '^/'",
+		"keyExpectedValue": "'basePath' value matches the pattern '^/'",
+		"keyActualValue": "'basePath' value doesn't match the pattern '^/'",
 	}
 }

--- a/assets/queries/openAPI/2.0/basepath_with_wrong_format/test/negative1.json
+++ b/assets/queries/openAPI/2.0/basepath_with_wrong_format/test/negative1.json
@@ -1,0 +1,43 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "basePath": "/api",
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "limit2",
+            "in": "body",
+            "description": "max records to return",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "limitParam": {
+      "name": "limit",
+      "in": "body",
+      "description": "max records to return",
+      "required": true,
+      "schema": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/basepath_with_wrong_format/test/negative2.yaml
+++ b/assets/queries/openAPI/2.0/basepath_with_wrong_format/test/negative2.yaml
@@ -1,0 +1,28 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+basePath: "/api"
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+      parameters:
+        - name: limit2
+          in: body
+          description: max records to return
+          required: true
+          schema:
+            type: object
+parameters:
+  limitParam:
+    name: limit
+    in: body
+    description: max records to return
+    required: true
+    schema:
+      type: object

--- a/assets/queries/openAPI/2.0/basepath_with_wrong_format/test/positive1.json
+++ b/assets/queries/openAPI/2.0/basepath_with_wrong_format/test/positive1.json
@@ -1,0 +1,43 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0"
+  },
+  "basePath": "api/incorrect",
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "limit2",
+            "in": "body",
+            "description": "max records to return",
+            "required": true,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {
+    "limitParam": {
+      "name": "limit",
+      "in": "body",
+      "description": "max records to return",
+      "required": true,
+      "schema": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/basepath_with_wrong_format/test/positive2.yaml
+++ b/assets/queries/openAPI/2.0/basepath_with_wrong_format/test/positive2.yaml
@@ -1,0 +1,28 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+basePath: "api/incorrect"
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+      parameters:
+        - name: limit2
+          in: body
+          description: max records to return
+          required: true
+          schema:
+            type: object
+parameters:
+  limitParam:
+    name: limit
+    in: body
+    description: max records to return
+    required: true
+    schema:
+      type: object

--- a/assets/queries/openAPI/2.0/basepath_with_wrong_format/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/basepath_with_wrong_format/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "BasePath With Wrong Format",
+    "severity": "INFO",
+    "line": 7,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "BasePath With Wrong Format",
+    "severity": "INFO",
+    "line": 5,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>


**Proposed Changes**
- Added BasePath With Wrong Format query to Swagger

The 'basePath' value format must match the pattern '^/'

I submit this contribution under the Apache-2.0 license.
