### PR TITLE
feat(parser): Added terraform functions on terraform parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ results.*
 
 # coverage report
 coverage.html
+
+# Local files for tests
+/local-files

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Checkmarx/kics/pkg/model"
+	"github.com/Checkmarx/kics/pkg/parser/terraform/functions"
 	"github.com/getsentry/sentry-go"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -128,6 +129,8 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 		return list, nil
 	case *hclsyntax.ObjectConsExpr:
 		return c.objectConsExpr(value)
+	case *hclsyntax.FunctionCallExpr:
+		return c.evalFunction(expr)
 	default:
 		// try to evaluate with variables
 		valueConverted, _ := expr.Value(&hcl.EvalContext{
@@ -273,4 +276,56 @@ func (c *converter) wrapExpr(expr hclsyntax.Expression) (string, error) {
 		log.Trace().Msgf("Variable ${%s} value not found", expression)
 	}
 	return "${" + expression + "}", nil
+}
+
+func (c *converter) evalFunction(expression hclsyntax.Expression) (interface{}, error) {
+	expressionEvaluated, err := expression.Value(&hcl.EvalContext{
+		Variables: inputVarMap,
+		Functions: functions.TerraformFuncs,
+	})
+	if err != nil {
+		for _, expressionError := range err {
+			if expressionError.Summary == "Unknown variable" {
+				jsonPath := c.rangeSource(expressionError.Expression.Range())
+				rootKey := strings.Split(jsonPath, ".")[0]
+				if strings.Contains(jsonPath, ".") {
+					jsonCtyValue, convertErr := createEntryInputVar(strings.Split(jsonPath, ".")[1:], jsonPath)
+					if convertErr != nil {
+						return c.wrapExpr(expression)
+					}
+					inputVarMap[rootKey] = jsonCtyValue
+				} else {
+					inputVarMap[rootKey] = cty.StringVal(jsonPath)
+				}
+			}
+		}
+		expressionEvaluated, err = expression.Value(&hcl.EvalContext{
+			Variables: inputVarMap,
+			Functions: functions.TerraformFuncs,
+		})
+		if err != nil {
+			return c.wrapExpr(expression)
+		}
+	}
+	return ctyjson.SimpleJSONValue{Value: expressionEvaluated}, nil
+}
+
+func createEntryInputVar(path []string, defaultValue string) (cty.Value, error) {
+	mapJSON := "{"
+	closeMap := "}"
+	for idx, key := range path {
+		if idx+1 < len(path) {
+			mapJSON += fmt.Sprintf("\"%s\":{", key)
+			closeMap += "}"
+		} else {
+			mapJSON += fmt.Sprintf("\"%s\": \"%s\"", key, defaultValue)
+		}
+	}
+	mapJSON += closeMap
+	jsonType, _ := ctyjson.ImpliedType([]byte(mapJSON))
+	value, err := ctyjson.Unmarshal([]byte(mapJSON), jsonType)
+	if err != nil {
+		return cty.NilVal, err
+	}
+	return value, nil
 }

--- a/pkg/parser/terraform/functions/default.go
+++ b/pkg/parser/terraform/functions/default.go
@@ -1,0 +1,62 @@
+package functions
+
+import (
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+// TerraformFuncs contains all functions, if KICS has to override a function
+// it should create a file in this package and add/change this function key here
+var TerraformFuncs = map[string]function.Function{
+	"abs":             stdlib.AbsoluteFunc,
+	"ceil":            stdlib.CeilFunc,
+	"chomp":           stdlib.ChompFunc,
+	"coalescelist":    stdlib.CoalesceListFunc,
+	"compact":         stdlib.CompactFunc,
+	"concat":          stdlib.ConcatFunc,
+	"contains":        stdlib.ContainsFunc,
+	"csvdecode":       stdlib.CSVDecodeFunc,
+	"distinct":        stdlib.DistinctFunc,
+	"element":         stdlib.ElementFunc,
+	"chunklist":       stdlib.ChunklistFunc,
+	"flatten":         stdlib.FlattenFunc,
+	"floor":           stdlib.FloorFunc,
+	"format":          stdlib.FormatFunc,
+	"formatdate":      stdlib.FormatDateFunc,
+	"formatlist":      stdlib.FormatListFunc,
+	"indent":          stdlib.IndentFunc,
+	"join":            stdlib.JoinFunc,
+	"jsondecode":      stdlib.JSONDecodeFunc,
+	"jsonencode":      stdlib.JSONEncodeFunc,
+	"keys":            stdlib.KeysFunc,
+	"log":             stdlib.LogFunc,
+	"lower":           stdlib.LowerFunc,
+	"max":             stdlib.MaxFunc,
+	"merge":           stdlib.MergeFunc,
+	"min":             stdlib.MinFunc,
+	"parseint":        stdlib.ParseIntFunc,
+	"pow":             stdlib.PowFunc,
+	"range":           stdlib.RangeFunc,
+	"regex":           stdlib.RegexFunc,
+	"regexall":        stdlib.RegexAllFunc,
+	"reverse":         stdlib.ReverseListFunc,
+	"setintersection": stdlib.SetIntersectionFunc,
+	"setproduct":      stdlib.SetProductFunc,
+	"setsubtract":     stdlib.SetSubtractFunc,
+	"setunion":        stdlib.SetUnionFunc,
+	"signum":          stdlib.SignumFunc,
+	"slice":           stdlib.SliceFunc,
+	"sort":            stdlib.SortFunc,
+	"split":           stdlib.SplitFunc,
+	"strrev":          stdlib.ReverseFunc,
+	"substr":          stdlib.SubstrFunc,
+	"timeadd":         stdlib.TimeAddFunc,
+	"title":           stdlib.TitleFunc,
+	"trim":            stdlib.TrimFunc,
+	"trimprefix":      stdlib.TrimPrefixFunc,
+	"trimspace":       stdlib.TrimSpaceFunc,
+	"trimsuffix":      stdlib.TrimSuffixFunc,
+	"upper":           stdlib.UpperFunc,
+	"values":          stdlib.ValuesFunc,
+	"zipmap":          stdlib.ZipmapFunc,
+}


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Parser evaluates standard functions from terraform;
- The list of functions that are evaluated can be found on `pkg/parser/terraform/functions/default.go`. This list only includes functions from terraform `stdlib`;

I submit this contribution under the Apache-2.0 license.
