### PR TITLE
ci(deps): bump golang to version 1.17 in pipelines

### DIFF
--- a/.github/workflows/go-ci-coverage.yaml
+++ b/.github/workflows/go-ci-coverage.yaml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
-      - name: Set up Go 1.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - name: Run test metrics script
         id: testcov
         run: |

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - name: Set up Go 1.16.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
@@ -24,10 +24,10 @@ jobs:
     name: go-generate
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - name: Check out code
         uses: actions/checkout@v2.3.4
         with:
@@ -39,11 +39,11 @@ jobs:
     name: unit-tests
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Set up Go 1.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go-e2e.yaml
+++ b/.github/workflows/go-e2e.yaml
@@ -9,7 +9,7 @@ jobs:
     name: e2e-tests
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -17,7 +17,7 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
-      - name: Set up Go 1.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/release-apispec.yml
+++ b/.github/workflows/release-apispec.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.7.0
         with:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.7.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.7.0
         with:


### PR DESCRIPTION

I submit this contribution under the Apache-2.0 license.
