### PR TITLE
docs(query): Added docs for `input-data` flag

### DIFF
--- a/docs/creating-queries.md
+++ b/docs/creating-queries.md
@@ -361,4 +361,4 @@ Starting on v1.3.5, KICS started to support custom data overwriting on queries. 
 2. Define **ALL** keys that can be overwritten with their default value;
 3. On `query.rego` file, use `data.<key_on_data_json_file>` to access the value of this key;
 
-With this simple steps, users will be able to overwrite the keys they want and others keys will use default value.
+With these simple steps, users will be able to overwrite the keys they want, elsewhere will use the default value.

--- a/docs/creating-queries.md
+++ b/docs/creating-queries.md
@@ -138,6 +138,10 @@ Observe the following metadata.json example and check the Guidelines below for m
 }
 ```
 
+👨‍💻 **Data File**
+
+This file contains a map, with string keys, which will have default values for keys that can be overwritten as described on [allowing users to overwrite query data section](#allowing-users-to-overwrite-query-data) and [using custom input data section of Running KICS](./running-kics.md#using-custom-input-data)
+
 👨‍💻 **Test Folder**
 
 Keep in mind that all the positive and negative files should contain only one breaking point case. This way, the results are more clear. As a best practice, the test folder should contain all the [extensions available](https://docs.kics.io/latest/platforms/) by the platform.
@@ -349,3 +353,12 @@ CxPolicy[result] {
 isTCPorUDP("TCP") = true
 isTCPorUDP("UDP") = true
 ```
+
+#### Allowing users to overwrite query data
+Starting on v1.3.5, KICS started to support custom data overwriting on queries. This can be useful if users want to provide their own dataset or if users has different datasets for multiple enviroments. This can be supported easy following some steps:
+
+1. Create a `data.json` file on the same level as `query.rego`;
+2. Define **ALL** keys that can be overwritten with their default value;
+3. On `query.rego` file, use `data.<key_on_data_json_file>` to access the value of this key;
+
+With this simple steps, users will be able to overwrite the keys they want and others keys will use default value.

--- a/docs/running-kics.md
+++ b/docs/running-kics.md
@@ -1,5 +1,7 @@
 # Running KICS
 
+## Supported resources
+
 KICS makes use of the <a href="https://github.com/hashicorp/go-getter#go-getter">go-getter</a> package in order to scan files or directories from various sources.
 
 KICS is able to perform scans on these types of paths:
@@ -13,13 +15,13 @@ KICS is able to perform scans on these types of paths:
  Files and directories that are not local will be placed in a temporarly folder during KICS execution.
 
 
-## Local Files
+### Local Files
 
 ```
 kics scan -p path/local
 ```
 
-## Archived Files
+### Archived Files
 
 Available archive formats:
 
@@ -38,7 +40,7 @@ kics scan -p path/local.zip
 More informatition can be seen [here](https://github.com/hashicorp/go-getter#unarchiving)
 
 
-## S3
+### S3
 
 S3 Bucket path syntax:
 
@@ -46,7 +48,7 @@ S3 Bucket path syntax:
 s3::{S3 Bucket URL}?{query parameters}
 ```
 
-### Query Parameters:
+#### Query Parameters:
 
 - `aws_access_key_id` - AWS access key.
 - `aws_access_key_secret` - AWS access key secret.
@@ -60,13 +62,13 @@ kics scan -p s3::https://s3.amazonaws.com/bucket/foo?aws_profile=~/.aws/profile
 
 More informatition can be seen [here](https://github.com/hashicorp/go-getter#s3-s3)
 
-## Git
+### Git
 
 ```
 kics scan -p git::https://github.com/Checkmarx/kics
 ```
 
-### SSH
+#### SSH
 
 ```
 kics scan -p git::git@github.com:Checkmarx/kics.git
@@ -76,7 +78,7 @@ Please make sure you have SSH private key configured with your github account
 
 More informatition can be seen [here](https://github.com/hashicorp/go-getter#git-git)
 
-## GSC
+### GSC
 
 ```
 kics scan -p gcs::https://www.googleapis.com/storage/v1/bucket
@@ -86,3 +88,46 @@ Please make sure you have set GSC authentication credentials to your application
 
 More informatition can be seen [here](https://github.com/hashicorp/go-getter#gcs-gcs)
 
+## Using custom input data
+Since from v1.3.5, KICS supports using custom input data to replace data on queries that has this feature supported. To check if a query supports overwriting, just check if query's folder contains `data.json` file, this file will contain all keys that can be overwritten.
+To overwrite the key, you need to create files following the pattern `<query_id>.json`, each file representing **one** query and passing folder path containing this files to the flag `input-data`, this will get all files from this folder and replace all keys on queries found.
+
+**NOTE**: Keys that are not overwritten will use the default value proposed by `data.json` file of targeted query.
+
+For example, on `queries/common/passwords_and_secrets_in_infrastructure_code/` contains the following `data.json`:
+
+```json
+{
+  "defaultPasswords": [
+    "!@",
+    "root",
+    "wubao",
+    ...
+  ],
+  "blackList": [
+    "RESOURCE",
+    "GROUP",
+    "SUBNET",
+    ...
+  ]
+}
+
+```
+
+This means there are two keys, `defaultPasswords` and `blackList`, that can be overwritten. On the query, you can search them on `query.rego` file with: `data.defaultPasswords` and `data.blackList`, to understand how it is used by the query.
+
+To overwrite `defaultPasswords`, you can create a file `f996f3cb-00fc-480c-8973-8ab04d44a8cc.json` on a folder `custom-input`, for example, as following:
+
+```json
+{
+  "defaultPasswords": [
+    "myCustomValue1",
+    "myCustomValue2",
+    "myCustomValue3",
+  ]
+}
+```
+
+Then you can execute KICS normally adding `--input-data ./custom-input/`, if `custom-input` folder is in current path, and it will replace the key `defaultPasswords` on `passwords_and_secrets_in_infrastructure_code` query with the custom value you defined.
+
+**NOTE**: The value which will replace the default value, **MUST** be the same type as the default key (e.g. `defaultPasswords` must be an array of strings)

--- a/docs/running-kics.md
+++ b/docs/running-kics.md
@@ -1,6 +1,6 @@
 # Running KICS
 
-## Supported resources
+## Supported Resources
 
 KICS makes use of the <a href="https://github.com/hashicorp/go-getter#go-getter">go-getter</a> package in order to scan files or directories from various sources.
 
@@ -89,8 +89,8 @@ Please make sure you have set GSC authentication credentials to your application
 More informatition can be seen [here](https://github.com/hashicorp/go-getter#gcs-gcs)
 
 ## Using custom input data
-Since from v1.3.5, KICS supports using custom input data to replace data on queries that has this feature supported. To check if a query supports overwriting, just check if query's folder contains `data.json` file, this file will contain all keys that can be overwritten.
-To overwrite the key, you need to create files following the pattern `<query_id>.json`, each file representing **one** query and passing folder path containing this files to the flag `input-data`, this will get all files from this folder and replace all keys on queries found.
+Since from v1.3.5, KICS supports using custom input data to replace data on queries that have this feature supported. To see if a query supports overwriting, check if the query's folder contains a `data.json` file, this file will contain all keys that can be overwritten.
+To overwrite the key, you need to create files following the pattern `<query_id>.json`, each file representing **one** query and passing folder path containing these files to the flag `input-data`, this will get all files from this folder and replace all keys on queries found.
 
 **NOTE**: Keys that are not overwritten will use the default value proposed by `data.json` file of targeted query.
 


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Added a section on creating query tutorial, referring to `data.json` file
- Added a section on running kics, explaining how to use `input-data` flag

I submit this contribution under the Apache-2.0 license.
