### PR TITLE
fix(query): corrected "S3 Bucket Should Have Bucket Policy" approach

### DIFF
--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/negative3.yaml
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/negative3.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: A sample template
+Resources:
+  MyS3Bucket22:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      AccessControl: PublicRead
+      MetricsConfigurations:
+        - Id: EntireBucket
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: error.html
+        RoutingRules:
+          - RoutingRuleCondition:
+              HttpErrorCodeReturnedEquals: '404'
+              KeyPrefixEquals: out1/
+            RedirectRule:
+              HostName: ec2-11-22-333-44.compute-1.amazonaws.com
+              ReplaceKeyPrefixWith: report-404/
+  SampleBucketPolicy2:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref MyS3Bucket22
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 's3:GetObject'
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'arn:aws:s3:::'
+                  - Ref: docexamplebucket
+                  - /*
+            Principal: '*'
+            Condition:
+              StringLike:
+                'aws:Referer':
+                  - 'http://www.example.com/*'
+                  - 'http://example.net/*'

--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/negative4.json
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/negative4.json
@@ -1,0 +1,72 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
+  "Description": "A sample template",
+  "Resources": {
+    "MyS3Bucket22": {
+      "Properties": {
+        "AccessControl": "PublicRead",
+        "MetricsConfigurations": [
+          {
+            "Id": "EntireBucket"
+          }
+        ],
+        "WebsiteConfiguration": {
+          "ErrorDocument": "error.html",
+          "IndexDocument": "index.html",
+          "RoutingRules": [
+            {
+              "RedirectRule": {
+                "HostName": "ec2-11-22-333-44.compute-1.amazonaws.com",
+                "ReplaceKeyPrefixWith": "report-404/"
+              },
+              "RoutingRuleCondition": {
+                "HttpErrorCodeReturnedEquals": "404",
+                "KeyPrefixEquals": "out1/"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::S3::Bucket"
+    },
+    "SampleBucketPolicy2": {
+      "Properties": {
+        "Bucket": "MyS3Bucket22",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject"
+              ],
+              "Condition": {
+                "StringLike": {
+                  "aws:Referer": [
+                    "http://www.example.com/*",
+                    "http://example.net/*"
+                  ]
+                }
+              },
+              "Effect": "Allow",
+              "Principal": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  {
+                    "playbooks": [
+                      "arn:aws:s3:::",
+                      {
+                        "Ref": "docexamplebucket"
+                      },
+                      "/*"
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::S3::BucketPolicy"
+    }
+  }
+}

--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/positive3.yaml
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/positive3.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: A sample template
+Resources:
+  MyS3Bucket2:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      AccessControl: PublicRead
+      MetricsConfigurations:
+        - Id: EntireBucket
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: error.html
+        RoutingRules:
+          - RoutingRuleCondition:
+              HttpErrorCodeReturnedEquals: '404'
+              KeyPrefixEquals: out1/
+            RedirectRule:
+              HostName: ec2-11-22-333-44.compute-1.amazonaws.com
+              ReplaceKeyPrefixWith: report-404/

--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/positive4.json
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/positive4.json
@@ -1,0 +1,33 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
+  "Description": "A sample template",
+  "Resources": {
+    "MyS3Bucket2": {
+      "Properties": {
+        "AccessControl": "PublicRead",
+        "MetricsConfigurations": [
+          {
+            "Id": "EntireBucket"
+          }
+        ],
+        "WebsiteConfiguration": {
+          "ErrorDocument": "error.html",
+          "IndexDocument": "index.html",
+          "RoutingRules": [
+            {
+              "RedirectRule": {
+                "HostName": "ec2-11-22-333-44.compute-1.amazonaws.com",
+                "ReplaceKeyPrefixWith": "report-404/"
+              },
+              "RoutingRuleCondition": {
+                "HttpErrorCodeReturnedEquals": "404",
+                "KeyPrefixEquals": "out1/"
+              }
+            }
+          ]
+        }
+      },
+      "Type": "AWS::S3::Bucket"
+    }
+  }
+}

--- a/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/s3_bucket_should_have_bucket_policy/test/positive_expected_result.json
@@ -1,38 +1,50 @@
 [
   {
-    "severity": "MEDIUM",
-    "line": 8,
-    "fileName": "positive1.yaml",
-    "queryName": "S3 Bucket Should Have Bucket Policy"
-  },
-  {
-    "line": 34,
-    "fileName": "positive1.yaml",
-    "queryName": "S3 Bucket Should Have Bucket Policy",
-    "severity": "MEDIUM"
-  },
-  {
     "queryName": "S3 Bucket Should Have Bucket Policy",
     "severity": "MEDIUM",
-    "line": 60,
+    "line": 4,
     "fileName": "positive1.yaml"
   },
   {
+    "queryName": "S3 Bucket Should Have Bucket Policy",
     "severity": "MEDIUM",
-    "line": 46,
-    "fileName": "positive2.json",
-    "queryName": "S3 Bucket Should Have Bucket Policy"
+    "line": 31,
+    "fileName": "positive1.yaml"
   },
   {
     "queryName": "S3 Bucket Should Have Bucket Policy",
     "severity": "MEDIUM",
-    "line": 133,
+    "line": 56,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "S3 Bucket Should Have Bucket Policy",
+    "severity": "MEDIUM",
+    "line": 42,
     "fileName": "positive2.json"
   },
   {
-    "line": 91,
-    "fileName": "positive2.json",
     "queryName": "S3 Bucket Should Have Bucket Policy",
-    "severity": "MEDIUM"
+    "severity": "MEDIUM",
+    "line": 88,
+    "fileName": "positive2.json"
+  },
+  {
+    "queryName": "S3 Bucket Should Have Bucket Policy",
+    "severity": "MEDIUM",
+    "line": 130,
+    "fileName": "positive2.json"
+  },
+  {
+    "queryName": "S3 Bucket Should Have Bucket Policy",
+    "severity": "MEDIUM",
+    "line": 4,
+    "fileName": "positive3.yaml"
+  },
+  {
+    "queryName": "S3 Bucket Should Have Bucket Policy",
+    "severity": "MEDIUM",
+    "line": 5,
+    "fileName": "positive4.json"
   }
 ]


### PR DESCRIPTION
Closes #4303

**Proposed Changes**
- Corrected "S3 Bucket Should Have Bucket Policy" approach: should be check if `Resources.%s.Properties.BucketName` or `Resources.[%s]` is not the same as an `AWS::S3::BucketPolicy Bucket`

I submit this contribution under the Apache-2.0 license.
