### PR TITLE
feat(query): added "S3 Bucket with Unsecured CORS Rule" query for Ansible, CloudFormation and Terraform

### DIFF
--- a/assets/libraries/common/library.rego
+++ b/assets/libraries/common/library.rego
@@ -245,3 +245,15 @@ valid_key(obj, key) {
 	_ = obj[key]
 	not is_null(obj[key])
 }
+
+unsecured_cors_rule(methods, headers, origins) {
+	# allows all methods
+	availableMethods := {"GET", "PUT", "POST", "DELETE", "HEAD"}
+	count({x | method := methods[x]; method == availableMethods[_]}) == count(availableMethods)
+} else {
+	# allows all headers
+	contains(headers[_], "*")
+} else {
+	# allows several origins
+	contains(origins[_], "*")
+}

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/metadata.json
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "3505094c-f77c-4ba0-95da-f83db712f86c",
+  "queryName": "S3 Bucket with Unsecured CORS Rule",
+  "severity": "HIGH",
+  "category": "Insecure Configurations",
+  "descriptionText": "If the CORS (Cross-Origin Resource Sharing) rule is defined in an S3 bucket, it should be secure",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/aws_s3_cors_module.html#parameter-rules",
+  "platform": "Ansible",
+  "descriptionID": "c700f52b",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/query.rego
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/query.rego
@@ -1,0 +1,23 @@
+package Cx
+
+import data.generic.ansible as ans_lib
+import data.generic.common as common_lib
+
+modules := {"community.aws.aws_s3_cors", "aws_s3_cors"}
+
+CxPolicy[result] {
+	task := ans_lib.tasks[id][t]
+	cors := task[modules[m]]
+	ans_lib.checkState(cors)
+
+	rule := cors.rules[c]
+	common_lib.unsecured_cors_rule(rule.allowed_methods, rule.allowed_headers, rule.allowed_origins)
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s[%d] does not allows all methods, all headers or several origins", [modules[m], c]),
+		"keyActualValue": sprintf("%s[%d] allows all methods, all headers or several origins", [modules[m], c]),
+	}
+}

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/negative1.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/negative1.yaml
@@ -1,0 +1,16 @@
+- name: Create s3 bucket
+  community.aws.aws_s3_cors:
+    name: mys3bucket3
+    state: present
+    rules:
+      - allowed_origins:
+          - http://www.example.com/
+        allowed_methods:
+          - GET
+          - POST
+        allowed_headers:
+          - Authorization
+        expose_headers:
+          - x-amz-server-side-encryption
+          - x-amz-request-id
+        max_age_seconds: 30000

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/negative2.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/negative2.yaml
@@ -1,0 +1,16 @@
+- name: Create s3 bucket1
+  aws_s3_cors:
+    name: mys3bucket4
+    state: present
+    rules:
+      - allowed_origins:
+          - http://www.example.com/
+        allowed_methods:
+          - GET
+          - POST
+        allowed_headers:
+          - Authorization
+        expose_headers:
+          - x-amz-server-side-encryption
+          - x-amz-request-id
+        max_age_seconds: 30000

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/positive1.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/positive1.yaml
@@ -1,0 +1,19 @@
+- name: Create s3 bucket2
+  community.aws.aws_s3_cors:
+    name: mys3bucket
+    state: present
+    rules:
+      - allowed_origins:
+          - http://www.example.com/
+        allowed_methods:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - HEAD
+        allowed_headers:
+          - Authorization
+        expose_headers:
+          - x-amz-server-side-encryption
+          - x-amz-request-id
+        max_age_seconds: 30000

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/positive2.yaml
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/positive2.yaml
@@ -1,0 +1,19 @@
+- name: Create s3 bucket4
+  aws_s3_cors:
+    name: mys3bucket2
+    state: present
+    rules:
+      - allowed_origins:
+          - http://www.example.com/
+        allowed_methods:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - HEAD
+        allowed_headers:
+          - Authorization
+        expose_headers:
+          - x-amz-server-side-encryption
+          - x-amz-request-id
+        max_age_seconds: 30000

--- a/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/s3_bucket_with_unsecured_cors_rule/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "S3 Bucket with Unsecured CORS Rule",
+    "severity": "HIGH",
+    "line": 5,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "S3 Bucket with Unsecured CORS Rule",
+    "severity": "HIGH",
+    "line": 5,
+    "fileName": "positive2.yaml"
+  }
+]

--- a/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/metadata.json
+++ b/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "3609d27c-3698-483a-9402-13af6ae80583",
+  "queryName": "S3 Bucket with Unsecured CORS Rule",
+  "severity": "HIGH",
+  "category": "Insecure Configurations",
+  "descriptionText": "If the CORS (Cross-Origin Resource Sharing) rule is defined in an S3 bucket, it should be secure",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors.html",
+  "platform": "CloudFormation",
+  "descriptionID": "f616509e",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/query.rego
+++ b/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/query.rego
@@ -1,0 +1,19 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::S3::Bucket"
+
+	rule := resource.Properties.CorsConfiguration.CorsRules[c]
+	common_lib.unsecured_cors_rule(rule.AllowedMethods, rule.AllowedHeaders, rule.AllowedOrigins)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.CorsConfiguration.CorsRules", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("Resources.%s.Properties.CorsConfiguration.CorsRules[%d] does not allows all methods, all headers or several origins", [name, c]),
+		"keyActualValue": sprintf("Resources.%s.Properties.CorsConfiguration.CorsRules[%d] allows all methods, all headers or several origins", [name, c]),
+	}
+}

--- a/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/test/negative1.yaml
+++ b/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/test/negative1.yaml
@@ -1,0 +1,27 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  S3Bucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      AccessControl: PublicRead
+      CorsConfiguration:
+        CorsRules:
+          - AllowedMethods:
+              - GET
+            AllowedOrigins:
+              - 'https://s3-website-test.hashicorp.com'
+            ExposedHeaders:
+              - Date
+            Id: myCORSRuleId1
+            MaxAge: 3600
+          - AllowedMethods:
+              - DELETE
+            AllowedOrigins:
+              - 'http://www.example.com'
+              - 'http://www.example.net'
+            ExposedHeaders:
+              - Connection
+              - Server
+              - Date
+            Id: myCORSRuleId2
+            MaxAge: 1800

--- a/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/test/negative2.json
+++ b/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/test/negative2.json
@@ -1,0 +1,44 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "S3Bucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "PublicRead",
+        "CorsConfiguration": {
+          "CorsRules": [
+            {
+              "AllowedMethods": [
+                "GET"
+              ],
+              "AllowedOrigins": [
+                "https://s3-website-test.hashicorp.com"
+              ],
+              "ExposedHeaders": [
+                "Date"
+              ],
+              "Id": "myCORSRuleId1",
+              "MaxAge": 3600
+            },
+            {
+              "AllowedMethods": [
+                "DELETE"
+              ],
+              "AllowedOrigins": [
+                "http://www.example.com",
+                "http://www.example.net"
+              ],
+              "ExposedHeaders": [
+                "Connection",
+                "Server",
+                "Date"
+              ],
+              "Id": "myCORSRuleId2",
+              "MaxAge": 1800
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/test/positive1.yaml
+++ b/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/test/positive1.yaml
@@ -1,0 +1,29 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  S3Bucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      AccessControl: PublicRead
+      CorsConfiguration:
+        CorsRules:
+          - AllowedHeaders:
+              - '*'
+            AllowedMethods:
+              - GET
+            AllowedOrigins:
+              - '*'
+            ExposedHeaders:
+              - Date
+            Id: myCORSRuleId1
+            MaxAge: 3600
+          - AllowedMethods:
+              - DELETE
+            AllowedOrigins:
+              - 'http://www.example.com'
+              - 'http://www.example.net'
+            ExposedHeaders:
+              - Connection
+              - Server
+              - Date
+            Id: myCORSRuleId2
+            MaxAge: 1800

--- a/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/test/positive2.json
+++ b/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/test/positive2.json
@@ -1,0 +1,47 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "S3Bucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "AccessControl": "PublicRead",
+        "CorsConfiguration": {
+          "CorsRules": [
+            {
+              "AllowedHeaders": [
+                "*"
+              ],
+              "AllowedMethods": [
+                "GET"
+              ],
+              "AllowedOrigins": [
+                "*"
+              ],
+              "ExposedHeaders": [
+                "Date"
+              ],
+              "Id": "myCORSRuleId1",
+              "MaxAge": 3600
+            },
+            {
+              "AllowedMethods": [
+                "DELETE"
+              ],
+              "AllowedOrigins": [
+                "http://www.example.com",
+                "http://www.example.net"
+              ],
+              "ExposedHeaders": [
+                "Connection",
+                "Server",
+                "Date"
+              ],
+              "Id": "myCORSRuleId2",
+              "MaxAge": 1800
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/s3_bucket_with_unsecured_cors_rule/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "S3 Bucket with Unsecured CORS Rule",
+    "severity": "HIGH",
+    "line": 8,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "S3 Bucket with Unsecured CORS Rule",
+    "severity": "HIGH",
+    "line": 9,
+    "fileName": "positive2.json"
+  }
+]

--- a/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "98a8f708-121b-455b-ae2f-da3fb59d17e1",
+  "queryName": "S3 Bucket with Unsecured CORS Rule",
+  "severity": "HIGH",
+  "category": "Insecure Configurations",
+  "descriptionText": "If the CORS (Cross-Origin Resource Sharing) rule is defined in an S3 bucket, it should be secure",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#cors_rule",
+  "platform": "Terraform",
+  "descriptionID": "28051a7f",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	bucket := input.document[i].resource.aws_s3_bucket[name]
+
+	rule := bucket.cors_rule
+	common_lib.unsecured_cors_rule(rule.allowed_methods, rule.allowed_headers, rule.allowed_origins)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_s3_bucket[%s].cors_rule", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'cors_rule' does not allows all methods, all headers or several origins",
+		"keyActualValue": "'cors_rule' allows all methods, all headers or several origins",
+	}
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/test/negative.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/test/negative.tf
@@ -1,0 +1,11 @@
+resource "aws_s3_bucket" "negative1" {
+  bucket = "s3-website-test.hashicorp.com"
+  acl    = "public-read"
+
+  cors_rule {
+    allowed_methods = ["PUT", "POST"]
+    allowed_origins = ["https://s3-website-test.hashicorp.com"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/test/positive1.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/test/positive1.tf
@@ -1,0 +1,22 @@
+
+resource "aws_s3_bucket" "positive1" {
+  bucket = "my-tf-test-bucket"
+  acl    = "public-read"
+
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
+  }
+
+  versioning {
+    enabled = false
+  }
+
+   cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT", "POST"]
+    allowed_origins = ["https://s3-website-test.hashicorp.com"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/test/positive2.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/test/positive2.tf
@@ -1,0 +1,22 @@
+
+resource "aws_s3_bucket" "positive2" {
+  bucket = "my-tf-test-bucket"
+  acl    = "public-read"
+
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
+  }
+
+  versioning {
+    enabled = false
+  }
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "PUT", "POST", "DELETE", "HEAD"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_with_unsecured_cors_rule/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "S3 Bucket with Unsecured CORS Rule",
+    "severity": "HIGH",
+    "line": 15,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "S3 Bucket with Unsecured CORS Rule",
+    "severity": "HIGH",
+    "line": 15,
+    "fileName": "positive2.tf"
+  }
+]


### PR DESCRIPTION
Closes #3819

**Proposed Changes**
- Added "S3 Bucket with Unsecured CORS Rule" query for Ansible, CloudFormation and Terraform

I submit this contribution under the Apache-2.0 license.
