### PR TITLE
fix(core): Fixed error treating when can't infer type from functions

### DIFF
--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -378,7 +378,10 @@ func createEntryInputVar(path []string, defaultValue string) (cty.Value, error) 
 		}
 	}
 	mapJSON += closeMap
-	jsonType, _ := ctyjson.ImpliedType([]byte(mapJSON))
+	jsonType, err := ctyjson.ImpliedType([]byte(mapJSON))
+	if err != nil {
+		return cty.NilVal, err
+	}
 	value, err := ctyjson.Unmarshal([]byte(mapJSON), jsonType)
 	if err != nil {
 		return cty.NilVal, err


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- KICS was not treating error when couldn't infer json type when evaluating terraform function

I submit this contribution under the Apache-2.0 license.
