### PR TITLE
feat(query): added EFS Volumes Not Encrypted for Terraform

### DIFF
--- a/assets/queries/terraform/aws/efs_volumes_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/efs_volumes_not_encrypted/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "69df0628-1686-4ad9-87e5-00a5b45f4c71",
+  "queryName": "EFS Volumes Not Encrypted",
+  "severity": "",
+  "category": "",
+  "descriptionText": "EFS volumes should have encryption in transit enabled",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition#transit_encryption",
+  "platform": "Terraform",
+  "descriptionID": "ef15de4e",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/terraform/aws/efs_volumes_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/efs_volumes_not_encrypted/query.rego
@@ -1,0 +1,30 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	efs := input.document[i].resource.aws_ecs_task_definition[name].volume
+	volume := efs.efs_volume_configuration
+	not common_lib.valid_key(volume, "transit_encryption")
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ecs_task_definition[%s].volume.efs_volume_configuration", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_ecs_task_definition.volume.efs_volume_configuration' is defined and not null",
+		"keyActualValue": "aws_ecs_task_definition.volume.efs_volume_configuration' is undefined or null",
+	}
+}
+
+CxPolicy[result] {
+	efs := input.document[i].resource.aws_ecs_task_definition[name].volume
+	volume := efs.efs_volume_configuration
+	common_lib.valid_key(volume, "transit_encryption")
+	volume.transit_encryption != "ENABLED"
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ecs_task_definition[%s].volume.efs_volume_configuration.transit_encryption", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "aws_ecs_task_definition.volume.efs_volume_configuration.transit_encryption' is defined and not null",
+		"keyActualValue": "aws_ecs_task_definition.volume.efs_volume_configuration.transit_encryption' is undefined or null",
+	}
+}

--- a/assets/queries/terraform/aws/efs_volumes_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/efs_volumes_not_encrypted/query.rego
@@ -12,6 +12,7 @@ CxPolicy[result] {
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "aws_ecs_task_definition.volume.efs_volume_configuration' is defined and not null",
 		"keyActualValue": "aws_ecs_task_definition.volume.efs_volume_configuration' is undefined or null",
+		"searchLine": ["efs_volume_configuration"],
 	}
 }
 
@@ -26,5 +27,6 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "aws_ecs_task_definition.volume.efs_volume_configuration.transit_encryption' is defined and not null",
 		"keyActualValue": "aws_ecs_task_definition.volume.efs_volume_configuration.transit_encryption' is undefined or null",
+		"searchLine": ["efs_volume_configuration"],
 	}
 }

--- a/assets/queries/terraform/aws/efs_volumes_not_encrypted/test/negative.tf
+++ b/assets/queries/terraform/aws/efs_volumes_not_encrypted/test/negative.tf
@@ -1,0 +1,16 @@
+resource "aws_ecs_task_definition" "negative" {
+  volume {
+    name = "service-storage"
+
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.fs.id
+      root_directory          = "/opt/data"
+      transit_encryption      = "ENABLED"
+      transit_encryption_port = 2999
+      authorization_config {
+        access_point_id = aws_efs_access_point.test.id
+        iam             = "ENABLED"
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/aws/efs_volumes_not_encrypted/test/positive.tf
+++ b/assets/queries/terraform/aws/efs_volumes_not_encrypted/test/positive.tf
@@ -1,0 +1,15 @@
+resource "aws_ecs_task_definition" "positive" {
+  volume {
+    name = "service-storage"
+
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.fs.id
+      root_directory          = "/opt/data"
+      transit_encryption_port = 2999
+      authorization_config {
+        access_point_id = aws_efs_access_point.test.id
+        iam             = "ENABLED"
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/aws/efs_volumes_not_encrypted/test/positive2.tf
+++ b/assets/queries/terraform/aws/efs_volumes_not_encrypted/test/positive2.tf
@@ -1,0 +1,16 @@
+resource "aws_ecs_task_definition" "positive2" {
+  volume {
+    name = "service-storage"
+
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.fs.id
+      root_directory          = "/opt/data"
+      transit_encryption      = "DISABLED"
+      transit_encryption_port = 2999
+      authorization_config {
+        access_point_id = aws_efs_access_point.test.id
+        iam             = "ENABLED"
+      }
+    }
+  }
+}

--- a/assets/queries/terraform/aws/efs_volumes_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/efs_volumes_not_encrypted/test/positive_expected_result.json
@@ -4,5 +4,11 @@
     "severity": "",
     "line": 5,
     "fileName": "positive.tf"
+  },
+  {
+    "queryName": "EFS Volumes Not Encrypted",
+    "severity": "",
+    "line": 8,
+    "fileName": "positive2.tf"
   }
 ]

--- a/assets/queries/terraform/aws/efs_volumes_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/efs_volumes_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "EFS Volumes Not Encrypted",
+    "severity": "",
+    "line": 5,
+    "fileName": "positive.tf"
+  }
+]


### PR DESCRIPTION

**Proposed Changes**
- added a query to check if "encryption" is enabled for EFS Volumes
- **category and severity are provisory**

I submit this contribution under the Apache-2.0 license.
