### PR TITLE
feat(query): added EBS Default Not Encrypted for Terraform

### DIFF
--- a/assets/queries/terraform/aws/ebs_default_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/ebs_default_not_encrypted/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "2be0d716-1ed5-4258-a934-fab37bd9848f",
+  "queryName": "EBS default not encrypted",
+  "severity": "",
+  "category": "",
+  "descriptionText": "EBS default encryption should be enabled",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_encryption_by_default#enabled",
+  "platform": "Terraform",
+  "descriptionID": "36f5943e",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/terraform/aws/ebs_default_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/ebs_default_not_encrypted/query.rego
@@ -1,0 +1,34 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	encryption := input.document[i].resource.aws_ebs_encryption_by_default[name]
+
+	not common_lib.valid_key(encryption, "enabled")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ebs_encryption_by_default[%s].enabled", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "aws_ebs_encryption_by_default.enabled is defined and not null",
+		"keyActualValue": "aws_ebs_encryption_by_default.enabled is undefined or null",
+		"searchLine": "enabled",
+	}
+}
+
+CxPolicy[result] {
+	encryption := input.document[i].resource.aws_ebs_encryption_by_default[name]
+
+	common_lib.valid_key(encryption, "enabled")
+	encryption.enabled == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ebs_encryption_by_default[%s].enabled", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "aws_ebs_encryption_by_default.enabled is set to true",
+		"keyActualValue": "aws_ebs_encryption_by_default.enabled is set to false",
+		"searchLine": ["enabled"],
+	}
+}

--- a/assets/queries/terraform/aws/ebs_default_not_encrypted/test/negative.tf
+++ b/assets/queries/terraform/aws/ebs_default_not_encrypted/test/negative.tf
@@ -1,0 +1,3 @@
+resource "aws_ebs_encryption_by_default" "negative" {
+  enabled = true
+}

--- a/assets/queries/terraform/aws/ebs_default_not_encrypted/test/positive.tf
+++ b/assets/queries/terraform/aws/ebs_default_not_encrypted/test/positive.tf
@@ -1,0 +1,3 @@
+resource "aws_ebs_encryption_by_default" "positive" {
+  enabled = false
+}

--- a/assets/queries/terraform/aws/ebs_default_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ebs_default_not_encrypted/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "EBS default not encrypted",
+    "severity": "",
+    "line": 2,
+    "fileName": "positive.tf"
+  }
+]


### PR DESCRIPTION

**Proposed Changes**
- added a query to check if encryption is enabled for EBS default service
- severity and category are provisory

I submit this contribution under the Apache-2.0 license.
