### PR TITLE
fix(report): Fix path always abs with windows and zip extraction

### DIFF
--- a/pkg/engine/provider/zipprovider.go
+++ b/pkg/engine/provider/zipprovider.go
@@ -53,7 +53,7 @@ func (z *ZipSystemSourceProvider) CheckAndExtractZip(absPath string) (string, er
 
 		if contentType == MimeTypeZip {
 			destination, err := os.MkdirTemp("", "kics-extract-*")
-			z.PathExtractionMap[destination] = absPath
+			z.PathExtractionMap[filepath.ToSlash(destination)] = filepath.ToSlash(absPath)
 
 			if err != nil {
 				return "", err


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Fixed path always abs with windows and zip extraction


I submit this contribution under the Apache-2.0 license.
