### PR TITLE
fix(query): correcting "keyExpectedValue" and "keyActualValue" for "Configuration Aggregator to All Regions Disabled"

### DIFF
--- a/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/query.rego
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/query.rego
@@ -10,8 +10,9 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_config_configuration_aggregator[%s].%s.all_regions", [name, type]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'aws_db_instance[%s].%s.all_regions' is set to true", [name, type]),
-		"keyActualValue": sprintf("'aws_db_instance[%s].%s.all_regions' is set to false", [name, type]),
+		"keyExpectedValue": sprintf("'aws_config_configuration_aggregator[%s].%s.all_regions' is set to true", [name, type]),
+		"keyActualValue": sprintf("'aws_config_configuration_aggregator[%s].%s.all_regions' is set to false", [name, type]),
+		"searchLine": common_lib.build_search_line(["resource", "aws_config_configuration_aggregator", name, type, "all_regions"], []),
 	}
 }
 
@@ -27,7 +28,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_config_configuration_aggregator[%s].%s", [name, type]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'aws_db_instance[%s].%s.all_regions' is set to true", [name, type]),
-		"keyActualValue": sprintf("'aws_db_instance[%s].%s.all_regions' is undefined", [name, type]),
+		"keyExpectedValue": sprintf("'aws_config_configuration_aggregator[%s].%s.all_regions' is set to true", [name, type]),
+		"keyActualValue": sprintf("'aws_config_configuration_aggregator[%s].%s.all_regions' is undefined", [name, type]),
+		"searchLine": common_lib.build_search_line(["resource", "aws_config_configuration_aggregator", name, type], []),
 	}
 }

--- a/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/config_configuration_aggregator_to_all_regions_disabled/test/positive_expected_result.json
@@ -2,11 +2,13 @@
   {
     "queryName": "Configuration Aggregator to All Regions Disabled",
     "severity": "HIGH",
-    "line": 4
+    "line": 4,
+    "fileName": "positive.tf"
   },
   {
     "queryName": "Configuration Aggregator to All Regions Disabled",
     "severity": "HIGH",
-    "line": 16
+    "line": 16,
+    "fileName": "positive.tf"
   }
 ]


### PR DESCRIPTION
**Proposed Changes**
- Correcting "keyExpectedValue" and "keyActualValue" for "Configuration Aggregator to All Regions Disabled"

I submit this contribution under the Apache-2.0 license.
