### PR TITLE
fix(engine): fixed go-getter not returning relative path on windows

### DIFF
--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -112,7 +112,7 @@ func replaceIfTemporaryPath(filePath string, pathExtractionMap map[string]Extrac
 
 func resolvePath(filePath string, pathExtractionMap map[string]ExtractedPathObject) string {
 	var returnPath string
-	returnPath = replaceIfTemporaryPath(filePath, pathExtractionMap)
+	returnPath = replaceIfTemporaryPath(filepath.FromSlash(filePath), pathExtractionMap)
 	pwd, err := os.Getwd()
 	if err != nil {
 		log.Error().Msgf("Unable to get current working dir %s", err)


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.Reigota@checkmarx.com>

I submit this contribution under the Apache-2.0 license.
