### PR TITLE
ci: sonarcloud should not run in forks

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,6 +9,7 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    if: github.repository == 'Checkmarx/kics'
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
Closes #2221

**Proposed Changes**
- Sonacloud scan should not run in forks since SONAR_TOKEN secret is not available

I submit this contribution under the Apache-2.0 license.
