### PR TITLE
bugfix(parser): Fixed issue when trying to parse invalid variable

### DIFF
--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -133,7 +133,7 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 		valueConverted, _ := expr.Value(&hcl.EvalContext{
 			Variables: inputVarMap,
 		})
-		if !valueConverted.Type().HasDynamicTypes() {
+		if !valueConverted.Type().HasDynamicTypes() && valueConverted.IsKnown() {
 			return ctyjson.SimpleJSONValue{Value: valueConverted}, nil
 		}
 		return c.wrapExpr(expr)


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Corrected parsing when cty value is unknown

I submit this contribution under the Apache-2.0 license.
