### PR TITLE
feat(query): Updated "S3 Bucket Policy Accepts HTTP Requests" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
@@ -33,5 +33,5 @@ check_action(action) {
 deny_http_requests(statement) {
 	check_action(statement.Action)
 	statement.Effect == "Deny"
-	statement.Condition.Bool["aws:SecureTransport"] == false
+	statement.Condition.Bool["aws:SecureTransport"] == "false"
 }

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/negative1.tf
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/negative1.tf
@@ -20,7 +20,7 @@ resource "aws_s3_bucket_policy" "b" {
         ],
         "Condition": {
           "Bool": {
-            "aws:SecureTransport" = "false"
+            "aws:SecureTransport": "false"
           }
         }
       }

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/negative2.tf
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/negative2.tf
@@ -16,7 +16,7 @@ resource "aws_s3_bucket" "b2" {
         ],
         "Condition": {
           "Bool": {
-            "aws:SecureTransport" = "false"
+            "aws:SecureTransport": "false"
           }
         }
       }


### PR DESCRIPTION
**Proposed Changes**
- Correcting "S3 Bucket Policy Accepts HTTP Requests" query. Should be `statement.Condition.Bool["aws:SecureTransport"] == "false"` instead of `statement.Condition.Bool["aws:SecureTransport"] == false`

I submit this contribution under the Apache-2.0 license.
