### PR TITLE
feat(core): Added a ignore/disable/enable feature on commented files

### DIFF
--- a/docs/running-kics.md
+++ b/docs/running-kics.md
@@ -131,3 +131,52 @@ To overwrite `defaultPasswords`, you can create a file `f996f3cb-00fc-480c-8973-
 Then you can execute KICS normally adding `--input-data ./custom-input/`, if `custom-input` folder is in current path, and it will replace the key `defaultPasswords` on `passwords_and_secrets_in_infrastructure_code` query with the custom value you defined.
 
 **NOTE**: The value which will replace the default value, **MUST** be the same type as the default key (e.g. `defaultPasswords` must be an array of strings)
+
+## Using commands on scanned files as comments
+KICS scan supports some special commands in the comments that are on the file beginning (i.e.: all comments before any valid line on IaC file). To use this feature you need to create a comment that starts with `kics-scan` and wanted command with values (if necessary).
+
+For example, if you want to ignore a tf file when running a scan, you can start your file as following:
+
+```hcl
+# kics-scan ignore
+# rest of the file...
+```
+
+If you need to start with a header comment, you can add another line below with the `kics-scan` command you want, but `kics-scan` will not works if there is any valid line above it, as you can see on the following example:
+
+```hcl
+# Some comment
+# This works
+# kics-scan ignore
+resource "google_storage_bucket" "example" {
+  # This does not works
+  # kics-scan ignore
+  name          = "image-store.com"
+  location      = "EU"
+  force_destroy = true
+}
+# This also not works, since there is valid script before this comment
+# kics-scan ignore
+```
+
+KICS currently supports three commands:
+- `ignore`: Will ignore file when running a scan;
+- `enable=<query_id>,<query_id>`: Will get results on this file **only** for listed queries;
+- `disable=<query_id>,<query_id>`: Will ignore results on this file for listed queries;
+
+The order of prescendence in above commands are:
+1. ignore
+2. enable
+3. disable
+
+For example:
+```hcl
+# kics-scan disable=0afa6ab8-a047-48cf-be07-93a2f8c34cf7
+# kics-scan
+```
+In this case, this file will be ignored by KICS, instead of ignoring results for query with id 0afa6ab8-a047-48cf-be07-93a2f8c34cf7.
+
+This feature is supported by all extensions that supports comments. Currently, KICS supports this features for:
+- Dockerfile;
+- HCL (Terraform);
+- YAML;

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -573,6 +573,73 @@ func TestEngine_GetFailedQueries(t *testing.T) {
 	}
 }
 
+func TestShouldSkipFile(t *testing.T) {
+	type args struct {
+		commands model.CommentsCommands
+		queryID  string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected bool
+	}{
+		{
+			name: "test_enabled_queries_valid_query",
+			args: args{
+				commands: model.CommentsCommands{
+					"enable": "ffdf4b37-7703-4dfe-a682-9d2e99bc6c09,0afa6ab8-a047-48cf-be07-93a2f8c34cf7",
+				},
+				queryID: "ffdf4b37-7703-4dfe-a682-9d2e99bc6c09",
+			},
+			expected: false,
+		},
+		{
+			name: "test_enabled_queries_invalid_query",
+			args: args{
+				commands: model.CommentsCommands{
+					"enable": "0afa6ab8-a047-48cf-be07-93a2f8c34cf7",
+				},
+				queryID: "ffdf4b37-7703-4dfe-a682-9d2e99bc6c09",
+			},
+			expected: true,
+		},
+		{
+			name: "test_disabled_queries_invalid_query",
+			args: args{
+				commands: model.CommentsCommands{
+					"disable": "ffdf4b37-7703-4dfe-a682-9d2e99bc6c09,0afa6ab8-a047-48cf-be07-93a2f8c34cf7",
+				},
+				queryID: "ffdf4b37-7703-4dfe-a682-9d2e99bc6c09",
+			},
+			expected: true,
+		},
+		{
+			name: "test_disabled_queries_invalid_query",
+			args: args{
+				commands: model.CommentsCommands{
+					"disable": "0afa6ab8-a047-48cf-be07-93a2f8c34cf7",
+				},
+				queryID: "ffdf4b37-7703-4dfe-a682-9d2e99bc6c09",
+			},
+			expected: false,
+		},
+		{
+			name: "test_withoutCommands",
+			args: args{
+				commands: model.CommentsCommands{},
+				queryID:  "ffdf4b37-7703-4dfe-a682-9d2e99bc6c09",
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldSkipFile(tt.args.commands, tt.args.queryID)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func newInspectorInstance(t *testing.T, queryPath string) *Inspector {
 	querySource := source.NewFilesystemSource(queryPath, []string{""}, []string{""})
 	var vb = func(ctx *QueryContext, tracker Tracker, v interface{},

--- a/pkg/kics/sink.go
+++ b/pkg/kics/sink.go
@@ -25,6 +25,9 @@ func (s *Service) sink(ctx context.Context, filename, scanID string, rc io.Reade
 		log.Err(err).Msgf("failed to parse file content: %s", filename)
 		return nil
 	}
+
+	fileCommands := s.Parser.CommentsCommands(filename, *content)
+
 	for _, document := range documents {
 		_, err = json.Marshal(document)
 		if err != nil {
@@ -40,6 +43,7 @@ func (s *Service) sink(ctx context.Context, filename, scanID string, rc io.Reade
 			OriginalData: string(*content),
 			Kind:         kind,
 			FileName:     filename,
+			Commands:     fileCommands,
 		}
 		s.saveToFile(ctx, &file)
 	}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -79,6 +79,7 @@ type ExtractedPathObject struct {
 	LocalPath bool
 }
 
+// CommentsCommands list of commands on a file that will be parsed
 type CommentsCommands map[string]string
 
 // FileMetadata is a representation of basic information and content of a file

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	_ "github.com/mailru/easyjson/gen" //nolint
+	"github.com/rs/zerolog/log"
 )
 
 // Constants to describe what kind of file refers
@@ -78,6 +79,8 @@ type ExtractedPathObject struct {
 	LocalPath bool
 }
 
+type CommentsCommands map[string]string
+
 // FileMetadata is a representation of basic information and content of a file
 type FileMetadata struct {
 	ID           string `db:"id"`
@@ -89,6 +92,7 @@ type FileMetadata struct {
 	Content      string
 	HelmID       string
 	IDInfo       map[int]interface{}
+	Commands     CommentsCommands
 }
 
 // QueryMetadata is a representation of general information about a query
@@ -201,7 +205,12 @@ type Document map[string]interface{}
 func (m FileMetadatas) Combine() Documents {
 	documents := Documents{Documents: make([]Document, 0, len(m))}
 	for i := 0; i < len(m); i++ {
+		_, ignore := m[i].Commands["ignore"]
 		if len(m[i].Document) == 0 {
+			continue
+		}
+		if ignore {
+			log.Debug().Msgf("Ignoring file %s", m[i].FileName)
 			continue
 		}
 		m[i].Document["id"] = m[i].ID

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -59,6 +59,21 @@ func TestFileMetadatas(t *testing.T) {
 		},
 	}
 
+	mIgnoreCommand := FileMetadatas{
+		{
+			ID:           "id",
+			ScanID:       "scan_id",
+			OriginalData: "orig_data",
+			FileName:     "file_name",
+			Document: Document{
+				"id": "",
+			},
+			Commands: CommentsCommands{
+				"ignore": "",
+			},
+		},
+	}
+
 	t.Run("to_map", func(t *testing.T) {
 		result := m.ToMap()
 		require.Len(t, result, 1)
@@ -72,6 +87,11 @@ func TestFileMetadatas(t *testing.T) {
 
 	t.Run("combine_empty_documents", func(t *testing.T) {
 		result := mEmptyDocuments.Combine()
+		require.Equal(t, Documents{Documents: []Document{}}, result)
+	})
+
+	t.Run("ignore_documents", func(t *testing.T) {
+		result := mIgnoreCommand.Combine()
 		require.Equal(t, Documents{Documents: []Document{}}, result)
 	})
 }

--- a/pkg/parser/docker/parser.go
+++ b/pkg/parser/docker/parser.go
@@ -107,3 +107,8 @@ func (p *Parser) SupportedExtensions() []string {
 func (p *Parser) SupportedTypes() []string {
 	return []string{"Dockerfile"}
 }
+
+// GetCommentToken return the comment token of Docker - #
+func (p *Parser) GetCommentToken() string {
+	return "#"
+}

--- a/pkg/parser/docker/parser_test.go
+++ b/pkg/parser/docker/parser_test.go
@@ -119,3 +119,9 @@ func Test_Resolve(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(have), *resolved)
 }
+
+// Test_GetCommentToken must get the token that represents a comment
+func Test_GetCommentToken(t *testing.T) {
+	parser := &Parser{}
+	require.Equal(t, "#", parser.GetCommentToken())
+}

--- a/pkg/parser/json/parser.go
+++ b/pkg/parser/json/parser.go
@@ -43,3 +43,8 @@ func (p *Parser) GetKind() model.FileKind {
 func (p *Parser) SupportedTypes() []string {
 	return []string{"CloudFormation", "OpenAPI", "AzureResourceManager"}
 }
+
+// GetCommentToken return an empty string, since JSON does not have comment token
+func (p *Parser) GetCommentToken() string {
+	return ""
+}

--- a/pkg/parser/json/parser_test.go
+++ b/pkg/parser/json/parser_test.go
@@ -51,3 +51,9 @@ func Test_Resolve(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(have), *resolved)
 }
+
+// Test_GetCommentToken must get the token that represents a comment
+func Test_GetCommentToken(t *testing.T) {
+	parser := &Parser{}
+	require.Equal(t, "", parser.GetCommentToken())
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -12,6 +12,7 @@ import (
 
 type kindParser interface {
 	GetKind() model.FileKind
+	GetCommentToken() string
 	SupportedExtensions() []string
 	SupportedTypes() []string
 	Parse(filePath string, fileContent []byte) ([]model.Document, error)
@@ -76,14 +77,41 @@ type Parser struct {
 	Platform   []string
 }
 
+// CommentsCommands gets commands on comments in the file beginning, before the code starts
+func (c *Parser) CommentsCommands(filePath string, fileContent []byte) model.CommentsCommands {
+	if c.isValidExtension(filePath) {
+		commentsCommands := make(model.CommentsCommands)
+		commentToken := c.parsers.GetCommentToken()
+		if commentToken != "" {
+			lines := strings.Split(string(fileContent), "\n")
+			for _, line := range lines {
+				line = strings.TrimSpace(line)
+				if line == "" {
+					continue
+				}
+				if !strings.HasPrefix(line, commentToken) {
+					break
+				}
+				fields := strings.Fields(strings.TrimSpace(strings.TrimPrefix(line, commentToken)))
+				if len(fields) > 1 && fields[0] == "kics-scan" && fields[1] != "" {
+					commandParameters := strings.SplitN(fields[1], "=", 2)
+					if len(commandParameters) > 1 {
+						commentsCommands[commandParameters[0]] = commandParameters[1]
+					} else {
+						commentsCommands[commandParameters[0]] = ""
+					}
+				}
+			}
+		}
+		return commentsCommands
+	}
+	return nil
+}
+
 // Parse executes a parser on the fileContent and returns the file content as a Document, the file kind and
 // an error, if an error has occurred
 func (c *Parser) Parse(filePath string, fileContent []byte) ([]model.Document, model.FileKind, error) {
-	ext := filepath.Ext(filePath)
-	if ext == "" {
-		ext = filepath.Base(filePath)
-	}
-	if _, ok := c.extensions[ext]; ok {
+	if c.isValidExtension(filePath) {
 		resolved, err := c.parsers.Resolve(fileContent, filePath)
 		if err != nil {
 			return nil, "", err
@@ -152,4 +180,13 @@ func removeDuplicateValues(stringSlice []string) []string {
 		}
 	}
 	return list
+}
+
+func (c *Parser) isValidExtension(filePath string) bool {
+	ext := filepath.Ext(filePath)
+	if ext == "" {
+		ext = filepath.Base(filePath)
+	}
+	_, ok := c.extensions[ext]
+	return ok
 }

--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -121,3 +121,8 @@ func (p *Parser) SupportedTypes() []string {
 func (p *Parser) GetKind() model.FileKind {
 	return model.KindTerraform
 }
+
+// GetCommentToken return the comment token of Terraform - #
+func (p *Parser) GetCommentToken() string {
+	return "#"
+}

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -94,3 +94,9 @@ func TestTerraform_ProcessContent(t *testing.T) {
 		})
 	}
 }
+
+// Test_GetCommentToken must get the token that represents a comment
+func Test_GetCommentToken(t *testing.T) {
+	parser := &Parser{}
+	require.Equal(t, "#", parser.GetCommentToken())
+}

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -169,3 +169,8 @@ func playbookParser(filePath string, fileContent []byte) ([]model.Document, erro
 
 	return addExtraInfo(documents, filePath), nil
 }
+
+// GetCommentToken return the comment token of YAML - #
+func (p *Parser) GetCommentToken() string {
+	return "#"
+}

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -143,3 +143,9 @@ func TestYaml_processElements(t *testing.T) {
 		})
 	}
 }
+
+// Test_GetCommentToken must get the token that represents a comment
+func Test_GetCommentToken(t *testing.T) {
+	parser := &Parser{}
+	require.Equal(t, "#", parser.GetCommentToken())
+}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -107,11 +107,14 @@ func MapToStringSlice(stringKeyMap map[string]string) []string {
 }
 
 var queryHigh = model.VulnerableQuery{
-	QueryName:     "ALB protocol is HTTP",
-	QueryID:       "de7f5e83-da88-4046-871f-ea18504b1d43",
-	Description:   "ALB protocol is HTTP Description",
-	DescriptionID: "504b1d43",
-	Severity:      model.SeverityHigh,
+	QueryName:                   "ALB protocol is HTTP",
+	QueryID:                     "de7f5e83-da88-4046-871f-ea18504b1d43",
+	Description:                 "ALB protocol is HTTP Description",
+	DescriptionID:               "504b1d43",
+	CISDescriptionIDFormatted:   "testCISID",
+	CISDescriptionTitle:         "testCISTitle",
+	CISDescriptionTextFormatted: "testCISDescription",
+	Severity:                    model.SeverityHigh,
 	Files: []model.VulnerableFile{
 		{
 			FileName:         positive,


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

Closes #3843 

**Proposed Changes**
- KICS now has the ability to ignore, disable/enable for some queries based on comments in file beginning;
- There is no importance in which order the comments are since it will get ALL commands in comments, however, it will always take the LAST values from a command. For example:
```yaml
# kics-scan disable=<query_id>
# kics-scan disable=<some_other_query_id>
#... rest of the file
```
In this case, the value of `disable` command will be `<some_other_query_id>`
- In this first version, only three commands are available: disable, enable and ignore
- Ignore does not receive any value;
- Enable/disable receive a list of query IDs, separated by comma;
- The precedence order for this commands are:
1. ignore: this will ignore file for ALL queries;
2. enable: this will flag file based given query's list and ignore ALL other queries;
3. disable: this will not flag based on given query's list.


Also, this PR have some improvements on tests.

I submit this contribution under the Apache-2.0 license.
