### PR TITLE
feat(query): Added Website Not Forcing HTTPS query for ARM

### DIFF
--- a/assets/queries/azureResourceManager/phone_number_not_set_security_contacts/metadata.json
+++ b/assets/queries/azureResourceManager/phone_number_not_set_security_contacts/metadata.json
@@ -6,6 +6,6 @@
   "descriptionText": "Microsoft.Security securityContacts should have a phone number defined",
   "descriptionUrl": "https://docs.microsoft.com/en-us/azure/templates/microsoft.security/securitycontacts?tabs=json",
   "platform": "AzureResourceManager",
-  "cloudProvider": "common",
+  "cloudProvider": "azure",
   "descriptionID": "8b9ef792"
 }

--- a/assets/queries/azureResourceManager/website_not_forcing_https/metadata.json
+++ b/assets/queries/azureResourceManager/website_not_forcing_https/metadata.json
@@ -2,7 +2,7 @@
   "id": "488847ff-6031-487c-bf42-98fd6ac5c9a0",
   "queryName": "Website Not Forcing HTTPS",
   "severity": "HIGH",
-  "category": "Insecure Configuration",
+  "category": "Insecure Configurations",
   "descriptionText": "'Microsoft.Web/sites' should force the use of HTTPS",
   "descriptionUrl": "https://docs.microsoft.com/en-us/azure/templates/microsoft.web/sites?tabs=json#siteproperties-object",
   "platform": "AzureResourceManager",

--- a/assets/queries/azureResourceManager/website_not_forcing_https/metadata.json
+++ b/assets/queries/azureResourceManager/website_not_forcing_https/metadata.json
@@ -2,7 +2,7 @@
   "id": "488847ff-6031-487c-bf42-98fd6ac5c9a0",
   "queryName": "Website Not Forcing HTTPS",
   "severity": "HIGH",
-  "category": "Encryption",
+  "category": "Insecure Configuration",
   "descriptionText": "'Microsoft.Web/sites' should force the use of HTTPS",
   "descriptionUrl": "https://docs.microsoft.com/en-us/azure/templates/microsoft.web/sites?tabs=json#siteproperties-object",
   "platform": "AzureResourceManager",

--- a/assets/queries/azureResourceManager/website_not_forcing_https/metadata.json
+++ b/assets/queries/azureResourceManager/website_not_forcing_https/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "488847ff-6031-487c-bf42-98fd6ac5c9a0",
+  "queryName": "Website Not Forcing HTTPS",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "'Microsoft.Web/sites' should force the use of HTTPS",
+  "descriptionUrl": "https://docs.microsoft.com/en-us/azure/templates/microsoft.web/sites?tabs=json#siteproperties-object",
+  "platform": "AzureResourceManager",
+  "cloudProvider": "azure",
+  "descriptionID": "3af52329"
+}

--- a/assets/queries/azureResourceManager/website_not_forcing_https/query.rego
+++ b/assets/queries/azureResourceManager/website_not_forcing_https/query.rego
@@ -1,0 +1,35 @@
+package Cx
+
+import data.generic.common as commonLib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	[path, value] = walk(doc)
+
+	value.type == "Microsoft.Web/sites"
+	not commonLib.valid_key(value.properties, "httpsOnly")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": "resources.type={{Microsoft.Web/sites}}.properties",
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "resource with type 'Microsoft.Web/sites' has the 'httpsOnly' property defined",
+		"keyActualValue": "resource with type 'Microsoft.Web/sites' doesn't have 'httpsOnly' property defined",
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	[path, value] = walk(doc)
+
+	value.type == "Microsoft.Web/sites"
+	value.properties.httpsOnly == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": "resources.type={{Microsoft.Web/sites}}.properties.httpsOnly",
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "resource with type 'Microsoft.Web/sites' has the 'httpsOnly' property set to true",
+		"keyActualValue": "resource with type 'Microsoft.Web/sites' doesn't have 'httpsOnly' set to true",
+	}
+}

--- a/assets/queries/azureResourceManager/website_not_forcing_https/test/negative.json
+++ b/assets/queries/azureResourceManager/website_not_forcing_https/test/negative.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "2.0.0.0",
+  "apiProfile": "2019-03-01-hybrid",
+  "parameters": {},
+  "variables": {},
+  "functions": [],
+  "resources": [
+    {
+      "name": "webSite",
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-12-01",
+      "location": "location1",
+      "tags": {},
+      "properties": {
+        "enabled": true,
+        "httpsOnly": true
+      },
+      "resources": []
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/website_not_forcing_https/test/positive1.json
+++ b/assets/queries/azureResourceManager/website_not_forcing_https/test/positive1.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "2.0.0.0",
+  "apiProfile": "2019-03-01-hybrid",
+  "parameters": {},
+  "variables": {},
+  "functions": [],
+  "resources": [
+    {
+      "name": "webSite",
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-12-01",
+      "location": "location1",
+      "tags": {},
+      "properties": {
+        "enabled": true
+      },
+      "resources": []
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/website_not_forcing_https/test/positive2.json
+++ b/assets/queries/azureResourceManager/website_not_forcing_https/test/positive2.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "2.0.0.0",
+  "apiProfile": "2019-03-01-hybrid",
+  "parameters": {},
+  "variables": {},
+  "functions": [],
+  "resources": [
+    {
+      "name": "webSite",
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-12-01",
+      "location": "location1",
+      "tags": {},
+      "properties": {
+        "enabled": true,
+        "httpsOnly": false
+      },
+      "resources": []
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/website_not_forcing_https/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/website_not_forcing_https/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Website Not Forcing HTTPS",
+    "severity": "HIGH",
+    "line": 15,
+    "fileName": "positive1.json"
+  },
+  {
+    "queryName": "Website Not Forcing HTTPS",
+    "severity": "HIGH",
+    "line": 17,
+    "fileName": "positive2.json"
+  }
+]


### PR DESCRIPTION
Signed-off-by: Rafaela Soares rafaela.soares@checkmarx.com

**Proposed Changes**
- Added Website Not Forcing HTTPS query for ARM
- Changed `cloudProvider `in metadata.json of "Phone Number Not Set For Security Contacts" query from `"cloudProvider": "common"` to `"cloudProvider": "azure"`


I submit this contribution under the Apache-2.0 license.
