### PR TITLE
feat(query): Added query S3 Bucket Allows All Actions From All Principals for terraform

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_allows_all_actions_from_all_principals/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_allows_all_actions_from_all_principals/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "51cf6f14-6a52-4642-97fb-10db078382d3",
+  "queryName": "S3 Bucket Allows All Actions From All Principals",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "S3 Buckets must not allow All Actions (wildcard) From All Principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering / deletion. This means the 'Effect' must not be 'Allow' when the 'Action' is *, for all Principals.",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy",
+  "platform": "Terraform",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/terraform/aws/s3_bucket_allows_all_actions_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_all_actions_from_all_principals/query.rego
@@ -12,13 +12,13 @@ CxPolicy[result] {
 
 	statement.Effect == "Allow"
 	terraLib.anyPrincipal(statement)
-	commonLib.containsOrInArrayContains(statement.Action, "delete")
+	commonLib.containsOrInArrayContains(statement.Action, "*")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("%s[%s].policy.Action", [pl[r], name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s[%s].policy.Action is not a 'Delete' action", [pl[r], name]),
-		"keyActualValue": sprintf("%s[%s].policy.Action is a 'Delete' action", [pl[r], name]),
+		"keyExpectedValue": sprintf("%s[%s].policy.Action is not a '*' action", [pl[r], name]),
+		"keyActualValue": sprintf("%s[%s].policy.Action is a '*' action", [pl[r], name]),
 	}
 }

--- a/assets/queries/terraform/aws/s3_bucket_allows_all_actions_from_all_principals/test/negative.tf
+++ b/assets/queries/terraform/aws/s3_bucket_allows_all_actions_from_all_principals/test/negative.tf
@@ -1,0 +1,25 @@
+resource "aws_s3_bucket" "negative1" {
+  bucket = "my_tf_test_bucket"
+}
+
+resource "aws_s3_bucket_policy" "negative2" {
+  bucket = aws_s3_bucket.b.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "MYBUCKETPOLICY",
+  "Statement": [
+    {
+      "Sid": "IPAllow",
+      "Effect": "Deny",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::my_tf_test_bucket/*",
+      "Condition": {
+         "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
+      }
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/s3_bucket_allows_all_actions_from_all_principals/test/positive.tf
+++ b/assets/queries/terraform/aws/s3_bucket_allows_all_actions_from_all_principals/test/positive.tf
@@ -1,0 +1,51 @@
+resource "aws_s3_bucket" "positive1" {
+  bucket = "my_tf_test_bucket"
+}
+
+resource "aws_s3_bucket_policy" "positive2" {
+  bucket = aws_s3_bucket.b.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "MYBUCKETPOLICY",
+  "Statement": [
+    {
+      "Sid": "IPAllow",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": "arn:aws:s3:::my_tf_test_bucket/*",
+      "Condition": {
+         "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_s3_bucket_policy" "positive3" {
+  bucket = aws_s3_bucket.b.id
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "MYBUCKETPOLICY",
+  "Statement": [
+    {
+      "Sid": "IPAllow",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:*",
+      "Resource": "arn:aws:s3:::my_tf_test_bucket/*",
+      "Condition": {
+         "IpAddress": {"aws:SourceIp": "8.8.8.8/32"}
+      }
+    }
+  ]
+}
+POLICY
+}

--- a/assets/queries/terraform/aws/s3_bucket_allows_all_actions_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_allows_all_actions_from_all_principals/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "S3 Bucket Allows All Actions From All Principals",
+    "severity": "HIGH",
+    "line": 17,
+    "filename": "positive.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows All Actions From All Principals",
+    "severity": "HIGH",
+    "line": 42,
+    "filename": "positive.tf"
+  }
+]

--- a/assets/queries/terraform/aws/s3_bucket_allows_delete_action_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_allows_delete_action_from_all_principals/test/positive_expected_result.json
@@ -2,11 +2,11 @@
   {
     "queryName": "S3 Bucket Allows Delete Action From All Principals",
     "severity": "HIGH",
-    "line": 8
+    "line": 17
   },
   {
     "queryName": "S3 Bucket Allows Delete Action From All Principals",
     "severity": "HIGH",
-    "line": 31
+    "line": 42
   }
 ]

--- a/assets/queries/terraform/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_allows_put_action_from_all_principals/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("%s[%s].policy", [pl[r], name]),
+		"searchKey": sprintf("%s[%s].policy.Action", [pl[r], name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s[%s].policy.Action is not a 'Put' action", [pl[r], name]),
 		"keyActualValue": sprintf("%s[%s].policy.Action is a 'Put' action", [pl[r], name]),

--- a/assets/queries/terraform/aws/s3_bucket_allows_put_action_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_allows_put_action_from_all_principals/test/positive_expected_result.json
@@ -2,11 +2,11 @@
   {
     "queryName": "S3 Bucket Allows Put Action From All Principals",
     "severity": "HIGH",
-    "line": 8
+    "line": 17
   },
   {
     "queryName": "S3 Bucket Allows Put Action From All Principals",
     "severity": "HIGH",
-    "line": 31
+    "line": 42
   }
 ]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #3748 

**Proposed Changes**
- Added query to check if action is too permissive, using `s3:*`;
- Corrected search key of `S3 Bucket Allows Delete Action From All Principals` and `S3 Bucket Allows Put Action From All Principals` queries

I submit this contribution under the Apache-2.0 license.
