### PR TITLE
fix(query): added searchLine to Container Running With Low UID to improve line detection (#4285)

### DIFF
--- a/assets/queries/k8s/containers_run_with_low_uid/query.rego
+++ b/assets/queries/k8s/containers_run_with_low_uid/query.rego
@@ -16,6 +16,7 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("%s.securityContext.runAsUser should not be a low UID", [common_lib.concat_path(path)]),
 		"keyActualValue": sprintf("%s.securityContext.runAsUser is a low UID", [common_lib.concat_path(path)]),
+		"searchLine": common_lib.build_search_line(path, ["securityContext", "runAsUser"]),
 	}
 }
 
@@ -33,5 +34,6 @@ CxPolicy[result] {
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s.securityContext.runAsUser should be defined", [common_lib.concat_path(path)]),
 		"keyActualValue": sprintf("%s.securityContext.runAsUser is undefined", [common_lib.concat_path(path)]),
+		"searchLine": common_lib.build_search_line(path, ["securityContext"]),
 	}
 }

--- a/assets/queries/k8s/containers_run_with_low_uid/test/positive3.yaml
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/positive3.yaml
@@ -4,7 +4,6 @@ metadata:
   name: containers-runs-as-root
 spec:
   securityContext:
-    runAsUser: 222
     runAsNonRoot: false
   containers:
     - name: sec-ctx-demo-100

--- a/assets/queries/k8s/containers_run_with_low_uid/test/positive_expected_result.json
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/positive_expected_result.json
@@ -32,13 +32,13 @@
   {
     "queryName": "Container Running With Low UID",
     "severity": "MEDIUM",
-    "line": 7,
+    "line": 6,
     "fileName": "positive3.yaml"
   },
   {
     "queryName": "Container Running With Low UID",
     "severity": "MEDIUM",
-    "line": 13,
+    "line": 12,
     "fileName": "positive3.yaml"
   }
 ]

--- a/pkg/detector/default_detect.go
+++ b/pkg/detector/default_detect.go
@@ -46,8 +46,6 @@ func (d defaultDetectLine) DetectLine(file *model.FileMetadata, searchKey string
 		}
 	}
 
-	logWithFields.Warn().Msgf("Failed to detect line, query response %s", searchKey)
-
 	return model.VulnerabilityLines{
 		Line:      undetectedVulnerabilityLine,
 		VulnLines: []model.CodeLine{},

--- a/pkg/engine/vulnerability_builder.go
+++ b/pkg/engine/vulnerability_builder.go
@@ -82,6 +82,10 @@ var DefaultVulnerabilityBuilder = func(ctx *QueryContext, tracker Tracker,
 	similarityIDLineInfo = searchLineCalc.similarityIDLineInfo
 	linesVulne = searchLineCalc.linesVulne
 
+	if linesVulne.Line == -1 {
+		logWithFields.Warn().Msgf("Failed to detect line, query response %s", searchKey)
+	}
+
 	searchValue := ""
 	if s, ok := vObj["searchValue"]; ok {
 		searchValue = s.(string)


### PR DESCRIPTION
Closes #4285

Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- added searchLine to Container Running With Low UID to improve line detection
- failed to detect line error msg now only appears when both searchLine and searchKey fail to detect line

I submit this contribution under the Apache-2.0 license.
