### PR TITLE
feat(query): added Autoscaling Groups Supply Tags for Terraform

### DIFF
--- a/assets/queries/terraform/aws/autoscaling_groups_supply_tags/metadata.json
+++ b/assets/queries/terraform/aws/autoscaling_groups_supply_tags/metadata.json
@@ -2,9 +2,9 @@
   "id": "ba48df05-eaa1-4d64-905e-4a4b051e7587",
   "queryName": "Autoscaling Groups Supply Tags",
   "severity": "LOW",
-  "category": "Encryption",
+  "category": "Availability",
   "descriptionText": "Autoscaling groups should supply tags to configurate",
-  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#launch_configuration",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#tag-and-tags",
   "platform": "Terraform",
   "descriptionID": "83cb6386",
   "cloudProvider": "aws"

--- a/assets/queries/terraform/aws/autoscaling_groups_supply_tags/metadata.json
+++ b/assets/queries/terraform/aws/autoscaling_groups_supply_tags/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "ba48df05-eaa1-4d64-905e-4a4b051e7587",
+  "queryName": "Autoscaling Groups Supply Tags",
+  "severity": "LOW",
+  "category": "Encryption",
+  "descriptionText": "Autoscaling groups should supply tags to configurate",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#launch_configuration",
+  "platform": "Terraform",
+  "descriptionID": "83cb6386",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/terraform/aws/autoscaling_groups_supply_tags/query.rego
+++ b/assets/queries/terraform/aws/autoscaling_groups_supply_tags/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	auto := input.document[i].resource.aws_autoscaling_group[name]
+	not common_lib.valid_key(auto, "tags")
+	not common_lib.valid_key(auto, "tag")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_autoscaling_group[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'tags' or 'tag' are defined and not null",
+		"keyActualValue": "'tags' or 'tag' are undefined or null",
+		"searchLine": common_lib.build_search_line(["resource", "aws_autoscaling_group", name], []),
+	}
+}

--- a/assets/queries/terraform/aws/autoscaling_groups_supply_tags/query.rego
+++ b/assets/queries/terraform/aws/autoscaling_groups_supply_tags/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("aws_autoscaling_group[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'tags' or 'tag' are defined and not null",
-		"keyActualValue": "'tags' or 'tag' are undefined or null",
+		"keyActualValue": "'tags' and 'tag' are undefined or null",
 		"searchLine": common_lib.build_search_line(["resource", "aws_autoscaling_group", name], []),
 	}
 }

--- a/assets/queries/terraform/aws/autoscaling_groups_supply_tags/test/negative.tf
+++ b/assets/queries/terraform/aws/autoscaling_groups_supply_tags/test/negative.tf
@@ -1,0 +1,22 @@
+resource "aws_autoscaling_group" "negative" {
+  name                 = "foobar3-terraform-test"
+  max_size             = 5
+  min_size             = 2
+  launch_configuration = aws_launch_configuration.foobar.name
+  vpc_zone_identifier  = [aws_subnet.example1.id, aws_subnet.example2.id]
+
+  tags = concat(
+    [
+      {
+        "key"                 = "interpolation1"
+        "value"               = "value3"
+        "propagate_at_launch" = true
+      },
+      {
+        "key"                 = "interpolation2"
+        "value"               = "value4"
+        "propagate_at_launch" = true
+      },
+    ],
+  )
+}

--- a/assets/queries/terraform/aws/autoscaling_groups_supply_tags/test/negative2.tf
+++ b/assets/queries/terraform/aws/autoscaling_groups_supply_tags/test/negative2.tf
@@ -1,0 +1,13 @@
+resource "aws_autoscaling_group" "negative2" {
+  name                 = "foobar3-terraform-test"
+  max_size             = 5
+  min_size             = 2
+  launch_configuration = aws_launch_configuration.foobar.name
+  vpc_zone_identifier  = [aws_subnet.example1.id, aws_subnet.example2.id]
+
+  tag {
+    key                 = "foo"
+    value               = "bar"
+    propagate_at_launch = true
+  }
+}

--- a/assets/queries/terraform/aws/autoscaling_groups_supply_tags/test/positive.tf
+++ b/assets/queries/terraform/aws/autoscaling_groups_supply_tags/test/positive.tf
@@ -1,0 +1,7 @@
+resource "aws_autoscaling_group" "positive" {
+  name                 = "foobar3-terraform-test"
+  max_size             = 5
+  min_size             = 2
+  launch_configuration = aws_launch_configuration.foobar.name
+  vpc_zone_identifier  = [aws_subnet.example1.id, aws_subnet.example2.id]
+}

--- a/assets/queries/terraform/aws/autoscaling_groups_supply_tags/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/autoscaling_groups_supply_tags/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Autoscaling Groups Supply Tags",
+    "severity": "LOW",
+    "line": 1,
+    "fileName": "positive.tf"
+  }
+]


### PR DESCRIPTION

**Proposed Changes**
- added a query to check if Autoscaling Groups supply tags to launch configurations

I submit this contribution under the Apache-2.0 license.
