### PR TITLE
fix(parser): fix panic with model.Document conversion in tf parser #4301

### DIFF
--- a/pkg/parser/terraform/terraform.go
+++ b/pkg/parser/terraform/terraform.go
@@ -77,8 +77,8 @@ func processResources(doc model.Document, path string) error {
 
 func addExtraInfo(json []model.Document, path string) ([]model.Document, error) {
 	for _, documents := range json { // iterate over documents
-		if documents["resource"] != nil {
-			err := processResources(documents["resource"].(model.Document), path)
+		if resources, ok := documents["resource"].(model.Document); ok {
+			err := processResources(resources, path)
 			if err != nil {
 				return []model.Document{}, err
 			}


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #4301

**Proposed Changes**
- fix panic with `model.Document` conversion in tf parser
- check if conversion is possible


I submit this contribution under the Apache-2.0 license.
