### PR TITLE
feat(query): add Schemes Uses HTTP query for Swagger

### DIFF
--- a/assets/queries/openAPI/2.0/schemes_uses_http copy/metadata.json
+++ b/assets/queries/openAPI/2.0/schemes_uses_http copy/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "a46928f1-43d7-4671-94e0-2dd99746f389",
+  "queryName": "Schemes Uses HTTP",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "Schemes should use 'https' protocol instead of 'http'. Scheme using 'http' allows for clear text credentials",
+  "descriptionUrl": "https://swagger.io/specification/v2/#swaggerObject",
+  "platform": "OpenAPI"
+}

--- a/assets/queries/openAPI/2.0/schemes_uses_http copy/query.rego
+++ b/assets/queries/openAPI/2.0/schemes_uses_http copy/query.rego
@@ -1,0 +1,21 @@
+package Cx
+
+import data.generic.openapi as openapi_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	openapi_lib.check_openapi(doc) == "2.0"
+
+	[path, value] := walk(doc)
+	count(path) > 0
+
+	value.schemes[_] == "http"
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("%s.schemes.http", [openapi_lib.concat_path(path)]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "The Scheme list uses only 'HTTPS' protocol",
+		"keyActualValue": "The Scheme list uses 'HTTP' protocol",
+	}
+}

--- a/assets/queries/openAPI/2.0/schemes_uses_http copy/test/negative1.json
+++ b/assets/queries/openAPI/2.0/schemes_uses_http copy/test/negative1.json
@@ -1,0 +1,23 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "schemes": [
+          "https"
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/schemes_uses_http copy/test/negative2.yaml
+++ b/assets/queries/openAPI/2.0/schemes_uses_http copy/test/negative2.yaml
@@ -1,0 +1,14 @@
+swagger: "2.0"
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      schemes:
+        - https
+      responses:
+        "200":
+          description: 200 response

--- a/assets/queries/openAPI/2.0/schemes_uses_http copy/test/positive1.json
+++ b/assets/queries/openAPI/2.0/schemes_uses_http copy/test/positive1.json
@@ -1,0 +1,23 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API overview",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "schemes": [
+          "http"
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response"
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/2.0/schemes_uses_http copy/test/positive2.yaml
+++ b/assets/queries/openAPI/2.0/schemes_uses_http copy/test/positive2.yaml
@@ -1,0 +1,14 @@
+swagger: "2.0"
+info:
+  title: Simple API overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      schemes:
+        - http
+      responses:
+        "200":
+          description: 200 response

--- a/assets/queries/openAPI/2.0/schemes_uses_http copy/test/positive_expected_result.json
+++ b/assets/queries/openAPI/2.0/schemes_uses_http copy/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Schemes Uses HTTP",
+    "severity": "MEDIUM",
+    "line": 13,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "Schemes Uses HTTP",
+    "severity": "MEDIUM",
+    "line": 11,
+    "filename": "positive2.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added Schemes Uses HTTP query for Swagger

Schemes should use 'https' protocol instead of 'http'. A scheme using 'http' allows for clear text credentials

I submit this contribution under the Apache-2.0 license.
