### PR TITLE
fix(Dockerfile): removing ENTRYPOINT from debian images fixes #4066

### DIFF
--- a/Dockerfile.apispec.debian
+++ b/Dockerfile.apispec.debian
@@ -65,5 +65,3 @@ ENV PATH $PATH:/app/bin
 # Healthcheck the container
 
 HEALTHCHECK CMD wget -q --method=HEAD localhost/system-status.txt
-
-ENTRYPOINT ["/app/bin/kics"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -61,5 +61,3 @@ ENV PATH $PATH:/app/bin
 # Healthcheck the container
 
 HEALTHCHECK CMD wget -q --method=HEAD localhost/system-status.txt
-
-ENTRYPOINT ["/app/bin/kics"]


### PR DESCRIPTION
Closes #4066

**Proposed Changes**
- Removing ENTRYPOINT instruction from Debian based Dockerfiles to enable compatibility with Azure DevOps

I submit this contribution under the Apache-2.0 license.
