### PR TITLE
feat(query): added "SSM Session Transit Encryption Disabled" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/metadata.json
+++ b/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "ce60cc6b-6831-4bd7-84a2-cc7f8ee71433",
+  "queryName": "SSM Session Transit Encryption Disabled",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "SSM Session should be encrypted in transit",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_document#content",
+  "platform": "Terraform",
+  "descriptionID": "8b30849b",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/query.rego
+++ b/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_ssm_document[name]
+
+	resource.document_type == "Session"
+
+	content := common_lib.json_unmarshal(resource.content)
+    not common_lib.valid_key(content, "inputs")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ssm_document[%s].content", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'inputs' is defined and not null",
+		"keyActualValue": "'inputs' is undefined or null",
+		"searchLine": common_lib.build_search_line(["resource", "aws_ssm_document", name, "content"], []),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_ssm_document[name]
+
+	resource.document_type == "Session"
+
+	content := common_lib.json_unmarshal(resource.content)
+    not common_lib.valid_key(content.inputs, "kmsKeyId")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ssm_document[%s].content", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'inputs.kmsKeyId' is defined and not null",
+		"keyActualValue": "'inputs.kmsKeyId' is undefined or null",
+		"searchLine": common_lib.build_search_line(["resource", "aws_ssm_document", name, "content"], []),
+	}
+}

--- a/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/test/negative.tf
+++ b/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/test/negative.tf
@@ -1,0 +1,18 @@
+resource "aws_ssm_document" "negative" {
+  name          = "test_document"
+  document_type = "Session"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check ip configuration of a Linux instance.",
+    "inputs": {
+      "s3EncryptionEnabled": true,
+      "cloudWatchEncryptionEnabled": true,
+      "cloudWatchStreamingEnabled": true,
+      "runAsEnabled": false,
+      "kmsKeyId": "${var.kms_key_id}"
+    }
+  }
+DOC
+}

--- a/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/test/positive1.tf
+++ b/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/test/positive1.tf
@@ -1,0 +1,11 @@
+resource "aws_ssm_document" "positive1" {
+  name          = "test_document"
+  document_type = "Session"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check ip configuration of a Linux instance."
+  }
+DOC
+}

--- a/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/test/positive2.tf
+++ b/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/test/positive2.tf
@@ -1,0 +1,17 @@
+resource "aws_ssm_document" "positive2" {
+  name          = "test_document"
+  document_type = "Session"
+
+  content = <<DOC
+  {
+    "schemaVersion": "1.2",
+    "description": "Check ip configuration of a Linux instance.",
+    "inputs": {
+      "s3EncryptionEnabled": true,
+      "cloudWatchEncryptionEnabled": true,
+      "cloudWatchStreamingEnabled": true,
+      "runAsEnabled": false
+    }
+  }
+DOC
+}

--- a/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ssm_session_transit_encryption_disabled/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "SSM Session Transit Encryption Disabled",
+    "severity": "MEDIUM",
+    "line": 5,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "SSM Session Transit Encryption Disabled",
+    "severity": "MEDIUM",
+    "line": 5,
+    "fileName": "positive2.tf"
+  }
+]


### PR DESCRIPTION
**Proposed Changes**
- Added "SSM Session Transit Encryption Disabled" for Terraform

I submit this contribution under the Apache-2.0 license.
