### PR TITLE
fix: incorrect descriptionUrl in 'HTTP Port Open' query

### DIFF
--- a/assets/queries/cloudFormation/http_port_open/metadata.json
+++ b/assets/queries/cloudFormation/http_port_open/metadata.json
@@ -4,7 +4,7 @@
   "severity": "HIGH",
   "category": "Networking and Firewall",
   "descriptionText": "The HTTP port is open in a Security Group",
-  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_group_module.html#ansible-collections-amazon-aws-ec2-group-module",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html",
   "platform": "CloudFormation",
   "descriptionID": "a39efd21",
   "cloudProvider": "aws"


### PR DESCRIPTION
**Proposed Changes**
- fixing wrong descriptionURL value


I submit this contribution under the Apache-2.0 license.
