### PR TITLE
feat(query): added "VPC Peering Route Table with Unrestricted CIDR" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/metadata.json
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "b3a41501-f712-4c4f-81e5-db9a7dc0e34e",
   "queryName": "VPC Peering Route Table with Unrestricted CIDR",
-  "severity": "",
+  "severity": "HIGH",
   "category": "",
   "descriptionText": "VPC Peering Route Table should restrict CIDR",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route",

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/metadata.json
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "b3a41501-f712-4c4f-81e5-db9a7dc0e34e",
+  "queryName": "VPC Peering Route Table with Unrestricted CIDR",
+  "severity": "",
+  "category": "",
+  "descriptionText": "VPC Peering Route Table should restrict CIDR",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route",
+  "platform": "Terraform",
+  "descriptionID": "3a60c60e",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/metadata.json
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/metadata.json
@@ -2,7 +2,7 @@
   "id": "b3a41501-f712-4c4f-81e5-db9a7dc0e34e",
   "queryName": "VPC Peering Route Table with Unrestricted CIDR",
   "severity": "HIGH",
-  "category": "",
+  "category": "Networking and Firewall",
   "descriptionText": "VPC Peering Route Table should restrict CIDR",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route",
   "platform": "Terraform",

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/query.rego
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/query.rego
@@ -1,0 +1,35 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_route[name]
+
+	common_lib.valid_key(resource, "vpc_peering_connection_id")
+
+	open_cidr(resource)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_route[%s]", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_route[%s] restricts CIDR", [name]),
+		"keyActualValue": sprintf("aws_route[%s] does not restrict CIDR", [name]),
+	}
+}
+
+openCidrs := {"cidr_block": "0.0.0.0/0", "ipv6_cidr_block": "::/0"}
+
+open_cidr(resource) {
+	vpcPeeringName := split(resource.vpc_peering_connection_id, ".")[2]
+	vpcPeering := input.document[_].data.aws_vpc_peering_connection[vpcPeeringName]
+	vpcPeering.peer_cidr_block == openCidrs[_]
+} else {
+	resource[x] == openCidrs[x]
+} else {
+	routeTableName := split(resource.route_table_id, ".")[1]
+	routeTable := input.document[_].resource.aws_route_table[routeTableName]
+	route := routeTable.route[r]
+
+	route[x] == openCidrs[x]
+}

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/negative.tf
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/negative.tf
@@ -1,0 +1,17 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_flow_log" "example" {
+  iam_role_arn    = aws_iam_role.example.arn
+  log_destination = aws_cloudwatch_log_group.example.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.example.id
+}
+
+resource "aws_flow_log" "example2" {
+  iam_role_arn    = aws_iam_role.example.arn
+  log_destination = aws_cloudwatch_log_group.example.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.main.id
+}

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/negative.tf
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/negative.tf
@@ -1,17 +1,26 @@
-resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
+data "aws_vpc_peering_connection" "negative1" {
+  vpc_id          = aws_vpc.foo2.id
+  peer_cidr_block = "10.0.1.0/24"
 }
 
-resource "aws_flow_log" "example" {
-  iam_role_arn    = aws_iam_role.example.arn
-  log_destination = aws_cloudwatch_log_group.example.arn
-  traffic_type    = "ALL"
-  vpc_id          = aws_vpc.example.id
+resource "aws_route_table" "example3" {
+  vpc_id = aws_vpc.foo2.id
+
+  route = [
+    {
+      cidr_block = "10.0.1.0/24"
+      gateway_id = aws_internet_gateway.example2.id
+    }
+  ]
+
+  tags = {
+    Name = "example"
+  }
 }
 
-resource "aws_flow_log" "example2" {
-  iam_role_arn    = aws_iam_role.example.arn
-  log_destination = aws_cloudwatch_log_group.example.arn
-  traffic_type    = "ALL"
-  vpc_id          = aws_vpc.main.id
+# Create a route
+resource "aws_route" "rr" {
+  route_table_id            = aws_route_table.example3.id
+  destination_cidr_block    = data.aws_vpc_peering_connection.negative1.peer_cidr_block
+  vpc_peering_connection_id = data.aws_vpc_peering_connection.negative1.id
 }

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive1.tf
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive1.tf
@@ -1,0 +1,26 @@
+data "aws_vpc_peering_connection" "pc" {
+  vpc_id          = aws_vpc.foo.id
+  peer_cidr_block = "0.0.0.0/0"
+}
+
+resource "aws_route_table" "example" {
+  vpc_id = aws_vpc.foo.id
+
+  route = [
+    {
+      cidr_block = "10.0.1.0/24"
+      gateway_id = aws_internet_gateway.example.id
+    }
+  ]
+
+  tags = {
+    Name = "example"
+  }
+}
+
+# Create a route
+resource "aws_route" "r" {
+  route_table_id            = aws_route_table.example.id
+  destination_cidr_block    = data.aws_vpc_peering_connection.pc.peer_cidr_block
+  vpc_peering_connection_id = data.aws_vpc_peering_connection.pc.id
+}

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive2.tf
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive2.tf
@@ -1,0 +1,30 @@
+data "aws_vpc_peering_connection" "pc2" {
+  vpc_id          = aws_vpc.foo2.id
+  peer_cidr_block = "10.0.1.0/22"
+}
+
+resource "aws_route_table" "example2" {
+  vpc_id = aws_vpc.foo2.id
+
+ route = [
+    {
+      cidr_block = "10.0.1.0/24"
+      gateway_id = aws_internet_gateway.example.id
+    },
+    {
+      ipv6_cidr_block        = "::/0"
+      egress_only_gateway_id = aws_egress_only_internet_gateway.example.id
+    }
+  ]
+
+  tags = {
+    Name = "example"
+  }
+}
+
+# Create a route
+resource "aws_route" "r2" {
+  route_table_id            = aws_route_table.example2.id
+  destination_cidr_block    = data.aws_vpc_peering_connection.pc2.peer_cidr_block
+  vpc_peering_connection_id = data.aws_vpc_peering_connection.pc2.id
+}

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive_expected_result.json
@@ -9,6 +9,6 @@
     "queryName": "VPC Peering Route Table with Unrestricted CIDR",
     "severity": "HIGH",
     "line": 26,
-    "fileName": "positive1.tf"
+    "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive_expected_result.json
@@ -1,7 +1,7 @@
 [
   {
     "queryName": "VPC Peering Route Table with Unrestricted CIDR",
-    "severity": "",
+    "severity": "HIGH",
     "line": 22,
     "fileName": "positive1.tf"
   },

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "VPC Peering Route Table with Unrestricted CIDR",
+    "severity": "",
+    "line": 22,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "VPC Peering Route Table with Unrestricted CIDR",
+    "severity": "",
+    "line": 26,
+    "fileName": "positive1.tf"
+  }
+]

--- a/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/vpc_peering_route_table_with_unrestricted_cidr/test/positive_expected_result.json
@@ -7,7 +7,7 @@
   },
   {
     "queryName": "VPC Peering Route Table with Unrestricted CIDR",
-    "severity": "",
+    "severity": "HIGH",
     "line": 26,
     "fileName": "positive1.tf"
   }


### PR DESCRIPTION
**Proposed Changes**
- Added "VPC Peering Route Table with Unrestricted CIDR" for Terraform (missing severity and severity)

I submit this contribution under the Apache-2.0 license.
