### PR TITLE
test(pkg): increase unit tests to 80% coverage

### DIFF
--- a/.github/scripts/coverage/.coverageignore
+++ b/.github/scripts/coverage/.coverageignore
@@ -3,3 +3,4 @@ test/*.go
 pkg/engine/mock/*.go
 */**/*_test.go
 **/*_mock.go
+pkg/parser/jsonfilter/parser/jsonfilter*

--- a/pkg/kics/sink_test.go
+++ b/pkg/kics/sink_test.go
@@ -1,0 +1,129 @@
+package kics
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Checkmarx/kics/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKics_prepareDocument(t *testing.T) {
+	type args struct {
+		bodyType string
+		kind     model.FileKind
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "prepare document simple test",
+			args: args{
+				bodyType: `
+				{
+					"document": [
+					  {
+						"resource": {
+						  "aws_cloudwatch_log_metric_filter": {
+							"cis_changes_nacl": {
+							  "name": "CIS-4.11-Changes-NACL",
+							  "pattern": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) || ($.eventName = DeleteNetworkAcl) || ($.eventName = DeleteNetworkAclEntry) || ($.eventName = ReplaceNetworkAclEntry) || ($.eventName = ReplaceNetworkAclAssociation) }",
+							  "log_group_name": "${aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup.name}",
+							  "metric_transformation": {
+								"name": "CIS-4.11-Changes-NACL",
+								"namespace": "CIS_Metric_Alarm_Namespace",
+								"value": "1",
+								"_kics_lines": {
+								  "_kics__default": {
+									"_kics_line": 6
+								  },
+								  "_kics_name": {
+									"_kics_line": 7
+								  },
+								  "_kics_namespace": {
+									"_kics_line": 8
+								  },
+								  "_kics_value": {
+									"_kics_line": 9
+								  }
+								}
+							  },
+							  "_kics_lines": {
+								"_kics__default": {
+								  "_kics_line": 1
+								},
+								"_kics_log_group_name": {
+								  "_kics_line": 4
+								},
+								"_kics_metric_transformation": {
+								  "_kics_line": 6
+								},
+								"_kics_name": {
+								  "_kics_line": 2
+								},
+								"_kics_pattern": {
+								  "_kics_line": 3
+								}
+							  }
+							}
+						  }
+						},
+						"_kics_lines": {
+						  "_kics__default": {
+							"_kics_line": 0
+						  },
+						  "_kics_resource": {
+							"_kics_line": 1
+						  }
+						}
+					  }
+					]
+				  }
+				`,
+				kind: model.KindTerraform,
+			},
+			want: `
+			{
+				"document": [
+				  {
+					"resource": {
+					  "aws_cloudwatch_log_metric_filter": {
+						"cis_changes_nacl": {
+						  "log_group_name": "${aws_cloudwatch_log_group.CIS_CloudWatch_LogsGroup.name}",
+						  "metric_transformation": {
+							"name": "CIS-4.11-Changes-NACL",
+							"namespace": "CIS_Metric_Alarm_Namespace",
+							"value": "1"
+						  },
+						  "name": "CIS-4.11-Changes-NACL",
+						  "pattern": "{\"_kics_filter_expr\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_op\":\"||\",\"_left\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAcl\"},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"CreateNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"DeleteNetworkAcl\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"DeleteNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"ReplaceNetworkAclEntry\"}},\"_right\":{\"_selector\":\"$.eventName\",\"_op\":\"=\",\"_value\":\"ReplaceNetworkAclAssociation\"}}}"
+						}
+					  }
+					}
+				  }
+				]
+			  }
+
+			`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interf := make(map[string]interface{})
+			err := json.Unmarshal([]byte(tt.args.bodyType), &interf)
+			require.NoError(t, err)
+
+			got := PrepareScanDocument(interf, tt.args.kind)
+			compareJSONLine(t, got, tt.want)
+		})
+	}
+}
+
+func compareJSONLine(t *testing.T, test1 interface{}, test2 string) {
+	stringefiedJSON, err := json.Marshal(&test1)
+	require.NoError(t, err)
+	require.JSONEq(t, test2, string(stringefiedJSON))
+}

--- a/pkg/parser/jsonfilter/parser/error_listener_test.go
+++ b/pkg/parser/jsonfilter/parser/error_listener_test.go
@@ -1,0 +1,117 @@
+package parser
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/antlr/antlr4/runtime/Go/antlr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCustomErrorListener(t *testing.T) {
+	tests := []struct {
+		name string
+		want *CustomErrorListener
+	}{
+		{
+			name: "test new custom error Listener",
+			want: &CustomErrorListener{
+				DefaultErrorListener: antlr.NewDefaultErrorListener(),
+				Errors:               make([]*CustomSyntaxError, 0),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewCustomErrorListener(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewCustomErrorListener() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCustomErrorListener_HasErrors(t *testing.T) {
+	type fields struct {
+		DefaultErrorListener *antlr.DefaultErrorListener
+		Errors               []*CustomSyntaxError
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "test custom error listener has 0 errors",
+			fields: fields{
+				DefaultErrorListener: antlr.NewDefaultErrorListener(),
+				Errors:               make([]*CustomSyntaxError, 0),
+			},
+			want: false,
+		},
+		{
+			name: "test custom error listener has 0 errors",
+			fields: fields{
+				DefaultErrorListener: antlr.NewDefaultErrorListener(),
+				Errors:               make([]*CustomSyntaxError, 1),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CustomErrorListener{
+				DefaultErrorListener: tt.fields.DefaultErrorListener,
+				Errors:               tt.fields.Errors,
+			}
+			if got := c.HasErrors(); got != tt.want {
+				t.Errorf("CustomErrorListener.HasErrors() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCustomErrorListener_SyntaxError(t *testing.T) {
+	type fields struct {
+		DefaultErrorListener *antlr.DefaultErrorListener
+		Errors               []*CustomSyntaxError
+	}
+	type args struct {
+		recognizer      antlr.Recognizer
+		offendingSymbol interface{}
+		line            int
+		column          int
+		msg             string
+		e               antlr.RecognitionException
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "custom error listen syntax error",
+			fields: fields{
+				DefaultErrorListener: antlr.NewDefaultErrorListener(),
+				Errors:               make([]*CustomSyntaxError, 0),
+			},
+			args: args{
+				recognizer:      nil,
+				offendingSymbol: nil,
+				line:            1,
+				column:          1,
+				msg:             "this is an error",
+				e:               nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CustomErrorListener{
+				DefaultErrorListener: tt.fields.DefaultErrorListener,
+				Errors:               tt.fields.Errors,
+			}
+			c.SyntaxError(tt.args.recognizer, tt.args.offendingSymbol, tt.args.line, tt.args.column, tt.args.msg, tt.args.e)
+			require.True(t, c.HasErrors())
+		})
+	}
+}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -132,3 +132,61 @@ func TestCommentsCommands(t *testing.T) {
 	}
 	require.Equal(t, expectedCommands, commands)
 }
+
+func TestParser_Contains(t *testing.T) {
+	type args struct {
+		types          []string
+		supportedTypes []string
+	}
+	tests := []struct {
+		name               string
+		args               args
+		wantInvalidArgsRes []string
+		wantContRes        bool
+		wantSupportedRes   bool
+	}{
+		{
+			name: "test contains",
+			args: args{
+				types: []string{
+					"cloudformation",
+				},
+				supportedTypes: []string{
+					"cloudformation",
+					"terraform",
+					"ansible",
+				},
+			},
+			wantInvalidArgsRes: nil,
+			wantContRes:        true,
+			wantSupportedRes:   true,
+		},
+		{
+			name: "test contains invalid",
+			args: args{
+				types: []string{
+					"dockerfile",
+				},
+				supportedTypes: []string{
+					"cloudformation",
+					"terraform",
+					"ansible",
+				},
+			},
+			wantInvalidArgsRes: []string{
+				"dockerfile",
+			},
+			wantContRes:      false,
+			wantSupportedRes: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotInv, gotCont, gotSup := contains(tt.args.types, tt.args.supportedTypes)
+			require.Equal(t, tt.wantInvalidArgsRes, gotInv)
+			require.Equal(t, tt.wantContRes, gotCont)
+			require.Equal(t, tt.wantSupportedRes, gotSup)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added unit tests to pkg/parser/jsonfilter/error_listener.go
- Added unit tests to pkg/parser/parser.go
- Added unit tests to pkg/kics/sink.go
- Added generated files to .coverageignore

I submit this contribution under the Apache-2.0 license.
