### PR TITLE
docs: fixing sitemap.xml generation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # Project
 site_name: KICS
-site_url: http://www.kics.io
+site_url: http://docs.kics.io
 site_description: >-
   Open source solution for static code analysis of Infrastructure as Code. Finding security vulnerabilities, compliance issues, and infrastructure misconfigurations during project development cycle.
 copyright: >-


### PR DESCRIPTION
Enable search engines to better crawl our documentation page

I submit this contribution under the Apache-2.0 license.
