### PR TITLE
feat(query): updated "IAM Password Without Minimum Length" query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/negative.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/negative.tf
@@ -5,7 +5,6 @@ resource "aws_elasticache_replication_group" "example3" {
   replication_group_description = "test description"
   node_type                     = "cache.m4.large"
   number_cache_clusters         = 2
-  parameter_group_name          = "default.redis3.2"
   port                          = 6379
   at_rest_encryption_enabled    = true
 }

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive1.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive1.tf
@@ -5,6 +5,5 @@ resource "aws_elasticache_replication_group" "example" {
   replication_group_description = "test description"
   node_type                     = "cache.m4.large"
   number_cache_clusters         = 2
-  parameter_group_name          = "default.redis3.2"
   port                          = 6379
 }

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive2.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive2.tf
@@ -5,7 +5,6 @@ resource "aws_elasticache_replication_group" "example2" {
   replication_group_description = "test description"
   node_type                     = "cache.m4.large"
   number_cache_clusters         = 2
-  parameter_group_name          = "default.redis3.2"
   port                          = 6379
   at_rest_encryption_enabled    = false
 }

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_rest/test/positive_expected_result.json
@@ -7,6 +7,6 @@
   {
     "queryName": "ElastiCache Replication Group Not Encrypted At Rest",
     "severity": "MEDIUM",
-    "line": 10
+    "line": 9
   }
 ]

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/negative1.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/negative1.tf
@@ -5,7 +5,6 @@ resource "aws_elasticache_replication_group" "example3" {
   replication_group_description = "test description"
   node_type                     = "cache.m4.large"
   number_cache_clusters         = 2
-  parameter_group_name          = "default.redis3.2"
   port                          = 6379
   at_rest_encryption_enabled    = true
   transit_encryption_enabled    = true

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive1.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive1.tf
@@ -5,6 +5,5 @@ resource "aws_elasticache_replication_group" "example" {
   replication_group_description = "test description"
   node_type                     = "cache.m4.large"
   number_cache_clusters         = 2
-  parameter_group_name          = "default.redis3.2"
   port                          = 6379
 }

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive2.tf
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive2.tf
@@ -5,7 +5,6 @@ resource "aws_elasticache_replication_group" "example" {
   replication_group_description = "test description"
   node_type                     = "cache.m4.large"
   number_cache_clusters         = 2
-  parameter_group_name          = "default.redis3.2"
   port                          = 6379
   transit_encryption_enabled    = false
 }

--- a/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticache_replication_group_not_encrypted_at_transit/test/positive_expected_result.json
@@ -8,7 +8,7 @@
   {
     "queryName": "ElastiCache Replication Group Not Encrypted At Transit",
     "severity": "MEDIUM",
-    "line": 10,
+    "line": 9,
     "filename": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/iam_password_without_minimum_length/query.rego
+++ b/assets/queries/terraform/aws/iam_password_without_minimum_length/query.rego
@@ -8,7 +8,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_iam_account_password_policy[%s]", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "'minimum_password_length' is set and no less than 8",
+		"keyExpectedValue": "'minimum_password_length' is set and no less than 14",
 		"keyActualValue": "'minimum_password_length' is undefined",
 	}
 }
@@ -16,13 +16,13 @@ CxPolicy[result] {
 CxPolicy[result] {
 	password_policy := input.document[i].resource.aws_iam_account_password_policy[name]
 	min_length := password_policy.minimum_password_length
-	to_number(min_length) < 8
+	to_number(min_length) < 14
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_iam_account_password_policy[%s].minimum_password_length", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'minimum_password_length' is set and no less than 8",
-		"keyActualValue": "'minimum_password_length' is less than 8",
+		"keyExpectedValue": "'minimum_password_length' is set and no less than 14",
+		"keyActualValue": "'minimum_password_length' is less than 14",
 	}
 }

--- a/assets/queries/terraform/aws/iam_password_without_minimum_length/test/negative.tf
+++ b/assets/queries/terraform/aws/iam_password_without_minimum_length/test/negative.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_account_password_policy" "negative1" {
-  minimum_password_length        = 8
+  minimum_password_length        = 14
   require_lowercase_characters   = true
   require_numbers                = true
   require_uppercase_characters   = true


### PR DESCRIPTION

**Proposed Changes**
- Updated "IAM Password Without Minimum Length" query for Terraform. Changed minimum password length from 8 to 14

I submit this contribution under the Apache-2.0 license.
