### PR TITLE
fix: filtering golang files for sonarcloud scan

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=checkmarx
 
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=.
+sonar.sources=**/*.go
 sonar.exclusions=**/*_test.go, **/vendor/**, pkg/model/sarif_categories.go, **/e2e/fixtures/**
 
 sonar.tests=.


### PR DESCRIPTION
Signed-off-by: Rogério Peixoto <rogerio.peixoto@checkmarx.com>

I submit this contribution under the Apache-2.0 license.
