### PR TITLE
fix: pdf report last grey line closes #4129

### DIFF
--- a/pkg/report/pdf.go
+++ b/pkg/report/pdf.go
@@ -212,6 +212,7 @@ func createResultsTable(m pdf.Maroto, query *model.VulnerableQuery) {
 			})
 		})
 	}
+	m.SetBackgroundColor(color.NewWhite())
 	m.Line(1.0)
 }
 


### PR DESCRIPTION
Closes #4129

**Proposed Changes**
- fixing broken footer when last table line is grey


I submit this contribution under the Apache-2.0 license.
