### PR TITLE
feat: added E2E tests to cover new flags

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -383,17 +383,8 @@ var tests = []testCase{
 		name: "E2E-CLI-022",
 		args: args{
 			args: []cmdArgs{
-				[]string{"scan",
-					"--profiling",
-					"CPU",
-					"-v",
-					"--no-progress",
-					"--no-color",
-					"-q",
-					"../assets/queries",
-					"-p",
-					"fixtures/samples/terraform.tf",
-				},
+				[]string{"scan", "--profiling", "CPU", "-v",
+					"--no-progress", "--no-color", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
 			},
 		},
 		validation: func(outputText string) bool {
@@ -645,6 +636,24 @@ var tests = []testCase{
 		args: args{
 			args: []cmdArgs{
 
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_036_RESULT",
+					"--include-queries", "275a3217-ca37-40c1-a6cf-bb57d245ab32,027a4b7a-8a59-4938-a04f-ed532512cf45," +
+						"e415f8d3-fc2b-4f52-88ab-1129e8c8d3f5,105ba098-1e34-48cd-b0f2-a8a43a51bf9b,ad21e616-5026-4b9d-990d-5b007bfe679c," +
+						"79d745f0-d5f3-46db-9504-bef73e9fd528,e200a6f3-c589-49ec-9143-7421d4a2c845,01d5a458-a6c4-452a-ac50-054d59275b7c," +
+						"7f384a5f-b5a2-4d84-8ca3-ee0a5247becb,87482183-a8e7-4e42-a566-7a23ec231c16,4a1e6b34-1008-4e61-a5f2-1f7c276f8d14," +
+						"d24389b4-b209-4ff0-8345-dc7a4569dcdd,5e6c9c68-8a82-408e-8749-ddad78cbb9c5"}, // Load Many Queries (13)
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_036_RESULT_2",
+					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec231c16"}, // Load 1 query
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec231c17"}, // Load 0 queries (valid, but doesn't exists)
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec23KICS"}, // Invalid query ID
+
 				[]string{"scan", "--include-queries", "cfdcabb0-fc06-427c-865b-c59f13e898ce",
 					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
 
@@ -659,9 +668,19 @@ var tests = []testCase{
 				[]string{"scan", "--include-queries",
 					"--queries-path", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
 			},
+			expectedResult: []ResultsValidation{
+				{
+					resultsFile:    "E2E_CLI_036_RESULT",
+					resultsFormats: []string{"json"},
+				},
+				{
+					resultsFile:    "E2E_CLI_036_RESULT_2",
+					resultsFormats: []string{"json"},
+				},
+			},
 		},
 
-		wantStatus: []int{50, 40, 20, 126, 126},
+		wantStatus: []int{50, 40, 0, 126, 50, 40, 20, 126, 126},
 	},
 	// E2E-CLI-037 - KICS scan command with --exclude-results and --include-queries
 	// should run only provided queries and does not run results (similarityID) provided by this flag
@@ -790,6 +809,102 @@ var tests = []testCase{
 		},
 		wantStatus: []int{50},
 	},
+	// E2E-CLI-043 - Kics scan command with --cloud-provider
+	// should execute only queries that have the same provider as given in the flag.
+	{
+		name: "E2E-CLI-043",
+		args: args{
+			args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "", "fixtures/samples/positive.yaml",
+					"--cloud-provider", "none"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--cloud-provider"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--cloud-provider", "aws"},
+			},
+		},
+		wantStatus: []int{126, 126, 50},
+	},
+	// E2E-CLI-044 - Kics scan command with --exclude-severities
+	// should only execute query-ids provided in the flag.
+	{
+		name: "E2E-CLI-044",
+		args: args{
+			args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities", "HIGH"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities", "HIGH,MEDIUM,LOW,INFO"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities", "HIGH,MEDIUM,LOW"},
+			},
+		},
+		wantStatus: []int{40, 0, 126, 20},
+	},
+	// E2E-CLI-045 - Kics scan command with --disable-secrets
+	// should not execute secret based queries.
+	{
+		name: "E2E-CLI-045",
+		args: args{
+			args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08",
+					"--disable-secrets"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08,e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
+					"--disable-secrets"},
+			},
+		},
+		wantStatus: []int{50, 0, 20},
+	},
+	// E2E-CLI-046 - Kics scan command with --disable-full-descriptions
+	// should fetch CIS descriptions from enviroment URL KICS_DESCRIPTIONS_ENDPOINT.
+	{
+		name: "E2E-CLI-046",
+		args: args{
+			args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--no-color", "-v",
+					"--disable-full-descriptions"},
+			},
+		},
+		validation: func(outputText string) bool {
+			uuidRegex := "Skipping CIS descriptions because provided disable flag is set"
+			match, _ := regexp.MatchString(uuidRegex, outputText)
+			return match
+		},
+		wantStatus: []int{50},
+	},
+	// E2E-CLI-047 - Kics scan command with --payload-lines
+	// should display additional information lines in the payload file.
+	{
+		name: "E2E-CLI-047",
+		args: args{
+			args: []cmdArgs{
+				[]string{"scan", "--silent", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--payload-path", "output/E2E_CLI_047_PAYLOAD.json", "--payload-lines"},
+			},
+			expectedPayload: []string{
+				"E2E_CLI_047_PAYLOAD.json",
+			},
+		},
+		wantStatus: []int{50},
+	},
 }
 
 func Test_E2E_CLI(t *testing.T) {
@@ -822,7 +937,7 @@ func Test_E2E_CLI(t *testing.T) {
 					require.True(t, validation, "KICS CLI output doesn't match the regex validation.")
 				}
 
-				if tt.args.expectedResult != nil {
+				if tt.args.expectedResult != nil && arg < len(tt.args.expectedResult) {
 					checkExpectedOutput(t, &tt, arg)
 				}
 

--- a/e2e/fixtures/E2E_CLI_036_RESULT.json
+++ b/e2e/fixtures/E2E_CLI_036_RESULT.json
@@ -1,0 +1,459 @@
+{
+	"kics_version": "development",
+	"files_scanned": 1,
+	"files_parsed": 1,
+	"files_failed_to_scan": 0,
+	"queries_total": 13,
+	"queries_failed_to_execute": 0,
+	"queries_failed_to_compute_similarity_id": 0,
+	"scan_id": "console",
+	"severity_counters": {
+		"HIGH": 4,
+		"INFO": 0,
+		"LOW": 5,
+		"MEDIUM": 11
+	},
+	"total_counter": 20,
+	"start": "2021-09-28T11:31:57.4326046+01:00",
+	"end": "2021-09-28T11:31:59.6045617+01:00",
+	"paths": [
+		"fixtures/samples/positive.yaml"
+	],
+	"queries": [
+		{
+			"query_name": "ALB Listening on HTTP",
+			"query_id": "275a3217-ca37-40c1-a6cf-bb57d245ab32",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-listener.html#cfn-ec2-elb-listener-protocol",
+			"severity": "HIGH",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "All Application Load Balancers (ALB) should block connection requests over HTTP",
+			"description_id": "55f05412",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "f9c0a2aed39f325f242beed63be5c53d938d2c02f243366523b2984fd10243de",
+					"line": 104,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.ALBListener.Properties.Protocol",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.ALBListener.Protocol' not equal to 'HTTP'",
+					"actual_value": "'Resources.ALBListener.Protocol' equals to 'HTTP'",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ECS Task Definition Network Mode Not Recommended",
+			"query_id": "027a4b7a-8a59-4938-a04f-ed532512cf45",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-networkmode",
+			"severity": "HIGH",
+			"platform": "CloudFormation",
+			"category": "Insecure Configurations",
+			"description": "Network_Mode should be 'awsvpc' in ecs_task_definition. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations",
+			"description_id": "bded2e99",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "dd2585b378b43193cc748c9f68b4c226b6face1e271f07f84dcb9113ff6f7446",
+					"line": 48,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.TaskDefinition.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.TaskDefinition.Properties.NetworkMode' is set and is 'awsvpc'",
+					"actual_value": "'Resources.TaskDefinition.Properties.NetworkMode' is undefined and defaults to 'bridge'",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Fully Open Ingress",
+			"query_id": "e415f8d3-fc2b-4f52-88ab-1129e8c8d3f5",
+			"query_url": "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/get-set-up-for-amazon-ecs.html#create-a-base-security-group",
+			"severity": "HIGH",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "ECS Service's security group should not allow unrestricted access to all ports from all IPv4 addresses",
+			"description_id": "747f49ac",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "88653ab159ca0a15095afc685f98da24685fa547bb5f1ca7c95ef468f209387c",
+					"line": 24,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupHTTPinbound02.Properties.CidrIp",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resource name 'EcsSecurityGroupHTTPinbound02' of type 'AWS::EC2::SecurityGroupIngress' should not accept ingress connections from all IPv4 adresses and to all available ports",
+					"actual_value": "Resource name 'EcsSecurityGroupHTTPinbound02' of type 'AWS::EC2::SecurityGroupIngress' should not accept ingress connections from CIDR 0.0.0.0/0 to all available ports",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "5f39aa8e63613a7e8bfd7641ccfb931fa0225e95b3449bc1210b50329d65d713",
+					"line": 32,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupSSHinbound.Properties.CidrIp",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resource name 'EcsSecurityGroupSSHinbound' of type 'AWS::EC2::SecurityGroupIngress' should not accept ingress connections from all IPv4 adresses and to all available ports",
+					"actual_value": "Resource name 'EcsSecurityGroupSSHinbound' of type 'AWS::EC2::SecurityGroupIngress' should not accept ingress connections from CIDR 0.0.0.0/0 to all available ports",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ALB Is Not Integrated With WAF",
+			"query_id": "105ba098-1e34-48cd-b0f2-a8a43a51bf9b",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-webaclassociation.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "All Application Load Balancers (ALB) must be protected with Web Application Firewall (WAF) service",
+			"description_id": "2cad71a7",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "d542c20ac3e6177847cf5a565ff82704a5b63ec87332191ded7baca361b611e8",
+					"line": 86,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.ECSALB",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.ECSALB' does not have an 'internal' scheme and has a 'WebACLAssociation' associated",
+					"actual_value": "'Resources.ECSALB' does not have an 'internal' scheme and a 'WebACLAssociation' associated",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Auto Scaling Group With No Associated ELB",
+			"query_id": "ad21e616-5026-4b9d-990d-5b007bfe679c",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Availability",
+			"description": "AWS Auto Scaling Groups must have associated ELBs to ensure high availability and improve application performance. This means the attribute 'LoadBalancerNames' must be defined and not empty.",
+			"description_id": "99966f58",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "ef5069fb260b351100126334b0ba9b2776f480652d8d4f72c81f387d785d22d2",
+					"line": 131,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.ECSAutoScalingGroup.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.ECSAutoScalingGroup.Properties.LoadBalancerNames' is defined",
+					"actual_value": "'Resources.ECSAutoScalingGroup.Properties.LoadBalancerNames' is not defined",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ECS Service Without Running Tasks",
+			"query_id": "79d745f0-d5f3-46db-9504-bef73e9fd528",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html#cfn-ecs-service-deploymentconfiguration",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Availability",
+			"description": "ECS Service should have at least 1 task running",
+			"description_id": "cd242bdd",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "5022c0ba8f17197cb6ef6163bf16e6dd8e13290b1d91192c61742bca491ff4f7",
+					"line": 159,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.service.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.service.Properties.DeploymentConfiguration is defined and not null",
+					"actual_value": "Resources.service.Properties.DeploymentConfiguration is undefined or null",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ELB With Security Group Without Inbound Rules",
+			"query_id": "e200a6f3-c589-49ec-9143-7421d4a2c845",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#cfn-ec2-securitygroup-securitygroupingress",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "An AWS Elastic Load Balancer (ELB) shouldn´t have security groups without outbound rules",
+			"description_id": "3ccdd7d2",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "d762780be8bebaa6b6bc6b6075a5dcee0edd37f639aa63061f29a13160eae116",
+					"line": 14,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.EcsSecurityGroup.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.EcsSecurityGroup.Properties.SecurityGroupIngress' is defined",
+					"actual_value": "'Resources.EcsSecurityGroup.Properties.SecurityGroupIngress' is undefined",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ELB With Security Group Without Outbound Rules",
+			"query_id": "01d5a458-a6c4-452a-ac50-054d59275b7c",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#cfn-ec2-securitygroup-securitygroupegress",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "An AWS Elastic Load Balancer (ELB) shouldn´t have security groups without outbound rules",
+			"description_id": "7b876844",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "ee0915eb8433ec18c3f357c5eb0d243ce5c3a077e63e222230c4c0d7bf049416",
+					"line": 14,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.EcsSecurityGroup.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.EcsSecurityGroup.Properties.SecurityGroupEgress' is defined",
+					"actual_value": "'Resources.EcsSecurityGroup.Properties.SecurityGroupEgress' is undefined",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Empty Roles For ECS Cluster Task Definitions",
+			"query_id": "7f384a5f-b5a2-4d84-8ca3-ee0a5247becb",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Access Control",
+			"description": "Check if any ECS cluster has not defined proper roles for services' task definitions.",
+			"description_id": "b47b42b2",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "cea2579f8b8eccc6008dcddba492fb4bd8802d0926f4cc33ae95b8a5f758d0e3",
+					"line": 167,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.service.Properties.TaskDefinition",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.service.Properties.TaskDefinition' refers to a TaskDefinition with Role",
+					"actual_value": "'Resources.service.Properties.TaskDefinition' does not refer to a TaskDefinition with Role",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Security Group Ingress With Port Range",
+			"query_id": "87482183-a8e7-4e42-a566-7a23ec231c16",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "AWS Security Group Ingress should have a single port",
+			"description_id": "5f2b65f3",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "810487007189ac4de717dffc3204a05756e80e910b34f89ee08fd14f612328aa",
+					"line": 27,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupSSHinbound.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupSSHinbound.Properties.FromPort is equal to Resources.EcsSecurityGroupSSHinbound.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupSSHinbound.Properties.FromPort is not equal to Resources.EcsSecurityGroupSSHinbound.Properties.ToPort",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "d60022e14f1b45c574f71c0f48b3fee882b471819597b770e3545988a8f5295a",
+					"line": 19,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupHTTPinbound02.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.FromPort is equal to Resources.EcsSecurityGroupHTTPinbound02.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.FromPort is not equal to Resources.EcsSecurityGroupHTTPinbound02.Properties.ToPort",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "000056cd0b9697e13f2f4561f1963e34c58c042b921c4d0fad0f2fa5214374eb",
+					"line": 35,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupALBports.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupALBports.Properties.FromPort is equal to Resources.EcsSecurityGroupALBports.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupALBports.Properties.FromPort is not equal to Resources.EcsSecurityGroupALBports.Properties.ToPort",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Unrestricted Security Group Ingress",
+			"query_id": "4a1e6b34-1008-4e61-a5f2-1f7c276f8d14",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "AWS Security Group Ingress CIDR should not be open to the world",
+			"description_id": "08256d31",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "f1f15967fd4bd2b39610dcbe3c2d641068dc1b409821142f41d179dbc360b3aa",
+					"line": 32,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupSSHinbound.Properties.CidrIp",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupSSHinbound.Properties.CidrIp is not open to the world (0.0.0.0/0)",
+					"actual_value": "Resources.EcsSecurityGroupSSHinbound.Properties.CidrIp is open to the world (0.0.0.0/0)",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "3c4976bcd6061315525a23a644cb6ed3bc4888794f21e8161a1cd38ea0495f30",
+					"line": 24,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupHTTPinbound02.Properties.CidrIp",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.CidrIp is not open to the world (0.0.0.0/0)",
+					"actual_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.CidrIp is open to the world (0.0.0.0/0)",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ECS Task Definition HealthCheck Missing",
+			"query_id": "d24389b4-b209-4ff0-8345-dc7a4569dcdd",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-healthcheck.html",
+			"severity": "LOW",
+			"platform": "CloudFormation",
+			"category": "Observability",
+			"description": "Amazon ECS must have the HealthCheck property defined to give more control over monitoring the health of tasks",
+			"description_id": "e2e3a50a",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "7d931711c3ba34527d9a6660c82f06f4a2174812dcfbd69bb271187edec91a06",
+					"line": 51,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.TaskDefinition.Properties.ContainerDefinitions",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.TaskDefinition.Properties.ContainerDefinitions' contains 'HealthCheck' property",
+					"actual_value": "'Resources.TaskDefinition.Properties.ContainerDefinitions' doesn't contain 'HealthCheck' property",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "e08fb6aa0ab3e2ed98aa9d08d8813df89af2b0005acdbda809c86f4897715c78",
+					"line": 67,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.TaskDefinition.Properties.ContainerDefinitions",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.TaskDefinition.Properties.ContainerDefinitions' contains 'HealthCheck' property",
+					"actual_value": "'Resources.TaskDefinition.Properties.ContainerDefinitions' doesn't contain 'HealthCheck' property",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Security Group Rule Without Description",
+			"query_id": "5e6c9c68-8a82-408e-8749-ddad78cbb9c5",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html",
+			"severity": "LOW",
+			"platform": "CloudFormation",
+			"category": "Best Practices",
+			"description": "AWS Security Group Rule should have description defined",
+			"description_id": "f7c62b11",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "e96cf20cc6e1e11dce2d40d9e2b37446a00f00c3f541aa7dd13861059f6fcce8",
+					"line": 19,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.EcsSecurityGroupHTTPinbound02.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.Description is set",
+					"actual_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.Description is undefined",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "39fec612777f59fb4181dd2330ee465ec860c962acfebb07a4f1ee1f122d24e7",
+					"line": 35,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.EcsSecurityGroupALBports.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupALBports.Properties.Description is set",
+					"actual_value": "Resources.EcsSecurityGroupALBports.Properties.Description is undefined",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "95883c9f983adb8f547c54e24837b6aa402978a00417be98441514959d4171d4",
+					"line": 27,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.EcsSecurityGroupSSHinbound.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupSSHinbound.Properties.Description is set",
+					"actual_value": "Resources.EcsSecurityGroupSSHinbound.Properties.Description is undefined",
+					"value": null
+				}
+			]
+		}
+	]
+}

--- a/e2e/fixtures/E2E_CLI_036_RESULT_2.json
+++ b/e2e/fixtures/E2E_CLI_036_RESULT_2.json
@@ -1,0 +1,75 @@
+{
+	"kics_version": "development",
+	"files_scanned": 1,
+	"files_parsed": 1,
+	"files_failed_to_scan": 0,
+	"queries_total": 1,
+	"queries_failed_to_execute": 0,
+	"queries_failed_to_compute_similarity_id": 0,
+	"scan_id": "console",
+	"severity_counters": {
+		"HIGH": 0,
+		"INFO": 0,
+		"LOW": 0,
+		"MEDIUM": 3
+	},
+	"total_counter": 3,
+	"start": "2021-09-28T12:07:37.9374314+01:00",
+	"end": "2021-09-28T12:07:40.1148004+01:00",
+	"paths": [
+		"fixtures/samples/positive.yaml"
+	],
+	"queries": [
+		{
+			"query_name": "Security Group Ingress With Port Range",
+			"query_id": "87482183-a8e7-4e42-a566-7a23ec231c16",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "AWS Security Group Ingress should have a single port",
+			"description_id": "5f2b65f3",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "810487007189ac4de717dffc3204a05756e80e910b34f89ee08fd14f612328aa",
+					"line": 27,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupSSHinbound.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupSSHinbound.Properties.FromPort is equal to Resources.EcsSecurityGroupSSHinbound.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupSSHinbound.Properties.FromPort is not equal to Resources.EcsSecurityGroupSSHinbound.Properties.ToPort",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "000056cd0b9697e13f2f4561f1963e34c58c042b921c4d0fad0f2fa5214374eb",
+					"line": 35,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupALBports.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupALBports.Properties.FromPort is equal to Resources.EcsSecurityGroupALBports.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupALBports.Properties.FromPort is not equal to Resources.EcsSecurityGroupALBports.Properties.ToPort",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "d60022e14f1b45c574f71c0f48b3fee882b471819597b770e3545988a8f5295a",
+					"line": 19,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupHTTPinbound02.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.FromPort is equal to Resources.EcsSecurityGroupHTTPinbound02.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.FromPort is not equal to Resources.EcsSecurityGroupHTTPinbound02.Properties.ToPort",
+					"value": null
+				}
+			]
+		}
+	]
+}

--- a/e2e/fixtures/E2E_CLI_047_PAYLOAD.json
+++ b/e2e/fixtures/E2E_CLI_047_PAYLOAD.json
@@ -1,0 +1,86 @@
+{
+	"document": [
+		{
+			"id": "0",
+			"file": "file",
+			"resource": {
+				"aws_redshift_cluster": {
+					"default": {
+						"cluster_identifier": "tf-redshift-cluster",
+						"database_name": "mydb",
+						"master_username": "foo",
+						"master_password": "Mustbe8characters",
+						"node_type": "dc1.large",
+						"cluster_type": "single-node",
+						"_kics_lines": {
+							"_kics__default": {
+								"_kics_line": 1
+							},
+							"_kics_cluster_identifier": {
+								"_kics_line": 2
+							},
+							"_kics_cluster_type": {
+								"_kics_line": 7
+							},
+							"_kics_database_name": {
+								"_kics_line": 3
+							},
+							"_kics_master_password": {
+								"_kics_line": 5
+							},
+							"_kics_master_username": {
+								"_kics_line": 4
+							},
+							"_kics_node_type": {
+								"_kics_line": 6
+							}
+						}
+					},
+					"default1": {
+						"master_username": "foo",
+						"master_password": "Mustbe8characters",
+						"_kics_lines": {
+							"_kics__default": {
+								"_kics_line": 10
+							},
+							"_kics_cluster_identifier": {
+								"_kics_line": 11
+							},
+							"_kics_cluster_type": {
+								"_kics_line": 16
+							},
+							"_kics_database_name": {
+								"_kics_line": 12
+							},
+							"_kics_master_password": {
+								"_kics_line": 14
+							},
+							"_kics_master_username": {
+								"_kics_line": 13
+							},
+							"_kics_node_type": {
+								"_kics_line": 15
+							},
+							"_kics_publicly_accessible": {
+								"_kics_line": 17
+							}
+						},
+						"node_type": "dc1.large",
+						"cluster_type": "single-node",
+						"publicly_accessible": true,
+						"cluster_identifier": "tf-redshift-cluster",
+						"database_name": "mydb"
+					}
+				}
+			},
+			"_kics_lines": {
+				"_kics__default": {
+					"_kics_line": 0
+				},
+				"_kics_resource": {
+					"_kics_line": 10
+				}
+			}
+		}
+	]
+}


### PR DESCRIPTION
Closes #

**Proposed Changes**

This PR adds several tests focused on increasing the coverage ratio of E2E tests, by testing flags that still weren't covered yet on E2E Tests.

Covered flags:
- cloud-provider
- exclude-severities
- include-queries
- disable-full-descriptions _(partial)_
- payload-lines

I submit this contribution under the Apache-2.0 license.
