### PR TITLE
fix: Network ACL queries covering more cases

### DIFF
--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -24,18 +24,12 @@ openPort(rules, port) {
 containsPort(rule, port) {
 	rule.from_port <= port
 	rule.to_port >= port
-}
-
-else {
+} else {
 	rule.from_port == 0
 	rule.to_port == 0
-}
-
-else {
+} else {
 	regex.match(sprintf("(^|\\s|,)%d(-|,|$|\\s)", [port]), rule.destination_port_range)
-}
-
-else {
+} else {
 	ports := split(rule.destination_port_range, ",")
 	sublist := split(ports[var], "-")
 	to_number(trim(sublist[0], " ")) <= port

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/query.rego
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/query.rego
@@ -3,8 +3,10 @@ package Cx
 import data.generic.terraform as terra_lib
 
 CxPolicy[result] {
-	resource := input.document[i].resource.aws_network_acl[name]
+	doc := input.document[i]
+	resource := doc.resource.aws_network_acl[name]
 
+	is_array(resource.ingress)
 	terra_lib.openPort(resource.ingress[idx], 3389)
 
 	result := {
@@ -13,5 +15,38 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_network_acl[%s].ingress[%d] 'RDP' (TCP:3389) is not public", [name, idx]),
 		"keyActualValue": sprintf("aws_network_acl[%s].ingress[%d] 'RDP' (TCP:3389) is public", [name, idx]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	net_acl := doc.resource.aws_network_acl[netAclName]
+	net_acl_rule := doc.resource.aws_network_acl_rule[netAclRuleName]
+	split(net_acl_rule.network_acl_id, ".")[1] == netAclName
+
+	terra_lib.openPort(net_acl_rule, 3389)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("aws_network_acl_rule[%s]", [netAclRuleName]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_network_acl[%s] 'RDP' (TCP:3389) is not public", [netAclRuleName]),
+		"keyActualValue": sprintf("aws_network_acl[%s] 'RDP' (TCP:3389) is public", [netAclRuleName]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	resource := doc.resource.aws_network_acl[name]
+
+	not is_array(resource.ingress)
+	terra_lib.openPort(resource.ingress, 3389)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("aws_network_acl[%s].ingress", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_network_acl[%s].ingress 'RDP' (TCP:3389) is not public", [name]),
+		"keyActualValue": sprintf("aws_network_acl[%s].ingress 'RDP' (TCP:3389) is public", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/negative1.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/negative1.tf
@@ -1,0 +1,42 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "negative1" {
+  vpc_id = aws_vpc.main.id
+
+  egress = [
+    {
+      protocol   = "tcp"
+      rule_no    = 200
+      action     = "allow"
+      cidr_block = "10.3.0.0/18"
+      from_port  = 443
+      to_port    = 443
+    }
+  ]
+
+  ingress = [
+    {
+      protocol   = "tcp"
+      rule_no    = 100
+      action     = "allow"
+      cidr_block = "10.3.0.0/18"
+      from_port   = 3389
+      to_port     = 3389
+    }
+  ]
+
+  tags = {
+    Name = "main"
+  }
+}

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/negative2.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/negative2.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "negative2" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "main"
+  }
+}
+
+resource "aws_network_acl_rule" "negative2" {
+  network_acl_id = aws_network_acl.positive1.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  from_port      = 3389
+  to_port        = 3389
+  cidr_block     = "10.3.0.0/18"
+}

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/negative3.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/negative3.tf
@@ -1,0 +1,38 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.52.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "negative3" {
+  vpc_id = aws_vpc.main.id
+
+  egress {
+      protocol   = "tcp"
+      rule_no    = 200
+      action     = "allow"
+      cidr_block = "10.3.0.0/18"
+      from_port  = 443
+      to_port    = 443
+  }
+
+  ingress {
+      protocol   = "tcp"
+      rule_no    = 100
+      action     = "allow"
+      cidr_block = "10.3.0.0/18"
+      from_port   = 3389
+      to_port     = 3389
+  }
+
+  tags = {
+    Name = "main"
+  }
+}

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/positive1.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/positive1.tf
@@ -1,0 +1,42 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "positive1" {
+  vpc_id = aws_vpc.main.id
+
+  egress = [
+    {
+      protocol   = "tcp"
+      rule_no    = 200
+      action     = "allow"
+      cidr_block = "10.3.0.0/18"
+      from_port  = 443
+      to_port    = 443
+    }
+  ]
+
+  ingress = [
+    {
+      protocol   = "tcp"
+      rule_no    = 100
+      action     = "allow"
+      cidr_block = "0.0.0.0/0"
+      from_port   = 3389
+      to_port     = 3389
+    }
+  ]
+
+  tags = {
+    Name = "main"
+  }
+}

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/positive2.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/positive2.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "positive2" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "main"
+  }
+}
+
+resource "aws_network_acl_rule" "postive2" {
+  network_acl_id = aws_network_acl.positive2.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  from_port      = 3389
+  to_port        = 3389
+  cidr_block     = "0.0.0.0/0"
+}

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/positive3.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/positive3.tf
@@ -1,27 +1,36 @@
-resource "aws_network_acl" "negative1" {
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "<= 3.52.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "positive3" {
   vpc_id = aws_vpc.main.id
 
-  egress = [
-    {
+  egress {
       protocol   = "tcp"
       rule_no    = 200
       action     = "allow"
       cidr_block = "10.3.0.0/18"
       from_port  = 443
       to_port    = 443
-    }
-  ]
+  }
 
-  ingress = [
-    {
+  ingress {
       protocol   = "tcp"
       rule_no    = 100
       action     = "allow"
-      cidr_block = "10.3.0.0/18"
+      cidr_block = "0.0.0.0/0"
       from_port   = 3389
       to_port     = 3389
-    }
-  ]
+  }
 
   tags = {
     Name = "main"

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_rdp/test/positive_expected_result.json
@@ -2,6 +2,19 @@
   {
     "queryName": "Network ACL With Unrestricted Access To RDP",
     "severity": "HIGH",
-    "line": 15
+    "line": 28,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "Network ACL With Unrestricted Access To RDP",
+    "severity": "HIGH",
+    "line": 22,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Network ACL With Unrestricted Access To RDP",
+    "severity": "HIGH",
+    "line": 26,
+    "fileName": "positive3.tf"
   }
 ]

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/query.rego
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/query.rego
@@ -3,15 +3,50 @@ package Cx
 import data.generic.terraform as terra_lib
 
 CxPolicy[result] {
-	resource := input.document[i].resource.aws_network_acl[name]
+	doc := input.document[i]
+	resource := doc.resource.aws_network_acl[name]
 
+	is_array(resource.ingress)
 	terra_lib.openPort(resource.ingress[idx], 22)
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": doc.id,
 		"searchKey": sprintf("aws_network_acl[%s].ingress", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_network_acl[%s].ingress[%d] 'SSH' (Port:22) is not public", [name, idx]),
 		"keyActualValue": sprintf("aws_network_acl[%s].ingress[%d] 'SSH' (Port:22) is public", [name, idx]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	net_acl := doc.resource.aws_network_acl[netAclName]
+	net_acl_rule := doc.resource.aws_network_acl_rule[netAclRuleName]
+	split(net_acl_rule.network_acl_id, ".")[1] == netAclName
+
+	terra_lib.openPort(net_acl_rule, 22)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("aws_network_acl_rule[%s]", [netAclRuleName]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_network_acl[%s] 'SSH' (TCP:22) is not public", [netAclRuleName]),
+		"keyActualValue": sprintf("aws_network_acl[%s] 'SSH' (TCP:22) is public", [netAclRuleName]),
+	}
+}
+
+CxPolicy[result] {
+	doc := input.document[i]
+	resource := doc.resource.aws_network_acl[name]
+
+	not is_array(resource.ingress)
+	terra_lib.openPort(resource.ingress, 22)
+
+	result := {
+		"documentId": doc.id,
+		"searchKey": sprintf("aws_network_acl[%s].ingress", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_network_acl[%s].ingress 'SSH' (TCP:22) is not public", [name]),
+		"keyActualValue": sprintf("aws_network_acl[%s].ingress 'SSH' (TCP:22) is public", [name]),
 	}
 }

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/negative1.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/negative1.tf
@@ -1,4 +1,17 @@
-resource "aws_network_acl" "positive1" {
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "negative1" {
   vpc_id = aws_vpc.main.id
 
   egress = [
@@ -17,9 +30,9 @@ resource "aws_network_acl" "positive1" {
       protocol   = "tcp"
       rule_no    = 100
       action     = "allow"
-      cidr_block = "0.0.0.0/0"
-      from_port   = 3389
-      to_port     = 3389
+      cidr_block = "10.3.0.0/18"
+      from_port   = 22
+      to_port     = 22
     }
   ]
 

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/negative2.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/negative2.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "negative2" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "main"
+  }
+}
+
+resource "aws_network_acl_rule" "negative2" {
+  network_acl_id = aws_network_acl.positive1.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  from_port      = 22
+  to_port        = 22
+  cidr_block     = "10.3.0.0/18"
+}

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/negative3.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/negative3.tf
@@ -1,27 +1,36 @@
-resource "aws_network_acl" "positive1" {
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.52.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "negative3" {
   vpc_id = aws_vpc.main.id
 
-  egress = [
-    {
+  egress {
       protocol   = "tcp"
       rule_no    = 200
       action     = "allow"
       cidr_block = "10.3.0.0/18"
       from_port  = 443
       to_port    = 443
-    }
-  ]
+  }
 
-  ingress = [
-    {
+  ingress {
       protocol   = "tcp"
       rule_no    = 100
       action     = "allow"
-      cidr_block = "0.0.0.0/0"
+      cidr_block = "10.3.0.0/18"
       from_port   = 22
       to_port     = 22
-    }
-  ]
+  }
 
   tags = {
     Name = "main"

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/positive1.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/positive1.tf
@@ -1,0 +1,42 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "positive1" {
+  vpc_id = aws_vpc.main.id
+
+  egress = [
+    {
+      protocol   = "tcp"
+      rule_no    = 200
+      action     = "allow"
+      cidr_block = "10.3.0.0/18"
+      from_port  = 443
+      to_port    = 443
+    }
+  ]
+
+  ingress = [
+    {
+      protocol   = "tcp"
+      rule_no    = 100
+      action     = "allow"
+      cidr_block = "0.0.0.0/0"
+      from_port   = 22
+      to_port     = 22
+    }
+  ]
+
+  tags = {
+    Name = "main"
+  }
+}

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/positive2.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/positive2.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "positive2" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "main"
+  }
+}
+
+resource "aws_network_acl_rule" "postive2" {
+  network_acl_id = aws_network_acl.positive2.id
+  rule_number    = 100
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "allow"
+  from_port      = 22
+  to_port        = 22
+  cidr_block     = "0.0.0.0/0"
+}

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/positive3.tf
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/positive3.tf
@@ -1,27 +1,36 @@
-resource "aws_network_acl" "negative1" {
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "<= 3.52.0"
+    }
+  }
+}
+
+resource "aws_network_acl" "positive3" {
   vpc_id = aws_vpc.main.id
 
-  egress = [
-    {
+  egress {
       protocol   = "tcp"
       rule_no    = 200
       action     = "allow"
       cidr_block = "10.3.0.0/18"
       from_port  = 443
       to_port    = 443
-    }
-  ]
+  }
 
-  ingress = [
-    {
+  ingress {
       protocol   = "tcp"
       rule_no    = 100
       action     = "allow"
-      cidr_block = "10.3.0.0/18"
+      cidr_block = "0.0.0.0/0"
       from_port   = 22
       to_port     = 22
-    }
-  ]
+  }
 
   tags = {
     Name = "main"

--- a/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/network_acl_with_unrestricted_access_to_ssh/test/positive_expected_result.json
@@ -2,6 +2,19 @@
   {
     "queryName": "Network ACL With Unrestricted Access To SSH",
     "severity": "HIGH",
-    "line": 15
+    "line": 28,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "Network ACL With Unrestricted Access To SSH",
+    "severity": "HIGH",
+    "line": 22,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Network ACL With Unrestricted Access To SSH",
+    "severity": "HIGH",
+    "line": 26,
+    "fileName": "positive3.tf"
   }
 ]


### PR DESCRIPTION
**Proposed Changes**
- network ACL queries now should cover old terraform providers and `aws_network_acl_rule` associated with `aws_network_acl` resources

I submit this contribution under the Apache-2.0 license.
