### PR TITLE
fix(query): wrong logic in apt-get install lists not deleted

### DIFF
--- a/assets/queries/dockerfile/apt_get_install_lists_were_not_deleted/query.rego
+++ b/assets/queries/dockerfile/apt_get_install_lists_were_not_deleted/query.rego
@@ -23,13 +23,14 @@ hasClean(resourceValue, aptGet) {
 	listCommands := split(resourceValue, "&& ")
 
 	startswith(listCommands[install], aptGet)
-
-	some clean
 	startswith(listCommands[clean], "apt-get clean")
 
-	some remove
+	install < clean
+} else {
+	listCommands := split(resourceValue, "&& ")
+
+	startswith(listCommands[install], aptGet)
 	startswith(listCommands[remove], "rm -rf")
 
-	install < clean
-	clean < remove
+	install < remove
 }

--- a/assets/queries/dockerfile/apt_get_install_lists_were_not_deleted/test/negative.dockerfile
+++ b/assets/queries/dockerfile/apt_get_install_lists_were_not_deleted/test/negative.dockerfile
@@ -1,4 +1,15 @@
-FROM busybox
+FROM busyboxneg1
 RUN apt-get update && apt-get install --no-install-recommends -y python \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+FROM busyboxneg2
+RUN apt-get update && apt-get install --no-install-recommends -y python && apt-get clean
+
+FROM busyboxneg3
+RUN apt-get update && apt-get install --no-install-recommends -y python \
+  && apt-get clean
+
+FROM busyboxneg4
+RUN apt-get update && apt-get install --no-install-recommends -y python \
+  && rm -rf /var/lib/apt/lists/*

--- a/assets/queries/dockerfile/apt_get_install_lists_were_not_deleted/test/positive.dockerfile
+++ b/assets/queries/dockerfile/apt_get_install_lists_were_not_deleted/test/positive.dockerfile
@@ -5,22 +5,10 @@ FROM busybox2
 RUN apt-get install python
 
 FROM busybox3
-RUN apt-get update && apt-get install --no-install-recommends -y python \
-    && apt-get clean
-
-FROM busybox4
-RUN apt-get update && apt-get install --no-install-recommends -y python \
-    && rm -rf /var/lib/apt/lists/*
-
-FROM busybox5
-RUN apt-get update && apt-get install --no-install-recommends -y python
-RUN apt-get clean
-
-FROM busybox6
 RUN apt-get update && apt-get install --no-install-recommends -y python
 RUN rm -rf /var/lib/apt/lists/*
 
-FROM busybox7
+FROM busybox4
 RUN apt-get update && apt-get install --no-install-recommends -y python
 RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get clean

--- a/assets/queries/dockerfile/apt_get_install_lists_were_not_deleted/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/apt_get_install_lists_were_not_deleted/test/positive_expected_result.json
@@ -1,37 +1,22 @@
 [
-	{
-		"queryName": "Apt Get Install Lists Were Not Deleted",
-		"severity": "INFO",
-		"line": 2
-	},
-	{
-		"queryName": "Apt Get Install Lists Were Not Deleted",
-		"severity": "INFO",
-		"line": 5
-	},
-	{
-		"queryName": "Apt Get Install Lists Were Not Deleted",
-		"severity": "INFO",
-		"line": 8
-	},
-	{
-		"queryName": "Apt Get Install Lists Were Not Deleted",
-		"severity": "INFO",
-		"line": 12
-	},
-	{
-		"queryName": "Apt Get Install Lists Were Not Deleted",
-		"severity": "INFO",
-		"line": 16
-	},
-	{
-		"queryName": "Apt Get Install Lists Were Not Deleted",
-		"severity": "INFO",
-		"line": 20
-	},
-	{
-		"queryName": "Apt Get Install Lists Were Not Deleted",
-		"severity": "INFO",
-		"line": 24
-	}
+  {
+    "queryName": "Apt Get Install Lists Were Not Deleted",
+    "severity": "INFO",
+    "line": 2
+  },
+  {
+    "queryName": "Apt Get Install Lists Were Not Deleted",
+    "severity": "INFO",
+    "line": 5
+  },
+  {
+    "queryName": "Apt Get Install Lists Were Not Deleted",
+    "severity": "INFO",
+    "line": 8
+  },
+  {
+    "queryName": "Apt Get Install Lists Were Not Deleted",
+    "severity": "INFO",
+    "line": 12
+  }
 ]


### PR DESCRIPTION
Closes #3717

**Proposed Changes**
- fixing false positive by replacing logical operator in `rm -rf /var/lib/apt/lists/*` AND `apt-get clean` check for `rm -rf /var/lib/apt/lists/*` OR `apt-get clean` after `apt-get install`

I submit this contribution under the Apache-2.0 license.
