### PR TITLE
feat(query): Added SQL Alert Policy Without Emails query to ARM

### DIFF
--- a/assets/queries/azureResourceManager/sql_alert_policy_without_emails/metadata.json
+++ b/assets/queries/azureResourceManager/sql_alert_policy_without_emails/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "89b79fe5-49bd-4d39-84ce-55f5fc6f7764",
+  "queryName": "SQL Alert Policy Without Emails",
+  "severity": "INFO",
+  "category": "Best Practices",
+  "descriptionText": "SQL Database Server should contain emails to be notified in the event of a Security Alert",
+  "descriptionUrl": "https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/servers/databases/securityalertpolicies?tabs=json",
+  "platform": "AzureResourceManager",
+  "cloudProvider": "azure",
+  "descriptionID": "3b84ba2d"
+}

--- a/assets/queries/azureResourceManager/sql_alert_policy_without_emails/query.rego
+++ b/assets/queries/azureResourceManager/sql_alert_policy_without_emails/query.rego
@@ -10,6 +10,7 @@ CxPolicy[result] {
 
 	value.type == types[_]
 	properties := value.properties
+	lower(properties.state) == "enabled"
 
 	not commonLib.valid_key(properties, "emailAddresses")
 
@@ -30,6 +31,7 @@ CxPolicy[result] {
 
 	value.type == types[_]
 	properties := value.properties
+	lower(properties.state) == "enabled"
 
 	check_emails(properties.emailAddresses)
 

--- a/assets/queries/azureResourceManager/sql_alert_policy_without_emails/query.rego
+++ b/assets/queries/azureResourceManager/sql_alert_policy_without_emails/query.rego
@@ -1,0 +1,53 @@
+package Cx
+
+import data.generic.common as commonLib
+
+CxPolicy[result] {
+	types := ["Microsoft.Sql/servers/databases/securityAlertPolicies", "securityAlertPolicies"]
+
+	doc := input.document[i]
+	[path, value] := walk(doc)
+
+	value.type == types[_]
+	properties := value.properties
+
+	not commonLib.valid_key(properties, "emailAddresses")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s.name={{%s}}.properties", [commonLib.concat_path(path), value.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "securityAlertPolicies.properties.emailAddresses is defined and contains emails",
+		"keyActualValue": "securityAlertPolicies.properties.emailAddresses is not defined",
+	}
+}
+
+CxPolicy[result] {
+	types := ["Microsoft.Sql/servers/databases/securityAlertPolicies", "securityAlertPolicies"]
+
+	doc := input.document[i]
+	[path, value] := walk(doc)
+
+	value.type == types[_]
+	properties := value.properties
+
+	check_emails(properties.emailAddresses)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s.name={{%s}}.properties.emailAddresses", [commonLib.concat_path(path), value.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "securityAlertPolicies.properties.emailAddresses is defined and contains emails",
+		"keyActualValue": "securityAlertPolicies.properties.emailAddresses doesn't contain emails",
+	}
+}
+
+check_emails(emailAddresses) {
+	count(emailAddresses) == 0
+} else {
+	count([x |
+		email := emailAddresses[_]
+		email == ""
+		x := email
+	]) > 0
+}

--- a/assets/queries/azureResourceManager/sql_alert_policy_without_emails/test/negative.json
+++ b/assets/queries/azureResourceManager/sql_alert_policy_without_emails/test/negative.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "functions": [],
+  "variables": {},
+  "resources": [
+    {
+      "name": "sqlServer1",
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-02-01-preview",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "displayName": "sqlServer1"
+      },
+      "properties": {
+        "administratorLogin": "adminUsername",
+        "administratorLoginPassword": "adminPassword"
+      },
+      "resources": [
+        {
+          "name": "sqlServer1/sqlDatabase1",
+          "type": "Microsoft.Sql/servers/databases",
+          "apiVersion": "2014-04-01",
+          "location": "[resourceGroup().location]",
+          "tags": {
+            "displayName": "sqlDatabase1"
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', 'sqlServer1')]"
+          ],
+          "properties": {
+            "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "edition": "Basic",
+            "maxSizeBytes": "1073741824",
+            "requestedServiceObjectiveName": "Basic"
+          }
+        },
+        {
+          "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
+          "apiVersion": "2021-02-01-preview",
+          "name": "sqlServer1/sqlDatabase1/securityPolicy1",
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', 'sqlServer1')]"
+          ],
+          "properties": {
+            "emailAccountAdmins": true,
+            "emailAddresses": [ "sample@email.com" ],
+            "retentionDays": 4,
+            "state": "Enabled"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/sql_alert_policy_without_emails/test/positive1.json
+++ b/assets/queries/azureResourceManager/sql_alert_policy_without_emails/test/positive1.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "functions": [],
+  "variables": {},
+  "resources": [
+    {
+      "name": "sqlServer1",
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-02-01-preview",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "displayName": "sqlServer1"
+      },
+      "properties": {
+        "administratorLogin": "adminUsername",
+        "administratorLoginPassword": "adminPassword"
+      },
+      "resources": [
+        {
+          "name": "sqlServer1/sqlDatabase1",
+          "type": "Microsoft.Sql/servers/databases",
+          "apiVersion": "2014-04-01",
+          "location": "[resourceGroup().location]",
+          "tags": {
+            "displayName": "sqlDatabase1"
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', 'sqlServer1')]"
+          ],
+          "properties": {
+            "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "edition": "Basic",
+            "maxSizeBytes": "1073741824",
+            "requestedServiceObjectiveName": "Basic"
+          }
+        },
+        {
+          "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
+          "apiVersion": "2021-02-01-preview",
+          "name": "sqlServer1/sqlDatabase1/securityPolicy1",
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', 'sqlServer1')]"
+          ],
+          "properties": {
+            "emailAccountAdmins": true,
+            "retentionDays": 4,
+            "state": "Enabled"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/sql_alert_policy_without_emails/test/positive2.json
+++ b/assets/queries/azureResourceManager/sql_alert_policy_without_emails/test/positive2.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "functions": [],
+  "variables": {},
+  "resources": [
+    {
+      "name": "sqlServer1",
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-02-01-preview",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "displayName": "sqlServer1"
+      },
+      "properties": {
+        "administratorLogin": "adminUsername",
+        "administratorLoginPassword": "adminPassword"
+      },
+      "resources": [
+        {
+          "name": "sqlServer1/sqlDatabase1",
+          "type": "Microsoft.Sql/servers/databases",
+          "apiVersion": "2014-04-01",
+          "location": "[resourceGroup().location]",
+          "tags": {
+            "displayName": "sqlDatabase1"
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', 'sqlServer1')]"
+          ],
+          "properties": {
+            "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "edition": "Basic",
+            "maxSizeBytes": "1073741824",
+            "requestedServiceObjectiveName": "Basic"
+          }
+        },
+        {
+          "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
+          "apiVersion": "2021-02-01-preview",
+          "name": "sqlServer1/sqlDatabase1/securityPolicy1",
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', 'sqlServer1')]"
+          ],
+          "properties": {
+            "emailAccountAdmins": true,
+            "emailAddresses": [],
+            "retentionDays": 4,
+            "state": "Enabled"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/sql_alert_policy_without_emails/test/positive3.json
+++ b/assets/queries/azureResourceManager/sql_alert_policy_without_emails/test/positive3.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "functions": [],
+  "variables": {},
+  "resources": [
+    {
+      "name": "sqlServer1",
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-02-01-preview",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "displayName": "sqlServer1"
+      },
+      "properties": {
+        "administratorLogin": "adminUsername",
+        "administratorLoginPassword": "adminPassword"
+      },
+      "resources": [
+        {
+          "name": "sqlServer1/sqlDatabase1",
+          "type": "Microsoft.Sql/servers/databases",
+          "apiVersion": "2014-04-01",
+          "location": "[resourceGroup().location]",
+          "tags": {
+            "displayName": "sqlDatabase1"
+          },
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', 'sqlServer1')]"
+          ],
+          "properties": {
+            "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "edition": "Basic",
+            "maxSizeBytes": "1073741824",
+            "requestedServiceObjectiveName": "Basic"
+          }
+        },
+        {
+          "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
+          "apiVersion": "2021-02-01-preview",
+          "name": "sqlServer1/sqlDatabase1/securityPolicy1",
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', 'sqlServer1')]"
+          ],
+          "properties": {
+            "emailAccountAdmins": true,
+            "emailAddresses": [ "", "" ],
+            "retentionDays": 4,
+            "state": "Enabled"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/sql_alert_policy_without_emails/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/sql_alert_policy_without_emails/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+  {
+    "queryName": "SQL Alert Policy Without Emails",
+    "severity": "INFO",
+    "line": 46,
+    "filename": "positive1.json"
+  },
+  {
+    "queryName": "SQL Alert Policy Without Emails",
+    "severity": "INFO",
+    "line": 48,
+    "filename": "positive3.json"
+  },
+  {
+    "queryName": "SQL Alert Policy Without Emails",
+    "severity": "INFO",
+    "line": 48,
+    "filename": "positive2.json"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added SQL Alert Policy Without Emails query to ARM

SQL Database Server should contain emails to be notified in the event of a Security Alert

I submit this contribution under the Apache-2.0 license.
