### PR TITLE
test(e2e): add schema validation for gl-sast & sarif results/reports

### DIFF
--- a/e2e/fixtures/E2E_CLI_032_RESULT.json
+++ b/e2e/fixtures/E2E_CLI_032_RESULT.json
@@ -1,100 +1,243 @@
 {
-  "files_scanned": 1,
-  "files_parsed": 1,
-  "files_failed_to_scan": 0,
-  "queries_total": 0,
-  "queries_failed_to_execute": 0,
-  "queries_failed_to_compute_similarity_id": 0,
-  "queries": [
-    {
-      "query_name": "Redshift Cluster Logging Disabled",
-      "query_id": "15ffbacc-fa42-4f6f-a57d-2feac7365caa",
-      "query_url": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#enable",
-      "severity": "MEDIUM",
-      "platform": "Terraform",
-      "files": [
-        {
-          "file_name": "file",
-          "similarity_id": "2abf26c3014fc445da69d8d5bb862c1c511e8e16ad3a6c6f6e14c28aa0adac1d",
-          "line": 1,
-          "issue_type": "MissingAttribute",
-          "search_key": "aws_redshift_cluster[default1]",
-          "search_value": "",
-          "expected_value": "'aws_redshift_cluster.logging' is true",
-          "actual_value": "'aws_redshift_cluster.logging' is undefined",
-          "value": null
-        }
-      ],
-      "category": "Observability",
-      "description": "Make sure Logging is enabled for Redshift Cluster"
-    },
-    {
-      "query_name": "Redshift Cluster Without VPC",
-      "query_id": "0a494a6a-ebe2-48a0-9d77-cf9d5125e1b3",
-      "query_url": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#vpc_security_group_ids",
-      "severity": "MEDIUM",
-      "platform": "Terraform",
-      "files": [
-        {
-          "file_name": "file",
-          "similarity_id": "d1c5f6aec84fd91ed24f5f06ccb8b6662e26c0202bcb5d4a58a1458c16456d20",
-          "line": 1,
-          "issue_type": "MissingAttribute",
-          "search_key": "aws_redshift_cluster[default1]",
-          "search_value": "",
-          "expected_value": "aws_redshift_cluster[default1].cluster_subnet_group_name is set",
-          "actual_value": "aws_redshift_cluster[default1].cluster_subnet_group_name is undefined",
-          "value": null
-        },
-        {
-          "file_name": "file",
-          "similarity_id": "d1c5f6aec84fd91ed24f5f06ccb8b6662e26c0202bcb5d4a58a1458c16456d20",
-          "line": 1,
-          "issue_type": "MissingAttribute",
-          "search_key": "aws_redshift_cluster[default1]",
-          "search_value": "",
-          "expected_value": "aws_redshift_cluster[default1].vpc_security_group_ids is set",
-          "actual_value": "aws_redshift_cluster[default1].vpc_security_group_ids is undefined",
-          "value": null
-        }
-      ],
-      "category": "Insecure Configurations",
-      "description": "Redshift Cluster should be configured in VPC (Virtual Private Cloud)"
-    },
-    {
-      "query_name": "Resource Not Using Tags",
-      "query_id": "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
-      "query_url": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging",
-      "severity": "INFO",
-      "platform": "Terraform",
-      "files": [
-        {
-          "file_name": "file",
-          "similarity_id": "406b71d9fd0edb656a4735df30dde77c5f8a6c4ec3caa3442f986a92832c653b",
-          "line": 1,
-          "issue_type": "MissingAttribute",
-          "search_key": "aws_redshift_cluster[{{default1}}]",
-          "search_value": "",
-          "expected_value": "aws_redshift_cluster[{{default1}}].tags is defined",
-          "actual_value": "aws_redshift_cluster[{{default1}}].tags is missing",
-          "value": null
-        }
-      ],
-      "category": "Best Practices",
-      "description": "AWS services resource tags are an essential part of managing components"
-    }
-  ],
-  "scan_id": "console",
-  "severity_counters": {
-    "HIGH": 0,
-    "INFO": 1,
-    "LOW": 0,
-    "MEDIUM": 3
-  },
-  "total_counter": 4,
-  "start": "2021-05-01T09:00:00.0+01:00",
-  "end": "2021-05-01T09:00:00.0+01:00",
-  "paths": [
-    "fixtures/samples/terraform-single.tf"
-  ]
+	"files_scanned": 1,
+	"files_parsed": 1,
+	"files_failed_to_scan": 0,
+	"queries_total": 579,
+	"queries_failed_to_execute": 0,
+	"queries_failed_to_compute_similarity_id": 0,
+	"queries": [
+		{
+			"query_name": "Passwords And Secrets In Infrastructure Code",
+			"query_id": "f996f3cb-00fc-480c-8973-8ab04d44a8cc",
+			"query_url": "https://kics.io/",
+			"severity": "HIGH",
+			"platform": "Common",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "ad5ddbe84fe54d121c8ef856217e0184958db4bf4c4e472f99c31718427b9053",
+					"line": 14,
+					"issue_type": "RedundantAttribute",
+					"search_key": "resource.aws_redshift_cluster.default1.master_password",
+					"search_value": "",
+					"expected_value": "Hardcoded secret key should not appear in source",
+					"actual_value": "Mustbe8characters",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "5f3789ae5dac05a64bba584fe201f769786cdaa5a8b7a32aaa057476c65535e2",
+					"line": 5,
+					"issue_type": "RedundantAttribute",
+					"search_key": "resource.aws_redshift_cluster.default.master_password",
+					"search_value": "",
+					"expected_value": "Hardcoded secret key should not appear in source",
+					"actual_value": "Mustbe8characters",
+					"value": null
+				}
+			],
+			"category": "Secret Management",
+			"description": "Query to find passwords and secrets in infrastructure code."
+		},
+		{
+			"query_name": "Redshift Not Encrypted",
+			"query_id": "cfdcabb0-fc06-427c-865b-c59f13e898ce",
+			"query_url": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#encrypted",
+			"severity": "HIGH",
+			"platform": "Terraform",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "e413b091a0cfff9b692ce5d9fa075e3f69e037a58030e9ef592d5f58ae446fbc",
+					"line": 1,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[default]",
+					"search_value": "",
+					"expected_value": "aws_redshift_cluster.encrypted is defined",
+					"actual_value": "aws_redshift_cluster.encrypted is undefined",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "a09d6aefe0fec02ce6b1b30afb3186c7fa4454165a4a1754ed104d22d6156af7",
+					"line": 10,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[default1]",
+					"search_value": "",
+					"expected_value": "aws_redshift_cluster.encrypted is defined",
+					"actual_value": "aws_redshift_cluster.encrypted is undefined",
+					"value": null
+				}
+			],
+			"category": "Encryption",
+			"description": "Check if 'encrypted' field is false or undefined (default is false)"
+		},
+		{
+			"query_name": "Redshift Publicly Accessible",
+			"query_id": "af173fde-95ea-4584-b904-bb3923ac4bda",
+			"query_url": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster",
+			"severity": "HIGH",
+			"platform": "Terraform",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "4234052fbe1fed19a465cec7fbed9eb156c22eeae7d97c3ac8096bcc7b39a2fe",
+					"line": 1,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[default]",
+					"search_value": "",
+					"expected_value": "aws_redshift_cluster.publicly_accessible is defined",
+					"actual_value": "aws_redshift_cluster.publicly_accessible is undefined",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "7ae2741fb3c480c38776368fbe21412672c6458d490e4648eb1ad1aadc24a741",
+					"line": 17,
+					"issue_type": "IncorrectValue",
+					"search_key": "aws_redshift_cluster[default1].publicly_accessible",
+					"search_value": "",
+					"expected_value": "aws_redshift_cluster.publicly_accessible is false",
+					"actual_value": "aws_redshift_cluster.publicly_accessible is true",
+					"value": null
+				}
+			],
+			"category": "Insecure Configurations",
+			"description": "Check if 'publicly_accessible' field is true or undefined (default is true)"
+		},
+		{
+			"query_name": "Redshift Cluster Logging Disabled",
+			"query_id": "15ffbacc-fa42-4f6f-a57d-2feac7365caa",
+			"query_url": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#enable",
+			"severity": "MEDIUM",
+			"platform": "Terraform",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "2abf26c3014fc445da69d8d5bb862c1c511e8e16ad3a6c6f6e14c28aa0adac1d",
+					"line": 10,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[default1]",
+					"search_value": "",
+					"expected_value": "'aws_redshift_cluster.logging' is true",
+					"actual_value": "'aws_redshift_cluster.logging' is undefined",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "0455ad9d92fa1dc1cbf20dd5042ee21d9ae176388662b5982501aa01724e50d9",
+					"line": 1,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[default]",
+					"search_value": "",
+					"expected_value": "'aws_redshift_cluster.logging' is true",
+					"actual_value": "'aws_redshift_cluster.logging' is undefined",
+					"value": null
+				}
+			],
+			"category": "Observability",
+			"description": "Make sure Logging is enabled for Redshift Cluster"
+		},
+		{
+			"query_name": "Redshift Cluster Without VPC",
+			"query_id": "0a494a6a-ebe2-48a0-9d77-cf9d5125e1b3",
+			"query_url": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#vpc_security_group_ids",
+			"severity": "MEDIUM",
+			"platform": "Terraform",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "e4d7e3bd4992042d27482311989d6224a553385eb5bcc0988c90c1c10bd99e8c",
+					"line": 1,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[default]",
+					"search_value": "",
+					"expected_value": "aws_redshift_cluster[default].cluster_subnet_group_name is set",
+					"actual_value": "aws_redshift_cluster[default].cluster_subnet_group_name is undefined",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "e4d7e3bd4992042d27482311989d6224a553385eb5bcc0988c90c1c10bd99e8c",
+					"line": 1,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[default]",
+					"search_value": "",
+					"expected_value": "aws_redshift_cluster[default].vpc_security_group_ids is set",
+					"actual_value": "aws_redshift_cluster[default].vpc_security_group_ids is undefined",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "d1c5f6aec84fd91ed24f5f06ccb8b6662e26c0202bcb5d4a58a1458c16456d20",
+					"line": 10,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[default1]",
+					"search_value": "",
+					"expected_value": "aws_redshift_cluster[default1].cluster_subnet_group_name is set",
+					"actual_value": "aws_redshift_cluster[default1].cluster_subnet_group_name is undefined",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "d1c5f6aec84fd91ed24f5f06ccb8b6662e26c0202bcb5d4a58a1458c16456d20",
+					"line": 10,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[default1]",
+					"search_value": "",
+					"expected_value": "aws_redshift_cluster[default1].vpc_security_group_ids is set",
+					"actual_value": "aws_redshift_cluster[default1].vpc_security_group_ids is undefined",
+					"value": null
+				}
+			],
+			"category": "Insecure Configurations",
+			"description": "Redshift Cluster should be configured in VPC (Virtual Private Cloud)"
+		},
+		{
+			"query_name": "Resource Not Using Tags",
+			"query_id": "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
+			"query_url": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging",
+			"severity": "INFO",
+			"platform": "Terraform",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "406b71d9fd0edb656a4735df30dde77c5f8a6c4ec3caa3442f986a92832c653b",
+					"line": 10,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[{{default1}}]",
+					"search_value": "",
+					"expected_value": "aws_redshift_cluster[{{default1}}].tags is defined",
+					"actual_value": "aws_redshift_cluster[{{default1}}].tags is missing",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\terraform.tf",
+					"similarity_id": "b44463ffd0f5c1eadc04ce6649982da68658349ad880daef470250661d3d1512",
+					"line": 1,
+					"issue_type": "MissingAttribute",
+					"search_key": "aws_redshift_cluster[{{default}}]",
+					"search_value": "",
+					"expected_value": "aws_redshift_cluster[{{default}}].tags is defined",
+					"actual_value": "aws_redshift_cluster[{{default}}].tags is missing",
+					"value": null
+				}
+			],
+			"category": "Best Practices",
+			"description": "AWS services resource tags are an essential part of managing components"
+		}
+	],
+	"scan_id": "console",
+	"severity_counters": {
+		"HIGH": 6,
+		"INFO": 2,
+		"LOW": 0,
+		"MEDIUM": 6
+	},
+	"total_counter": 14,
+	"start": "2021-06-23T18:46:23.0440648+01:00",
+	"end": "2021-06-23T18:46:32.7134865+01:00",
+	"paths": [
+		"fixtures/samples/terraform.tf"
+	]
 }

--- a/e2e/fixtures/schemas/result-gl-sast.json
+++ b/e2e/fixtures/schemas/result-gl-sast.json
@@ -1,0 +1,220 @@
+{
+    "type": "object",
+    "required": [
+        "schema",
+        "version",
+        "scan",
+        "vulnerabilities"
+    ],
+    "properties": {
+        "schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "version": {
+            "type": "string",
+            "minLength": 1
+        },
+        "scan": {
+            "type": "object",
+            "required": [
+                "start_time",
+                "end_time",
+                "status",
+                "type",
+                "scanner"
+            ],
+            "properties": {
+                "start_time": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "end_time": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "status": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "type": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "scanner": {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "name",
+                        "url",
+                        "version",
+                        "vendor"
+                    ],
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "name": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "url": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "version": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "vendor": {
+                            "type": "object",
+                            "required": [
+                                "name"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "const": "Checkmarx"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "vulnerabilities": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "category",
+                    "severity",
+                    "cve",
+                    "scanner",
+                    "name",
+                    "message",
+                    "links",
+                    "location",
+                    "identifiers"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "pattern": "^[A-Fa-f0-9]{64}$"
+                    },
+                    "category": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "severity": {
+                        "type": "string",
+                        "enum": [
+                            "High",
+                            "Medium",
+                            "Low",
+                            "Info"
+                        ]
+                    },
+                    "cve": {
+                        "type": "string",
+                        "pattern": "^[A-Fa-f0-9]{64}$"
+                    },
+                    "scanner": {
+                        "type": "object",
+                        "required": [
+                            "id",
+                            "name"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "minLength": 1
+                            },
+                            "name": {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        }
+                    },
+                    "name": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "message": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "links": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "url"
+                            ],
+                            "properties": {
+                                "url": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            }
+                        }
+                    },
+                    "location": {
+                        "type": "object",
+                        "required": [
+                            "file",
+                            "start_line",
+                            "end_line"
+                        ],
+                        "properties": {
+                            "file": {
+                                "type": "string",
+                                "pattern": "^([\\w\\-. ]+(\\\\|\\/))*([\\w\\-. ]+(\\\\|\\/).(.)*)$"
+                            },
+                            "start_line": {
+                                "type": "integer",
+                                "minimum": 1
+                            },
+                            "end_line": {
+                                "type": "integer",
+                                "minimum": 1
+                            }
+                        }
+                    },
+                    "identifiers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "type",
+                                "name",
+                                "url",
+                                "value"
+                            ],
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "url": {
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-4{1}[a-f0-9]{3}-[89ab]{1}[a-f0-9]{3}-[a-f0-9]{12}$"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/e2e/fixtures/schemas/result-sarif-required.json
+++ b/e2e/fixtures/schemas/result-sarif-required.json
@@ -1,0 +1,265 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "$schema",
+        "runs"
+    ],
+    "definitions": {
+        "uuid_pattern": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-4{1}[a-f0-9]{3}-[89ab]{1}[a-f0-9]{3}-[a-f0-9]{12}$"
+        },
+        "text_object": {
+            "type": "object",
+            "required": [
+                "text"
+            ],
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        }
+    },
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "version": {
+            "type": "string",
+            "minLength": 1
+        },
+        "runs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "tool",
+                    "results",
+                    "taxonomies"
+                ],
+                "properties": {
+                    "tool": {
+                        "type": "object",
+                        "required": [
+                            "driver"
+                        ],
+                        "properties": {
+                            "driver": {
+                                "type": "object",
+                                "required": [
+                                    "name",
+                                    "version",
+                                    "fullName",
+                                    "informationUri",
+                                    "rules"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "version": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "fullName": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "informationUri": {
+                                        "type": "string",
+                                        "format": "uri"
+                                    },
+                                    "rules": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "required": [
+                                                "id",
+                                                "name",
+                                                "shortDescription",
+                                                "fullDescription",
+                                                "defaultConfiguration",
+                                                "helpUri",
+                                                "relationships"
+                                            ],
+                                            "properties": {
+                                                "id": {
+                                                    "$ref": "#/definitions/uuid_pattern"
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                },
+                                                "shortDescription": {
+                                                    "$ref": "#/definitions/text_object"
+                                                },
+                                                "fullDescription": {
+                                                    "$ref": "#/definitions/text_object"
+                                                },
+                                                "defaultConfiguration": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "level"
+                                                    ],
+                                                    "properties": {
+                                                        "level": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "none",
+                                                                "note",
+                                                                "error",
+                                                                "warning"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "helpUri": {
+                                                    "type": "string",
+                                                    "format": "uri"
+                                                },
+                                                "relationships": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "target"
+                                                        ],
+                                                        "properties": {
+                                                            "target": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                    "id",
+                                                                    "index",
+                                                                    "toolComponent"
+                                                                ],
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string",
+                                                                        "minLength": 1
+                                                                    },
+                                                                    "index": {
+                                                                        "type": "integer",
+                                                                        "minimum": 0
+                                                                    },
+                                                                    "toolComponent": {
+                                                                        "type": "object",
+                                                                        "required": [
+                                                                            "name",
+                                                                            "guid",
+                                                                            "index"
+                                                                        ],
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string",
+                                                                                "minLength": 1
+                                                                            },
+                                                                            "guid": {
+                                                                                "$ref": "#/definitions/uuid_pattern"
+                                                                            },
+                                                                            "index": {
+                                                                                "type": "integer",
+                                                                                "minimum": 0
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "ruleId",
+                                "ruleIndex",
+                                "kind",
+                                "message",
+                                "locations"
+                            ],
+                            "properties": {
+                                "ruleId": {
+                                    "$ref": "#/definitions/uuid_pattern"
+                                },
+                                "ruleIndex": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                "kind": {
+                                    "type": "string",
+                                    "enum": [
+                                        "fail",
+                                        "informational"
+                                    ]
+                                },
+                                "message": {
+                                    "$ref": "#/definitions/text_object"
+                                },
+                                "locations": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "required": [
+                                            "physicalLocation"
+                                        ],
+                                        "properties": {
+                                            "physicalLocation": {
+                                                "type": "object",
+                                                "required": [
+                                                    "artifactLocation",
+                                                    "region"
+                                                ],
+                                                "properties": {
+                                                    "artifactLocation": {
+                                                        "required": [
+                                                            "uri"
+                                                        ],
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "uri": {
+                                                                "type": "string",
+                                                                "pattern": "^([\\w\\-. ]+(\\|\\/))*([\\w\\-. ]+(\\\\|\\/).(.)*)$"
+                                                            }
+                                                        }
+                                                    },
+                                                    "region": {
+                                                        "type": "object",
+                                                        "required": [
+                                                            "startLine"
+                                                        ],
+                                                        "properties": {
+                                                            "startLine": {
+                                                                "type": "integer",
+                                                                "minimum": 1
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "taxonomies": {
+                        "type": "array"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/e2e/fixtures/schemas/result-sarif.json
+++ b/e2e/fixtures/schemas/result-sarif.json
@@ -1,0 +1,335 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "$schema",
+        "version",
+        "runs"
+    ],
+    "definitions": {
+        "uuid_pattern": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-4{1}[a-f0-9]{3}-[89ab]{1}[a-f0-9]{3}-[a-f0-9]{12}$"
+        },
+        "text_object": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "text"
+            ],
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        }
+    },
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "version": {
+            "type": "string",
+            "minLength": 1
+        },
+        "runs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "tool",
+                    "results",
+                    "taxonomies"
+                ],
+                "properties": {
+                    "tool": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "driver"
+                        ],
+                        "properties": {
+                            "driver": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                    "name",
+                                    "version",
+                                    "fullName",
+                                    "informationUri",
+                                    "rules"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "version": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "fullName": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "informationUri": {
+                                        "type": "string",
+                                        "format": "uri"
+                                    },
+                                    "rules": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "required": [
+                                                "id",
+                                                "name",
+                                                "shortDescription",
+                                                "fullDescription",
+                                                "defaultConfiguration",
+                                                "helpUri",
+                                                "relationships"
+                                            ],
+                                            "properties": {
+                                                "id": {
+                                                    "$ref": "#/definitions/uuid_pattern"
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "minLength": 1
+                                                },
+                                                "shortDescription": {
+                                                    "$ref": "#/definitions/text_object"
+                                                },
+                                                "fullDescription": {
+                                                    "$ref": "#/definitions/text_object"
+                                                },
+                                                "defaultConfiguration": {
+                                                    "type": "object",
+                                                    "additionalProperties": false,
+                                                    "required": [
+                                                        "level"
+                                                    ],
+                                                    "properties": {
+                                                        "level": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "none",
+                                                                "note",
+                                                                "error",
+                                                                "warning"
+                                                            ]
+                                                        }
+                                                    }
+                                                },
+                                                "helpUri": {
+                                                    "type": "string",
+                                                    "format": "uri"
+                                                },
+                                                "relationships": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "required": [
+                                                            "target"
+                                                        ],
+                                                        "properties": {
+                                                            "target": {
+                                                                "type": "object",
+                                                                "additionalProperties": false,
+                                                                "required": [
+                                                                    "id",
+                                                                    "index",
+                                                                    "toolComponent"
+                                                                ],
+                                                                "properties": {
+                                                                    "id": {
+                                                                        "type": "string",
+                                                                        "minLength": 1
+                                                                    },
+                                                                    "index": {
+                                                                        "type": "integer",
+                                                                        "minimum": 0
+                                                                    },
+                                                                    "toolComponent": {
+                                                                        "type": "object",
+                                                                        "additionalProperties": false,
+                                                                        "required": [
+                                                                            "name",
+                                                                            "guid",
+                                                                            "index"
+                                                                        ],
+                                                                        "properties": {
+                                                                            "name": {
+                                                                                "type": "string",
+                                                                                "minLength": 1
+                                                                            },
+                                                                            "guid": {
+                                                                                "$ref": "#/definitions/uuid_pattern"
+                                                                            },
+                                                                            "index": {
+                                                                                "type": "integer",
+                                                                                "minimum": 0
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                                "ruleId",
+                                "ruleIndex",
+                                "kind",
+                                "message",
+                                "locations"
+                            ],
+                            "properties": {
+                                "ruleId": {
+                                    "$ref": "#/definitions/uuid_pattern"
+                                },
+                                "ruleIndex": {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                "kind": {
+                                    "type": "string",
+                                    "enum": [
+                                        "fail",
+                                        "informational"
+                                    ]
+                                },
+                                "message": {
+                                    "$ref": "#/definitions/text_object"
+                                },
+                                "locations": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "required": [
+                                            "physicalLocation"
+                                        ],
+                                        "properties": {
+                                            "physicalLocation": {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "artifactLocation",
+                                                    "region"
+                                                ],
+                                                "properties": {
+                                                    "artifactLocation": {
+                                                        "required": [
+                                                            "uri"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "properties": {
+                                                            "uri": {
+                                                                "type": "string",
+                                                                "pattern": "^([\\w\\-. ]+(\\|\\/))*([\\w\\-. ]+(\\\\|\\/).(.)*)$"
+                                                            }
+                                                        }
+                                                    },
+                                                    "region": {
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "required": [
+                                                            "startLine"
+                                                        ],
+                                                        "properties": {
+                                                            "startLine": {
+                                                                "type": "integer",
+                                                                "minimum": 1
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "taxonomies": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": [
+                                "guid",
+                                "name",
+                                "fullDescription",
+                                "shortDescription",
+                                "taxa"
+                            ],
+                            "properties": {
+                                "guid": {
+                                    "$ref": "#/definitions/uuid_pattern"
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "minLength": 1
+                                },
+                                "shortDescription": {
+                                    "$ref": "#/definitions/text_object"
+                                },
+                                "fullDescription": {
+                                    "$ref": "#/definitions/text_object"
+                                },
+                                "taxa": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "required": [
+                                            "id",
+                                            "name",
+                                            "fullDescription",
+                                            "shortDescription"
+                                        ],
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "minLength": 1
+                                            },
+                                            "name": {
+                                                "type": "string",
+                                                "minLength": 1
+                                            },
+                                            "fullDescription": {
+                                                "$ref": "#/definitions/text_object"
+                                            },
+                                            "shortDescription": {
+                                                "$ref": "#/definitions/text_object"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/e2e/fixtures/schemas/result.json
+++ b/e2e/fixtures/schemas/result.json
@@ -72,7 +72,7 @@
                     },
                     "platform": {
                         "type": "string",
-                        "enum": ["Ansible", "CloudFormation", "Dockerfile", "Kubernetes", "OpenAPI", "Terraform"]
+                        "enum": ["Common", "Ansible", "CloudFormation", "Dockerfile", "Kubernetes", "OpenAPI", "Terraform"]
                     },
                     "files": {
                         "type": "array",

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -166,15 +166,17 @@ func setFields(t *testing.T, expect, want []string, location string) {
 		expectI.Start = timeValue
 		expectI.End = timeValue
 		for i := range wantI.Queries {
+			wantQuery := wantI.Queries[i]
+			expectQuery := expectI.Queries[i]
 			for j := range wantI.Queries[i].Files {
-				wantI.Queries[i].Files[j].FileName = ""
-				expectI.Queries[i].Files[j].FileName = ""
+				wantQuery.Files[j].FileName = ""
+				expectQuery.Files[j].FileName = ""
 			}
-			sort.Slice(wantI.Queries[i].Files, func(a, b int) bool {
-				return wantI.Queries[i].Files[a].SimilarityID < wantI.Queries[i].Files[b].SimilarityID
+			sort.Slice(wantQuery.Files, func(a, b int) bool {
+				return wantQuery.Files[a].SimilarityID < wantQuery.Files[b].SimilarityID
 			})
-			sort.Slice(expectI.Queries[i].Files, func(a, b int) bool {
-				return expectI.Queries[i].Files[a].SimilarityID < expectI.Queries[i].Files[b].SimilarityID
+			sort.Slice(expectQuery.Files, func(a, b int) bool {
+				return expectQuery.Files[a].SimilarityID < expectQuery.Files[b].SimilarityID
 			})
 		}
 


### PR DESCRIPTION
**Proposed Changes**
- Add JSON Schema Validation for "gl-sast" and "sarif" results
- This validation allows E2E tests to check the integrity of results (reports) in other formats (**gl-sast** and **sarif**), as it has already been implemented in json report format.

I submit this contribution under the Apache-2.0 license.