### PR TITLE
feat(query): Added MySQL Server SSL Enforcement Disabled query for ARM

### DIFF
--- a/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/metadata.json
+++ b/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "90120147-f2e7-4fda-bb21-6fa9109afd63",
+  "queryName": "MySQL Server SSL Enforcement Disabled",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "'Microsoft.DBforMySQL/servers' should enforce SSL",
+  "descriptionUrl": "https://docs.microsoft.com/en-us/azure/templates/microsoft.dbformysql/servers?tabs=json#serverpropertiesforcreate-object",
+  "platform": "AzureResourceManager",
+  "cloudProvider": "azure",
+  "descriptionID": "69fea5b1"
+}

--- a/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/metadata.json
+++ b/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/metadata.json
@@ -2,7 +2,7 @@
   "id": "90120147-f2e7-4fda-bb21-6fa9109afd63",
   "queryName": "MySQL Server SSL Enforcement Disabled",
   "severity": "HIGH",
-  "category": "Encryption",
+  "category": "Networking and Firewall",
   "descriptionText": "'Microsoft.DBforMySQL/servers' should enforce SSL",
   "descriptionUrl": "https://docs.microsoft.com/en-us/azure/templates/microsoft.dbformysql/servers?tabs=json#serverpropertiesforcreate-object",
   "platform": "AzureResourceManager",

--- a/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/query.rego
+++ b/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/query.rego
@@ -1,0 +1,35 @@
+package Cx
+
+import data.generic.common as commonLib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	[path, value] = walk(doc)
+
+	value.type == "Microsoft.DBforMySQL/servers"
+	not commonLib.valid_key(value.properties, "sslEnforcement")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": "resources.type={{Microsoft.DBforMySQL/servers}}.properties",
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "resource with type 'Microsoft.DBforMySQL/servers' has the 'sslEnforcement' property defined",
+		"keyActualValue": "resource with type 'Microsoft.DBforMySQL/servers' doesn't have 'sslEnforcement' property defined",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	[path, value] = walk(doc)
+
+	value.type == "Microsoft.DBforMySQL/servers"
+	value.properties.sslEnforcement == "Disabled"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": "resources.type={{Microsoft.DBforMySQL/servers}}.properties.sslEnforcement",
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "resource with type 'Microsoft.DBforMySQL/servers' has the 'sslEnforcement' property set to 'Enabled'",
+		"keyActualValue": "resource with type 'Microsoft.DBforMySQL/servers' doesn't have 'sslEnforcement' set to 'Enabled'",
+	}
+}

--- a/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/negative.json
+++ b/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/negative.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "2.0.0.0",
+  "apiProfile": "2019-03-01-hybrid",
+  "parameters": {},
+  "variables": {},
+  "functions": [],
+  "resources": [
+    {
+      "name": "server",
+      "type": "Microsoft.DBforMySQL/servers",
+      "apiVersion": "2017-12-01",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "version": "5.6",
+        "sslEnforcement": "Enabled"
+      },
+      "location": "location",
+      "tags": {},
+      "resources": []
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/negative.json
+++ b/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/negative.json
@@ -15,7 +15,9 @@
       },
       "properties": {
         "version": "5.6",
-        "sslEnforcement": "Enabled"
+        "sslEnforcement": "Enabled",
+        "createMode": "GeoRestore",
+        "sourceServerId": "id"
       },
       "location": "location",
       "tags": {},

--- a/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/positive1.json
+++ b/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/positive1.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "2.0.0.0",
+  "apiProfile": "2019-03-01-hybrid",
+  "parameters": {},
+  "variables": {},
+  "functions": [],
+  "resources": [
+    {
+      "name": "server",
+      "type": "Microsoft.DBforMySQL/servers",
+      "apiVersion": "2017-12-01",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "version": "5.6"
+      },
+      "location": "location",
+      "tags": {},
+      "resources": []
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/positive1.json
+++ b/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/positive1.json
@@ -14,7 +14,9 @@
         "type": "SystemAssigned"
       },
       "properties": {
-        "version": "5.6"
+        "version": "5.6",
+        "createMode": "GeoRestore",
+        "sourceServerId": "id"
       },
       "location": "location",
       "tags": {},

--- a/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/positive2.json
+++ b/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/positive2.json
@@ -15,7 +15,9 @@
       },
       "properties": {
         "version": "5.6",
-        "sslEnforcement": "Disabled"
+        "sslEnforcement": "Disabled",
+        "createMode": "GeoRestore",
+        "sourceServerId": "id"
       },
       "location": "location",
       "tags": {},

--- a/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/positive2.json
+++ b/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/positive2.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "2.0.0.0",
+  "apiProfile": "2019-03-01-hybrid",
+  "parameters": {},
+  "variables": {},
+  "functions": [],
+  "resources": [
+    {
+      "name": "server",
+      "type": "Microsoft.DBforMySQL/servers",
+      "apiVersion": "2017-12-01",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "version": "5.6",
+        "sslEnforcement": "Disabled"
+      },
+      "location": "location",
+      "tags": {},
+      "resources": []
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/mysql_server_ssl_enforcement_disabled/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "MySQL Server SSL Enforcement Disabled",
+    "severity": "HIGH",
+    "line": 16,
+    "fileName": "positive1.json"
+  },
+  {
+    "queryName": "MySQL Server SSL Enforcement Disabled",
+    "severity": "HIGH",
+    "line": 18,
+    "fileName": "positive2.json"
+  }
+]

--- a/assets/queries/azureResourceManager/phone_number_not_set_security_contacts/metadata.json
+++ b/assets/queries/azureResourceManager/phone_number_not_set_security_contacts/metadata.json
@@ -6,6 +6,6 @@
   "descriptionText": "Microsoft.Security securityContacts should have a phone number defined",
   "descriptionUrl": "https://docs.microsoft.com/en-us/azure/templates/microsoft.security/securitycontacts?tabs=json",
   "platform": "AzureResourceManager",
-  "cloudProvider": "common",
+  "cloudProvider": "azure",
   "descriptionID": "8b9ef792"
 }


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added MySQL Server SSL Enforcement Disabled query for ARM
- Changed `cloudProvider `in metadata.json of "Phone Number Not Set For Security Contacts" query from `"cloudProvider": "common"` to `"cloudProvider": "azure"`


I submit this contribution under the Apache-2.0 license.
