### PR TITLE
fix(query): IAM policies was too permissive

### DIFF
--- a/assets/queries/terraform/aws/iam_policies_attached_to_user/metadata.json
+++ b/assets/queries/terraform/aws/iam_policies_attached_to_user/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "IAM Policies Attached To User",
   "severity": "LOW",
   "category": "Best Practices",
-  "descriptionText": "IAM policies should be attached only to groups or roles",
+  "descriptionText": "IAM policies should be attached only to groups",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment",
   "platform": "Terraform",
   "descriptionID": "32ec58ec",

--- a/assets/queries/terraform/aws/iam_policies_attached_to_user/query.rego
+++ b/assets/queries/terraform/aws/iam_policies_attached_to_user/query.rego
@@ -1,6 +1,6 @@
 package Cx
 
-resourcesTest = ["aws_iam_policy_attachment", "aws_iam_user_policy", "aws_iam_user_policy_attachment"]
+resourcesTest = ["aws_iam_policy_attachment", "aws_iam_user_policy", "aws_iam_user_policy_attachment", "aws_iam_role_policy", "aws_iam_role_policy_attachment"]
 
 CxPolicy[result] {
 	resource := input.document[i].resource[resourcesTest[idx]][name]
@@ -27,5 +27,33 @@ CxPolicy[result] {
 		"issueType": "RedundantAttribute",
 		"keyExpectedValue": "'users' is redundant",
 		"keyActualValue": "'users' exists",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourcesTest[idx]][name]
+	resource.role
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[{{%s}}].role", [resourcesTest[idx], name]),
+		"issueType": "RedundantAttribute",
+		"keyExpectedValue": "'role' is redundant",
+		"keyActualValue": "'role' exists",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource[resourcesTest[idx]][name]
+	resource.roles != null
+	is_array(resource.roles)
+	count(resource.roles) > 0
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s[{{%s}}].roles", [resourcesTest[idx], name]),
+		"issueType": "RedundantAttribute",
+		"keyExpectedValue": "'roles' is redundant",
+		"keyActualValue": "'roles' exists",
 	}
 }

--- a/assets/queries/terraform/aws/iam_policies_attached_to_user/test/positive4.tf
+++ b/assets/queries/terraform/aws/iam_policies_attached_to_user/test/positive4.tf
@@ -1,0 +1,37 @@
+resource "aws_iam_role_policy" "test_policy" {
+  name = "test_policy"
+  role = aws_iam_role.test_role.id
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "test_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}

--- a/assets/queries/terraform/aws/iam_policies_attached_to_user/test/positive5.tf
+++ b/assets/queries/terraform/aws/iam_policies_attached_to_user/test/positive5.tf
@@ -1,0 +1,14 @@
+resource "aws_iam_user" "user" {
+  name = "test-user"
+}
+
+resource "aws_iam_policy" "policy" {
+  name        = "test-policy"
+  description = "A test policy"
+  policy      = "{ ... policy JSON ... }"
+}
+
+resource "aws_iam_role_policy_attachment" "test-attach" {
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.policy.arn
+}

--- a/assets/queries/terraform/aws/iam_policies_attached_to_user/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/iam_policies_attached_to_user/test/positive_expected_result.json
@@ -16,5 +16,17 @@
     "severity": "LOW",
     "line": 12,
     "filename": "positive3.tf"
+  },
+  {
+    "queryName": "IAM Policies Attached To User",
+    "severity": "LOW",
+    "line": 3,
+    "filename": "positive4.tf"
+  },
+  {
+    "queryName": "IAM Policies Attached To User",
+    "severity": "LOW",
+    "line": 12,
+    "filename": "positive5.tf"
   }
 ]


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- IAM policies should just use groups

I submit this contribution under the Apache-2.0 license.
