### PR TITLE
feat(query): updated "IAM Policies With Full Privileges" query for Terraform

### DIFF
--- a/assets/queries/terraform/aws/iam_policies_with_full_privileges/query.rego
+++ b/assets/queries/terraform/aws/iam_policies_with_full_privileges/query.rego
@@ -3,7 +3,7 @@ package Cx
 import data.generic.common as commonLib
 
 CxPolicy[result] {
-	resourceType := {"aws_iam_role_policy", "aws_iam_user_policy", "aws_iam_group_policy", "aws_iam_policy_attachment", "aws_iam_policy"}
+	resourceType := {"aws_iam_role_policy", "aws_iam_user_policy", "aws_iam_group_policy", "aws_iam_policy"}
 	resource := input.document[i].resource[resourceType[idx]][name]
 
 	policy := commonLib.json_unmarshal(resource.policy)


### PR DESCRIPTION
**Proposed Changes**
- Updated "IAM Policies With Full Privileges" query for Terraform. The resource `aws_iam_policy_attachment` does not have the attribute `policy` but actually `policy_arn`, which does not fit this query

I submit this contribution under the Apache-2.0 license.
