### PR TITLE
fix: remove auth information in URL closes #4125

### DIFF
--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -567,7 +567,6 @@ func getSummary(t *tracker.CITracker, results []model.Vulnerability, start, end 
 		Start: start,
 		End:   end,
 	}
-	summary.ScannedPaths = pathParameters.ScannedPaths
 
 	if flags.GetBoolFlag(flags.DisableCISDescFlag) || flags.GetBoolFlag(flags.DisableFullDescFlag) {
 		log.Warn().Msg("Skipping CIS descriptions because provided disable flag is set")

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -92,7 +92,7 @@ type PathParameters struct {
 
 var (
 	queryRegex   = regexp.MustCompile(`\?([\w-]+(=[\w-]*)?(&[\w-]+(=[\w-]*)?)*)?`)
-	urlAuthRegex = regexp.MustCompile(`((ftp|tcp|udp|wss?|https?)://)(\S+(:\S*)?@).*`)
+	urlAuthRegex = regexp.MustCompile(`((ssh|https?)://)(\S+(:\S*)?@).*`)
 )
 
 const authGroupPosition = 3

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -143,7 +143,7 @@ func removeAllURLCredentials(pathExtractionMap map[string]ExtractedPathObject) [
 func removeURLCredentials(url string) string {
 	authGroup := ""
 	groups := urlAuthRegex.FindStringSubmatch(url)
-	// authentication is present in URL
+	// credentials are present in the URL
 	if len(groups) > authGroupPosition {
 		authGroup = groups[authGroupPosition]
 	}

--- a/pkg/model/summary_test.go
+++ b/pkg/model/summary_test.go
@@ -51,7 +51,8 @@ func TestCreateSummary(t *testing.T) {
 					SeverityHigh:   0,
 				},
 			},
-			Queries: []VulnerableQuery{},
+			Queries:      []VulnerableQuery{},
+			ScannedPaths: []string{},
 		})
 	})
 
@@ -87,6 +88,7 @@ func TestCreateSummary(t *testing.T) {
 					},
 				},
 			},
+			ScannedPaths: []string{},
 		})
 	})
 }
@@ -152,5 +154,87 @@ func TestModel_resolvePath(t *testing.T) {
 			got := resolvePath(tt.args.filePath, tt.args.pathExtractionMap)
 			require.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func TestRemoveURLCredentials(t *testing.T) {
+	type args struct {
+		url string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test_with_url_credentials",
+			args: args{
+				url: "https://user:password@test.git.com/test.git",
+			},
+			want: "https://test.git.com/test.git",
+		},
+		{
+			name: "test_with_url_no_credentials",
+			args: args{
+				url: "https://test.git.com/test.git",
+			},
+			want: "https://test.git.com/test.git",
+		},
+		{
+			name: "test_http_with_url_credentials",
+			args: args{
+				url: "http://test:password@test.git.com/test",
+			},
+			want: "http://test.git.com/test",
+		},
+		{
+			name: "test_https_with_url_token",
+			args: args{
+				url: "https://myTOken123a12e@test.git.com:8080/test",
+			},
+			want: "https://test.git.com:8080/test",
+		},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.want, removeURLCredentials(tt.args.url))
+	}
+}
+
+func TestRemoveAllURLCredentials(t *testing.T) {
+	input := []struct {
+		pathExtractionMap map[string]ExtractedPathObject
+		want              []string
+	}{
+		{
+			pathExtractionMap: map[string]ExtractedPathObject{
+				"/tmp/file/vuln": {
+					Path:      "https://user:password@git1.url.com/test.git",
+					LocalPath: false,
+				},
+				"/tmp/file/vuln2": {
+					Path:      "https://myToken123@my2.domain/test.git",
+					LocalPath: false,
+				},
+			},
+			want: []string{
+				"https://git1.url.com/test.git",
+				"https://my2.domain/test.git",
+			},
+		},
+		{
+			pathExtractionMap: map[string]ExtractedPathObject{
+				"/tmp/file/vuln": {
+					Path:      "/user/archive.zip",
+					LocalPath: true,
+				},
+			},
+			want: []string{
+				"/user/archive.zip",
+			},
+		},
+	}
+	for _, tt := range input {
+		got := removeAllURLCredentials(tt.pathExtractionMap)
+		require.Equal(t, tt.want, got)
 	}
 }


### PR DESCRIPTION
Closes #4125

**Proposed Changes**
- Removing auth information in URL from reports when remote paths are provided

I submit this contribution under the Apache-2.0 license.
