### PR TITLE
fix(core): detect line checking first term when multiple terms exists

### DIFF
--- a/pkg/detector/helper.go
+++ b/pkg/detector/helper.go
@@ -223,7 +223,8 @@ func DetectCurrentLine(lines []string, str1, str2 string,
 			if strings.Contains(lines[i], str1) {
 				restLine := lines[i][strings.Index(lines[i], str1)+len(str1):]
 				if strings.Contains(restLine, str2) {
-					distances[i] = levenshtein.ComputeDistance(ExtractLineFragment(restLine, str2, false), str2)
+					distances[i] = levenshtein.ComputeDistance(ExtractLineFragment(lines[i], str1, false), str1)
+					distances[i] += levenshtein.ComputeDistance(ExtractLineFragment(restLine, str2, false), str2)
 				}
 			}
 		} else if str1 != "" {


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #3824 

**Proposed Changes**
- This changes the way detect line works, now checking the distance on the first term too

I submit this contribution under the Apache-2.0 license.
