### PR TITLE
fix: add generic id to passwords and secrets for descriptions api

### DIFF
--- a/assets/queries/common/passwords_and_secrets/metadata.json
+++ b/assets/queries/common/passwords_and_secrets/metadata.json
@@ -1,4 +1,5 @@
 {
+  "id": "a88baa34-e2ad-44ea-ad6f-8cac87bc7c71",
   "queryName": "Passwords And Secrets",
   "severity": "HIGH",
   "category": "Secret Management",


### PR DESCRIPTION


I submit this contribution under the Apache-2.0 license.
