### PR TITLE
feat(query): support of Terraform modules for "S3 Bucket Policy Accepts HTTP Requests"

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/query.rego
@@ -2,22 +2,40 @@ package Cx
 
 import data.generic.common as common_lib
 
+resources := {"aws_s3_bucket_policy", "aws_s3_bucket"}
+
 CxPolicy[result] {
-	resources := {"aws_s3_bucket_policy", "aws_s3_bucket"}
-	resource := input.document[i].resource[resources[r]][name]
+	resourceType := resources[r]
+	resource := input.document[i].resource[resourceType][name]
 
-	policy := common_lib.json_unmarshal(resource.policy)
-
-	statement := policy.Statement[s]
-
-	not deny_http_requests(statement)
+	not deny_http_requests(resource.policy)
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("aws_s3_bucket[%s].policy", [name]),
+		"searchKey": sprintf("%s[%s].policy", [resourceType, name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("aws_s3_bucket[%s].policy does not accept HTTP Requests", [name]),
-		"keyActualValue": sprintf("aws_s3_bucket[%s].policy accepts HTTP Requests", [name]),
+		"keyExpectedValue": sprintf("%s[%s].policy does not accept HTTP Requests", [resourceType, name]),
+		"keyActualValue": sprintf("%s[%s].policy accepts HTTP Requests", [resourceType, name]),
+		"searchLine": common_lib.build_search_line(["resource", resourceType, name, "policy"], []),
+	}
+}
+
+CxPolicy[result] {
+	module := input.document[i].module[name]
+	resourceType := resources[r]
+	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, resourceType, "policy")
+
+	policy := module[keyToCheck]
+
+	not deny_http_requests(policy)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("module[%s].policy", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'policy' does not accept HTTP Requests",
+		"keyActualValue": "'policy' accepts HTTP Requests",
+		"searchLine": common_lib.build_search_line(["module", name, "policy"], []),
 	}
 }
 
@@ -30,7 +48,9 @@ check_action(action) {
 	action[a] == validActions[x]
 }
 
-deny_http_requests(statement) {
+deny_http_requests(policyValue) {
+	policy := common_lib.json_unmarshal(policyValue)
+	statement := policy.Statement[s]
 	check_action(statement.Action)
 	statement.Effect == "Deny"
 	statement.Condition.Bool["aws:SecureTransport"] == "false"

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/negative3.tf
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/negative3.tf
@@ -1,0 +1,34 @@
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+  version = "3.7.0"
+
+  bucket = "my-s3-bucket"
+  acl    = "private"
+
+  versioning = {
+    enabled = true
+  }
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Id": "MYBUCKETPOLICY",
+    "Statement": [
+      {
+        "Sid": "IPAllow",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "aws_s3_bucket.b.arn"
+        ],
+        "Condition": {
+          "Bool": {
+            "aws:SecureTransport": "false"
+          }
+        }
+      }
+    ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive3.tf
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive3.tf
@@ -1,0 +1,34 @@
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+  version = "3.7.0"
+
+  bucket = "my-s3-bucket"
+  acl    = "private"
+
+  versioning = {
+    enabled = true
+  }
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Id": "MYBUCKETPOLICY",
+    "Statement": [
+      {
+        "Sid": "IPAllow",
+        "Effect": "Deny",
+        "Principal": "*",
+        "Action": "s3:*",
+        "Resource": [
+          "aws_s3_bucket.b.arn"
+        ],
+        "Condition": {
+          "IpAddress": {
+            "aws:SourceIp": "8.8.8.8/32"
+          }
+        }
+      }
+    ]
+}
+EOF
+}

--- a/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_policy_accepts_http_requests/test/positive_expected_result.json
@@ -10,5 +10,11 @@
     "severity": "MEDIUM",
     "line": 4,
     "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "S3 Bucket Policy Accepts HTTP Requests",
+    "severity": "MEDIUM",
+    "line": 12,
+    "fileName": "positive3.tf"
   }
 ]


### PR DESCRIPTION
**Proposed Changes**
- Support of Terraform modules for "S3 Bucket Policy Accepts HTTP Requests"

I submit this contribution under the Apache-2.0 license.
