### PR TITLE
feat(query): Added SQL Database Server Firewall Allows All IPS query for ARM

### DIFF
--- a/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/metadata.json
+++ b/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "6a3201a5-1630-494b-b294-3129d06b0eca",
+  "queryName": "SQL Database Server Firewall Allows All IPS",
+  "severity": "HIGH",
+  "category": "Networking and Firewall",
+  "descriptionText": "SQL Database Server Firewall endIpAddress should not be '255.255.255.255' when startIpAddress is '0.0.0.0' since this allows all IPS",
+  "descriptionUrl": "https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/2014-04-01/servers/firewallrules?tabs=json",
+  "platform": "AzureResourceManager",
+  "cloudProvider": "azure",
+  "descriptionID": "6664d4d6"
+}

--- a/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/query.rego
+++ b/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	types := ["Microsoft.Sql/servers/firewallRules", "firewallRules", "firewallrules"]
+	doc := input.document[i]
+
+	[path, value] := walk(doc)
+	value.type == types[x]
+
+	properties := value.properties
+	check_all_ips(properties.startIpAddress, properties.endIpAddress)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s.name={{%s}}.properties.endIpAddress", [common_lib.concat_path(path), value.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "endIpAddress is not '255.255.255.255' when startIpAddress is '0.0.0.0'",
+		"keyActualValue": sprintf("endIpAddress is '%s' and startIpAddress is '%s'", [properties.endIpAddress, properties.startIpAddress]),
+	}
+}
+
+check_all_ips(start, end) {
+	ipsOpts := ["0.0.0.0", "0.0.0.0/0"]
+	start == ipsOpts[_]
+	end == "255.255.255.255"
+}

--- a/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/negative1.json
+++ b/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/negative1.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "2.0.0.0",
+  "apiProfile": "2019-03-01-hybrid",
+  "parameters": {},
+  "variables": {},
+  "functions": [],
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/firewallRules",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sample/firewall",
+      "properties": {
+        "endIpAddress": "0.0.0.0",
+        "startIpAddress": "0.0.0.0"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/negative2.json
+++ b/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/negative2.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "2.0.0.0",
+  "apiProfile": "2019-03-01-hybrid",
+  "parameters": {},
+  "variables": {},
+  "functions": [],
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/firewallRules",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sample/firewall",
+      "properties": {
+        "endIpAddress": "192.168.1.2",
+        "startIpAddress": "192.168.1.254"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/positive1.json
+++ b/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/positive1.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "2.0.0.0",
+  "apiProfile": "2019-03-01-hybrid",
+  "parameters": {},
+  "variables": {},
+  "functions": [],
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/firewallRules",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sample/firewall",
+      "properties": {
+        "endIpAddress": "255.255.255.255",
+        "startIpAddress": "0.0.0.0"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/positive1.json
+++ b/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/positive1.json
@@ -7,13 +7,32 @@
   "functions": [],
   "resources": [
     {
-      "type": "Microsoft.Sql/servers/firewallRules",
+      "name": "sqlServer1",
+      "type": "Microsoft.Sql/servers",
       "apiVersion": "2021-02-01-preview",
-      "name": "sample/firewall",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "displayName": "sqlServer1"
+      },
       "properties": {
-        "endIpAddress": "255.255.255.255",
-        "startIpAddress": "0.0.0.0"
-      }
+        "administratorLogin": "adminUsername",
+        "administratorLoginPassword": "adminPassword"
+      },
+      "resources": [
+        {
+          "type": "firewallRules",
+          "apiVersion": "2021-02-01-preview",
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', 'sqlServer1')]"
+          ],
+          "location": "[resourceGroup().location]",
+          "name": "AllowAllWindowsAzureIps",
+          "properties": {
+            "endIpAddress": "255.255.255.255",
+            "startIpAddress": "0.0.0.0"
+          }
+        }
+      ]
     }
   ],
   "outputs": {}

--- a/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/positive2.json
+++ b/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/positive2.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "2.0.0.0",
+  "apiProfile": "2019-03-01-hybrid",
+  "parameters": {},
+  "variables": {},
+  "functions": [],
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/firewallRules",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sample/firewall",
+      "properties": {
+        "endIpAddress": "255.255.255.255",
+        "startIpAddress": "0.0.0.0/0"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "SQL Database Server Firewall Allows All IPS",
+    "severity": "HIGH",
+    "line": 14,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "SQL Database Server Firewall Allows All IPS",
+    "severity": "HIGH",
+    "line": 14,
+    "filename": "positive2.json"
+  }
+]

--- a/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/sql_database_server_firewall_allows_all_ips/test/positive_expected_result.json
@@ -2,7 +2,7 @@
   {
     "queryName": "SQL Database Server Firewall Allows All IPS",
     "severity": "HIGH",
-    "line": 14,
+    "line": 31,
     "filename": "positive1.json"
   },
   {


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>


**Proposed Changes**
- Added SQL Database Server Firewall Allows All IPS query for ARM

SQL Database Server Firewall endIpAddress should not be '255.255.255.255' when startIpAddress is '0.0.0.0' since this allows all IPS

I submit this contribution under the Apache-2.0 license.
