### PR TITLE
fix: excluding query samples from sonarcloud scan

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=checkmarx
 
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=.
+sonar.sources=**/*.go
 sonar.exclusions=**/*_test.go, **/vendor/**, pkg/model/sarif_categories.go, **/e2e/fixtures/**
 
 sonar.tests=.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,8 +4,8 @@ sonar.organization=checkmarx
 
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=**/*.go
-sonar.exclusions=**/*_test.go, **/vendor/**, pkg/model/sarif_categories.go, **/e2e/fixtures/**
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/vendor/**,pkg/model/sarif_categories.go,**/e2e/fixtures/**,assets/queries/**
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION


I submit this contribution under the Apache-2.0 license.
