### PR TITLE
refactor(query): 'object.get' function for cloudFormation

### DIFF
--- a/assets/queries/cloudFormation/access_key_not_rotated_within_90_days/query.rego
+++ b/assets/queries/cloudFormation/access_key_not_rotated_within_90_days/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
     resource.Type == "AWS::Config::ConfigRule"
@@ -20,7 +22,7 @@ CxPolicy[result] {
 	configRule.Type == "AWS::Config::ConfigRule"
 	configRule.Properties.Source.SourceIdentifier == "ACCESS_KEYS_ROTATED"
 
-	object.get(configRule.Properties, "InputParameters", "undefined") == "undefined"
+	not common_lib.valid_key(configRule.Properties, "InputParameters")
 
 	result := {
 		"documentId": document.id,

--- a/assets/queries/cloudFormation/amazon_mq_broker_encryption_disabled/query.rego
+++ b/assets/queries/cloudFormation/amazon_mq_broker_encryption_disabled/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::AmazonMQ::Broker"
 	properties := resource.Properties
-	object.get(properties, "EncryptionOptions", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "EncryptionOptions")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/amplify_app_access_token_exposed/query.rego
+++ b/assets/queries/cloudFormation/amplify_app_access_token_exposed/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	document := input.document[i]
@@ -32,8 +33,8 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.AccessToken
-	object.get(document, "Parameters", "undefined") != "undefined"
-	object.get(document.Parameters, paramName, "undefined") == "undefined"
+	common_lib.valid_key(document, "Parameters")
+	not common_lib.valid_key(document.Parameters, paramName)
 
 	defaultToken := paramName
 	count(defaultToken) > 50
@@ -56,7 +57,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.AccessToken
-	object.get(document, "Parameters", "undefined") == "undefined"
+	not common_lib.valid_key(document, "Parameters")
 
 	defaultToken := paramName
 	count(defaultToken) > 50

--- a/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_exposed/query.rego
+++ b/assets/queries/cloudFormation/amplify_app_basic_auth_config_password_exposed/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	document := input.document[i]
@@ -33,8 +34,8 @@ CxPolicy[result] {
 	properties := resource.Properties
 	properties.BasicAuthConfig.EnableBasicAuth == true
 	paramName := properties.BasicAuthConfig.Password
-	object.get(document, "Parameters", "undefined") != "undefined"
-	object.get(document.Parameters, paramName, "undefined") == "undefined"
+	common_lib.valid_key(document, "Parameters")
+	not common_lib.valid_key(document.Parameters, paramName)
 
 	defaultToken := paramName
 
@@ -58,7 +59,7 @@ CxPolicy[result] {
 	properties := resource.Properties
 	properties.BasicAuthConfig.EnableBasicAuth == true
 	paramName := properties.BasicAuthConfig.Password
-	object.get(document, "Parameters", "undefined") == "undefined"
+	not common_lib.valid_key(document, "Parameters")
 
 	defaultToken := paramName
 

--- a/assets/queries/cloudFormation/amplify_app_oauth_token_exposed/query.rego
+++ b/assets/queries/cloudFormation/amplify_app_oauth_token_exposed/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	document := input.document[i]
@@ -33,8 +34,8 @@ CxPolicy[result] {
 	paramName := properties.OauthToken
 	count(paramName) >= 50
 	defaultToken := paramName
-	object.get(document, "Parameters", "undefined") != "undefined"
-	object.get(document.Parameters, paramName, "undefined") == "undefined"
+	common_lib.valid_key(document, "Parameters")
+	not common_lib.valid_key(document.Parameters, paramName)
 
 	regex.match(`[A-Za-z0-9\-\._~\+\/]+=*`, defaultToken)
 	not cloudFormationLib.hasSecretManager(defaultToken, document.Resources)
@@ -55,7 +56,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.OauthToken
-	object.get(document, "Parameters", "undefined") == "undefined"
+	not common_lib.valid_key(document, "Parameters")
 	count(paramName) >= 50
 	defaultToken := paramName
 

--- a/assets/queries/cloudFormation/amplify_branch_basic_auth_config_password_exposed/query.rego
+++ b/assets/queries/cloudFormation/amplify_branch_basic_auth_config_password_exposed/query.rego
@@ -1,6 +1,8 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
+
 
 CxPolicy[result] {
 	document := input.document[i]
@@ -33,8 +35,8 @@ CxPolicy[result] {
 	properties := resource.Properties
 	properties.BasicAuthConfig.EnableBasicAuth == true
 	paramName := properties.BasicAuthConfig.Password
-	object.get(document, "Parameters", "undefined") != "undefined"
-	object.get(document.Parameters, paramName, "undefined") == "undefined"
+	common_lib.valid_key(document, "Parameters")
+	not common_lib.valid_key(document.Parameters, paramName)
 
 	defaultToken := paramName
 
@@ -57,7 +59,7 @@ CxPolicy[result] {
 	properties := resource.Properties
 	properties.BasicAuthConfig.EnableBasicAuth == true
 	paramName := properties.BasicAuthConfig.Password
-	object.get(document, "Parameters", "undefined") == "undefined"
+	not common_lib.valid_key(document, "Parameters")
 
 	defaultToken := paramName
 

--- a/assets/queries/cloudFormation/api_gateway_deployment_without_access_log_setting/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_deployment_without_access_log_setting/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
@@ -41,7 +43,7 @@ CxPolicy[result] {
 	check_resources_type("AWS::ApiGateway::Stage")
 	settings_are_equal(document[i].Resources, name)
 
-	object.get(resource.Properties, "StageDescription", "undefined") = "undefined"
+	not common_lib.valid_key(resource.Properties, "StageDescription")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -60,7 +62,7 @@ CxPolicy[result] {
 	check_resources_type("AWS::ApiGateway::Stage")
 	settings_are_equal(document[i].Resources, name)
 
-	object.get(resource.Properties.StageDescription, "AccessLogSetting", "undefined") = "undefined"
+	not common_lib.valid_key(resource.Properties.StageDescription, "AccessLogSetting")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/api_gateway_endpoint_config_is_not_private/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_endpoint_config_is_not_private/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ApiGateway::RestApi"
 
-	object.get(resource.Properties, "EndpointConfiguration", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "EndpointConfiguration")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -20,7 +22,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::ApiGateway::RestApi"
 	endpointConfig := resource.Properties.EndpointConfiguration
 
-	object.get(endpointConfig, "Types", "undefined") == "undefined"
+	not common_lib.valid_key(endpointConfig, "Types")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/api_gateway_method_does_not_contains_an_api_key/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_method_does_not_contains_an_api_key/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource = document.Resources[name]
 	resource.Type == "AWS::ApiGateway::Method"
 
-	object.get(resource.Properties, "ApiKeyRequired", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "ApiKeyRequired")
 
 	result := {
 		"documentId": document.id,

--- a/assets/queries/cloudFormation/api_gateway_v2_stage_access_logging_settings_not_defined/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_v2_stage_access_logging_settings_not_defined/query.rego
@@ -1,18 +1,20 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::ApiGatewayV2::Stage"
 
 	properties := resource.Properties
-	object.get(resource.Properties, "AccessLogSettings", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "AccessLogSettings")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.AccessLogSettings is defined", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.AccessLogSettings is not defined", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.AccessLogSettings is defined and not null", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.AccessLogSettings is undefined or null", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/api_gateway_without_content_encoding/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_without_content_encoding/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
@@ -40,7 +42,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::ApiGateway::RestApi"
 	properties := resource.Properties
 
-	object.get(properties, "MinimumCompressionSize", "undefined") = "undefined"
+	not common_lib.valid_key(properties, "MinimumCompressionSize")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/api_gateway_without_security_policy/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_without_security_policy/query.rego
@@ -1,13 +1,14 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::ApiGateway::DomainName"
 
 	properties := resource.Properties
-	exists_security_policy := object.get(properties, "SecurityPolicy", "undefined") != "undefined"
-	not exists_security_policy
+	not common_lib.valid_key(properties, "SecurityPolicy")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_without_ssl_certificate/query.rego
@@ -1,12 +1,14 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::ApiGateway::Stage"
 
 	properties := resource.Properties
-	object.get(properties, "ClientCertificateId", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "ClientCertificateId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/api_gateway_xray_disabled/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_xray_disabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
@@ -21,7 +23,7 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::ApiGateway::Stage"
 	properties := resource.Properties
-	object.get(properties, "TracingEnabled", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "TracingEnabled")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/query.rego
+++ b/assets/queries/cloudFormation/auto_scaling_group_with_no_associated_elb/query.rego
@@ -1,9 +1,11 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::AutoScaling::AutoScalingGroup"
-	object.get(resource.Properties, "LoadBalancerNames", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "LoadBalancerNames")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/automatic_minor_upgrades_disabled/query.rego
+++ b/assets/queries/cloudFormation/automatic_minor_upgrades_disabled/query.rego
@@ -1,9 +1,11 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
-	object.get(resource.Properties, "AutoMinorVersionUpgrade", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "AutoMinorVersionUpgrade")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/cdn_configuration_is_missing/query.rego
+++ b/assets/queries/cloudFormation/cdn_configuration_is_missing/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[name]
@@ -23,7 +25,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::CloudFront::Distribution"
 	properties := resource.Properties.DistributionConfig
 
-	object.get(properties, "Origins", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "Origins")
 
 	result := {
 		"documentId": document.id,

--- a/assets/queries/cloudFormation/cloudformation_specifying_credentials_not_safe/query.rego
+++ b/assets/queries/cloudFormation/cloudformation_specifying_credentials_not_safe/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::EC2::Instance"
@@ -7,7 +9,7 @@ CxPolicy[result] {
 	mdata == "AWS::CloudFormation::Authentication"
 	creds := metadata[accessCreds]
 	creds.type == "S3"
-	object.get(creds, "accessKeyId", "undefined") != "undefined"
+	common_lib.valid_key(creds, "accessKeyId")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -25,7 +27,7 @@ CxPolicy[result] {
 	mdata == "AWS::CloudFormation::Authentication"
 	creds := metadata[accessCreds]
 	creds.type == "S3"
-	object.get(creds, "secretKey", "undefined") != "undefined"
+	common_lib.valid_key(creds, "secretKey")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -43,7 +45,7 @@ CxPolicy[result] {
 	mdata == "AWS::CloudFormation::Authentication"
 	creds := metadata[accessCreds]
 	creds.type == "basic"
-	object.get(creds, "password", "undefined") != "undefined"
+	common_lib.valid_key(creds, "password")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/cloudfront_logging_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudfront_logging_disabled/query.rego
@@ -23,7 +23,6 @@ CxPolicy[result] {
 	resource.Type == "AWS::CloudFront::Distribution"
 
 	distributionConfig := resource.Properties.DistributionConfig
-	common_lib.valid_key(distributionConfig, "Logging")
 
 	bucketCorrect := resource.Properties.DistributionConfig.Logging.Bucket
 	endswith(bucketCorrect, ".s3.amazonaws.com") == false

--- a/assets/queries/cloudFormation/cloudfront_logging_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudfront_logging_disabled/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudFront::Distribution"
 
 	distributionConfig := resource.Properties.DistributionConfig
-	object.get(distributionConfig, "Logging", "notfound") == "notfound"
+	not common_lib.valid_key(distributionConfig, "Logging")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -21,7 +23,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::CloudFront::Distribution"
 
 	distributionConfig := resource.Properties.DistributionConfig
-	object.get(distributionConfig, "Logging", "notfound") != "notfound"
+	common_lib.valid_key(distributionConfig, "Logging")
 
 	bucketCorrect := resource.Properties.DistributionConfig.Logging.Bucket
 	endswith(bucketCorrect, ".s3.amazonaws.com") == false

--- a/assets/queries/cloudFormation/cloudfront_without_minimum_protocol_tls_1.2/query.rego
+++ b/assets/queries/cloudFormation/cloudfront_without_minimum_protocol_tls_1.2/query.rego
@@ -1,12 +1,12 @@
 package Cx
 
-import data.generic.common as commonLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudFront::Distribution"
 	properties := resource.Properties
-	object.get(properties.DistributionConfig, "ViewerCertificate", "undefined") == "undefined"
+	not common_lib.valid_key(properties.DistributionConfig, "ViewerCertificate")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -22,7 +22,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::CloudFront::Distribution"
 	properties := resource.Properties
 	protocolVer := properties.DistributionConfig.ViewerCertificate.MinimumProtocolVersion
-	not commonLib.inArray({"TLSv1.2_2018", "TLSv1.2_2019","TLSv1.2-2018", "TLSv1.2-2019"}, protocolVer)
+	not common_lib.inArray({"TLSv1.2_2018", "TLSv1.2_2019","TLSv1.2-2018", "TLSv1.2-2019"}, protocolVer)
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/cloudfront_without_waf/query.rego
+++ b/assets/queries/cloudFormation/cloudfront_without_waf/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudFront::Distribution"
 	distributionConfig := resource.Properties.DistributionConfig
 
-	object.get(distributionConfig, "WebACLId", "undefined") == "undefined"
+	not common_lib.valid_key(distributionConfig, "WebACLId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/cloudtrail_log_file_validation_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudtrail_log_file_validation_disabled/query.rego
@@ -1,9 +1,11 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudTrail::Trail"
-	object.get(resource.Properties, "EnableLogFileValidation", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "EnableLogFileValidation")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -17,7 +19,8 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudTrail::Trail"
-	object.get(resource.Properties, "EnableLogFileValidation", "undefined") == false
+	common_lib.valid_key(resource.Properties, "EnableLogFileValidation")
+	resource.Properties.EnableLogFileValidation == false
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/cloudtrail_log_file_validation_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudtrail_log_file_validation_disabled/query.rego
@@ -19,7 +19,6 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudTrail::Trail"
-	common_lib.valid_key(resource.Properties, "EnableLogFileValidation")
 	resource.Properties.EnableLogFileValidation == false
 
 	result := {

--- a/assets/queries/cloudFormation/cloudtrail_log_files_not_encrypted/query.rego
+++ b/assets/queries/cloudFormation/cloudtrail_log_files_not_encrypted/query.rego
@@ -1,15 +1,17 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudTrail::Trail"
-	object.get(resource.Properties, "KMSKeyId", "not found") == "not found"
+	not common_lib.valid_key(resource.Properties, "KMSKeyId")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.KMSKeyId' should exist", [name]),
-		"keyActualValue": sprintf("'Resources.%s.Properties.KMSKeyId' doesn't exist", [name]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.KMSKeyId' is defined and not null", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.KMSKeyId' is undefined or null", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/cloudtrail_logging_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudtrail_logging_disabled/query.rego
@@ -5,7 +5,6 @@ import data.generic.common as common_lib
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudTrail::Trail"
-	common_lib.valid_key(resource.Properties, "IsLogging")
 	resource.Properties.IsLogging == false
 
 	result := {

--- a/assets/queries/cloudFormation/cloudtrail_logging_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudtrail_logging_disabled/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudTrail::Trail"
-	object.get(resource.Properties, "IsLogging", "undefined") == false
+	common_lib.valid_key(resource.Properties, "IsLogging")
+	resource.Properties.IsLogging == false
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/cloudtrail_logging_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudtrail_logging_disabled/query.rego
@@ -1,7 +1,5 @@
 package Cx
 
-import data.generic.common as common_lib
-
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudTrail::Trail"

--- a/assets/queries/cloudFormation/cloudtrail_multi_region_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudtrail_multi_region_disabled/query.rego
@@ -1,9 +1,11 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudTrail::Trail"
-	not object.get(resource.Properties, "IsMultiRegionTrail", "undefined") == "undefined"
+	common_lib.valid_key(resource.Properties, "IsMultiRegionTrail")
 	not checkRegion(resource)
 
 	result := {
@@ -18,7 +20,7 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudTrail::Trail"
-	object.get(resource.Properties, "IsMultiRegionTrail", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "IsMultiRegionTrail")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/cloudtrail_not_integrated_with_cloudwatch/query.rego
+++ b/assets/queries/cloudFormation/cloudtrail_not_integrated_with_cloudwatch/query.rego
@@ -1,18 +1,21 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[name]
 	resource.Type == "AWS::CloudTrail::Trail"
-	attr := {"CloudWatchLogsLogGroupArn", "CloudWatchLogsRoleArn"}
-
-	object.get(resource.Properties, attr[a], "not found") == "not found"
+	attributes := {"CloudWatchLogsLogGroupArn", "CloudWatchLogsRoleArn"}
+	attr := attributes[a]
+	
+	not common_lib.valid_key(resource.Properties, attr)
 
 	result := {
 		"documentId": document.id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.%s' is declared", [name, attr[a]]),
-		"keyActualValue": sprintf("'Resources.%s.Properties.%s' is not declared", [name, attr[a]]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.%s' is declared", [name, attr]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.%s' is not declared", [name, attr]),
 	}
 }

--- a/assets/queries/cloudFormation/cloudtrail_sns_topic_name_undefined/query.rego
+++ b/assets/queries/cloudFormation/cloudtrail_sns_topic_name_undefined/query.rego
@@ -22,6 +22,5 @@ isMissing(properties,attribute) {
 }
 
 isMissing(properties,attribute) {
-    common_lib.valid_key(properties, attribute)
     properties[attribute] == ""
 }

--- a/assets/queries/cloudFormation/cloudtrail_sns_topic_name_undefined/query.rego
+++ b/assets/queries/cloudFormation/cloudtrail_sns_topic_name_undefined/query.rego
@@ -1,5 +1,6 @@
 package Cx
 
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
@@ -17,11 +18,10 @@ CxPolicy[result] {
 }
 
 isMissing(properties,attribute) {
-    object.get(properties, attribute, "undefined") == "undefined"
+    not common_lib.valid_key(properties, attribute)
 }
 
 isMissing(properties,attribute) {
-    attr := object.get(properties, attribute, "undefined")
-    attr != "undefined"
-    attr == ""
+    common_lib.valid_key(properties, attribute)
+    properties[attribute] == ""
 }

--- a/assets/queries/cloudFormation/cloudwatch_logging_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudwatch_logging_disabled/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::Route53::HostedZone"
 
-	object.get(resource.Properties,"QueryLoggingConfig","undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties,"QueryLoggingConfig")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/cloudwatch_metrics_disabled/query.rego
+++ b/assets/queries/cloudFormation/cloudwatch_metrics_disabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[key]
@@ -7,7 +9,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 
-	object.get(properties, "Metrics", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "Metrics")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/cmk_rotation_disabled/query.rego
+++ b/assets/queries/cloudFormation/cmk_rotation_disabled/query.rego
@@ -1,18 +1,20 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::KMS::Key"
 	resource.Properties.Enabled == true
-	object.get(resource.Properties, "PendingWindowInDays", "undefined") == "undefined"
-	object.get(resource.Properties, "EnableKeyRotation", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "PendingWindowInDays")
+	not common_lib.valid_key(resource.Properties, "EnableKeyRotation")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.EnableKeyRotation' is defined", [name]),
-		"keyActualValue": sprintf("'Resources.%s.Properties.EnableKeyRotation' is not defined", [name]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.EnableKeyRotation' is defined and not null", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.EnableKeyRotation' is undefined or null", [name]),
 	}
 }
 
@@ -20,7 +22,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::KMS::Key"
 	resource.Properties.Enabled == true
-	object.get(resource.Properties, "PendingWindowInDays", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "PendingWindowInDays")
 	resource.Properties.EnableKeyRotation == false
 
 	result := {

--- a/assets/queries/cloudFormation/cmk_unencrypted_storage/query.rego
+++ b/assets/queries/cloudFormation/cmk_unencrypted_storage/query.rego
@@ -1,12 +1,12 @@
 package Cx
 
 import data.generic.cloudformation as cldLib
-import data.generic.common as commonLib
+import data.generic.common as common_lib
 
 CxPolicy[result] { #Resource Type DB  and StorageEncrypted is False
 	document := input.document[i]
 	resource := document.Resources[key]
-    commonLib.inArray({"AWS::DocDB::DBCluster", "AWS::Neptune::DBCluster", "AWS::RDS::DBCluster", "AWS::RDS::DBInstance", "AWS::RDS::GlobalCluster"}, resource.Type)
+    common_lib.inArray({"AWS::DocDB::DBCluster", "AWS::Neptune::DBCluster", "AWS::RDS::DBCluster", "AWS::RDS::DBInstance", "AWS::RDS::GlobalCluster"}, resource.Type)
 
     properties := resource.Properties
 	cldLib.isCloudFormationFalse(properties.StorageEncrypted)
@@ -23,10 +23,10 @@ CxPolicy[result] { #Resource Type DB  and StorageEncrypted is False
 CxPolicy[result] { # DBTypes any DB, but without storage encrypted is undefined
 	document := input.document[i]
 	resource := document.Resources[key]
-    commonLib.inArray({"AWS::DocDB::DBCluster", "AWS::Neptune::DBCluster", "AWS::RDS::DBCluster", "AWS::RDS::DBInstance", "AWS::RDS::GlobalCluster"}, resource.Type)
+    common_lib.inArray({"AWS::DocDB::DBCluster", "AWS::Neptune::DBCluster", "AWS::RDS::DBCluster", "AWS::RDS::DBInstance", "AWS::RDS::GlobalCluster"}, resource.Type)
 
 	properties := resource.Properties
-	object.get(properties, "StorageEncrypted", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "StorageEncrypted")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -40,10 +40,10 @@ CxPolicy[result] { # DBTypes any DB, but without storage encrypted is undefined
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[key]
-	commonLib.inArray({"AWS::DocDB::DBCluster", "AWS::Neptune::DBCluster", "AWS::RDS::DBCluster", "AWS::RDS::DBInstance", "AWS::Redshift::Cluster"}, resource.Type)
+	common_lib.inArray({"AWS::DocDB::DBCluster", "AWS::Neptune::DBCluster", "AWS::RDS::DBCluster", "AWS::RDS::DBInstance", "AWS::Redshift::Cluster"}, resource.Type)
 
 	properties := resource.Properties
-	object.get(properties, "KmsKeyId", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "KmsKeyId")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -60,7 +60,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::Redshift::Cluster"
 
 	properties := resource.Properties
-	object.get(properties, "Encrypted", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "Encrypted")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/codebuild_not_encrypted/query.rego
+++ b/assets/queries/cloudFormation/codebuild_not_encrypted/query.rego
@@ -1,16 +1,18 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Project.Type == "AWS::CodeBuild::Project"
 	properties := resource.Project.Properties
-	object.get(properties, "EncryptionKey", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "EncryptionKey")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Project.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Project.Properties.EncryptionKey' is defined", [name]),
-		"keyActualValue": sprintf("Resources.%s.Project.Properties.EncryptionKey' is undefined", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Project.Properties.EncryptionKey' is defined and not null", [name]),
+		"keyActualValue": sprintf("Resources.%s.Project.Properties.EncryptionKey' is undefined or null", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/cognito_userpool_without_mfa/query.rego
+++ b/assets/queries/cloudFormation/cognito_userpool_without_mfa/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Cognito::UserPool"
 
-	object.get(resource.Properties, "MfaConfiguration", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "MfaConfiguration")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/config_configuration_aggregator_to_all_regions_disabled/query.rego
+++ b/assets/queries/cloudFormation/config_configuration_aggregator_to_all_regions_disabled/query.rego
@@ -22,9 +22,6 @@ CxPolicy[result] {
 	resource.Type == "AWS::Config::ConfigurationAggregator"
     aggregators := ["AccountAggregationSources","OrganizationAggregationSource"]
 
-
-	common_lib.valid_key(resource.Properties, aggregators[type])
-
     aggregators[type] == "AccountAggregationSources"
 
     accSources := resource.Properties.AccountAggregationSources

--- a/assets/queries/cloudFormation/config_configuration_aggregator_to_all_regions_disabled/query.rego
+++ b/assets/queries/cloudFormation/config_configuration_aggregator_to_all_regions_disabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Config::ConfigurationAggregator"
@@ -21,13 +23,13 @@ CxPolicy[result] {
     aggregators := ["AccountAggregationSources","OrganizationAggregationSource"]
 
 
-	object.get(resource.Properties, aggregators[type], "undefined") != "undefined"
+	common_lib.valid_key(resource.Properties, aggregators[type])
 
     aggregators[type] == "AccountAggregationSources"
 
     accSources := resource.Properties.AccountAggregationSources
-
-    object.get(accSources[j],"AllAwsRegions","undefined") == "undefined"
+	accs := accSources[j]
+    not common_lib.valid_key(accs,"AllAwsRegions")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -44,13 +46,13 @@ CxPolicy[result] {
     aggregators := ["AccountAggregationSources","OrganizationAggregationSource"]
 
 
-	object.get(resource.Properties, aggregators[type], "undefined") != "undefined"
+	common_lib.valid_key(resource.Properties, aggregators[type])
 
     aggregators[type] == "AccountAggregationSources"
 
     accSources := resource.Properties.AccountAggregationSources
 
-    object.get(accSources[j],"AllAwsRegions","undefined") != "undefined"
+    common_lib.valid_key(accSources[j],"AllAwsRegions")
 
     not accSources[j].AllAwsRegions
 
@@ -69,13 +71,13 @@ CxPolicy[result] {
     aggregators := ["AccountAggregationSources","OrganizationAggregationSource"]
 
 
-	object.get(resource.Properties, aggregators[type], "undefined") != "undefined"
+	common_lib.valid_key(resource.Properties, aggregators[type])
 
     aggregators[type] == "OrganizationAggregationSource"
 
     orgSource := resource.Properties.OrganizationAggregationSource
 
-    object.get(orgSource,"AllAwsRegions","undefined") == "undefined"
+    not common_lib.valid_key(orgSource,"AllAwsRegions")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -92,13 +94,13 @@ CxPolicy[result] {
     aggregators := ["AccountAggregationSources","OrganizationAggregationSource"]
 
 
-	object.get(resource.Properties, aggregators[type], "undefined") != "undefined"
+	common_lib.valid_key(resource.Properties, aggregators[type])
 
     aggregators[type] == "OrganizationAggregationSource"
 
     orgSource := resource.Properties.OrganizationAggregationSource
 
-    object.get(orgSource,"AllAwsRegions","undefined") != "undefined"
+    common_lib.valid_key(orgSource,"AllAwsRegions")
 
     not orgSource.AllAwsRegions
 
@@ -113,5 +115,5 @@ CxPolicy[result] {
 
 hasAggregationSources(resource) {
     aggregators := ["AccountAggregationSources","OrganizationAggregationSource"]
-	object.get(resource, aggregators[_], "undefined") != "undefined"
+	common_lib.valid_key(resource, aggregators[_])
 }

--- a/assets/queries/cloudFormation/config_configuration_aggregator_to_all_regions_disabled/query.rego
+++ b/assets/queries/cloudFormation/config_configuration_aggregator_to_all_regions_disabled/query.rego
@@ -20,9 +20,6 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Config::ConfigurationAggregator"
-    aggregators := ["AccountAggregationSources","OrganizationAggregationSource"]
-
-    aggregators[type] == "AccountAggregationSources"
 
     accSources := resource.Properties.AccountAggregationSources
 	accs := accSources[j]
@@ -40,18 +37,10 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Config::ConfigurationAggregator"
-    aggregators := ["AccountAggregationSources","OrganizationAggregationSource"]
-
-
-	common_lib.valid_key(resource.Properties, aggregators[type])
-
-    aggregators[type] == "AccountAggregationSources"
 
     accSources := resource.Properties.AccountAggregationSources
 
-    common_lib.valid_key(accSources[j],"AllAwsRegions")
-
-    not accSources[j].AllAwsRegions
+    accSources[j].AllAwsRegions == false
 
 	result := {
 		"documentId": input.document[i].id,
@@ -65,12 +54,6 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Config::ConfigurationAggregator"
-    aggregators := ["AccountAggregationSources","OrganizationAggregationSource"]
-
-
-	common_lib.valid_key(resource.Properties, aggregators[type])
-
-    aggregators[type] == "OrganizationAggregationSource"
 
     orgSource := resource.Properties.OrganizationAggregationSource
 
@@ -88,18 +71,10 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Config::ConfigurationAggregator"
-    aggregators := ["AccountAggregationSources","OrganizationAggregationSource"]
-
-
-	common_lib.valid_key(resource.Properties, aggregators[type])
-
-    aggregators[type] == "OrganizationAggregationSource"
 
     orgSource := resource.Properties.OrganizationAggregationSource
 
-    common_lib.valid_key(orgSource,"AllAwsRegions")
-
-    not orgSource.AllAwsRegions
+    orgSource.AllAwsRegions == false
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/db_security_group_open_to_large_scope/query.rego
+++ b/assets/queries/cloudFormation/db_security_group_open_to_large_scope/query.rego
@@ -1,9 +1,11 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::EC2::SecurityGroup"
-	object.get(resource.Properties.SecurityGroupIngress, "CidrIpv6", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties.SecurityGroupIngress, "CidrIpv6")
 	ipv4 := resource.Properties.SecurityGroupIngress.CidrIp
 	not check_mask_ipv4(ipv4)
 
@@ -19,7 +21,7 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::EC2::SecurityGroup"
-	object.get(resource.Properties.SecurityGroupIngress, "CidrIp", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties.SecurityGroupIngress, "CidrIp")
 	ipv6 := resource.Properties.SecurityGroupIngress.CidrIpv6
 	not check_ipv6(ipv6)
 

--- a/assets/queries/cloudFormation/directory_service_microsoft_ad_password_set_to_plaintext_or_default_ref/query.rego
+++ b/assets/queries/cloudFormation/directory_service_microsoft_ad_password_set_to_plaintext_or_default_ref/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	document := input.document[i]
@@ -30,7 +31,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.Password
-	object.get(document, "Parameters", "undefined") == "undefined"
+	not common_lib.valid_key(document, "Parameters")
 
 	defaultToken := paramName
 
@@ -53,8 +54,8 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.Password
-	object.get(document, "Parameters", "undefined") != "undefined"
-	object.get(document.Parameters, paramName, "undefined") == "undefined"
+	common_lib.valid_key(document, "Parameters")
+	not common_lib.valid_key(document.Parameters, paramName)
 
 	defaultToken := paramName
 

--- a/assets/queries/cloudFormation/directory_service_simple_ad_password_exposed/query.rego
+++ b/assets/queries/cloudFormation/directory_service_simple_ad_password_exposed/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	document := input.document[i]
@@ -30,7 +31,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.Password
-	object.get(document, "Parameters", "undefined") == "undefined"
+	not common_lib.valid_key(document, "Parameters")
 
 	defaultToken := paramName
 
@@ -53,8 +54,8 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.Password
-	object.get(document, "Parameters", "undefined") != "undefined"
-	object.get(document.Parameters, paramName, "undefined") == "undefined"
+	common_lib.valid_key(document, "Parameters")
+	not common_lib.valid_key(document.Parameters, paramName)
 
 	defaultToken := paramName
 

--- a/assets/queries/cloudFormation/dms_endpoint_mongo_db_settings_password_exposed/query.rego
+++ b/assets/queries/cloudFormation/dms_endpoint_mongo_db_settings_password_exposed/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	document := input.document[i]
@@ -30,7 +31,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.MongoDbSettings.Password
-	object.get(document, "Parameters", "undefined") == "undefined"
+	not common_lib.valid_key(document, "Parameters")
 
 	defaultToken := paramName
 
@@ -53,8 +54,8 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.MongoDbSettings.Password
-	object.get(document, "Parameters", "undefined") != "undefined"
-	object.get(document.Parameters, paramName, "undefined") == "undefined"
+	common_lib.valid_key(document, "Parameters")
+	not common_lib.valid_key(document.Parameters, paramName)
 
 	defaultToken := paramName
 

--- a/assets/queries/cloudFormation/dms_endpoint_password_exposed/query.rego
+++ b/assets/queries/cloudFormation/dms_endpoint_password_exposed/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	document := input.document[i]
@@ -30,7 +31,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.Password
-	object.get(document, "Parameters", "undefined") == "undefined"
+	not common_lib.valid_key(document, "Parameters")
 
 	defaultToken := paramName
 
@@ -53,8 +54,8 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.Password
-	object.get(document, "Parameters", "undefined") != "undefined"
-	object.get(document.Parameters, paramName, "undefined") == "undefined"
+	common_lib.valid_key(document, "Parameters")
+	not common_lib.valid_key(document.Parameters, paramName)
 
 	defaultToken := paramName
 

--- a/assets/queries/cloudFormation/docdb_cluster_master_password_in_plaintext/query.rego
+++ b/assets/queries/cloudFormation/docdb_cluster_master_password_in_plaintext/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	document := input.document[i]
@@ -30,8 +31,8 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.MasterUserPassword
-	object.get(document, "Parameters", "undefined") != "undefined"
-	object.get(document.Parameters, paramName, "undefined") == "undefined"
+	common_lib.valid_key(document, "Parameters")
+	not common_lib.valid_key(document.Parameters, paramName)
 
 	defaultToken := paramName
 
@@ -54,7 +55,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	paramName := properties.MasterUserPassword
-	object.get(document, "Parameters", "undefined") == "undefined"
+	not common_lib.valid_key(document, "Parameters")
 
 	defaultToken := paramName
 

--- a/assets/queries/cloudFormation/dynamodb_with_aws_owned_cmk/query.rego
+++ b/assets/queries/cloudFormation/dynamodb_with_aws_owned_cmk/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[key]
@@ -22,7 +24,7 @@ CxPolicy[result] {
 	resource := document.Resources[key]
 	resource.Type == "AWS::DynamoDB::Table"
 	properties := resource.Properties
-	object.get(properties, "SSESpecification", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "SSESpecification")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -38,7 +40,7 @@ CxPolicy[result] {
 	resource := document.Resources[key]
 	resource.Type == "AWS::DynamoDB::Table"
 	properties := resource.Properties
-	object.get(properties.SSESpecification, "SSEType", "undefined") == "undefined"
+	not common_lib.valid_key(properties.SSESpecification, "SSEType")
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.properties;", [key]),
@@ -54,7 +56,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::DynamoDB::Table"
 	properties := resource.Properties
 
-	object.get(properties.SSESpecification, "SSEEnabled", "undefined") == "undefined"
+	not common_lib.valid_key(properties.SSESpecification, "SSEEnabled")
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.properties;", [key]),

--- a/assets/queries/cloudFormation/ebs_volume_encryption_disabled/query.rego
+++ b/assets/queries/cloudFormation/ebs_volume_encryption_disabled/query.rego
@@ -1,18 +1,20 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::EC2::Volume"
 	properties := resource.Properties
-	object.get(properties, "Encrypted", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "Encrypted")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.Encrypted is defined", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.Encrypted is not defined", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.Encrypted is defined and not null", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.Encrypted is undefined or null", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/ebs_volume_without_kms_key_id/query.rego
+++ b/assets/queries/cloudFormation/ebs_volume_without_kms_key_id/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[key]
@@ -7,7 +9,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 
-	object.get(properties, "KmsKeyId", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "KmsKeyId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/ec2_instance_has_no_iam_role/query.rego
+++ b/assets/queries/cloudFormation/ec2_instance_has_no_iam_role/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	doc := input.document[i].Resources
 	resource := doc[name]
 	resource.Type == "AWS::EC2::Instance"
 
-	object.get(resource.Properties, "IamInstanceProfile", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "IamInstanceProfile")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -21,10 +23,10 @@ CxPolicy[result] {
 	resource := doc[name]
 	resource.Type == "AWS::EC2::Instance"
 
-	object.get(resource.Properties, "IamInstanceProfile", "undefined") != "undefined"
+	common_lib.valid_key(resource.Properties, "IamInstanceProfile")
 
 	iamProfile := get_iam_instance_profile(resource.Properties.IamInstanceProfile)
-	object.get(doc, iamProfile, "undefined") == "undefined"
+	not common_lib.valid_key(doc, iamProfile)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -40,11 +42,11 @@ CxPolicy[result] {
 	resource := doc[name]
 	resource.Type == "AWS::EC2::Instance"
 
-	object.get(resource.Properties, "IamInstanceProfile", "undefined") != "undefined"
+	common_lib.valid_key(resource.Properties, "IamInstanceProfile")
 
 	iamProfile := get_iam_instance_profile(resource.Properties.IamInstanceProfile)
-	object.get(doc, iamProfile, "undefined") != "undefined"
-	object.get(doc[iamProfile].Properties, "Roles", "undefined") == "undefined"
+	common_lib.valid_key(doc, iamProfile)
+	not common_lib.valid_key(doc[iamProfile].Properties, "Roles")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
+++ b/assets/queries/cloudFormation/ec2_network_acl_duplicate_rule/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	entry1 := input.document[i].Resources[name]
 	entry1.Type == "AWS::EC2::NetworkAclEntry"
@@ -28,7 +30,7 @@ CxPolicy[result] {
 }
 
 getRef(obj) = obj.Ref {
-	object.get(obj, "Ref", "undefined") != "undefined"
+	common_lib.valid_key(obj, "Ref")
 } else = obj {
 	true
 }

--- a/assets/queries/cloudFormation/ecr_image_tag_not_immutable/query.rego
+++ b/assets/queries/cloudFormation/ecr_image_tag_not_immutable/query.rego
@@ -1,17 +1,19 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ECR::Repository"
 
-	object.get(resource.Properties, "ImageTagMutability", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "ImageTagMutability")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.ImageTagMutability is defined", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.ImageTagMutability is undefined", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.ImageTagMutability is defined and not null", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.ImageTagMutability is undefined or null", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/ecs_cluster_not_encrypted_at_rest/query.rego
+++ b/assets/queries/cloudFormation/ecs_cluster_not_encrypted_at_rest/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources
 	elem := resource[key]
@@ -26,7 +28,7 @@ CxPolicy[result] {
 	elem.Type == "AWS::ECS::Service"
 	clustername := elem.Properties.Cluster
 	taskdefinitionkey := elem.Properties.TaskDefinition
-	object.get(resource, taskdefinitionkey, "undefined") == "undefined"
+	not common_lib.valid_key(resource, taskdefinitionkey)
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/ecs_service_without_running_tasks/query.rego
+++ b/assets/queries/cloudFormation/ecs_service_without_running_tasks/query.rego
@@ -1,18 +1,20 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ECS::Service"
 	properties := resource.Properties
 
-	object.get(properties, "DeploymentConfiguration", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "DeploymentConfiguration")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.DeploymentConfiguration is defined", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.DeploymentConfiguration is undefined", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.DeploymentConfiguration is defined and not null", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.DeploymentConfiguration is undefined or null", [name]),
 	}
 }
 
@@ -33,13 +35,13 @@ CxPolicy[result] {
 }
 
 checkContent(deploymentConfiguration) {
-	object.get(deploymentConfiguration, "MaximumPercent", "undefined") != "undefined"
+	common_lib.valid_key(deploymentConfiguration, "MaximumPercent")
 }
 
 checkContent(deploymentConfiguration) {
-	object.get(deploymentConfiguration, "MinimumHealthyPercent", "undefined") != "undefined"
+	common_lib.valid_key(deploymentConfiguration, "MinimumHealthyPercent")
 }
 
 checkContent(deploymentConfiguration) {
-	object.get(deploymentConfiguration, "DeploymentCircuitBreaker", "undefined") != "undefined"
+	common_lib.valid_key(deploymentConfiguration, "DeploymentCircuitBreaker")
 }

--- a/assets/queries/cloudFormation/ecs_task_definition_healthcheck_missing/query.rego
+++ b/assets/queries/cloudFormation/ecs_task_definition_healthcheck_missing/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ECS::TaskDefinition"
 	contDef := resource.Properties.ContainerDefinitions[_]
-	object.get(contDef, "HealthCheck", "not found") == "not found"
+	not common_lib.valid_key(contDef, "HealthCheck")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/ecs_task_definition_network_mode_not_recommended/query.rego
+++ b/assets/queries/cloudFormation/ecs_task_definition_network_mode_not_recommended/query.rego
@@ -21,7 +21,6 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ECS::TaskDefinition"
 	properties := resource.Properties
-	common_lib.valid_key(properties, "NetworkMode")
 
     properties.NetworkMode != "awsvpc"
 	result := {

--- a/assets/queries/cloudFormation/ecs_task_definition_network_mode_not_recommended/query.rego
+++ b/assets/queries/cloudFormation/ecs_task_definition_network_mode_not_recommended/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ECS::TaskDefinition"
 	properties := resource.Properties
-	object.get(properties, "NetworkMode", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "NetworkMode")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -19,7 +21,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ECS::TaskDefinition"
 	properties := resource.Properties
-	object.get(properties, "NetworkMode", "undefined") != "undefined"
+	common_lib.valid_key(properties, "NetworkMode")
 
     properties.NetworkMode != "awsvpc"
 	result := {

--- a/assets/queries/cloudFormation/efs_without_kms/query.rego
+++ b/assets/queries/cloudFormation/efs_without_kms/query.rego
@@ -1,12 +1,14 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource = document.Resources[name]
 	resource.Type == "AWS::EFS::FileSystem"
 	properties := resource.Properties
 	properties.Encrypted == false
-	object.get(properties, "KmsKeyId", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "KmsKeyId")
 
 	result := {
 		"documentId": document.id,

--- a/assets/queries/cloudFormation/efs_without_tags/query.rego
+++ b/assets/queries/cloudFormation/efs_without_tags/query.rego
@@ -1,17 +1,19 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource = document.Resources[name]
 	resource.Type == "AWS::EFS::FileSystem"
 	properties := resource.Properties
-	object.get(properties, "FileSystemTags", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "FileSystemTags")
 
 	result := {
 		"documentId": document.id,
 		"searchKey": sprintf("Resources.%s", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.FileSystemTags' is defined", [name]),
-		"keyActualValue": sprintf("'Resources.%s.Properties.FileSystemTags' is undefined", [name]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.FileSystemTags' is defined and not null", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.FileSystemTags' is undefined or null", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/elastic_search_without_slow_logs/query.rego
+++ b/assets/queries/cloudFormation/elastic_search_without_slow_logs/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Elasticsearch::Domain"
@@ -36,14 +38,14 @@ CxPolicy[result] {
 	resource := document.Resources[name]
 	resource.Type == "AWS::Elasticsearch::Domain"
 	properties := resource.Properties
-	object.get(properties, "LogPublishingOptions", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "LogPublishingOptions")
 
 	result := {
 		"documentId": document.id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.LogPublishingOptions is defined", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions is undefined", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.LogPublishingOptions is defined and not null", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.LogPublishingOptions is undefined or null", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/elasticache_nodes_not_created_across_multi_az/query.rego
+++ b/assets/queries/cloudFormation/elasticache_nodes_not_created_across_multi_az/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ElastiCache::CacheCluster"
@@ -24,7 +26,7 @@ CxPolicy[result] {
 	properties := resource.Properties
 	properties.Engine == "memcached"
 	to_number(properties.NumCacheNodes) > 1
-	object.get(properties, "AZMode", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "AZMode")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/elasticache_with_disabled_at_rest_encryption/query.rego
+++ b/assets/queries/cloudFormation/elasticache_with_disabled_at_rest_encryption/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[key]
@@ -22,7 +24,7 @@ CxPolicy[result] {
 	resource.Type = "AWS::ElastiCache::ReplicationGroup"
 	properties := resource.Properties
 	lower(properties.Engine) == "redis"
-	object.get(properties, "AtRestEncryptionEnabled", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "AtRestEncryptionEnabled")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/elasticache_with_disabled_transit_encryption/query.rego
+++ b/assets/queries/cloudFormation/elasticache_with_disabled_transit_encryption/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[key]
@@ -22,7 +24,7 @@ CxPolicy[result] {
 	properties := resource.Properties
 	resource.Type = "AWS::ElastiCache::ReplicationGroup"
 	lower(properties.Engine) == "redis"
-	object.get(properties, "TransitEncryptionEnabled", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "TransitEncryptionEnabled")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/elasticsearch_domain_encryption_with_kms_disabled/query.rego
+++ b/assets/queries/cloudFormation/elasticsearch_domain_encryption_with_kms_disabled/query.rego
@@ -1,19 +1,21 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::Elasticsearch::Domain"
 	properties := resource.Properties
 
-	object.get(properties, "EncryptionAtRestOptions", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "EncryptionAtRestOptions")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is defined", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is undefined", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is defined and not null", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is undefined or null", [name]),
 	}
 }
 
@@ -23,10 +25,9 @@ CxPolicy[result] {
 	resource.Type == "AWS::Elasticsearch::Domain"
 	properties := resource.Properties
 
-	encryptAtRest := object.get(properties, "EncryptionAtRestOptions", "undefined")
-    encryptAtRest != "undefined"
+	common_lib.valid_key(properties, "EncryptionAtRestOptions")
 
-    object.get(encryptAtRest,"KmsKeyId","undefined") == "undefined"
+    not common_lib.valid_key(properties.EncryptionAtRestOptions,"KmsKeyId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/elasticsearch_domain_encryption_with_kms_disabled/test/positive3.yaml
+++ b/assets/queries/cloudFormation/elasticsearch_domain_encryption_with_kms_disabled/test/positive3.yaml
@@ -1,0 +1,33 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Creates RDS Cluster2
+Resources:
+  ElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: "test"
+      ElasticsearchClusterConfig:
+        DedicatedMasterEnabled: "true"
+        InstanceCount: "2"
+        ZoneAwarenessEnabled: "true"
+        InstanceType: "m3.medium.elasticsearch"
+        DedicatedMasterType: "m3.medium.elasticsearch"
+        DedicatedMasterCount: "3"
+      EBSOptions:
+        EBSEnabled: true
+        Iops: 0
+        VolumeSize: 20
+        VolumeType: "gp2"
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: "0"
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::123456789012:user/es-user"
+            Action: "es:*"
+            Resource: "arn:aws:es:us-east-1:846973539254:domain/test/*"
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+

--- a/assets/queries/cloudFormation/elasticsearch_domain_encryption_with_kms_disabled/test/positive4.json
+++ b/assets/queries/cloudFormation/elasticsearch_domain_encryption_with_kms_disabled/test/positive4.json
@@ -1,0 +1,45 @@
+{
+  "Description": "Creates RDS Cluster2",
+  "Resources": {
+    "ElasticsearchDomain": {
+      "Type": "AWS::Elasticsearch::Domain",
+      "Properties": {
+        "EBSOptions": {
+          "EBSEnabled": true,
+          "Iops": 0,
+          "VolumeSize": 20,
+          "VolumeType": "gp2"
+        },
+        "SnapshotOptions": {
+          "AutomatedSnapshotStartHour": "0"
+        },
+        "AccessPolicies": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::123456789012:user/es-user"
+              },
+              "Action": "es:*",
+              "Resource": "arn:aws:es:us-east-1:846973539254:domain/test/*"
+            }
+          ]
+        },
+        "AdvancedOptions": {
+          "rest.action.multi.allow_explicit_index": "true"
+        },
+        "DomainName": "test",
+        "ElasticsearchClusterConfig": {
+          "DedicatedMasterType": "m3.medium.elasticsearch",
+          "DedicatedMasterCount": "3",
+          "DedicatedMasterEnabled": "true",
+          "InstanceCount": "2",
+          "ZoneAwarenessEnabled": "true",
+          "InstanceType": "m3.medium.elasticsearch"
+        }
+      }
+    }
+  },
+  "AWSTemplateFormatVersion": "2010-09-09"
+}

--- a/assets/queries/cloudFormation/elasticsearch_domain_encryption_with_kms_disabled/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/elasticsearch_domain_encryption_with_kms_disabled/test/positive_expected_result.json
@@ -10,5 +10,17 @@
     "fileName": "positive2.json",
     "queryName": "ElasticSearch Encryption With KMS Disabled",
     "severity": "MEDIUM"
+  },
+  {
+    "line": 6,
+    "fileName": "positive3.yaml",
+    "queryName": "ElasticSearch Encryption With KMS Disabled",
+    "severity": "MEDIUM"
+  },
+  {
+    "line": 6,
+    "fileName": "positive4.json",
+    "queryName": "ElasticSearch Encryption With KMS Disabled",
+    "severity": "MEDIUM"
   }
 ]

--- a/assets/queries/cloudFormation/elasticsearch_not_encrypted_at_rest/query.rego
+++ b/assets/queries/cloudFormation/elasticsearch_not_encrypted_at_rest/query.rego
@@ -1,19 +1,21 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::Elasticsearch::Domain"
 	properties := resource.Properties
 
-	object.get(properties, "EncryptionAtRestOptions", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "EncryptionAtRestOptions")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is defined", [name]),
-		"keyActualValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is undefined", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is defined and not null", [name]),
+		"keyActualValue": sprintf("Resources.%s.Properties.EncryptionAtRestOptions is undefined or null", [name]),
 	}
 }
 

--- a/assets/queries/cloudFormation/elb_access_log_disabled/query.rego
+++ b/assets/queries/cloudFormation/elb_access_log_disabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ElasticLoadBalancing::LoadBalancer"
@@ -31,7 +33,7 @@ CxPolicy[result] {
 }
 
 checkALP(prop) {
-	object.get(prop, "AccessLoggingPolicy", "not found") == "not found"
+	not common_lib.valid_key(prop, "AccessLoggingPolicy")
 }
 
 checkALPAttr(prop) {

--- a/assets/queries/cloudFormation/elb_sensitive_port_is_exposed_to_entire_network/query.rego
+++ b/assets/queries/cloudFormation/elb_sensitive_port_is_exposed_to_entire_network/query.rego
@@ -1,7 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
-import data.generic.common as commonLib
+import data.generic.common as common_lib
 
 isAccessibleFromEntireNetwork(ingress) {
 	endswith(ingress.CidrIp, "/0")
@@ -30,7 +30,7 @@ getProtocolPorts(protocols, tcpPortsMap, udpPortsMap) = portsMap {
 }
 
 getELBType(elb) = type {
-	object.get(elb.Properties, "Type", "unspecified") != "unspecified"
+	common_lib.valid_key(elb.Properties, "Type")
 	type = elb.Properties.Type
 } else = type {
 	elb.Type == "AWS::ElasticLoadBalancing::LoadBalancer"
@@ -41,12 +41,12 @@ getELBType(elb) = type {
 }
 
 getLinkedSecGroupList(elb, resources) = elbSecGroupName {
-	object.get(elb.Properties, "SecurityGroups", "unspecified") != "unspecified"
+	common_lib.valid_key(elb.Properties, "SecurityGroups")
 	elbSecGroupName = elb.Properties.SecurityGroups
 } else = ec2SecGroup {
 	ec2InstanceList := [ec2 | ec2 := resources[name]; contains(upper(ec2.Type), "INSTANCE")]
 	ec2Instance := ec2InstanceList[i]
-	object.get(ec2Instance.Properties, "SecurityGroups", "unspecified") != "unspecified"
+	common_lib.valid_key(ec2Instance.Properties, "SecurityGroups")
 	ec2SecGroup = ec2Instance.Properties.SecurityGroups
 }
 
@@ -73,7 +73,7 @@ CxPolicy[result] {
 
 	protocols := getProtocolList(ingress.IpProtocol)
 	protocol := protocols[n]
-	portsMap = getProtocolPorts(protocols, commonLib.tcpPortsMap, cloudFormationLib.udpPortsMap)
+	portsMap = getProtocolPorts(protocols, common_lib.tcpPortsMap, cloudFormationLib.udpPortsMap)
 
 	#############	Checks
 	isAccessibleFromEntireNetwork(ingress)

--- a/assets/queries/cloudFormation/elb_v2_alb_access_log_disabled/query.rego
+++ b/assets/queries/cloudFormation/elb_v2_alb_access_log_disabled/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ElasticLoadBalancingV2::LoadBalancer"
 	prop := resource.Properties
 
-    object.get(prop, "LoadBalancerAttributes", "undefined") == "undefined"
+    not common_lib.valid_key(prop, "LoadBalancerAttributes")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -21,7 +23,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::ElasticLoadBalancingV2::LoadBalancer"
 	prop := resource.Properties
 
-    not object.get(prop, "LoadBalancerAttributes", "undefined") == "undefined"
+    common_lib.valid_key(prop, "LoadBalancerAttributes")
 	contains(prop.LoadBalancerAttributes, "access_logs.s3.enabled")
 
 	result := {

--- a/assets/queries/cloudFormation/elb_v2_alb_access_log_disabled/query.rego
+++ b/assets/queries/cloudFormation/elb_v2_alb_access_log_disabled/query.rego
@@ -23,7 +23,6 @@ CxPolicy[result] {
 	resource.Type == "AWS::ElasticLoadBalancingV2::LoadBalancer"
 	prop := resource.Properties
 
-    common_lib.valid_key(prop, "LoadBalancerAttributes")
 	contains(prop.LoadBalancerAttributes, "access_logs.s3.enabled")
 
 	result := {

--- a/assets/queries/cloudFormation/elb_with_security_group_without_inbound_rules/query.rego
+++ b/assets/queries/cloudFormation/elb_with_security_group_without_inbound_rules/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
@@ -23,7 +24,7 @@ CxPolicy[result] {
 
 withoutOutboundRules(securityGroupName) = result {
 	securityGroup := input.document[i].Resources[securityGroupName]
-	object.get(securityGroup.Properties, "SecurityGroupIngress", "undefined") == "undefined"
+	not common_lib.valid_key(securityGroup.Properties, "SecurityGroupIngress")
 	result := {"expected": "defined", "actual": "undefined", "path": "", "issue": "MissingAttribute"}
 }
 

--- a/assets/queries/cloudFormation/elb_with_security_group_without_outbound_rules/query.rego
+++ b/assets/queries/cloudFormation/elb_with_security_group_without_outbound_rules/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.cloudformation as cloudFormationLib
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
@@ -23,7 +24,7 @@ CxPolicy[result] {
 
 withoutOutboundRules(securityGroupName) = result {
 	securityGroup := input.document[i].Resources[securityGroupName]
-	object.get(securityGroup.Properties, "SecurityGroupEgress", "undefined") == "undefined"
+	not common_lib.valid_key(securityGroup.Properties, "SecurityGroupEgress")
 	result := {"expected": "defined", "actual": "undefined", "path": "", "issue": "MissingAttribute"}
 }
 

--- a/assets/queries/cloudFormation/empty_roles_for_ecs_cluster_task_definitions/query.rego
+++ b/assets/queries/cloudFormation/empty_roles_for_ecs_cluster_task_definitions/query.rego
@@ -1,12 +1,14 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ECS::Service"
 
 	isInCluster(resource, i)
 
-	object.get(resource.Properties, "TaskDefinition", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "TaskDefinition")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -23,7 +25,7 @@ CxPolicy[result] {
 
 	isInCluster(resource, i)
 
-	object.get(resource.Properties, "TaskDefinition", "undefined") != "undefined"
+	common_lib.valid_key(resource.Properties, "TaskDefinition")
 	taskDefinition := resource.Properties.TaskDefinition
 
 	existsTaskDefinition(taskDefinition, i) == null
@@ -43,7 +45,7 @@ CxPolicy[result] {
 
 	isInCluster(resource, i)
 
-	object.get(resource.Properties, "TaskDefinition", "undefined") != "undefined"
+	common_lib.valid_key(resource.Properties, "TaskDefinition")
 	taskDefinition := resource.Properties.TaskDefinition
 
 	taskDef := existsTaskDefinition(taskDefinition, i)
@@ -67,7 +69,7 @@ isInCluster(service, i) {
 } else {
 	cluster := service.Properties.Cluster
 	is_object(cluster)
-	object.get(cluster, "Ref", "undefined") != "undefined"
+	common_lib.valid_key(cluster, "Ref")
 } else = false {
 	true
 }
@@ -78,8 +80,7 @@ existsTaskDefinition(taskDefName, i) = taskDef {
 	taskDef := input.document[i].Resources[taskDefName]
 } else = taskDef {
 	is_object(taskDefName)
-	object.get(taskDefName, "Ref", "undefined") != "undefined"
-	ref := object.get(taskDefName, "Ref", "undefined")
+	common_lib.valid_key(taskDefName, "Ref")
 	input.document[i].Resources[ref].Type == "AWS::ECS::TaskDefinition"
 	taskDef := input.document[i].Resources[ref]
 } else = null {
@@ -87,7 +88,7 @@ existsTaskDefinition(taskDefName, i) = taskDef {
 }
 
 hasTaskRole(taskDef) {
-	object.get(taskDef.Properties, "TaskRoleArn", "undefined") != "undefined"
+	common_lib.valid_key(taskDef.Properties, "TaskRoleArn")
 } else = false {
 	true
 }

--- a/assets/queries/cloudFormation/empty_roles_for_ecs_cluster_task_definitions/query.rego
+++ b/assets/queries/cloudFormation/empty_roles_for_ecs_cluster_task_definitions/query.rego
@@ -25,7 +25,6 @@ CxPolicy[result] {
 
 	isInCluster(resource, i)
 
-	common_lib.valid_key(resource.Properties, "TaskDefinition")
 	taskDefinition := resource.Properties.TaskDefinition
 
 	existsTaskDefinition(taskDefinition, i) == null
@@ -45,7 +44,6 @@ CxPolicy[result] {
 
 	isInCluster(resource, i)
 
-	common_lib.valid_key(resource.Properties, "TaskDefinition")
 	taskDefinition := resource.Properties.TaskDefinition
 
 	taskDef := existsTaskDefinition(taskDefinition, i)
@@ -80,7 +78,7 @@ existsTaskDefinition(taskDefName, i) = taskDef {
 	taskDef := input.document[i].Resources[taskDefName]
 } else = taskDef {
 	is_object(taskDefName)
-	common_lib.valid_key(taskDefName, "Ref")
+	ref := taskDefName.Ref
 	input.document[i].Resources[ref].Type == "AWS::ECS::TaskDefinition"
 	taskDef := input.document[i].Resources[ref]
 } else = null {

--- a/assets/queries/cloudFormation/emr_cluster_without_security_configuration/query.rego
+++ b/assets/queries/cloudFormation/emr_cluster_without_security_configuration/query.rego
@@ -1,13 +1,14 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::EMR::Cluster"
 	properties := resource.Properties
 
-	exists_security_configuration := object.get(properties, "SecurityConfiguration", "undefined") != "undefined"
-	not exists_security_configuration
+	not common_lib.valid_key(properties, "SecurityConfiguration")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/emr_security_configuration_encryptions_enabled/query.rego
+++ b/assets/queries/cloudFormation/emr_security_configuration_encryptions_enabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[key]
@@ -58,7 +60,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	encryptionConfiguration := properties.SecurityConfiguration
-	object.get(encryptionConfiguration, "EncryptionConfiguration", "undefined") == "undefined"
+	not common_lib.valid_key(encryptionConfiguration, "EncryptionConfiguration")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -76,8 +78,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 	localDiskEncryptionConfiguration := properties.SecurityConfiguration.EncryptionConfiguration.AtRestEncryptionConfiguration.LocalDiskEncryptionConfiguration
-	object.get(localDiskEncryptionConfiguration, "EncryptionKeyProviderType", "undefined") == "undefined"
-
+	not common_lib.valid_key(localDiskEncryptionConfiguration, "EncryptionKeyProviderType")
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.SecurityConfiguration.EncryptionConfiguration.AtRestEncryptionConfiguration.LocalDiskEncryptionConfiguration", [key]),

--- a/assets/queries/cloudFormation/github_repository_set_to_public/query.rego
+++ b/assets/queries/cloudFormation/github_repository_set_to_public/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 
 	resource.Type == "AWS::CodeStar::GitHubRepository"
 
-	object.get(resource.Properties, "IsPrivate", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "IsPrivate")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/iam_user_with_no_group/query.rego
+++ b/assets/queries/cloudFormation/iam_user_with_no_group/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::IAM::User"
 	properties := resource.Properties
 
-	object.get(properties, "Groups", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "Groups")
 
     result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/inline_policies_are_attached_to_ecs_service/query.rego
+++ b/assets/queries/cloudFormation/inline_policies_are_attached_to_ecs_service/query.rego
@@ -21,7 +21,6 @@ CxPolicy[result] {
 
 getInlinePolicy(role) = policy {
 	is_string(role)
-	common_lib.valid_key(input.document[_].Resources, role)
 	input.document[_].Resources[role].Type == "AWS::IAM::Policy"
 	policy := role
 } else = policy {

--- a/assets/queries/cloudFormation/inline_policies_are_attached_to_ecs_service/query.rego
+++ b/assets/queries/cloudFormation/inline_policies_are_attached_to_ecs_service/query.rego
@@ -1,7 +1,5 @@
 package Cx
 
-import data.generic.common as common_lib
-
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ECS::Service"

--- a/assets/queries/cloudFormation/inline_policies_are_attached_to_ecs_service/query.rego
+++ b/assets/queries/cloudFormation/inline_policies_are_attached_to_ecs_service/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ECS::Service"
@@ -19,16 +21,13 @@ CxPolicy[result] {
 
 getInlinePolicy(role) = policy {
 	is_string(role)
-	object.get(input.document[_].Resources, role, "undefined") != "undefined"
-	object.get(input.document[_].Resources[role], "Type", "undefined") == "AWS::IAM::Policy"
+	common_lib.valid_key(input.document[_].Resources, role)
+	input.document[_].Resources[role].Type == "AWS::IAM::Policy"
 	policy := role
 } else = policy {
 	is_object(role)
-	object.get(role, "Ref", "undefined") != "undefined"
-	ref := object.get(role, "Ref", "undefined")
-	object.get(input.document[_].Resources, ref, "undefined") != "undefined"
-	object.get(input.document[_].Resources[ref], "Type", "undefined") == "AWS::IAM::Policy"
-	policy := ref
+	input.document[_].Resources[role.Ref].Type == "AWS::IAM::Policy"
+	policy := role.Ref
 } else = "undefined" {
 	true
 }

--- a/assets/queries/cloudFormation/instance_with_no_vpc/query.rego
+++ b/assets/queries/cloudFormation/instance_with_no_vpc/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[key]
@@ -8,7 +10,7 @@ CxPolicy[result] {
 	properties := resource.Properties
 	subnetName := properties.NetworkInterfaces[j].SubnetId
 	subNetObj := document.Resources[subnetName]
-	object.get(subNetObj.Properties, "VpcId", "undefined") == "undefined"
+	not common_lib.valid_key(subNetObj.Properties, "VpcId")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -25,7 +27,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::EC2::Instance"
 
 	properties := resource.Properties
-	object.get(properties, "NetworkInterfaces", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "NetworkInterfaces")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/kinesis_sse_not_configured/query.rego
+++ b/assets/queries/cloudFormation/kinesis_sse_not_configured/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Kinesis::Stream"
 
-	object.get(resource.Properties, "StreamEncryption", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "StreamEncryption")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -19,7 +21,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Kinesis::Stream"
 
-	object.get(resource.Properties.StreamEncryption, "EncryptionType", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties.StreamEncryption, "EncryptionType")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -34,7 +36,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Kinesis::Stream"
 
-	object.get(resource.Properties.StreamEncryption, "KeyId", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties.StreamEncryption, "KeyId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/kms_enable_key_rotation_disabled/query.rego
+++ b/assets/queries/cloudFormation/kms_enable_key_rotation_disabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resources := input.document[i].Resources[name]
 	resources.Type == "AWS::KMS::Key"
@@ -19,7 +21,7 @@ CxPolicy[result] {
 	resources := input.document[i].Resources[name]
 	resources.Type == "AWS::KMS::Key"
 	properties := resources.Properties
-	object.get(properties, "EnableKeyRotation", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "EnableKeyRotation")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/lambda_function_without_tags/query.rego
+++ b/assets/queries/cloudFormation/lambda_function_without_tags/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource = document.Resources[name]
 	resource.Type == "AWS::Lambda::Function"
 	properties := resource.Properties
-	object.get(properties, "Tags", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "Tags")
 
 	result := {
 		"documentId": document.id,

--- a/assets/queries/cloudFormation/lambda_functions_without_x-ray_tracing/query.rego
+++ b/assets/queries/cloudFormation/lambda_functions_without_x-ray_tracing/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource = document.Resources[name]
@@ -21,7 +23,7 @@ CxPolicy[result] {
 	resource = document.Resources[name]
 	resource.Type == "AWS::Lambda::Function"
 	properties := resource.Properties
-	object.get(properties, "TracingConfig", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "TracingConfig")
 
 	result := {
 		"documentId": document.id,

--- a/assets/queries/cloudFormation/mq_broker_is_publicly_accessible/query.rego
+++ b/assets/queries/cloudFormation/mq_broker_is_publicly_accessible/query.rego
@@ -1,7 +1,5 @@
 package Cx
 
-import data.generic.common as common_lib
-
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]

--- a/assets/queries/cloudFormation/mq_broker_is_publicly_accessible/query.rego
+++ b/assets/queries/cloudFormation/mq_broker_is_publicly_accessible/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::AmazonMQ::Broker"
 	properties := resource.Properties
-	object.get(properties, "PubliclyAccessible", "undefined") != "undefined"
+	common_lib.valid_key(properties, "PubliclyAccessible")
 
     properties.PubliclyAccessible
 

--- a/assets/queries/cloudFormation/mq_broker_is_publicly_accessible/query.rego
+++ b/assets/queries/cloudFormation/mq_broker_is_publicly_accessible/query.rego
@@ -7,7 +7,6 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::AmazonMQ::Broker"
 	properties := resource.Properties
-	common_lib.valid_key(properties, "PubliclyAccessible")
 
     properties.PubliclyAccessible
 

--- a/assets/queries/cloudFormation/mq_broker_logging_disabled/query.rego
+++ b/assets/queries/cloudFormation/mq_broker_logging_disabled/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::AmazonMQ::Broker"
 	properties := resource.Properties
-	object.get(properties, "Logs", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "Logs")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -21,19 +23,18 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::AmazonMQ::Broker"
 	properties := resource.Properties
-	object.get(properties, "Logs", "undefined") != "undefined"
+	common_lib.valid_key(properties, "Logs")
 
     logTypes := ["Audit","General"]
-
-    some j
-    object.get(properties.Logs,logTypes[j],"undefined") == "undefined"
+	lTypes := logTypes[j]
+    not common_lib.valid_key(properties.Logs,lTypes)
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("Resources.%s.Properties.Logs", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.Logs.%s is set", [name,logTypes[j]]),
-		"keyActualValue": sprintf("Resources.%s.Properties.Logs.%s is undefined", [name,logTypes[j]]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.Logs.%s is set", [name,lTypes]),
+		"keyActualValue": sprintf("Resources.%s.Properties.Logs.%s is undefined", [name,lTypes]),
 	}
 }
 
@@ -42,13 +43,12 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::AmazonMQ::Broker"
 	properties := resource.Properties
-	object.get(properties, "Logs", "undefined") != "undefined"
+	common_lib.valid_key(properties, "Logs")
 
     logTypes := ["Audit","General"]
 
-    some j
-    object.get(properties.Logs,logTypes[j],"undefined") != "undefined"
-    not object.get(properties.Logs,logTypes[j],"undefined")
+    common_lib.valid_key(properties.Logs,logTypes[j])
+	properties.Logs[logTypes[j]] == false
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/msk_cluster_encryption_disabled/query.rego
+++ b/assets/queries/cloudFormation/msk_cluster_encryption_disabled/query.rego
@@ -1,12 +1,14 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[key]
 	resource.Type == "AWS::MSK::Cluster"
 
 	properties := resource.Properties
-	object.get(properties, "EncryptionInfo", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "EncryptionInfo")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/msk_cluster_logging_disabled/query.rego
+++ b/assets/queries/cloudFormation/msk_cluster_logging_disabled/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resources := input.document[i].Resources[name]
 	resources.Type == "AWS::MSK::Cluster"
 	properties := resources.Properties
-	object.get(properties, "LoggingInfo", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "LoggingInfo")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/query.rego
+++ b/assets/queries/cloudFormation/neptune_cluster_with_iam_database_authentication_disabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Neptune::DBCluster"
@@ -20,7 +22,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::Neptune::DBCluster"
 	properties := resource.Properties
 
-	object.get(properties, "IamAuthEnabled", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "IamAuthEnabled")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/rds_backup_retention_period_insufficient/query.rego
+++ b/assets/queries/cloudFormation/rds_backup_retention_period_insufficient/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBCluster"
@@ -19,7 +21,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBCluster"
 	properties := resource.Properties
-	object.get(properties, "BackupRetentionPeriod", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "BackupRetentionPeriod")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -35,7 +37,7 @@ CxPolicy[result] {
 	resource := doc.Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
 	properties := resource.Properties
-	object.get(properties, "BackupRetentionPeriod", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "BackupRetentionPeriod")
 
 	clusterList := [cluster |
 		doc.Resources[key].Type == "AWS::RDS::DBCluster"

--- a/assets/queries/cloudFormation/rds_db_cluster_storage_encryption_disabled/query.rego
+++ b/assets/queries/cloudFormation/rds_db_cluster_storage_encryption_disabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
@@ -19,7 +21,7 @@ CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBCluster"
-	object.get(resource.Properties, "StorageEncrypted", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "StorageEncrypted")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/query.rego
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/query.rego
@@ -7,7 +7,7 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
 	properties := resource.Properties
-	not properties.EnableIAMDatabaseAuthentication
+	properties.EnableIAMDatabaseAuthentication == false
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/query.rego
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
 	properties := resource.Properties
-    object.get(properties, "EnableIAMDatabaseAuthentication", "undefined") != "undefined"
+    common_lib.valid_key(properties, "EnableIAMDatabaseAuthentication")
 	not properties.EnableIAMDatabaseAuthentication
 
 	result := {
@@ -22,7 +24,7 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
 	properties := resource.Properties
-	object.get(properties, "EnableIAMDatabaseAuthentication", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "EnableIAMDatabaseAuthentication")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/query.rego
+++ b/assets/queries/cloudFormation/rds_db_instance_iam_auth_not_enabled/query.rego
@@ -7,7 +7,6 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
 	properties := resource.Properties
-    common_lib.valid_key(properties, "EnableIAMDatabaseAuthentication")
 	not properties.EnableIAMDatabaseAuthentication
 
 	result := {

--- a/assets/queries/cloudFormation/rds_db_instance_with_deletion_protection_disabled/query.rego
+++ b/assets/queries/cloudFormation/rds_db_instance_with_deletion_protection_disabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
@@ -21,7 +23,7 @@ CxPolicy[result] {
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
 	properties := resource.Properties
-	object.get(properties, "DeletionProtection", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "DeletionProtection")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/rds_multi_az_deployment_disabled/query.rego
+++ b/assets/queries/cloudFormation/rds_multi_az_deployment_disabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
@@ -19,7 +21,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
 	properties := resource.Properties
-	object.get(properties, "MultiAZ", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "MultiAZ")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/rds_storage_not_encrypted/query.rego
+++ b/assets/queries/cloudFormation/rds_storage_not_encrypted/query.rego
@@ -23,8 +23,6 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 
-	common_lib.valid_key(properties, "StorageEncrypted")
-
 	properties.StorageEncrypted == false
 
 	result := {

--- a/assets/queries/cloudFormation/rds_storage_not_encrypted/query.rego
+++ b/assets/queries/cloudFormation/rds_storage_not_encrypted/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::RDS::DBInstance"
 
-	object.get(resource.Properties, "StorageEncrypted", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "StorageEncrypted")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -21,7 +23,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 
-	object.get(properties, "StorageEncrypted", "undefined") != "undefined"
+	common_lib.valid_key(properties, "StorageEncrypted")
 
 	properties.StorageEncrypted == false
 

--- a/assets/queries/cloudFormation/redshift_cluster_logging_disabled/query.rego
+++ b/assets/queries/cloudFormation/redshift_cluster_logging_disabled/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Redshift::Cluster"
 
-	object.get(resource.Properties, "LoggingProperties", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "LoggingProperties")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/redshift_cluster_without_kms_cmk/query.rego
+++ b/assets/queries/cloudFormation/redshift_cluster_without_kms_cmk/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Redshift::Cluster"
 
-	object.get(resource.Properties, "KmsKeyId", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "KmsKeyId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/redshift_not_encrypted/query.rego
+++ b/assets/queries/cloudFormation/redshift_not_encrypted/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Redshift::Cluster"
 
-	object.get(resource.Properties, "Encrypted", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "Encrypted")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -21,7 +23,7 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 
-	object.get(properties, "Encrypted", "undefined") != "undefined"
+	common_lib.valid_key(properties, "Encrypted")
 
 	properties.Encrypted == false
 

--- a/assets/queries/cloudFormation/redshift_not_encrypted/query.rego
+++ b/assets/queries/cloudFormation/redshift_not_encrypted/query.rego
@@ -23,8 +23,6 @@ CxPolicy[result] {
 
 	properties := resource.Properties
 
-	common_lib.valid_key(properties, "Encrypted")
-
 	properties.Encrypted == false
 
 	result := {

--- a/assets/queries/cloudFormation/redshift_publicly_accessible/query.rego
+++ b/assets/queries/cloudFormation/redshift_publicly_accessible/query.rego
@@ -1,9 +1,11 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::Redshift::Cluster"
-	object.get(resource.Properties, "PubliclyAccessible", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "PubliclyAccessible")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/routertable_with_default_routing/query.rego
+++ b/assets/queries/cloudFormation/routertable_with_default_routing/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[key]
@@ -40,7 +42,7 @@ CxPolicy[result] {
 	resource.Type == "AWS::EC2::Route"
 
 	properties := resource.Properties
-	object.get(properties, "NatGatewayId", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "NatGatewayId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/s3_bucket_disabled_cloudtrail_logging/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_disabled_cloudtrail_logging/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::S3::Bucket"
@@ -8,7 +10,7 @@ CxPolicy[result] {
 	resource2.Properties.Bucket.Ref == name
 	resource2.Properties.PolicyDocument.Statement[0].Principal.Service == "cloudtrail.amazonaws.com"
 
-	object.get(resource.Properties, "LoggingConfiguration", "not found") == "not found"
+	not common_lib.valid_key(resource.Properties, "LoggingConfiguration")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/s3_bucket_logging_disabled/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_logging_disabled/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::S3::Bucket"
 	prop := resource.Properties
-	object.get(prop, "LoggingConfiguration", "undefined") == "undefined"
+	not common_lib.valid_key(prop, "LoggingConfiguration")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::S3::Bucket"
@@ -19,7 +21,7 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::S3::Bucket"
-	object.get(resource.Properties, "BucketName", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "BucketName")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/s3_bucket_sse_disabled/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_sse_disabled/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 # return every bucket as result if there are no policies defined
 CxPolicy[result] {
 	document := input.document[i]
@@ -9,7 +11,7 @@ CxPolicy[result] {
 
 	bucket := resources[resource].Properties
 
-	object.get(bucket,"BucketEncryption","undefined") == "undefined"
+	not common_lib.valid_key(bucket,"BucketEncryption")
 
 	result := {
 		"documentId": document.id,
@@ -94,11 +96,11 @@ CxPolicy[result] {
 
 hasServerEncryptionRules(list) {
     some i
-    object.get(list[i],"ServerSideEncryptionByDefault","undefined") != "undefined"
+    common_lib.valid_key(list[i],"ServerSideEncryptionByDefault")
 }
 
 checkMasterKey(assed) {
-	object.get(assed, "KMSMasterKeyID", "undefined") == "undefined"
+	not common_lib.valid_key(assed, "KMSMasterKeyID")
 }
 
 checkMasterKey(assed) {

--- a/assets/queries/cloudFormation/s3_bucket_without_versioning/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_without_versioning/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::S3::Bucket"
-    object.get(resource, "Properties", "undefined") != "undefined"
-    object.get(resource.Properties, "VersioningConfiguration", "undefined") == "undefined"
+    common_lib.valid_key(resource, "Properties")
+    not common_lib.valid_key(resource.Properties, "VersioningConfiguration")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/sagemaker_data_encryption_disabled/query.rego
+++ b/assets/queries/cloudFormation/sagemaker_data_encryption_disabled/query.rego
@@ -1,9 +1,11 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::SageMaker::NotebookInstance"
-	object.get(resource.Properties, "KmsKeyId", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "KmsKeyId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/sagemaker_endpoint_config_should_specify_kms_key_id_attribute/query.rego
+++ b/assets/queries/cloudFormation/sagemaker_endpoint_config_should_specify_kms_key_id_attribute/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::SageMaker::EndpointConfig"
 	properties := resource.Properties
-	object.get(properties, "KmsKeyId", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "KmsKeyId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/sagemaker_notebook_not_placed_in_vpc/query.rego
+++ b/assets/queries/cloudFormation/sagemaker_notebook_not_placed_in_vpc/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resource = document[i].Resources[name]
 	resource.Type == "AWS::SageMaker::NotebookInstance"
 
-	object.get(resource.Properties, "SubnetId", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "SubnetId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/secrets_manager_should_specify_kms_key_id/query.rego
+++ b/assets/queries/cloudFormation/secrets_manager_should_specify_kms_key_id/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::SecretsManager::Secret"
 	properties := resource.Properties
-	object.get(properties, "KmsKeyId", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "KmsKeyId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/security_group_rule_without_description/query.rego
+++ b/assets/queries/cloudFormation/security_group_rule_without_description/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::EC2::SecurityGroup"
 
-	object.get(resource.Properties, "GroupDescription", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "GroupDescription")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -20,7 +22,8 @@ CxPolicy[result] {
 	resource.Type == "AWS::EC2::SecurityGroup"
 
 	properties := {"SecurityGroupIngress", "SecurityGroupEgress"}
-	object.get(resource.Properties[properties[index]][j], "Description", "undefined") == "undefined"
+	prop := resource.Properties[properties[index]][j]
+	not common_lib.valid_key(prop, "Description")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -37,7 +40,7 @@ CxPolicy[result] {
 
 	resourceTypes[resource.Type]
 
-	object.get(resource.Properties, "Description", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "Description")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/security_groups_do_not_have_vpc/query.rego
+++ b/assets/queries/cloudFormation/security_groups_do_not_have_vpc/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document
 	resources := document[i].Resources[name]
@@ -18,5 +20,5 @@ check_not_exists_vpc(resource) {
 	resource.Type == "AWS::EC2::SecurityGroup"
 	security_group := resource.Properties
 	security_group.GroupName != "default"
-	object.get(security_group, "VpcId", "undefined") == "undefined"
+	not common_lib.valid_key(security_group, "VpcId")
 }

--- a/assets/queries/cloudFormation/sns_topic_publicity_has_allow_and_not_action_simultaneously/query.rego
+++ b/assets/queries/cloudFormation/sns_topic_publicity_has_allow_and_not_action_simultaneously/query.rego
@@ -1,12 +1,14 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::SNS::TopicPolicy"
 	document := resource.Properties.PolicyDocument
 	statements = document.Statement
 	statements[k].Effect == "Allow"
-	object.get(statements[k], "NotAction", "undefined") != "undefined"
+	common_lib.valid_key(statements[k], "NotAction")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/sns_topic_without_kms_master_key_id/query.rego
+++ b/assets/queries/cloudFormation/sns_topic_without_kms_master_key_id/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::SNS::Topic"
 	properties := resource.Properties
-	object.get(properties, "KmsMasterKeyId", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "KmsMasterKeyId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/sqs_policy_with_public_access/query.rego
+++ b/assets/queries/cloudFormation/sqs_policy_with_public_access/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 
@@ -22,7 +24,7 @@ CxPolicy[result] {
 isUnsafeStatement(stmt) = result {
 	stmt.Effect == "Allow"
 	action := hasDangerousAction(stmt.Action)
-	object.get(stmt, "Condition", "undefined") == "undefined"
+	not common_lib.valid_key(stmt, "Condition")
 	result := [action, hasWildcardPrincipal(stmt.Principal)]
 }
 

--- a/assets/queries/cloudFormation/sqs_queue_policy_allows_not_action/query.rego
+++ b/assets/queries/cloudFormation/sqs_queue_policy_allows_not_action/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::SQS::QueuePolicy"
@@ -7,7 +9,7 @@ CxPolicy[result] {
 	statement := resource.Properties.PolicyDocument.Statement
 
 	statement[index].Effect == "Allow"
-	object.get(statement[index], "NotAction", "undefined") != "undefined"
+	common_lib.valid_key(statement[index], "NotAction")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/sqs_queue_policy_allows_not_principal/query.rego
+++ b/assets/queries/cloudFormation/sqs_queue_policy_allows_not_principal/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 
@@ -21,5 +23,5 @@ CxPolicy[result] {
 
 isUnsafeStatement(stmt) {
 	stmt.Effect == "Allow"
-	object.get(stmt, "NotPrincipal", "undefined") != "undefined"
+	common_lib.valid_key(stmt, "NotPrincipal")
 }

--- a/assets/queries/cloudFormation/sqs_with_sse_disabled/query.rego
+++ b/assets/queries/cloudFormation/sqs_with_sse_disabled/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::SQS::Queue"
 
-	object.get(resource.Properties, "KmsMasterKeyId", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "KmsMasterKeyId")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/stack_notifications_disabled/query.rego
+++ b/assets/queries/cloudFormation/stack_notifications_disabled/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudFormation::Stack"
 
-	object.get(resource.Properties, "NotificationARNs", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "NotificationARNs")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/stack_retention_disabled/query.rego
+++ b/assets/queries/cloudFormation/stack_retention_disabled/query.rego
@@ -40,9 +40,8 @@ CxPolicy[result] {
 	resource.Type == "AWS::CloudFormation::StackSet"
 
     autoDeployment := resource.Properties.AutoDeployment
-	common_lib.valid_key(autoDeployment, "Enabled")
 
-    not autoDeployment.Enabled
+    autoDeployment.Enabled == false
 
 	result := {
 		"documentId": input.document[i].id,
@@ -76,9 +75,8 @@ CxPolicy[result] {
     autoDeployment := resource.Properties.AutoDeployment
 
     autoDeployment.Enabled
-	common_lib.valid_key(autoDeployment, "RetainStacksOnAccountRemoval")
 
-    not autoDeployment.RetainStacksOnAccountRemoval
+    autoDeployment.RetainStacksOnAccountRemoval == false
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/stack_retention_disabled/query.rego
+++ b/assets/queries/cloudFormation/stack_retention_disabled/query.rego
@@ -1,10 +1,12 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudFormation::StackSet"
 
-	object.get(resource.Properties, "AutoDeployment", "undefined") == "undefined"
+	not common_lib.valid_key(resource.Properties, "AutoDeployment")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -19,10 +21,10 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudFormation::StackSet"
 
-	object.get(resource.Properties, "AutoDeployment", "undefined") != "undefined"
+	common_lib.valid_key(resource.Properties, "AutoDeployment")
 
     autoDeployment := resource.Properties.AutoDeployment
-	object.get(autoDeployment, "Enabled", "undefined") == "undefined"
+	not common_lib.valid_key(autoDeployment, "Enabled")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -37,10 +39,10 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudFormation::StackSet"
 
-	object.get(resource.Properties, "AutoDeployment", "undefined") != "undefined"
+	common_lib.valid_key(resource.Properties, "AutoDeployment")
 
     autoDeployment := resource.Properties.AutoDeployment
-	object.get(autoDeployment, "Enabled", "undefined") != "undefined"
+	common_lib.valid_key(autoDeployment, "Enabled")
 
     not autoDeployment.Enabled
 
@@ -59,7 +61,7 @@ CxPolicy[result] {
     autoDeployment := resource.Properties.AutoDeployment
 
     autoDeployment.Enabled
-	object.get(autoDeployment, "RetainStacksOnAccountRemoval", "undefined") == "undefined"
+	not common_lib.valid_key(autoDeployment, "RetainStacksOnAccountRemoval")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -76,7 +78,7 @@ CxPolicy[result] {
     autoDeployment := resource.Properties.AutoDeployment
 
     autoDeployment.Enabled
-	object.get(autoDeployment, "RetainStacksOnAccountRemoval", "undefined") != "undefined"
+	common_lib.valid_key(autoDeployment, "RetainStacksOnAccountRemoval")
 
     not autoDeployment.RetainStacksOnAccountRemoval
 

--- a/assets/queries/cloudFormation/stack_retention_disabled/query.rego
+++ b/assets/queries/cloudFormation/stack_retention_disabled/query.rego
@@ -39,8 +39,6 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::CloudFormation::StackSet"
 
-	common_lib.valid_key(resource.Properties, "AutoDeployment")
-
     autoDeployment := resource.Properties.AutoDeployment
 	common_lib.valid_key(autoDeployment, "Enabled")
 

--- a/assets/queries/cloudFormation/support_has_no_role_associated/query.rego
+++ b/assets/queries/cloudFormation/support_has_no_role_associated/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Properties.PolicyName == "AWSSupportAccess"
@@ -49,7 +51,7 @@ CxPolicy[result] {
 }
 
 hasAttributeList(resource, attribute) {
-	object.get(resource, attribute, "undefined") != "undefined"
+	common_lib.valid_key(resource, attribute)
 	count(resource[attribute]) > 0
 } else = false {
 	true

--- a/assets/queries/cloudFormation/support_has_no_role_associated/query.rego
+++ b/assets/queries/cloudFormation/support_has_no_role_associated/query.rego
@@ -1,7 +1,5 @@
 package Cx
 
-import data.generic.common as common_lib
-
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Properties.PolicyName == "AWSSupportAccess"

--- a/assets/queries/cloudFormation/support_has_no_role_associated/query.rego
+++ b/assets/queries/cloudFormation/support_has_no_role_associated/query.rego
@@ -51,7 +51,6 @@ CxPolicy[result] {
 }
 
 hasAttributeList(resource, attribute) {
-	common_lib.valid_key(resource, attribute)
 	count(resource[attribute]) > 0
 } else = false {
 	true

--- a/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/query.rego
+++ b/assets/queries/cloudFormation/tcp_or_udp_protocol_network_acl_entry_allows_all_ports/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::EC2::NetworkAclEntry"
@@ -8,7 +10,7 @@ CxPolicy[result] {
 
 	checkProtocol(properties.Protocol)
 
-	object.get(properties, "PortRange", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "PortRange")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -28,7 +30,8 @@ CxPolicy[result] {
 	checkProtocol(properties.Protocol)
 
 	attributes := {"From", "To"}
-	object.get(properties.PortRange, attributes[y], "undefined") == "undefined"
+	attr := attributes[y]
+	not common_lib.valid_key(properties.PortRange, attr)
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/unscanned_ecr_image/query.rego
+++ b/assets/queries/cloudFormation/unscanned_ecr_image/query.rego
@@ -1,11 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::ECR::Repository"
 	properties := resource.Properties
 
-	object.get(properties, "ImageScanningConfiguration", "undefined") == "undefined"
+	not common_lib.valid_key(properties, "ImageScanningConfiguration")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/user_iam_missing_password_reset_required/query.rego
+++ b/assets/queries/cloudFormation/user_iam_missing_password_reset_required/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::IAM::User"
@@ -20,7 +22,7 @@ CxPolicy[result] {
 	resource := input.document[i].Resources[name]
 	resource.Type == "AWS::IAM::User"
 	loginProfile := resource.Properties
-	object.get(loginProfile, "LoginProfile", "undefined") == "undefined"
+	not common_lib.valid_key(loginProfile, "LoginProfile")
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/cloudFormation/vulnerable_default_ssl_certificate/query.rego
+++ b/assets/queries/cloudFormation/vulnerable_default_ssl_certificate/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	resource := document.Resources[name]
@@ -22,11 +24,11 @@ CxPolicy[result] {
 	resource := document.Resources[name]
 	resource.Type == "AWS::CloudFront::Distribution"
 	attr := {"MinimumProtocolVersion", "SslSupportMethod"}
-
+	attributes := attr[a]
 	viewerCertificate := resource.Properties.DistributionConfig.ViewerCertificate
 
 	hasCustomConfig(viewerCertificate)
-	object.get(viewerCertificate, attr[a], "undefined") == "undefined"
+	not common_lib.valid_key(viewerCertificate, attributes)
 
 	result := {
 		"documentId": document.id,
@@ -44,9 +46,9 @@ isAttrTrue(value) {
 }
 
 hasCustomConfig(viewerCertificate) {
-	object.get(viewerCertificate, "IamCertificateId", "undefined") != "undefined"
+	common_lib.valid_key(viewerCertificate, "IamCertificateId")
 }
 
 hasCustomConfig(viewerCertificate) {
-	object.get(viewerCertificate, "AcmCertificateArn", "undefined") != "undefined"
+	common_lib.valid_key(viewerCertificate, "AcmCertificateArn")
 }

--- a/assets/queries/cloudFormation/workspace_without_encryption/query.rego
+++ b/assets/queries/cloudFormation/workspace_without_encryption/query.rego
@@ -9,7 +9,6 @@ CxPolicy[result] {
 	workspace := document.Resources[workspaceName]
 
 	# The UserVolumeEncryptionEnabled property is defined, but is set to false
-	common_lib.valid_key(workspace.Properties, "UserVolumeEncryptionEnabled")
 	not isTrue(workspace.Properties.UserVolumeEncryptionEnabled)
 
 	result := {

--- a/assets/queries/cloudFormation/workspace_without_encryption/query.rego
+++ b/assets/queries/cloudFormation/workspace_without_encryption/query.rego
@@ -1,5 +1,7 @@
 package Cx
 
+import data.generic.common as common_lib
+
 CxPolicy[result] {
 	document := input.document[i]
 	some workspaceName
@@ -7,7 +9,7 @@ CxPolicy[result] {
 	workspace := document.Resources[workspaceName]
 
 	# The UserVolumeEncryptionEnabled property is defined, but is set to false
-	object.get(workspace.Properties, "UserVolumeEncryptionEnabled", "undefined") != "undefined"
+	common_lib.valid_key(workspace.Properties, "UserVolumeEncryptionEnabled")
 	not isTrue(workspace.Properties.UserVolumeEncryptionEnabled)
 
 	result := {
@@ -26,7 +28,7 @@ CxPolicy[result] {
 	workspace := document.Resources[workspaceName]
 
 	# The UserVolumeEncryptionEnabled property is not defined
-	object.get(workspace.Properties, "UserVolumeEncryptionEnabled", "undefined") == "undefined"
+	not common_lib.valid_key(workspace.Properties, "UserVolumeEncryptionEnabled")
 
 	result := {
 		"documentId": document.id,


### PR DESCRIPTION
Signed-off-by: Tiago Cruz tiago.cruz@checkmarx.com

**Proposed Changes**
- refactoring `object.get` function to `valid.key` function

I submit this contribution under the Apache-2.0 license.
