### PR TITLE
feat(query): Added PostgresSQL Database Server Connection Throttling Disabled query to ARM

### DIFF
--- a/assets/libraries/azureresourcemanager/library.rego
+++ b/assets/libraries/azureresourcemanager/library.rego
@@ -1,1 +1,19 @@
 package generic.azureresourcemanager
+
+# get_children returns an Array of all children of the resource
+# doc is input.document[i]
+# parent is the parent resource
+get_children(doc, parent, path) = childArr {
+	resourceArr := [x | x := {"value": parent.resources[_], "path": array.concat(path, ["resources"])}]
+	outerArr := get_outer_children(doc, parent.name)
+	childArr := array.concat(resourceArr, outerArr)
+}
+
+get_outer_children(doc, nameParent) = outerArr {
+	outerArr := [x |
+		[path, value] := walk(doc)
+		startswith(value.name, nameParent)
+		value.name != nameParent
+		x := {"value": value, "path": path}
+	]
+}

--- a/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/metadata.json
+++ b/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "a6d774b6-d9ea-4bf4-8433-217bf15d2fb8",
+  "queryName": "PostgresSQL Database Server Connection Throttling Disabled",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Microsoft.DBforPostgreSQL/servers/configurations should have 'connection_throttling' property set to 'on'",
+  "descriptionUrl": "https://docs.microsoft.com/en-us/azure/templates/microsoft.dbforpostgresql/servers/configurations?tabs=json",
+  "platform": "AzureResourceManager",
+  "cloudProvider": "azure",
+  "descriptionID": "2eb0e3a8"
+}

--- a/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/query.rego
+++ b/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/query.rego
@@ -1,0 +1,50 @@
+package Cx
+
+import data.generic.azureresourcemanager as arm_lib
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	types := ["configurations", "Microsoft.DBforPostgreSQL/servers/configurations"]
+
+	doc := input.document[i]
+	[path, value] = walk(doc)
+
+	value.type == "Microsoft.DBforPostgreSQL/servers"
+	childrenArr := arm_lib.get_children(doc, value, path)
+
+	children := childrenArr[c].value
+	children.type == types[_]
+	endswith(children.name, "connection_throttling")
+
+	lower(children.properties.value) != "on"
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s.name=%s.properties.value", [common_lib.concat_path(childrenArr[c].path), children.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("resource '%s' has an 'auditingsettings' resource enabled", [value.name]),
+		"keyActualValue": sprintf("resource '%s' doesn't have an 'auditingsettings' resource enabled", [value.name]),
+	}
+}
+
+CxPolicy[result] {
+	types := ["configurations", "Microsoft.DBforPostgreSQL/servers/configurations"]
+	doc := input.document[i]
+	[path, value] = walk(doc)
+	value.type == "Microsoft.DBforPostgreSQL/servers"
+	childrenArr := arm_lib.get_children(doc, value, path)
+	count([x |
+		children := childrenArr[c].value
+		children.type == types[_]
+		endswith(children.name, "connection_throttling")
+		x := children
+	]) == 0
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s.name=%s", [common_lib.concat_path(path), value.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("resource '%s' has an 'auditingsettings' resource enabled", [value.name]),
+		"keyActualValue": sprintf("resource '%s' doesn't have an 'auditingsettings' resource enabled", [value.name]),
+	}
+}

--- a/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/negative1.json
+++ b/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/negative1.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "functions": [],
+  "variables": {},
+  "resources": [
+    {
+      "name": "servers1",
+      "type": "Microsoft.DBforPostgreSQL/servers",
+      "apiVersion": "2017-12-01",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "sku": {
+        "name": "B_Gen4_1",
+        "tier": "Basic",
+        "capacity": 500,
+        "size": "500MB",
+        "family": "family"
+      },
+      "properties": {
+        "version": "11",
+        "sslEnforcement": "Enabled",
+        "minimalTlsVersion": "TLS1_2",
+        "infrastructureEncryption": "Enabled",
+        "publicNetworkAccess": "Disabled",
+        "storageProfile": {
+          "backupRetentionDays": 90,
+          "geoRedundantBackup": "Enabled",
+          "storageMB": 50,
+          "storageAutogrow": "Enabled"
+        },
+        "createMode": "Replica",
+        "sourceServerId": "sample_id"
+      },
+      "location": "string",
+      "tags": {},
+      "resources": [
+        {
+          "name": "connection_throttling",
+          "type": "configurations",
+          "apiVersion": "2017-12-01",
+          "properties": {
+            "value": "On"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/negative2.json
+++ b/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/negative2.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "functions": [],
+  "variables": {},
+  "resources": [
+    {
+      "name": "servers1",
+      "type": "Microsoft.DBforPostgreSQL/servers",
+      "apiVersion": "2017-12-01",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "sku": {
+        "name": "B_Gen4_1",
+        "tier": "Basic",
+        "capacity": 500,
+        "size": "500MB",
+        "family": "family"
+      },
+      "properties": {
+        "version": "11",
+        "sslEnforcement": "Enabled",
+        "minimalTlsVersion": "TLS1_2",
+        "infrastructureEncryption": "Enabled",
+        "publicNetworkAccess": "Disabled",
+        "storageProfile": {
+          "backupRetentionDays": 90,
+          "geoRedundantBackup": "Enabled",
+          "storageMB": 50,
+          "storageAutogrow": "Enabled"
+        },
+        "createMode": "Replica",
+        "sourceServerId": "sample_id"
+      },
+      "location": "string",
+      "tags": {}
+    },
+    {
+      "name": "servers1/connection_throttling",
+      "type": "Microsoft.DBforPostgreSQL/servers/configurations",
+      "apiVersion": "2017-12-01",
+      "properties": {
+        "value": "On"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/positive1.json
+++ b/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/positive1.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "functions": [],
+  "variables": {},
+  "resources": [
+    {
+      "name": "servers1",
+      "type": "Microsoft.DBforPostgreSQL/servers",
+      "apiVersion": "2017-12-01",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "sku": {
+        "name": "B_Gen4_1",
+        "tier": "Basic",
+        "capacity": 500,
+        "size": "500MB",
+        "family": "family"
+      },
+      "properties": {
+        "version": "11",
+        "sslEnforcement": "Enabled",
+        "minimalTlsVersion": "TLS1_2",
+        "infrastructureEncryption": "Enabled",
+        "publicNetworkAccess": "Disabled",
+        "storageProfile": {
+          "backupRetentionDays": 90,
+          "geoRedundantBackup": "Enabled",
+          "storageMB": 50,
+          "storageAutogrow": "Enabled"
+        },
+        "createMode": "Replica",
+        "sourceServerId": "sample_id"
+      },
+      "location": "string",
+      "tags": {},
+      "resources": [
+        {
+          "name": "connection_throttling",
+          "type": "configurations",
+          "apiVersion": "2017-12-01",
+          "properties": {
+            "value": "Off"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/positive2.json
+++ b/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/positive2.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "functions": [],
+  "variables": {},
+  "resources": [
+    {
+      "name": "servers1",
+      "type": "Microsoft.DBforPostgreSQL/servers",
+      "apiVersion": "2017-12-01",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "sku": {
+        "name": "B_Gen4_1",
+        "tier": "Basic",
+        "capacity": 500,
+        "size": "500MB",
+        "family": "family"
+      },
+      "properties": {
+        "version": "11",
+        "sslEnforcement": "Enabled",
+        "minimalTlsVersion": "TLS1_2",
+        "infrastructureEncryption": "Enabled",
+        "publicNetworkAccess": "Disabled",
+        "storageProfile": {
+          "backupRetentionDays": 90,
+          "geoRedundantBackup": "Enabled",
+          "storageMB": 50,
+          "storageAutogrow": "Enabled"
+        },
+        "createMode": "Replica",
+        "sourceServerId": "sample_id"
+      },
+      "location": "string",
+      "tags": {},
+      "resources": []
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/positive3.json
+++ b/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/positive3.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "functions": [],
+  "variables": {},
+  "resources": [
+    {
+      "name": "servers1",
+      "type": "Microsoft.DBforPostgreSQL/servers",
+      "apiVersion": "2017-12-01",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "sku": {
+        "name": "B_Gen4_1",
+        "tier": "Basic",
+        "capacity": 500,
+        "size": "500MB",
+        "family": "family"
+      },
+      "properties": {
+        "version": "11",
+        "sslEnforcement": "Enabled",
+        "minimalTlsVersion": "TLS1_2",
+        "infrastructureEncryption": "Enabled",
+        "publicNetworkAccess": "Disabled",
+        "storageProfile": {
+          "backupRetentionDays": 90,
+          "geoRedundantBackup": "Enabled",
+          "storageMB": 50,
+          "storageAutogrow": "Enabled"
+        },
+        "createMode": "Replica",
+        "sourceServerId": "sample_id"
+      },
+      "location": "string",
+      "tags": {},
+      "resources": [
+        {
+          "name": "sample_config",
+          "type": "configurations",
+          "apiVersion": "2017-12-01",
+          "properties": {
+            "value": "Off"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/postgres_sql_database_server_connection_throttling_disabled/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+  {
+    "queryName": "PostgresSQL Database Server Connection Throttling Disabled",
+    "severity": "MEDIUM",
+    "line": 45,
+    "fileName": "positive1.json"
+  },
+  {
+    "queryName": "PostgresSQL Database Server Connection Throttling Disabled",
+    "severity": "MEDIUM",
+    "line": 9,
+    "fileName": "positive2.json"
+  },
+  {
+    "queryName": "PostgresSQL Database Server Connection Throttling Disabled",
+    "severity": "MEDIUM",
+    "line": 9,
+    "fileName": "positive3.json"
+  }
+]


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added PostgresSQL Database Server Connection Throttling Disabled query to ARM

Microsoft.DBforPostgreSQL/servers/configurations should have 'connection_throttling' property set to 'on'

I submit this contribution under the Apache-2.0 license.
