### PR TITLE
bugfix(docs): fixed CSV export on queries page

### DIFF
--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -150,11 +150,17 @@ function exportToCSV(filename) {
     var row = []
     var cols = r.querySelectorAll("td, th")
     for (var j = 0; j < cols.length; j++) {
-      var text = `"${cols[j].innerText.replace(/\\n/g, " ").replaceAll(/"/g, '')}"`
+      var text = `"${cols[j].innerText.replace(/\n/g, " ").replaceAll(/"/g, '').trim()}"`
       if (cols[j].tagName == "TH") {
         text = text.match(/[0-9a-zA-Z ]+/)[0]
+        if (headerArray[j] == "query") {
+          text = "Query ID,Query Name"
+        }
       } else if (headerArray[j] == "help") {
         text = cols[j].children[0].href
+      } else if (headerArray[j] == "query") {
+        var lastIndex = text.lastIndexOf(" ")
+        text = `"${text.substring(lastIndex + 1)},${text.substring(0, lastIndex)}"`
       }
       row.push(text)
     }


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Fixed typo on regex that was not replacing `\n` characters with white spaces
- Updated script to split query id and query name and put them in two different columns

I submit this contribution under the Apache-2.0 license.
