### PR TITLE
fix: excluding .github folder from CxSAST scan

### DIFF
--- a/cx.configuration
+++ b/cx.configuration
@@ -8,6 +8,6 @@
     "incremental": "false",
     "forceScan" : "true",
     "fileExcludes": "pkg/model/model_easyjson.go,*_test.go",
-    "folderExcludes": "test,e2e/fixtures"
+    "folderExcludes": "test,e2e/fixtures,.github"
   }
 }


### PR DESCRIPTION


I submit this contribution under the Apache-2.0 license.
