### PR TITLE
feat(query): added "S3 Bucket Policy Accepts HTTP Requests" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "4bc4dd4c-7d8d-405e-a0fb-57fa4c31b4d9",
   "queryName": "S3 Bucket Policy Accepts HTTP Requests",
-  "severity": "",
+  "severity": "MEDIUM",
   "category": "",
   "descriptionText": "S3 Bucket policy should not accept HTTP Requests",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy#policy",

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/metadata.json
@@ -2,7 +2,7 @@
   "id": "4bc4dd4c-7d8d-405e-a0fb-57fa4c31b4d9",
   "queryName": "S3 Bucket Policy Accepts HTTP Requests",
   "severity": "MEDIUM",
-  "category": "",
+  "category": "Encryption",
   "descriptionText": "S3 Bucket policy should not accept HTTP Requests",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy#policy",
   "platform": "Terraform",

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "4bc4dd4c-7d8d-405e-a0fb-57fa4c31b4d9",
+  "queryName": "S3 Bucket Policy Accepts HTTP Requests",
+  "severity": "",
+  "category": "",
+  "descriptionText": "S3 Bucket policy should not accept HTTP Requests",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy#policy",
+  "platform": "Terraform",
+  "descriptionID": "edbcd7bc",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
@@ -1,0 +1,37 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resources := {"aws_s3_bucket_policy", "aws_s3_bucket"}
+	resource := input.document[i].resource[resources[r]][name]
+
+	policy := common_lib.json_unmarshal(resource.policy)
+
+	statement := policy.Statement[s]
+
+	not deny_http_requests(statement)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_s3_bucket[%s].policy", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_s3_bucket[%s].policy does not accept HTTP Requests", [name]),
+		"keyActualValue": sprintf("aws_s3_bucket[%s].policy accepts HTTP Requests", [name]),
+	}
+}
+
+validActions := {"*", "s3:*", "s3:GetObject"}
+
+check_action(action) {
+	is_string(action)
+	action == validActions[x]
+} else {
+	action[a] == validActions[x]
+}
+
+deny_http_requests(statement) {
+	check_action(statement.Action)
+	statement.Effect == "Deny"
+	statement.Condition.Bool["aws:SecureTransport"] == false
+}

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/negative1.tf
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/negative1.tf
@@ -1,0 +1,34 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+}
+
+resource "aws_s3_bucket_policy" "b" {
+  bucket = aws_s3_bucket.b.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Id": "MYBUCKETPOLICY",
+    "Statement": [
+      {
+        "Sid": "IPAllow",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "aws_s3_bucket.b.arn"
+        ],
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+}
+EOF
+}
+
+
+
+

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/negative2.tf
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/negative2.tf
@@ -1,0 +1,26 @@
+resource "aws_s3_bucket" "b2" {
+  bucket = "my-tf-test-bucket"
+
+   policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Id": "MYBUCKETPOLICY",
+    "Statement": [
+      {
+        "Sid": "IPAllow",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "aws_s3_bucket.b.arn"
+        ],
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive1.tf
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive1.tf
@@ -1,0 +1,34 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+}
+
+resource "aws_s3_bucket_policy" "b" {
+  bucket = aws_s3_bucket.b.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Id": "MYBUCKETPOLICY",
+    "Statement": [
+      {
+        "Sid": "IPAllow",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "aws_s3_bucket.b.arn"
+        ],
+        "Condition": {
+          "IpAddress": {
+            "aws:SourceIp": "8.8.8.8/32"
+          }
+        }
+      }
+    ]
+}
+EOF
+}
+
+
+
+

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive2.tf
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive2.tf
@@ -1,0 +1,26 @@
+resource "aws_s3_bucket" "b2" {
+  bucket = "my-tf-test-bucket"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Id": "MYBUCKETPOLICY",
+    "Statement": [
+      {
+        "Sid": "IPAllow",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "aws_s3_bucket.b.arn"
+        ],
+        "Condition": {
+          "IpAddress": {
+            "aws:SourceIp": "8.8.8.8/32"
+          }
+        }
+      }
+    ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "S3 Bucket Policy Accepts HTTP Requests",
+    "severity": "",
+    "line": 8,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "S3 Bucket Policy Accepts HTTP Requests",
+    "severity": "",
+    "line": 4,
+    "fileName": "positive2.tf"
+  }
+]

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive_expected_result.json
@@ -1,7 +1,7 @@
 [
   {
     "queryName": "S3 Bucket Policy Accepts HTTP Requests",
-    "severity": "",
+    "severity": "MEDIUM",
     "line": 8,
     "fileName": "positive1.tf"
   },

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive_expected_result.json
@@ -7,7 +7,7 @@
   },
   {
     "queryName": "S3 Bucket Policy Accepts HTTP Requests",
-    "severity": "",
+    "severity": "MEDIUM",
     "line": 4,
     "fileName": "positive2.tf"
   }


### PR DESCRIPTION
**Proposed Changes**
- Added "S3 Bucket Policy Accepts HTTP Requests" for Terraform (missing severity and severity)

I submit this contribution under the Apache-2.0 license.
