### PR TITLE
fix: moving custom library not provided warning to debug level

### DIFF
--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -682,7 +682,7 @@ func (m *mockSource) GetQueryLibrary(platform string) (string, error) {
 		return string(content), err
 	}
 
-	log.Warn().Msgf("Custom library not provided. Loading embedded library instead")
+	log.Debug().Msgf("Custom library not provided. Loading embedded library instead")
 
 	// getting embedded library
 	embeddedLibrary, errGettingEmbeddedLibrary := assets.GetEmbeddedLibrary(strings.ToLower(platform))

--- a/pkg/engine/source/filesystem.go
+++ b/pkg/engine/source/filesystem.go
@@ -132,7 +132,7 @@ func (s *FilesystemSource) GetQueryLibrary(platform string) (string, error) {
 		}
 		content = string(byteContent)
 	} else {
-		log.Warn().Msgf("Custom library not provided. Loading embedded library instead")
+		log.Debug().Msgf("Custom library not provided. Loading embedded library instead")
 	}
 	// getting embedded library
 	embeddedLibrary, errGettingEmbeddedLibrary := assets.GetEmbeddedLibrary(strings.ToLower(platform))

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -228,7 +228,7 @@ func readLibrary(platform string) (string, error) {
 		return string(content), err
 	}
 
-	log.Warn().Msgf("Custom library not provided. Loading embedded library instead")
+	log.Debug().Msgf("Custom library not provided. Loading embedded library instead")
 
 	// getting embedded library
 	embeddedLibrary, errGettingEmbeddedLibrary := assets.GetEmbeddedLibrary(strings.ToLower(platform))


### PR DESCRIPTION

I submit this contribution under the Apache-2.0 license.
