### PR TITLE
fix(parser): fix terraform parser returning null instead of empty array

### DIFF
--- a/assets/queries/terraform/aws/auto_scaling_group_with_no_associated_elb/query.rego
+++ b/assets/queries/terraform/aws/auto_scaling_group_with_no_associated_elb/query.rego
@@ -6,7 +6,6 @@ CxPolicy[result] {
 	document = input.document[i]
 	resource = document.resource.aws_autoscaling_group[name]
 
-	# not common_lib.valid_key(resource, "load_balancers")
 	count(resource.load_balancers) == 0
 
 	result := {

--- a/assets/queries/terraform/aws/auto_scaling_group_with_no_associated_elb/query.rego
+++ b/assets/queries/terraform/aws/auto_scaling_group_with_no_associated_elb/query.rego
@@ -6,11 +6,27 @@ CxPolicy[result] {
 	document = input.document[i]
 	resource = document.resource.aws_autoscaling_group[name]
 
-	not common_lib.valid_key(resource, "load_balancers")
+	# not common_lib.valid_key(resource, "load_balancers")
+	count(resource.load_balancers) == 0
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_autoscaling_group[%s].load_balancers", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("aws_autoscaling_group[%s].load_balancers is set and not empty", [name]),
+		"keyActualValue": sprintf("aws_autoscaling_group[%s].load_balancers is empty", [name]),
+	}
+}
+
+CxPolicy[result] {
+	document = input.document[i]
+	resource = document.resource.aws_autoscaling_group[name]
+
+	not common_lib.valid_key(resource, "load_balancers")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_autoscaling_group[%s]", [name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("aws_autoscaling_group[%s].load_balancers is set and not empty", [name]),
 		"keyActualValue": sprintf("aws_autoscaling_group[%s].load_balancers is undefined", [name]),

--- a/assets/queries/terraform/aws/iam_group_without_users/query.rego
+++ b/assets/queries/terraform/aws/iam_group_without_users/query.rego
@@ -24,5 +24,5 @@ has_membership_associated(resource, name) {
 }
 
 empty(resource) {
-	resource[_].users == null
+	count(resource[_].users) == 0
 }

--- a/assets/queries/terraform/aws/rds_without_logging/query.rego
+++ b/assets/queries/terraform/aws/rds_without_logging/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 CxPolicy[result] {
 	db := input.document[i].resource.aws_db_instance[name]
 
-	db.enabled_cloudwatch_logs_exports == null
+	count(db.enabled_cloudwatch_logs_exports) == 0
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/terraform/aws/route53_record_undefined/query.rego
+++ b/assets/queries/terraform/aws/route53_record_undefined/query.rego
@@ -4,7 +4,7 @@ import data.generic.common as commonLib
 
 CxPolicy[result] {
 	route := input.document[i].resource.aws_route53_record[name]
-	commonLib.emptyOrNull(route.records)
+	count(route.records) == 0
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/terraform/azure/vm_not_attached_to_network/query.rego
+++ b/assets/queries/terraform/azure/vm_not_attached_to_network/query.rego
@@ -3,7 +3,7 @@ package Cx
 CxPolicy[result] {
 	vm := input.document[i].resource.azurerm_virtual_machine[name]
 
-	vm.network_interface_ids == null
+	count(vm.network_interface_ids) == 0
 
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/query.rego
+++ b/assets/queries/terraform/gcp/cloud_storage_anonymous_or_publicly_accessible/query.rego
@@ -2,7 +2,7 @@ package Cx
 
 CxPolicy[result] {
 	resource := input.document[i].resource.google_storage_bucket_iam_binding[name]
-	resource.members == null
+	count(resource.members) == 0
 
 	result := {
 		"documentId": input.document[i].id,

--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -173,7 +173,7 @@ func (c *converter) convertExpression(expr hclsyntax.Expression) (interface{}, e
 	case *hclsyntax.TemplateWrapExpr:
 		return c.convertExpression(value.Wrapped)
 	case *hclsyntax.TupleConsExpr:
-		var list []interface{}
+		list := make([]interface{}, 0)
 		for _, ex := range value.Exprs {
 			elem, err := c.convertExpression(ex)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #

**Proposed Changes**
- fixed bug where parsing an empty array in terraform would return null instead of an empty array
- fixed queries related to this problem

I submit this contribution under the Apache-2.0 license.
