### PR TITLE
refactor: E2E Tests Structure

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -4,908 +4,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"text/template"
 	"time"
 
+	"github.com/Checkmarx/kics/e2e/testcases"
 	"github.com/Checkmarx/kics/e2e/utils"
 	"github.com/stretchr/testify/require"
 )
-
-type TestTemplates struct {
-	Help     string
-	ScanHelp string
-}
-
-type cmdArgs []string
-
-type args struct {
-	args            []cmdArgs // args to pass to kics binary
-	expectedOut     []string  // path to file with expected output
-	expectedPayload []string
-	expectedResult  []ResultsValidation
-	expectedLog     LogValidation
-}
-
-type ResultsValidation struct {
-	resultsFile    string
-	resultsFormats []string
-}
-
-type LogValidation struct {
-	logFile        string
-	validationFunc Validation
-}
-
-type Validation func(string) bool
-
-type testCase struct {
-	name       string
-	args       args
-	wantStatus []int
-	validation Validation
-}
-
-var tests = []testCase{
-	// E2E-CLI-001 - KICS command should display a help text in the CLI when provided with the
-	// 	 --help flag and it should describe the available commands plus the global flags
-	{
-		name: "E2E-CLI-001",
-		args: args{
-			args: []cmdArgs{
-				[]string{"--help"},
-			},
-			expectedOut: []string{"E2E_CLI_001"},
-		},
-		wantStatus: []int{0},
-	},
-	// E2E-CLI-002 - KICS scan command should display a help text in the CLI when provided with the
-	// --help flag and it should describe the options related with scan plus the global options
-	{
-		name: "E2E-CLI-002",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--help"},
-			},
-			expectedOut: []string{"E2E_CLI_002"},
-		},
-		wantStatus: []int{0},
-	},
-	// E2E-CLI-003 - KICS scan command had a mandatory flag -p the CLI should exhibit
-	// an error message and return exit code 1
-	{
-		name: "E2E-CLI-003",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan"},
-			},
-			expectedOut: []string{"E2E_CLI_003"},
-		},
-		wantStatus: []int{126},
-	},
-	// E2E-CLI-004 - KICS has an invalid flag combination
-	// an error message and return exit code 1
-	{
-		name: "E2E-CLI-004",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--ci", "--verbose"},
-				[]string{"--ci", "scan", "--verbose"},
-			},
-			expectedOut: []string{
-				"E2E_CLI_004",
-				"E2E_CLI_004",
-			},
-		},
-		wantStatus: []int{126, 126},
-	},
-	// E2E-CLI-005 - KICS scan with -- payload-path flag should create a file with the
-	// passed name containing the payload of the files scanned
-	{
-		name: "E2E-CLI-005",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--silent", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
-					"--payload-path", "output/E2E_CLI_005_PAYLOAD.json"},
-			},
-			expectedOut: []string{
-				"E2E_CLI_005",
-			},
-			expectedPayload: []string{
-				"E2E_CLI_005_PAYLOAD.json",
-			},
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-006 - KICS generate-id should exhibit
-	// a valid UUID in the CLI and return exit code 0
-	{
-		name: "E2E-CLI-006",
-		args: args{
-			args: []cmdArgs{
-				[]string{"generate-id"},
-			},
-		},
-		wantStatus: []int{0},
-		validation: func(outputText string) bool {
-			uuidRegex := "[a-f0-9]{8}-[a-f0-9]{4}-4{1}[a-f0-9]{3}-[89ab]{1}[a-f0-9]{3}-[a-f0-9]{12}"
-			match, _ := regexp.MatchString(uuidRegex, outputText)
-			return match
-		},
-	},
-	// E2E-CLI-007 - the default kics scan must show informations such as 'Files scanned',
-	// 'Queries loaded', 'Scan Duration', '...' in the CLI
-	{
-		name: "E2E-CLI-007",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
-			},
-		},
-		wantStatus: []int{50},
-		validation: func(outputText string) bool {
-			match1, _ := regexp.MatchString(`Files scanned: \d+`, outputText)
-			match2, _ := regexp.MatchString(`Parsed files: \d+`, outputText)
-			match3, _ := regexp.MatchString(`Queries loaded: \d+`, outputText)
-			match4, _ := regexp.MatchString(`Queries failed to execute: \d+`, outputText)
-			match5, _ := regexp.MatchString(`Results Summary:`, outputText)
-			match6, _ := regexp.MatchString(`Scan duration: \d+(m\d+)?(.\d+)?s`, outputText)
-			return match1 && match2 && match3 && match4 && match5 && match6
-		},
-	},
-	// E2E-CLI-008 - KICS  scan with --silent global flag
-	// must hide all the output text in the CLI (empty output)
-	{
-		name: "E2E-CLI-008",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--silent", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
-			},
-			expectedOut: []string{"E2E_CLI_008"},
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-009 - kics scan with no-progress flag should perform a scan
-	// without showing progress bar in the CLI
-	{
-		name: "E2E-CLI-009",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf", "--no-progress"},
-			},
-		},
-		wantStatus: []int{50},
-		validation: func(outputText string) bool {
-			getProgressRegex := "Executing queries:"
-			match, _ := regexp.MatchString(getProgressRegex, outputText)
-			// if not found -> the the test was successful
-			return !match
-		},
-	},
-	// E2E-CLI-010 - KICS  scan with invalid --type flag
-	// should exhibit an error message and return exit code 1
-	{
-		name: "E2E-CLI-010",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf", "-t", "xml", "--silent"},
-			},
-		},
-		validation: func(outputText string) bool {
-			unknownArgRegex := regexp.MustCompile(`Error: unknown argument\(s\) for --type: xml`)
-			match := unknownArgRegex.MatchString(outputText)
-			return match
-		},
-		wantStatus: []int{126},
-	},
-	// E2E-CLI-011 - KICS  scan with a valid case insensitive --type flag
-	// must perform the scan successfully and return exit code 50
-	{
-		name: "E2E-CLI-011",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
-					"-t", "TeRraFOrM", "--silent", "--payload-path", "output/E2E_CLI_011_PAYLOAD.json"},
-			},
-			expectedPayload: []string{
-				"E2E_CLI_011_PAYLOAD.json",
-			},
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-012 - kics scan with minimal-ui flag should perform a scan
-	// without showing detailed results on each line of code
-	{
-		name: "E2E-CLI-012",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-q", "../assets/queries", "-p", "../test/fixtures/tc-sim01/positive1.tf", "--minimal-ui"},
-			},
-		},
-		wantStatus: []int{50},
-		validation: func(outputText string) bool {
-			match1, _ := regexp.MatchString("Description:", outputText)
-			match2, _ := regexp.MatchString("Platform:", outputText)
-			// if not found -> the the test was successful
-			return !match1 && !match2
-		},
-	},
-	// E2E-CLI-013 - KICS root command list-platforms
-	// must return all the supported platforms in the CLI
-	{
-		name: "E2E-CLI-013",
-		args: args{
-			args: []cmdArgs{
-				[]string{"list-platforms"},
-			},
-			expectedOut: []string{
-				"E2E_CLI_013",
-			},
-		},
-		wantStatus: []int{0},
-	},
-	// E2E-CLI-014 - KICS preview-lines command must delimit the number of
-	// code lines that are displayed in each scan results code block.
-	{
-		name: "E2E-CLI-014",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--preview-lines", "1", "--no-color", "--no-progress",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-		},
-		validation: func(outputText string) bool {
-			// only the match1 must be true
-			match1, _ := regexp.MatchString(`001\: resource \"aws_redshift_cluster\" \"default1\" \{`, outputText)
-			match2, _ := regexp.MatchString(`002\:   publicly_accessible = false`, outputText)
-			return match1 && !match2
-		},
-		wantStatus: []int{40},
-	},
-	// E2E-CLI-015 KICS scan with --no-color flag
-	// must disable the colored outputs of kics in the CLI
-	{
-		name: "E2E-CLI-015",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--no-color", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
-			},
-		},
-		validation: func(outputText string) bool {
-			match1, _ := regexp.MatchString(`HIGH: \d+`, outputText)
-			match2, _ := regexp.MatchString(`MEDIUM: \d+`, outputText)
-			match3, _ := regexp.MatchString(`LOW: \d+`, outputText)
-			match4, _ := regexp.MatchString(`INFO: \d+`, outputText)
-			return match1 && match2 && match3 && match4
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-016 - KICS has an invalid flag or invalid command
-	// an error message and return exit code 1
-	{
-		name: "E2E-CLI-016",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--invalid-flag"},
-				[]string{"--invalid-flag"},
-				[]string{"invalid"},
-				[]string{"-i"},
-			},
-			expectedOut: []string{
-				"E2E_CLI_016_INVALID_SCAN_FLAG",
-				"E2E_CLI_016_INVALID_FLAG",
-				"E2E_CLI_016_INVALID_COMMAND",
-				"E2E_CLI_016_INVALID_SHOTHAND",
-			},
-		},
-		wantStatus: []int{126, 126, 126, 126},
-	},
-	// E2E-CLI-017 - KICS scan command with the -v (--verbose) flag
-	// should display additional informations in the CLI, such as 'Inspector initialized'...
-	{
-		name: "E2E-CLI-017",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-v", "--no-progress", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
-			},
-		},
-		validation: func(outputText string) bool {
-			match1, _ := regexp.MatchString(`Inspector initialized, number of queries=\d+`, outputText)
-			match2, _ := regexp.MatchString(`Inspector stopped`, outputText)
-			return match1 && match2
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-018  - KICS scan command with --exclude-categories flag should
-	// not run queries that are part of the provided categories.
-	{
-		name: "E2E-CLI-018",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--exclude-categories", "Observability,Insecure Configurations", "-s",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-
-				[]string{"scan", "-s",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-		},
-		wantStatus: []int{20, 40},
-	},
-	// E2E-CLI-019 - KICS scan with multiple paths
-	// should run a scan for all provided paths/files
-	{
-		name: "E2E-CLI-019",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--silent", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf,fixtures/samples/terraform-single.tf"},
-			},
-			expectedOut: []string{
-				"E2E_CLI_019",
-			},
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-020 - KICS scan with --exclude-queries flag
-	// should not run queries that was provided in this flag.
-	{
-		name: "E2E-CLI-020",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--exclude-queries", "15ffbacc-fa42-4f6f-a57d-2feac7365caa,0a494a6a-ebe2-48a0-9d77-cf9d5125e1b3", "-s",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-		},
-		wantStatus: []int{20},
-	},
-	// E2E-CLI-021 - KICS can return different status code based in the scan results (High/Medium/Low..)
-	// when excluding categories/queries and losing results we can get a different status code.
-	{
-		name: "E2E-CLI-021",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan",
-					"-q", "../assets/queries", "-p", "../test/fixtures/all_auth_users_get_read_access/test/positive.tf"},
-
-				[]string{"scan", "--exclude-categories",
-					"Access Control,Availability,Backup,Best Practices,Build Process,Encryption," +
-						"Insecure Configurations,Insecure Defaults,Networking and Firewall,Observability," +
-						"Resource Management,Secret Management,Supply-Chain,Structure and Semantics",
-					"-q", "../assets/queries", "-p", "../test/fixtures/all_auth_users_get_read_access/test/positive.tf"},
-			},
-		},
-		wantStatus: []int{50, 0},
-	},
-	// E2E-CLI-022 - Kics  scan command with --profiling CPU and -v flags
-	// must display CPU usage in the CLI
-	{
-		name: "E2E-CLI-022",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--profiling", "CPU", "-v",
-					"--no-progress", "--no-color", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
-			},
-		},
-		validation: func(outputText string) bool {
-			match, _ := regexp.MatchString(`Total CPU usage for start_scan: \d+`, outputText)
-			return match
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-023 - Kics  scan command with --profiling MEM and -v flags
-	// must display MEM usage in the CLI
-	{
-		name: "E2E-CLI-023",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--profiling", "MEM", "-v",
-					"--no-progress", "--no-color", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
-			},
-		},
-		validation: func(outputText string) bool {
-			match, _ := regexp.MatchString(`Total MEM usage for start_scan: \d+`, outputText)
-			return match
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-024  - KICS version command
-	// should display the version of the kics in the CLI.
-	{
-		name: "E2E-CLI-024",
-		args: args{
-			args: []cmdArgs{
-				[]string{"version"},
-			},
-		},
-		validation: func(outputText string) bool {
-			match, _ := regexp.MatchString(`Keeping Infrastructure as Code Secure [0-9a-zA-Z]+`, outputText)
-			return match
-		},
-		wantStatus: []int{0},
-	},
-	// E2E-CLI-025 - KICS scan command with --fail-on flag should
-	// return status code different from 0 only when results match the severity provided in this flag
-	{
-		name: "E2E-CLI-025",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--fail-on", "info,low",
-					"-s", "-q", "../assets/queries", "-p", "../assets/queries/dockerfile/apk_add_using_local_cache_path/test/positive.dockerfile"},
-
-				[]string{"scan", "--fail-on", "info",
-					"-s", "-q", "../assets/queries", "-p", "../assets/queries/dockerfile/apk_add_using_local_cache_path/test/positive.dockerfile"},
-			},
-		},
-		wantStatus: []int{30, 20},
-	},
-	// E2E-CLI-026 - KICS scan command with --ignore-on-exit flag
-	// should return status code 0 if the provided flag occurs.
-	// Example: '--ignore-on-exit errors' -> Returns 0 if an error was found, instead of 126/130...
-	{
-		name: "E2E-CLI-026",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--ignore-on-exit",
-					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.invalid.name"},
-
-				[]string{"scan", "--ignore-on-exit", "errors",
-					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.invalid.name"},
-
-				[]string{"scan", "--ignore-on-exit", "errors",
-					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-
-				[]string{"scan", "--ignore-on-exit", "all",
-					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-		},
-		wantStatus: []int{126, 0, 40, 0},
-	},
-	// E2E-CLI-027 - KICS scan command with --exclude-paths
-	// should not perform the scan on the files/folders provided by this flag
-	{
-		name: "E2E-CLI-027",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--exclude-paths", "../test/fixtures/all_auth_users_get_read_access/test/positive.tf",
-					"-q", "../assets/queries", "-p", "../test/fixtures/all_auth_users_get_read_access/test/"},
-			},
-		},
-		validation: func(outputText string) bool {
-			match, _ := regexp.MatchString(`Files scanned: 1`, outputText)
-			return match
-		},
-		wantStatus: []int{50},
-	},
-
-	// E2E-CLI-028 - KICS scan command with --log-format
-	// should modify the view structure of output messages in the CLI (json/pretty)
-	{
-		name: "E2E-CLI-028",
-		args: args{
-			args: []cmdArgs{
-
-				[]string{"scan", "--log-format", "json", "--verbose",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-		},
-
-		validation: func(outputText string) bool {
-			match1, _ := regexp.MatchString(`{"level":"info"`, outputText)
-			match2, _ := regexp.MatchString(`"message":"Inspector initialized, number of queries=\d+"`, outputText)
-			return match1 && match2
-		},
-
-		wantStatus: []int{40},
-	},
-
-	// E2E-CLI-029 - KICS scan command with --config flag
-	// should load a config file that provides commands and arguments to kics.
-	{
-		name: "E2E-CLI-029",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--config", "fixtures/samples/config.json"},
-
-				[]string{"scan", "--config", "fixtures/samples/config.json", "--silent"},
-			},
-		},
-
-		wantStatus: []int{40, 126},
-	},
-	// E2E-CLI-030 - Kics scan command with --output-path flags
-	// should export the result files to the path provided by this flag.
-	{
-		name: "E2E-CLI-030",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--output-path", "output",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-		},
-		wantStatus: []int{40},
-	},
-	// E2E-CLI-031 - Kics  scan command with --report-formats and --output-path flags
-	// should export the results based on the formats provided by this flag.
-	{
-		name: "E2E-CLI-031",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_031_RESULT",
-					"--report-formats", "json,sarif,glsast,html",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
-			},
-			expectedResult: []ResultsValidation{
-				{
-					resultsFile:    "E2E_CLI_031_RESULT",
-					resultsFormats: []string{"json", "sarif", "glsast", "html"},
-				},
-			},
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-032 - KICS scan command with --output-path flag
-	// and check the results.json report format
-	{
-		name: "E2E-CLI-032",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-o", "output", "--output-name", "E2E_CLI_032_RESULT",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
-				},
-			},
-			expectedResult: []ResultsValidation{
-				{
-					resultsFile:    "E2E_CLI_032_RESULT",
-					resultsFormats: []string{"json"},
-				},
-			},
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-033 - KICS scan command with --output-path and --payload-path flags
-	// should performe a scan and create result file(s) and payload file
-	{
-		name: "E2E-CLI-033",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan",
-					"--output-path", "output",
-					"--output-name", "E2E_CLI_033_RESULT",
-					"--report-formats", "json,sarif,glsast",
-					"--payload-path", "output/E2E_CLI_033_PAYLOAD.json",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf",
-				},
-			},
-			expectedResult: []ResultsValidation{
-				{
-					resultsFile:    "E2E_CLI_033_RESULT",
-					resultsFormats: []string{"json", "sarif", "glsast"},
-				},
-			},
-			expectedPayload: []string{
-				"E2E_CLI_033_PAYLOAD.json",
-			},
-		},
-		wantStatus: []int{40},
-	},
-	// E2E-CLI-034 - KICS scan command with --log-format without --verbose
-	// should not output log messages in the CLI (json)
-	{
-		name: "E2E-CLI-034",
-		args: args{
-			args: []cmdArgs{
-
-				[]string{"scan", "--log-format", "json",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-		},
-
-		validation: func(outputText string) bool {
-			match1, _ := regexp.MatchString(`{"level":"info"`, outputText)
-			match2, _ := regexp.MatchString(`"message":"Inspector initialized, number of queries=\d+"`, outputText)
-			return !match1 && !match2
-		},
-
-		wantStatus: []int{40},
-	},
-	// E2E-CLI-035 - KICS scan command with --exclude-results
-	// should not run/found results (similarityID) provided by this flag
-	{
-		name: "E2E-CLI-035",
-		args: args{
-			args: []cmdArgs{
-
-				[]string{"scan",
-					"--exclude-results",
-					"2abf26c3014fc445da69d8d5bb862c1c511e8e16ad3a6c6f6e14c28aa0adac1d," +
-						"4aa3f159f39767de53b49ed871977b8b499bf19b3b0865b1631042aa830598aa," +
-						"83461a5eac8fed2264fac68a6d352d1ed752867a9b0a131afa9ba7e366159b59",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-
-				[]string{"scan", "--exclude-results", "-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-		},
-
-		wantStatus: []int{20, 126},
-	},
-	// E2E-CLI-036 - KICS scan command with --include-queries
-	// should performe a scan running only the provided queries
-	{
-		name: "E2E-CLI-036",
-		args: args{
-			args: []cmdArgs{
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
-					"--output-path", "output", "--output-name", "E2E_CLI_036_RESULT",
-					"--include-queries", "275a3217-ca37-40c1-a6cf-bb57d245ab32,027a4b7a-8a59-4938-a04f-ed532512cf45," +
-						"e415f8d3-fc2b-4f52-88ab-1129e8c8d3f5,105ba098-1e34-48cd-b0f2-a8a43a51bf9b,ad21e616-5026-4b9d-990d-5b007bfe679c," +
-						"79d745f0-d5f3-46db-9504-bef73e9fd528,e200a6f3-c589-49ec-9143-7421d4a2c845,01d5a458-a6c4-452a-ac50-054d59275b7c," +
-						"7f384a5f-b5a2-4d84-8ca3-ee0a5247becb,87482183-a8e7-4e42-a566-7a23ec231c16,4a1e6b34-1008-4e61-a5f2-1f7c276f8d14," +
-						"d24389b4-b209-4ff0-8345-dc7a4569dcdd,5e6c9c68-8a82-408e-8749-ddad78cbb9c5"}, // Load Many Queries (13)
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
-					"--output-path", "output", "--output-name", "E2E_CLI_036_RESULT_2",
-					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec231c16"}, // Load 1 query
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
-					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec231c17"}, // Load 0 queries (valid, but doesn't exists)
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
-					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec23KICS"}, // Invalid query ID
-
-				[]string{"scan", "--include-queries", "cfdcabb0-fc06-427c-865b-c59f13e898ce",
-					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
-
-				[]string{"scan", "--include-queries", "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10,15ffbacc-fa42-4f6f-a57d-2feac7365caa",
-					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
-
-				[]string{"scan", "--include-queries", "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
-					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
-
-				[]string{"scan", "--include-queries",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-				[]string{"scan", "--include-queries",
-					"--queries-path", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-			expectedResult: []ResultsValidation{
-				{
-					resultsFile:    "E2E_CLI_036_RESULT",
-					resultsFormats: []string{"json"},
-				},
-				{
-					resultsFile:    "E2E_CLI_036_RESULT_2",
-					resultsFormats: []string{"json"},
-				},
-			},
-		},
-
-		wantStatus: []int{50, 40, 0, 126, 50, 40, 20, 126, 126},
-	},
-	// E2E-CLI-037 - KICS scan command with --exclude-results and --include-queries
-	// should run only provided queries and does not run results (similarityID) provided by this flag
-	{
-		name: "E2E-CLI-037",
-		args: args{
-			args: []cmdArgs{
-
-				[]string{"scan", "--include-queries", "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
-					"--exclude-results", "406b71d9fd0edb656a4735df30dde77c5f8a6c4ec3caa3442f986a92832c653b",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-
-				[]string{"scan", "--include-queries", "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
-					"--exclude-results", "d1c5f6aec84fd91ed24f5f06ccb8b6662e26c0202bcb5d4a58a1458c16456d20",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-		},
-
-		wantStatus: []int{0, 20},
-	},
-
-	// E2E-CLI-038 - KICS scan command with --log-path
-	// should generate and save a log file for the scan
-	{
-		name: "E2E-CLI-038",
-		args: args{
-			args: []cmdArgs{
-
-				[]string{"scan", "--log-path", "output/E2E_CLI_038_LOG",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-
-			expectedLog: LogValidation{
-				logFile: "E2E_CLI_038_LOG",
-				validationFunc: func(logText string) bool {
-					match1, _ := regexp.MatchString("Scanning with Keeping Infrastructure as Code Secure", logText)
-					match2, _ := regexp.MatchString(`Files scanned: \d+`, logText)
-					match3, _ := regexp.MatchString(`Queries loaded: \d+`, logText)
-					return match1 && match2 && match3
-				},
-			},
-		},
-		wantStatus: []int{40},
-	},
-
-	// E2E-CLI-039 - KICS scan command with --log-path and --log-level
-	// should generate and save a log file based in the provided log-level
-	{
-		name: "E2E-CLI-039",
-		args: args{
-			args: []cmdArgs{
-
-				[]string{"scan", "--log-path", "output/E2E_CLI_039_LOG",
-					"--log-level", "TRACE",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-			},
-
-			expectedLog: LogValidation{
-				logFile: "E2E_CLI_039_LOG",
-				validationFunc: func(logText string) bool {
-					match1, _ := regexp.MatchString("TRACE", logText)
-					match2, _ := regexp.MatchString(`Inspector executed with result`, logText)
-					match3, _ := regexp.MatchString(`Scan duration: \d+`, logText)
-					return match1 && match2 && match3
-				},
-			},
-		},
-		wantStatus: []int{40},
-	},
-
-	// E2E-CLI-040 - Kics  scan command with --report-formats and --output-path flags
-	// should export the results based on the formats provided by this flag.
-	{
-		name: "E2E-CLI-040",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_040_RESULT",
-					"--report-formats", "json,sarif,glsast,html",
-					"-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml"},
-			},
-			expectedResult: []ResultsValidation{
-				{
-					resultsFile:    "E2E_CLI_040_RESULT",
-					resultsFormats: []string{"json", "sarif", "glsast", "html"},
-				},
-			},
-		},
-		wantStatus: []int{50},
-	},
-
-	// E2E-CLI-041 - Kics scan command with -p targeting remote path (git)
-	// should download and scan the provided path.
-	{
-		name: "E2E-CLI-041",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_041_RESULT",
-					"--report-formats", "json,sarif,glsast", "-q", "../assets/queries",
-					"-p", "git::https://github.com/dockersamples/example-voting-app"},
-			},
-			expectedResult: []ResultsValidation{
-				{
-					resultsFile:    "E2E_CLI_041_RESULT",
-					resultsFormats: []string{"json", "sarif", "glsast"},
-				},
-			},
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-042 - Kics scan command with -p targeting remote path (http/https)
-	// should download and scan the provided path/file.
-	{
-		name: "E2E-CLI-042",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_042_RESULT",
-					"--report-formats", "json,sarif,glsast", "-q", "../assets/queries",
-					"-p", "https://raw.githubusercontent.com/dockersamples/example-voting-app/master/docker-compose-simple.yml"},
-			},
-			expectedResult: []ResultsValidation{
-				{
-					resultsFile:    "E2E_CLI_042_RESULT",
-					resultsFormats: []string{"json", "sarif", "glsast"},
-				},
-			},
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-043 - Kics scan command with --cloud-provider
-	// should execute only queries that have the same provider as given in the flag.
-	{
-		name: "E2E-CLI-043",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-q", "../assets/queries", "", "fixtures/samples/positive.yaml",
-					"--cloud-provider", "none"},
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
-					"--cloud-provider"},
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
-					"--cloud-provider", "aws"},
-			},
-		},
-		wantStatus: []int{126, 126, 50},
-	},
-	// E2E-CLI-044 - Kics scan command with --exclude-severities
-	// should only execute query-ids provided in the flag.
-	{
-		name: "E2E-CLI-044",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
-					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
-					"--exclude-severities", "HIGH"},
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
-					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
-					"--exclude-severities", "HIGH,MEDIUM,LOW,INFO"},
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
-					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
-					"--exclude-severities"},
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
-					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
-					"--exclude-severities", "HIGH,MEDIUM,LOW"},
-			},
-		},
-		wantStatus: []int{40, 0, 126, 20},
-	},
-	// E2E-CLI-045 - Kics scan command with --disable-secrets
-	// should not execute secret based queries.
-	{
-		name: "E2E-CLI-045",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
-					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08"},
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
-					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08",
-					"--disable-secrets"},
-
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
-					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08,e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
-					"--disable-secrets"},
-			},
-		},
-		wantStatus: []int{50, 0, 20},
-	},
-	// E2E-CLI-046 - Kics scan command with --disable-full-descriptions
-	// should fetch CIS descriptions from enviroment URL KICS_DESCRIPTIONS_ENDPOINT.
-	{
-		name: "E2E-CLI-046",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
-					"--no-color", "-v",
-					"--disable-full-descriptions"},
-			},
-		},
-		validation: func(outputText string) bool {
-			uuidRegex := "Skipping CIS descriptions because provided disable flag is set"
-			match, _ := regexp.MatchString(uuidRegex, outputText)
-			return match
-		},
-		wantStatus: []int{50},
-	},
-	// E2E-CLI-047 - Kics scan command with --payload-lines
-	// should display additional information lines in the payload file.
-	{
-		name: "E2E-CLI-047",
-		args: args{
-			args: []cmdArgs{
-				[]string{"scan", "--silent", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
-					"--payload-path", "output/E2E_CLI_047_PAYLOAD.json", "--payload-lines"},
-			},
-			expectedPayload: []string{
-				"E2E_CLI_047_PAYLOAD.json",
-			},
-		},
-		wantStatus: []int{50},
-	},
-}
 
 func Test_E2E_CLI(t *testing.T) {
 	kicsPath := utils.GetKICSBinaryPath("")
@@ -917,55 +24,55 @@ func Test_E2E_CLI(t *testing.T) {
 
 	templates := prepareTemplates()
 
-	for _, tt := range tests {
-		for arg := range tt.args.args {
+	for _, tt := range testcases.Tests {
+		for arg := range tt.Args.Args {
 			tt := tt
 			arg := arg
-			t.Run(fmt.Sprintf("%s_%d", tt.name, arg), func(t *testing.T) {
+			t.Run(fmt.Sprintf("%s_%d", tt.Name, arg), func(t *testing.T) {
 				t.Parallel()
-				out, err := utils.RunCommand(append(kicsPath, tt.args.args[arg]...))
+				out, err := utils.RunCommand(append(kicsPath, tt.Args.Args[arg]...))
 				// Check command Error
 				require.NoError(t, err, "Capture CLI output should not yield an error")
 				// Check exit status code
-				require.Equalf(t, out.Status, tt.wantStatus[arg],
+				require.Equalf(t, out.Status, tt.WantStatus[arg],
 					"Actual KICS status code: %v\nExpected KICS status code: %v",
-					out.Status, tt.wantStatus[arg])
+					out.Status, tt.WantStatus[arg])
 
-				if tt.validation != nil {
+				if tt.Validation != nil {
 					fullString := strings.Join(out.Output, ";")
-					validation := tt.validation(fullString)
+					validation := tt.Validation(fullString)
 					require.True(t, validation, "KICS CLI output doesn't match the regex validation.")
 				}
 
-				if tt.args.expectedResult != nil && arg < len(tt.args.expectedResult) {
+				if tt.Args.ExpectedResult != nil && arg < len(tt.Args.ExpectedResult) {
 					checkExpectedOutput(t, &tt, arg)
 				}
 
-				if tt.args.expectedPayload != nil {
+				if tt.Args.ExpectedPayload != nil {
 					// Check payload file
-					utils.FileCheck(t, tt.args.expectedPayload[arg], tt.args.expectedPayload[arg], "payload")
+					utils.FileCheck(t, tt.Args.ExpectedPayload[arg], tt.Args.ExpectedPayload[arg], "payload")
 				}
 
-				if tt.args.expectedLog.validationFunc != nil {
+				if tt.Args.ExpectedLog.ValidationFunc != nil {
 					// Check log file
-					logData, _ := utils.ReadFixture(tt.args.expectedLog.logFile, "output")
-					validation := tt.args.expectedLog.validationFunc(logData)
+					logData, _ := utils.ReadFixture(tt.Args.ExpectedLog.LogFile, "output")
+					validation := tt.Args.ExpectedLog.ValidationFunc(logData)
 					require.Truef(t, validation, "The output log file 'output/%s' doesn't match the regex validation",
-						tt.args.expectedLog.logFile)
+						tt.Args.ExpectedLog.LogFile)
 				}
 
-				if tt.args.expectedOut != nil {
+				if tt.Args.ExpectedOut != nil {
 					// Get and preapare expected output
-					want, errPrep := utils.PrepareExpected(tt.args.expectedOut[arg], "fixtures")
+					want, errPrep := utils.PrepareExpected(tt.Args.ExpectedOut[arg], "fixtures")
 					require.NoErrorf(t, errPrep, "[fixtures/%s] Reading a fixture should not yield an error",
-						tt.args.expectedOut[arg])
+						tt.Args.ExpectedOut[arg])
 
 					formattedWant := loadTemplates(want, templates)
 
 					// Check number of Lines
 					require.Equal(t, len(formattedWant), len(out.Output),
 						"[fixtures/%s] Expected number lines: %d\n[CLI] Actual KICS output lines: %d",
-						tt.args.expectedOut[arg], len(formattedWant), len(out.Output))
+						tt.Args.ExpectedOut[arg], len(formattedWant), len(out.Output))
 
 					// Check output lines
 					for idx := range formattedWant {
@@ -983,9 +90,9 @@ func Test_E2E_CLI(t *testing.T) {
 	})
 }
 
-func checkExpectedOutput(t *testing.T, tt *testCase, argIndex int) {
-	jsonFileName := tt.args.expectedResult[argIndex].resultsFile + ".json"
-	resultsFormats := tt.args.expectedResult[argIndex].resultsFormats
+func checkExpectedOutput(t *testing.T, tt *testcases.TestCase, argIndex int) {
+	jsonFileName := tt.Args.ExpectedResult[argIndex].ResultsFile + ".json"
+	resultsFormats := tt.Args.ExpectedResult[argIndex].ResultsFormats
 	// Check result file (compare with sample)
 	if _, err := os.Stat(filepath.Join("fixtures", jsonFileName)); err == nil {
 		utils.FileCheck(t, jsonFileName, jsonFileName, "result")
@@ -1000,15 +107,15 @@ func checkExpectedOutput(t *testing.T, tt *testCase, argIndex int) {
 	}
 	// Check result file (SARIF)
 	if utils.Contains(resultsFormats, "sarif") {
-		utils.JSONSchemaValidation(t, tt.args.expectedResult[argIndex].resultsFile+".sarif", "result-sarif.json")
+		utils.JSONSchemaValidation(t, tt.Args.ExpectedResult[argIndex].ResultsFile+".sarif", "result-sarif.json")
 	}
 	// Check result file (HTML)
 	if utils.Contains(resultsFormats, "html") {
-		utils.HTMLValidation(t, tt.args.expectedResult[argIndex].resultsFile+".html")
+		utils.HTMLValidation(t, tt.Args.ExpectedResult[argIndex].ResultsFile+".html")
 	}
 }
 
-func prepareTemplates() TestTemplates {
+func prepareTemplates() testcases.TestTemplates {
 	var help, errH = utils.PrepareExpected("help", "fixtures/assets")
 	if errH != nil {
 		help = []string{}
@@ -1019,12 +126,13 @@ func prepareTemplates() TestTemplates {
 		scanHelp = []string{}
 	}
 
-	return TestTemplates{
-		strings.Join(help, "\n"),
-		strings.Join(scanHelp, "\n")}
+	return testcases.TestTemplates{
+		Help:     strings.Join(help, "\n"),
+		ScanHelp: strings.Join(scanHelp, "\n"),
+	}
 }
 
-func loadTemplates(lines []string, templates TestTemplates) []string {
+func loadTemplates(lines []string, templates testcases.TestTemplates) []string {
 	temp, err := template.New("templates").Parse(strings.Join(lines, "\n"))
 	if err != nil {
 		return []string{}

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -383,17 +383,8 @@ var tests = []testCase{
 		name: "E2E-CLI-022",
 		args: args{
 			args: []cmdArgs{
-				[]string{"scan",
-					"--profiling",
-					"CPU",
-					"-v",
-					"--no-progress",
-					"--no-color",
-					"-q",
-					"../assets/queries",
-					"-p",
-					"fixtures/samples/terraform.tf",
-				},
+				[]string{"scan", "--profiling", "CPU", "-v",
+					"--no-progress", "--no-color", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
 			},
 		},
 		validation: func(outputText string) bool {
@@ -645,6 +636,24 @@ var tests = []testCase{
 		args: args{
 			args: []cmdArgs{
 
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_036_RESULT",
+					"--include-queries", "275a3217-ca37-40c1-a6cf-bb57d245ab32,027a4b7a-8a59-4938-a04f-ed532512cf45," +
+						"e415f8d3-fc2b-4f52-88ab-1129e8c8d3f5,105ba098-1e34-48cd-b0f2-a8a43a51bf9b,ad21e616-5026-4b9d-990d-5b007bfe679c," +
+						"79d745f0-d5f3-46db-9504-bef73e9fd528,e200a6f3-c589-49ec-9143-7421d4a2c845,01d5a458-a6c4-452a-ac50-054d59275b7c," +
+						"7f384a5f-b5a2-4d84-8ca3-ee0a5247becb,87482183-a8e7-4e42-a566-7a23ec231c16,4a1e6b34-1008-4e61-a5f2-1f7c276f8d14," +
+						"d24389b4-b209-4ff0-8345-dc7a4569dcdd,5e6c9c68-8a82-408e-8749-ddad78cbb9c5"}, // Load Many Queries (13)
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_036_RESULT_2",
+					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec231c16"}, // Load 1 query
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec231c17"}, // Load 0 queries (valid, but doesn't exists)
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec23KICS"}, // Invalid query ID
+
 				[]string{"scan", "--include-queries", "cfdcabb0-fc06-427c-865b-c59f13e898ce",
 					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
 
@@ -659,9 +668,19 @@ var tests = []testCase{
 				[]string{"scan", "--include-queries",
 					"--queries-path", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
 			},
+			expectedResult: []ResultsValidation{
+				{
+					resultsFile:    "E2E_CLI_036_RESULT",
+					resultsFormats: []string{"json"},
+				},
+				{
+					resultsFile:    "E2E_CLI_036_RESULT_2",
+					resultsFormats: []string{"json"},
+				},
+			},
 		},
 
-		wantStatus: []int{50, 40, 20, 126, 126},
+		wantStatus: []int{50, 40, 0, 126, 50, 40, 20, 126, 126},
 	},
 	// E2E-CLI-037 - KICS scan command with --exclude-results and --include-queries
 	// should run only provided queries and does not run results (similarityID) provided by this flag
@@ -790,6 +809,102 @@ var tests = []testCase{
 		},
 		wantStatus: []int{50},
 	},
+	// E2E-CLI-043 - Kics scan command with --cloud-provider
+	// should execute only queries that have the same provider as given in the flag.
+	{
+		name: "E2E-CLI-043",
+		args: args{
+			args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "", "fixtures/samples/positive.yaml",
+					"--cloud-provider", "none"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--cloud-provider"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--cloud-provider", "aws"},
+			},
+		},
+		wantStatus: []int{126, 126, 50},
+	},
+	// E2E-CLI-044 - Kics scan command with --exclude-severities
+	// should only execute query-ids provided in the flag.
+	{
+		name: "E2E-CLI-044",
+		args: args{
+			args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities", "HIGH"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities", "HIGH,MEDIUM,LOW,INFO"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities", "HIGH,MEDIUM,LOW"},
+			},
+		},
+		wantStatus: []int{40, 0, 126, 20},
+	},
+	// E2E-CLI-045 - Kics scan command with --disable-secrets
+	// should not execute secret based queries.
+	{
+		name: "E2E-CLI-045",
+		args: args{
+			args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08",
+					"--disable-secrets"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08,e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
+					"--disable-secrets"},
+			},
+		},
+		wantStatus: []int{50, 0, 20},
+	},
+	// E2E-CLI-046 - Kics scan command with --disable-full-descriptions
+	// should fetch CIS descriptions from enviroment URL KICS_DESCRIPTIONS_ENDPOINT.
+	{
+		name: "E2E-CLI-046",
+		args: args{
+			args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--no-color", "-v",
+					"--disable-full-descriptions"},
+			},
+		},
+		validation: func(outputText string) bool {
+			uuidRegex := "Skipping CIS descriptions because provided disable flag is set"
+			match, _ := regexp.MatchString(uuidRegex, outputText)
+			return match
+		},
+		wantStatus: []int{50},
+	},
+	// E2E-CLI-047 - Kics scan command with --payload-lines
+	// should display additional information lines in the payload file.
+	{
+		name: "E2E-CLI-047",
+		args: args{
+			args: []cmdArgs{
+				[]string{"scan", "--silent", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--payload-path", "output/E2E_CLI_047_PAYLOAD.json", "--payload-lines"},
+			},
+			expectedPayload: []string{
+				"E2E_CLI_047_PAYLOAD.json",
+			},
+		},
+		wantStatus: []int{50},
+	},
 }
 
 func Test_E2E_CLI(t *testing.T) {
@@ -822,7 +937,7 @@ func Test_E2E_CLI(t *testing.T) {
 					require.True(t, validation, "KICS CLI output doesn't match the regex validation.")
 				}
 
-				if tt.args.expectedResult != nil {
+				if tt.args.expectedResult != nil && arg < len(tt.args.expectedResult) {
 					checkExpectedOutput(t, &tt, arg)
 				}
 

--- a/e2e/fixtures/E2E_CLI_036_RESULT.json
+++ b/e2e/fixtures/E2E_CLI_036_RESULT.json
@@ -1,0 +1,459 @@
+{
+	"kics_version": "development",
+	"files_scanned": 1,
+	"files_parsed": 1,
+	"files_failed_to_scan": 0,
+	"queries_total": 13,
+	"queries_failed_to_execute": 0,
+	"queries_failed_to_compute_similarity_id": 0,
+	"scan_id": "console",
+	"severity_counters": {
+		"HIGH": 4,
+		"INFO": 0,
+		"LOW": 5,
+		"MEDIUM": 11
+	},
+	"total_counter": 20,
+	"start": "2021-09-28T11:31:57.4326046+01:00",
+	"end": "2021-09-28T11:31:59.6045617+01:00",
+	"paths": [
+		"fixtures/samples/positive.yaml"
+	],
+	"queries": [
+		{
+			"query_name": "ALB Listening on HTTP",
+			"query_id": "275a3217-ca37-40c1-a6cf-bb57d245ab32",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-listener.html#cfn-ec2-elb-listener-protocol",
+			"severity": "HIGH",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "All Application Load Balancers (ALB) should block connection requests over HTTP",
+			"description_id": "55f05412",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "f9c0a2aed39f325f242beed63be5c53d938d2c02f243366523b2984fd10243de",
+					"line": 104,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.ALBListener.Properties.Protocol",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.ALBListener.Protocol' not equal to 'HTTP'",
+					"actual_value": "'Resources.ALBListener.Protocol' equals to 'HTTP'",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ECS Task Definition Network Mode Not Recommended",
+			"query_id": "027a4b7a-8a59-4938-a04f-ed532512cf45",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-networkmode",
+			"severity": "HIGH",
+			"platform": "CloudFormation",
+			"category": "Insecure Configurations",
+			"description": "Network_Mode should be 'awsvpc' in ecs_task_definition. AWS VPCs provides the controls to facilitate a formal process for approving and testing all network connections and changes to the firewall and router configurations",
+			"description_id": "bded2e99",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "dd2585b378b43193cc748c9f68b4c226b6face1e271f07f84dcb9113ff6f7446",
+					"line": 48,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.TaskDefinition.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.TaskDefinition.Properties.NetworkMode' is set and is 'awsvpc'",
+					"actual_value": "'Resources.TaskDefinition.Properties.NetworkMode' is undefined and defaults to 'bridge'",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Fully Open Ingress",
+			"query_id": "e415f8d3-fc2b-4f52-88ab-1129e8c8d3f5",
+			"query_url": "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/get-set-up-for-amazon-ecs.html#create-a-base-security-group",
+			"severity": "HIGH",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "ECS Service's security group should not allow unrestricted access to all ports from all IPv4 addresses",
+			"description_id": "747f49ac",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "88653ab159ca0a15095afc685f98da24685fa547bb5f1ca7c95ef468f209387c",
+					"line": 24,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupHTTPinbound02.Properties.CidrIp",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resource name 'EcsSecurityGroupHTTPinbound02' of type 'AWS::EC2::SecurityGroupIngress' should not accept ingress connections from all IPv4 adresses and to all available ports",
+					"actual_value": "Resource name 'EcsSecurityGroupHTTPinbound02' of type 'AWS::EC2::SecurityGroupIngress' should not accept ingress connections from CIDR 0.0.0.0/0 to all available ports",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "5f39aa8e63613a7e8bfd7641ccfb931fa0225e95b3449bc1210b50329d65d713",
+					"line": 32,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupSSHinbound.Properties.CidrIp",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resource name 'EcsSecurityGroupSSHinbound' of type 'AWS::EC2::SecurityGroupIngress' should not accept ingress connections from all IPv4 adresses and to all available ports",
+					"actual_value": "Resource name 'EcsSecurityGroupSSHinbound' of type 'AWS::EC2::SecurityGroupIngress' should not accept ingress connections from CIDR 0.0.0.0/0 to all available ports",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ALB Is Not Integrated With WAF",
+			"query_id": "105ba098-1e34-48cd-b0f2-a8a43a51bf9b",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafregional-webaclassociation.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "All Application Load Balancers (ALB) must be protected with Web Application Firewall (WAF) service",
+			"description_id": "2cad71a7",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "d542c20ac3e6177847cf5a565ff82704a5b63ec87332191ded7baca361b611e8",
+					"line": 86,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.ECSALB",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.ECSALB' does not have an 'internal' scheme and has a 'WebACLAssociation' associated",
+					"actual_value": "'Resources.ECSALB' does not have an 'internal' scheme and a 'WebACLAssociation' associated",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Auto Scaling Group With No Associated ELB",
+			"query_id": "ad21e616-5026-4b9d-990d-5b007bfe679c",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-group.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Availability",
+			"description": "AWS Auto Scaling Groups must have associated ELBs to ensure high availability and improve application performance. This means the attribute 'LoadBalancerNames' must be defined and not empty.",
+			"description_id": "99966f58",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "ef5069fb260b351100126334b0ba9b2776f480652d8d4f72c81f387d785d22d2",
+					"line": 131,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.ECSAutoScalingGroup.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.ECSAutoScalingGroup.Properties.LoadBalancerNames' is defined",
+					"actual_value": "'Resources.ECSAutoScalingGroup.Properties.LoadBalancerNames' is not defined",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ECS Service Without Running Tasks",
+			"query_id": "79d745f0-d5f3-46db-9504-bef73e9fd528",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html#cfn-ecs-service-deploymentconfiguration",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Availability",
+			"description": "ECS Service should have at least 1 task running",
+			"description_id": "cd242bdd",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "5022c0ba8f17197cb6ef6163bf16e6dd8e13290b1d91192c61742bca491ff4f7",
+					"line": 159,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.service.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.service.Properties.DeploymentConfiguration is defined and not null",
+					"actual_value": "Resources.service.Properties.DeploymentConfiguration is undefined or null",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ELB With Security Group Without Inbound Rules",
+			"query_id": "e200a6f3-c589-49ec-9143-7421d4a2c845",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#cfn-ec2-securitygroup-securitygroupingress",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "An AWS Elastic Load Balancer (ELB) shouldn´t have security groups without outbound rules",
+			"description_id": "3ccdd7d2",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "d762780be8bebaa6b6bc6b6075a5dcee0edd37f639aa63061f29a13160eae116",
+					"line": 14,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.EcsSecurityGroup.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.EcsSecurityGroup.Properties.SecurityGroupIngress' is defined",
+					"actual_value": "'Resources.EcsSecurityGroup.Properties.SecurityGroupIngress' is undefined",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ELB With Security Group Without Outbound Rules",
+			"query_id": "01d5a458-a6c4-452a-ac50-054d59275b7c",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html#cfn-ec2-securitygroup-securitygroupegress",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "An AWS Elastic Load Balancer (ELB) shouldn´t have security groups without outbound rules",
+			"description_id": "7b876844",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "ee0915eb8433ec18c3f357c5eb0d243ce5c3a077e63e222230c4c0d7bf049416",
+					"line": 14,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.EcsSecurityGroup.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.EcsSecurityGroup.Properties.SecurityGroupEgress' is defined",
+					"actual_value": "'Resources.EcsSecurityGroup.Properties.SecurityGroupEgress' is undefined",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Empty Roles For ECS Cluster Task Definitions",
+			"query_id": "7f384a5f-b5a2-4d84-8ca3-ee0a5247becb",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Access Control",
+			"description": "Check if any ECS cluster has not defined proper roles for services' task definitions.",
+			"description_id": "b47b42b2",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "cea2579f8b8eccc6008dcddba492fb4bd8802d0926f4cc33ae95b8a5f758d0e3",
+					"line": 167,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.service.Properties.TaskDefinition",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.service.Properties.TaskDefinition' refers to a TaskDefinition with Role",
+					"actual_value": "'Resources.service.Properties.TaskDefinition' does not refer to a TaskDefinition with Role",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Security Group Ingress With Port Range",
+			"query_id": "87482183-a8e7-4e42-a566-7a23ec231c16",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "AWS Security Group Ingress should have a single port",
+			"description_id": "5f2b65f3",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "810487007189ac4de717dffc3204a05756e80e910b34f89ee08fd14f612328aa",
+					"line": 27,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupSSHinbound.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupSSHinbound.Properties.FromPort is equal to Resources.EcsSecurityGroupSSHinbound.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupSSHinbound.Properties.FromPort is not equal to Resources.EcsSecurityGroupSSHinbound.Properties.ToPort",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "d60022e14f1b45c574f71c0f48b3fee882b471819597b770e3545988a8f5295a",
+					"line": 19,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupHTTPinbound02.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.FromPort is equal to Resources.EcsSecurityGroupHTTPinbound02.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.FromPort is not equal to Resources.EcsSecurityGroupHTTPinbound02.Properties.ToPort",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "000056cd0b9697e13f2f4561f1963e34c58c042b921c4d0fad0f2fa5214374eb",
+					"line": 35,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupALBports.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupALBports.Properties.FromPort is equal to Resources.EcsSecurityGroupALBports.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupALBports.Properties.FromPort is not equal to Resources.EcsSecurityGroupALBports.Properties.ToPort",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Unrestricted Security Group Ingress",
+			"query_id": "4a1e6b34-1008-4e61-a5f2-1f7c276f8d14",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "AWS Security Group Ingress CIDR should not be open to the world",
+			"description_id": "08256d31",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "f1f15967fd4bd2b39610dcbe3c2d641068dc1b409821142f41d179dbc360b3aa",
+					"line": 32,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupSSHinbound.Properties.CidrIp",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupSSHinbound.Properties.CidrIp is not open to the world (0.0.0.0/0)",
+					"actual_value": "Resources.EcsSecurityGroupSSHinbound.Properties.CidrIp is open to the world (0.0.0.0/0)",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "3c4976bcd6061315525a23a644cb6ed3bc4888794f21e8161a1cd38ea0495f30",
+					"line": 24,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupHTTPinbound02.Properties.CidrIp",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.CidrIp is not open to the world (0.0.0.0/0)",
+					"actual_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.CidrIp is open to the world (0.0.0.0/0)",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "ECS Task Definition HealthCheck Missing",
+			"query_id": "d24389b4-b209-4ff0-8345-dc7a4569dcdd",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-healthcheck.html",
+			"severity": "LOW",
+			"platform": "CloudFormation",
+			"category": "Observability",
+			"description": "Amazon ECS must have the HealthCheck property defined to give more control over monitoring the health of tasks",
+			"description_id": "e2e3a50a",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "7d931711c3ba34527d9a6660c82f06f4a2174812dcfbd69bb271187edec91a06",
+					"line": 51,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.TaskDefinition.Properties.ContainerDefinitions",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.TaskDefinition.Properties.ContainerDefinitions' contains 'HealthCheck' property",
+					"actual_value": "'Resources.TaskDefinition.Properties.ContainerDefinitions' doesn't contain 'HealthCheck' property",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "e08fb6aa0ab3e2ed98aa9d08d8813df89af2b0005acdbda809c86f4897715c78",
+					"line": 67,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.TaskDefinition.Properties.ContainerDefinitions",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "'Resources.TaskDefinition.Properties.ContainerDefinitions' contains 'HealthCheck' property",
+					"actual_value": "'Resources.TaskDefinition.Properties.ContainerDefinitions' doesn't contain 'HealthCheck' property",
+					"value": null
+				}
+			]
+		},
+		{
+			"query_name": "Security Group Rule Without Description",
+			"query_id": "5e6c9c68-8a82-408e-8749-ddad78cbb9c5",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html",
+			"severity": "LOW",
+			"platform": "CloudFormation",
+			"category": "Best Practices",
+			"description": "AWS Security Group Rule should have description defined",
+			"description_id": "f7c62b11",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "e96cf20cc6e1e11dce2d40d9e2b37446a00f00c3f541aa7dd13861059f6fcce8",
+					"line": 19,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.EcsSecurityGroupHTTPinbound02.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.Description is set",
+					"actual_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.Description is undefined",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "39fec612777f59fb4181dd2330ee465ec860c962acfebb07a4f1ee1f122d24e7",
+					"line": 35,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.EcsSecurityGroupALBports.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupALBports.Properties.Description is set",
+					"actual_value": "Resources.EcsSecurityGroupALBports.Properties.Description is undefined",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "95883c9f983adb8f547c54e24837b6aa402978a00417be98441514959d4171d4",
+					"line": 27,
+					"issue_type": "MissingAttribute",
+					"search_key": "Resources.EcsSecurityGroupSSHinbound.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupSSHinbound.Properties.Description is set",
+					"actual_value": "Resources.EcsSecurityGroupSSHinbound.Properties.Description is undefined",
+					"value": null
+				}
+			]
+		}
+	]
+}

--- a/e2e/fixtures/E2E_CLI_036_RESULT_2.json
+++ b/e2e/fixtures/E2E_CLI_036_RESULT_2.json
@@ -1,0 +1,75 @@
+{
+	"kics_version": "development",
+	"files_scanned": 1,
+	"files_parsed": 1,
+	"files_failed_to_scan": 0,
+	"queries_total": 1,
+	"queries_failed_to_execute": 0,
+	"queries_failed_to_compute_similarity_id": 0,
+	"scan_id": "console",
+	"severity_counters": {
+		"HIGH": 0,
+		"INFO": 0,
+		"LOW": 0,
+		"MEDIUM": 3
+	},
+	"total_counter": 3,
+	"start": "2021-09-28T12:07:37.9374314+01:00",
+	"end": "2021-09-28T12:07:40.1148004+01:00",
+	"paths": [
+		"fixtures/samples/positive.yaml"
+	],
+	"queries": [
+		{
+			"query_name": "Security Group Ingress With Port Range",
+			"query_id": "87482183-a8e7-4e42-a566-7a23ec231c16",
+			"query_url": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html",
+			"severity": "MEDIUM",
+			"platform": "CloudFormation",
+			"category": "Networking and Firewall",
+			"description": "AWS Security Group Ingress should have a single port",
+			"description_id": "5f2b65f3",
+			"cis_description_id": "",
+			"cis_description_title": "",
+			"cis_description_text": "",
+			"files": [
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "810487007189ac4de717dffc3204a05756e80e910b34f89ee08fd14f612328aa",
+					"line": 27,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupSSHinbound.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupSSHinbound.Properties.FromPort is equal to Resources.EcsSecurityGroupSSHinbound.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupSSHinbound.Properties.FromPort is not equal to Resources.EcsSecurityGroupSSHinbound.Properties.ToPort",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "000056cd0b9697e13f2f4561f1963e34c58c042b921c4d0fad0f2fa5214374eb",
+					"line": 35,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupALBports.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupALBports.Properties.FromPort is equal to Resources.EcsSecurityGroupALBports.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupALBports.Properties.FromPort is not equal to Resources.EcsSecurityGroupALBports.Properties.ToPort",
+					"value": null
+				},
+				{
+					"file_name": "fixtures\\samples\\positive.yaml",
+					"similarity_id": "d60022e14f1b45c574f71c0f48b3fee882b471819597b770e3545988a8f5295a",
+					"line": 19,
+					"issue_type": "IncorrectValue",
+					"search_key": "Resources.EcsSecurityGroupHTTPinbound02.Properties",
+					"search_line": 0,
+					"search_value": "",
+					"expected_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.FromPort is equal to Resources.EcsSecurityGroupHTTPinbound02.Properties.ToPort",
+					"actual_value": "Resources.EcsSecurityGroupHTTPinbound02.Properties.FromPort is not equal to Resources.EcsSecurityGroupHTTPinbound02.Properties.ToPort",
+					"value": null
+				}
+			]
+		}
+	]
+}

--- a/e2e/fixtures/E2E_CLI_047_PAYLOAD.json
+++ b/e2e/fixtures/E2E_CLI_047_PAYLOAD.json
@@ -1,0 +1,86 @@
+{
+	"document": [
+		{
+			"id": "0",
+			"file": "file",
+			"resource": {
+				"aws_redshift_cluster": {
+					"default": {
+						"cluster_identifier": "tf-redshift-cluster",
+						"database_name": "mydb",
+						"master_username": "foo",
+						"master_password": "Mustbe8characters",
+						"node_type": "dc1.large",
+						"cluster_type": "single-node",
+						"_kics_lines": {
+							"_kics__default": {
+								"_kics_line": 1
+							},
+							"_kics_cluster_identifier": {
+								"_kics_line": 2
+							},
+							"_kics_cluster_type": {
+								"_kics_line": 7
+							},
+							"_kics_database_name": {
+								"_kics_line": 3
+							},
+							"_kics_master_password": {
+								"_kics_line": 5
+							},
+							"_kics_master_username": {
+								"_kics_line": 4
+							},
+							"_kics_node_type": {
+								"_kics_line": 6
+							}
+						}
+					},
+					"default1": {
+						"master_username": "foo",
+						"master_password": "Mustbe8characters",
+						"_kics_lines": {
+							"_kics__default": {
+								"_kics_line": 10
+							},
+							"_kics_cluster_identifier": {
+								"_kics_line": 11
+							},
+							"_kics_cluster_type": {
+								"_kics_line": 16
+							},
+							"_kics_database_name": {
+								"_kics_line": 12
+							},
+							"_kics_master_password": {
+								"_kics_line": 14
+							},
+							"_kics_master_username": {
+								"_kics_line": 13
+							},
+							"_kics_node_type": {
+								"_kics_line": 15
+							},
+							"_kics_publicly_accessible": {
+								"_kics_line": 17
+							}
+						},
+						"node_type": "dc1.large",
+						"cluster_type": "single-node",
+						"publicly_accessible": true,
+						"cluster_identifier": "tf-redshift-cluster",
+						"database_name": "mydb"
+					}
+				}
+			},
+			"_kics_lines": {
+				"_kics__default": {
+					"_kics_line": 0
+				},
+				"_kics_resource": {
+					"_kics_line": 10
+				}
+			}
+		}
+	]
+}

--- a/e2e/testcases/e2e-cli-001_help_text.go
+++ b/e2e/testcases/e2e-cli-001_help_text.go
@@ -1,0 +1,18 @@
+package testcases
+
+// E2E-CLI-001 - KICS command should display a help text in the CLI when provided with the
+// --help flag and it should describe the available commands plus the global flags
+func init() {
+	testSample := TestCase{
+		Name: "should display the kics help text [E2E-CLI-001]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"--help"},
+			},
+			ExpectedOut: []string{"E2E_CLI_001"},
+		},
+		WantStatus: []int{0},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-002_help_scan.go
+++ b/e2e/testcases/e2e-cli-002_help_scan.go
@@ -1,0 +1,18 @@
+package testcases
+
+// E2E-CLI-002 - KICS scan command should display a help text in the CLI when provided with the
+// --help flag and it should describe the options related with scan plus the global options
+func init() {
+	testSample := TestCase{
+		Name: "should display the kics scan help text [E2E-CLI-002]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--help"},
+			},
+			ExpectedOut: []string{"E2E_CLI_002"},
+		},
+		WantStatus: []int{0},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-003_scan_text.go
+++ b/e2e/testcases/e2e-cli-003_scan_text.go
@@ -1,0 +1,19 @@
+package testcases
+
+// E2E-CLI-003 - KICS scan command had a mandatory flag -p the CLI should exhibit
+// an error message and return exit code 1
+
+func init() {
+	testSample := TestCase{
+		Name: "should display an error [E2E-CLI-003]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan"},
+			},
+			ExpectedOut: []string{"E2E_CLI_003"},
+		},
+		WantStatus: []int{126},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-004_invalid_combination.go
+++ b/e2e/testcases/e2e-cli-004_invalid_combination.go
@@ -1,0 +1,23 @@
+package testcases
+
+// E2E-CLI-004 - KICS has an invalid flag combination
+// an error message and return exit code 1
+
+func init() {
+	testSample := TestCase{
+		Name: "should display an error [E2E-CLI-004]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--ci", "--verbose"},
+				[]string{"--ci", "scan", "--verbose"},
+			},
+			ExpectedOut: []string{
+				"E2E_CLI_004",
+				"E2E_CLI_004",
+			},
+		},
+		WantStatus: []int{126, 126},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-005_payload-path.go
+++ b/e2e/testcases/e2e-cli-005_payload-path.go
@@ -1,0 +1,25 @@
+package testcases
+
+// E2E-CLI-005 - KICS scan with -- payload-path flag should create a file with the
+// passed name containing the payload of the files scanned
+
+func init() {
+	testSample := TestCase{
+		Name: "should create a payload file [E2E-CLI-005]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--silent", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--payload-path", "output/E2E_CLI_005_PAYLOAD.json"},
+			},
+			ExpectedOut: []string{
+				"E2E_CLI_005",
+			},
+			ExpectedPayload: []string{
+				"E2E_CLI_005_PAYLOAD.json",
+			},
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-006_generate-id.go
+++ b/e2e/testcases/e2e-cli-006_generate-id.go
@@ -1,0 +1,24 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-006 - KICS generate-id should exhibit
+// a valid UUID in the CLI and return exit code 0
+func init() {
+	testSample := TestCase{
+		Name: "should generate a valid ID [E2E-CLI-006]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"generate-id"},
+			},
+		},
+		WantStatus: []int{0},
+		Validation: func(outputText string) bool {
+			uuidRegex := "[a-f0-9]{8}-[a-f0-9]{4}-4{1}[a-f0-9]{3}-[89ab]{1}[a-f0-9]{3}-[a-f0-9]{12}"
+			match, _ := regexp.MatchString(uuidRegex, outputText)
+			return match
+		},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-007_scan.go
+++ b/e2e/testcases/e2e-cli-007_scan.go
@@ -1,0 +1,28 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-007 - the default kics scan must show informations such as 'Files scanned',
+// 'Queries loaded', 'Scan Duration', '...' in the CLI
+func init() {
+	testSample := TestCase{
+		Name: "should perform a simple scan [E2E-CLI-007]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
+			},
+		},
+		WantStatus: []int{50},
+		Validation: func(outputText string) bool {
+			match1, _ := regexp.MatchString(`Files scanned: \d+`, outputText)
+			match2, _ := regexp.MatchString(`Parsed files: \d+`, outputText)
+			match3, _ := regexp.MatchString(`Queries loaded: \d+`, outputText)
+			match4, _ := regexp.MatchString(`Queries failed to execute: \d+`, outputText)
+			match5, _ := regexp.MatchString(`Results Summary:`, outputText)
+			match6, _ := regexp.MatchString(`Scan duration: \d+(m\d+)?(.\d+)?s`, outputText)
+			return match1 && match2 && match3 && match4 && match5 && match6
+		},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-008_scan_silent.go
+++ b/e2e/testcases/e2e-cli-008_scan_silent.go
@@ -1,0 +1,19 @@
+package testcases
+
+// E2E-CLI-008 - KICS  scan with --silent global flag
+// should hide all the output text in the CLI (empty output)
+
+func init() {
+	testSample := TestCase{
+		Name: "should hide all output text in CLI [E2E-CLI-008]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--silent", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
+			},
+			ExpectedOut: []string{"E2E_CLI_008"},
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-009_scan_no-progress.go
+++ b/e2e/testcases/e2e-cli-009_scan_no-progress.go
@@ -1,0 +1,25 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-009 - kics scan with no-progress flag
+// should perform a scan without showing progress bar in the CLI
+func init() {
+	testSample := TestCase{
+		Name: "should hide the progress bar in the CLI [E2E-CLI-009]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf", "--no-progress"},
+			},
+		},
+		WantStatus: []int{50},
+		Validation: func(outputText string) bool {
+			getProgressRegex := "Executing queries:"
+			match, _ := regexp.MatchString(getProgressRegex, outputText)
+			// if not found -> the the test was successful
+			return !match
+		},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-010_scan_invalid_type.go
+++ b/e2e/testcases/e2e-cli-010_scan_invalid_type.go
@@ -1,0 +1,24 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-010 - KICS  scan with invalid --type flag
+// should exhibit an error message and return exit code 1
+func init() {
+	testSample := TestCase{
+		Name: "should display an error message [E2E-CLI-010]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf", "-t", "xml", "--silent"},
+			},
+		},
+		Validation: func(outputText string) bool {
+			unknownArgRegex := regexp.MustCompile(`Error: unknown argument\(s\) for --type: xml`)
+			match := unknownArgRegex.MatchString(outputText)
+			return match
+		},
+		WantStatus: []int{126},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-011_scan_type.go
+++ b/e2e/testcases/e2e-cli-011_scan_type.go
@@ -1,0 +1,21 @@
+package testcases
+
+// E2E-CLI-011 - KICS  scan with a valid case insensitive --type flag
+// should perform the scan successfully and return exit code 50
+func init() {
+	testSample := TestCase{
+		Name: "should perform a valid scan [E2E-CLI-011]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"-t", "TeRraFOrM", "--silent", "--payload-path", "output/E2E_CLI_011_PAYLOAD.json"},
+			},
+			ExpectedPayload: []string{
+				"E2E_CLI_011_PAYLOAD.json",
+			},
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-012_scan_minimal-ui.go
+++ b/e2e/testcases/e2e-cli-012_scan_minimal-ui.go
@@ -1,0 +1,25 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-012 - kics scan with minimal-ui flag should perform a scan
+// without showing detailed results on each line of code
+func init() {
+	testSample := TestCase{
+		Name: "should display minimal-ui [E2E-CLI-012]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "../test/fixtures/tc-sim01/positive1.tf", "--minimal-ui"},
+			},
+		},
+		WantStatus: []int{50},
+		Validation: func(outputText string) bool {
+			match1, _ := regexp.MatchString("Description:", outputText)
+			match2, _ := regexp.MatchString("Platform:", outputText)
+			// if not found -> the the test was successful
+			return !match1 && !match2
+		},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-013_list-platforms.go
+++ b/e2e/testcases/e2e-cli-013_list-platforms.go
@@ -1,0 +1,20 @@
+package testcases
+
+// E2E-CLI-013 - KICS root command list-platforms
+// should return all the supported platforms in the CLI
+func init() {
+	testSample := TestCase{
+		Name: "should list all supported platforms [E2E-CLI-013]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"list-platforms"},
+			},
+			ExpectedOut: []string{
+				"E2E_CLI_013",
+			},
+		},
+		WantStatus: []int{0},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-014_scan_preview-lines.go
+++ b/e2e/testcases/e2e-cli-014_scan_preview-lines.go
@@ -1,0 +1,26 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-014 - KICS preview-lines command must delimit the number of
+// code lines that are displayed in each scan results code block.
+func init() {
+	testSample := TestCase{
+		Name: "should modify the default preview-lines value [E2E-CLI-014]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--preview-lines", "1", "--no-color", "--no-progress",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+		},
+		Validation: func(outputText string) bool {
+			// only the match1 must be true
+			match1, _ := regexp.MatchString(`001\: resource \"aws_redshift_cluster\" \"default1\" \{`, outputText)
+			match2, _ := regexp.MatchString(`002\:   publicly_accessible = false`, outputText)
+			return match1 && !match2
+		},
+		WantStatus: []int{40},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-015_scan_no-color.go
+++ b/e2e/testcases/e2e-cli-015_scan_no-color.go
@@ -1,0 +1,26 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-015 KICS scan with --no-color flag
+// should disable the colored outputs of kics in the CLI
+func init() {
+	testSample := TestCase{
+		Name: "should disable colored output in the CLI [E2E-CLI-015]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--no-color", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
+			},
+		},
+		Validation: func(outputText string) bool {
+			match1, _ := regexp.MatchString(`HIGH: \d+`, outputText)
+			match2, _ := regexp.MatchString(`MEDIUM: \d+`, outputText)
+			match3, _ := regexp.MatchString(`LOW: \d+`, outputText)
+			match4, _ := regexp.MatchString(`INFO: \d+`, outputText)
+			return match1 && match2 && match3 && match4
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-016_scan_invalid_flag.go
+++ b/e2e/testcases/e2e-cli-016_scan_invalid_flag.go
@@ -1,0 +1,26 @@
+package testcases
+
+// E2E-CLI-016 - KICS has an invalid flag or invalid command
+// an error message and return exit code 1
+func init() {
+	testSample := TestCase{
+		Name: "should validate kics error messages [E2E-CLI-016]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--invalid-flag"},
+				[]string{"--invalid-flag"},
+				[]string{"invalid"},
+				[]string{"-i"},
+			},
+			ExpectedOut: []string{
+				"E2E_CLI_016_INVALID_SCAN_FLAG",
+				"E2E_CLI_016_INVALID_FLAG",
+				"E2E_CLI_016_INVALID_COMMAND",
+				"E2E_CLI_016_INVALID_SHOTHAND",
+			},
+		},
+		WantStatus: []int{126, 126, 126, 126},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-017_scan_verbose.go
+++ b/e2e/testcases/e2e-cli-017_scan_verbose.go
@@ -1,0 +1,25 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-017 - KICS scan command with the -v (--verbose) flag
+// should display additional information in the CLI, such as 'Inspector initialized'...
+
+func init() {
+	testSample := TestCase{
+		Name: "should display verbose information in the CLI [E2E-CLI-017]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-v", "--no-progress", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
+			},
+		},
+		Validation: func(outputText string) bool {
+			match1, _ := regexp.MatchString(`Inspector initialized, number of queries=\d+`, outputText)
+			match2, _ := regexp.MatchString(`Inspector stopped`, outputText)
+			return match1 && match2
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-018_scan_exclude-categories.go
+++ b/e2e/testcases/e2e-cli-018_scan_exclude-categories.go
@@ -1,0 +1,21 @@
+package testcases
+
+// E2E-CLI-018  - KICS scan command with --exclude-categories flag
+// should not run queries that are part of the provided categories.
+func init() {
+	testSample := TestCase{
+		Name: "should exclude provided categories [E2E-CLI-018]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--exclude-categories", "Observability,Insecure Configurations", "-s",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+
+				[]string{"scan", "-s",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+		},
+		WantStatus: []int{20, 40},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-019_scan_multiple_paths.go
+++ b/e2e/testcases/e2e-cli-019_scan_multiple_paths.go
@@ -1,0 +1,20 @@
+package testcases
+
+// E2E-CLI-019 - KICS scan with multiple paths
+// should run a scan for all provided paths/files
+func init() {
+	testSample := TestCase{
+		Name: "should run a scan in multiple paths [E2E-CLI-019]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--silent", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf,fixtures/samples/terraform-single.tf"},
+			},
+			ExpectedOut: []string{
+				"E2E_CLI_019",
+			},
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-020_scan_exclude-queries.go
+++ b/e2e/testcases/e2e-cli-020_scan_exclude-queries.go
@@ -1,0 +1,18 @@
+package testcases
+
+// E2E-CLI-020 - KICS scan with --exclude-queries flag
+// should not run queries that was provided in this flag.
+func init() {
+	testSample := TestCase{
+		Name: "should exclude provided queries [E2E-CLI-020]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--exclude-queries", "15ffbacc-fa42-4f6f-a57d-2feac7365caa,0a494a6a-ebe2-48a0-9d77-cf9d5125e1b3", "-s",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+		},
+		WantStatus: []int{20},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-021_scan_status_code.go
+++ b/e2e/testcases/e2e-cli-021_scan_status_code.go
@@ -1,0 +1,24 @@
+package testcases
+
+// E2E-CLI-021 - KICS can return different status code based in the scan results (High/Medium/Low..)
+// when excluding categories/queries and losing results we can get a different status code.
+func init() {
+	testSample := TestCase{
+		Name: "should validate the kics status code [E2E-CLI-021]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan",
+					"-q", "../assets/queries", "-p", "../test/fixtures/all_auth_users_get_read_access/test/positive.tf"},
+
+				[]string{"scan", "--exclude-categories",
+					"Access Control,Availability,Backup,Best Practices,Build Process,Encryption," +
+						"Insecure Configurations,Insecure Defaults,Networking and Firewall,Observability," +
+						"Resource Management,Secret Management,Supply-Chain,Structure and Semantics",
+					"-q", "../assets/queries", "-p", "../test/fixtures/all_auth_users_get_read_access/test/positive.tf"},
+			},
+		},
+		WantStatus: []int{50, 0},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-022_scan_profiling_cpu.go
+++ b/e2e/testcases/e2e-cli-022_scan_profiling_cpu.go
@@ -1,0 +1,24 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-022 - Kics  scan command with --profiling CPU and -v flags
+// should display CPU usage in the CLI
+func init() {
+	testSample := TestCase{
+		Name: "should display CPU usage in the CLI [E2E-CLI-022]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--profiling", "CPU", "-v",
+					"--no-progress", "--no-color", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
+			},
+		},
+		Validation: func(outputText string) bool {
+			match, _ := regexp.MatchString(`Total CPU usage for start_scan: \d+`, outputText)
+			return match
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-023_scan_profiling_mem.go
+++ b/e2e/testcases/e2e-cli-023_scan_profiling_mem.go
@@ -1,0 +1,24 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-023 - Kics  scan command with --profiling MEM and -v flags
+// should display MEM usage in the CLI
+func init() {
+	testSample := TestCase{
+		Name: "should display memory usage in the CLI [E2E-CLI-023]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--profiling", "MEM", "-v",
+					"--no-progress", "--no-color", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
+			},
+		},
+		Validation: func(outputText string) bool {
+			match, _ := regexp.MatchString(`Total MEM usage for start_scan: \d+`, outputText)
+			return match
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-024_version.go
+++ b/e2e/testcases/e2e-cli-024_version.go
@@ -1,0 +1,23 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-024  - KICS version command
+// should display the version of the kics in the CLI.
+func init() {
+	testSample := TestCase{
+		Name: "should display the kics version [E2E-CLI-024]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"version"},
+			},
+		},
+		Validation: func(outputText string) bool {
+			match, _ := regexp.MatchString(`Keeping Infrastructure as Code Secure [0-9a-zA-Z]+`, outputText)
+			return match
+		},
+		WantStatus: []int{0},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-025_scan_fail-on.go
+++ b/e2e/testcases/e2e-cli-025_scan_fail-on.go
@@ -1,0 +1,21 @@
+package testcases
+
+// E2E-CLI-025 - KICS scan command with --fail-on flag should
+// return status code different from 0 only when results match the severity provided in this flag
+func init() {
+	testSample := TestCase{
+		Name: "should fail-on provided values [E2E-CLI-025]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--fail-on", "info,low",
+					"-s", "-q", "../assets/queries", "-p", "../assets/queries/dockerfile/apk_add_using_local_cache_path/test/positive.dockerfile"},
+
+				[]string{"scan", "--fail-on", "info",
+					"-s", "-q", "../assets/queries", "-p", "../assets/queries/dockerfile/apk_add_using_local_cache_path/test/positive.dockerfile"},
+			},
+		},
+		WantStatus: []int{30, 20},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-026_scan_ignore-on-exit.go
+++ b/e2e/testcases/e2e-cli-026_scan_ignore-on-exit.go
@@ -1,0 +1,28 @@
+package testcases
+
+// E2E-CLI-026 - KICS scan command with --ignore-on-exit flag
+// should return status code 0 if the provided flag occurs.
+// Example: '--ignore-on-exit errors' -> Returns 0 if an error was found, instead of 126/130...
+func init() {
+	testSample := TestCase{
+		Name: "should ignore on exit provided flags [E2E-CLI-026]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--ignore-on-exit",
+					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.invalid.name"},
+
+				[]string{"scan", "--ignore-on-exit", "errors",
+					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.invalid.name"},
+
+				[]string{"scan", "--ignore-on-exit", "errors",
+					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+
+				[]string{"scan", "--ignore-on-exit", "all",
+					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+		},
+		WantStatus: []int{126, 0, 40, 0},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-027_scan_exclude-paths.go
+++ b/e2e/testcases/e2e-cli-027_scan_exclude-paths.go
@@ -1,0 +1,24 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-027 - KICS scan command with --exclude-paths
+// should not perform the scan on the files/folders provided by this flag
+func init() {
+	testSample := TestCase{
+		Name: " should exclude provided paths [E2E-CLI-027]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--exclude-paths", "../test/fixtures/all_auth_users_get_read_access/test/positive.tf",
+					"-q", "../assets/queries", "-p", "../test/fixtures/all_auth_users_get_read_access/test/"},
+			},
+		},
+		Validation: func(outputText string) bool {
+			match, _ := regexp.MatchString(`Files scanned: 1`, outputText)
+			return match
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-028_scan_log-format.go
+++ b/e2e/testcases/e2e-cli-028_scan_log-format.go
@@ -1,0 +1,27 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-028 - KICS scan command with --log-format
+// should modify the view structure of output messages in the CLI (json/pretty)
+func init() {
+	testSample := TestCase{
+		Name: "should modify log format messages in the CLI [E2E-CLI-028]",
+		Args: args{
+			Args: []cmdArgs{
+
+				[]string{"scan", "--log-format", "json", "--verbose",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+		},
+
+		Validation: func(outputText string) bool {
+			match1, _ := regexp.MatchString(`{"level":"info"`, outputText)
+			match2, _ := regexp.MatchString(`"message":"Inspector initialized, number of queries=\d+"`, outputText)
+			return match1 && match2
+		},
+		WantStatus: []int{40},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-029_scan_config.go
+++ b/e2e/testcases/e2e-cli-029_scan_config.go
@@ -1,0 +1,19 @@
+package testcases
+
+// E2E-CLI-029 - KICS scan command with --config flag
+// should load a config file that provides commands and arguments to kics.
+func init() {
+	testSample := TestCase{
+		Name: "should load a config file [E2E-CLI-029]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--config", "fixtures/samples/config.json"},
+
+				[]string{"scan", "--config", "fixtures/samples/config.json", "--silent"},
+			},
+		},
+		WantStatus: []int{40, 126},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-030_output-path.go
+++ b/e2e/testcases/e2e-cli-030_output-path.go
@@ -1,0 +1,18 @@
+package testcases
+
+// E2E-CLI-030 - Kics scan command with --output-path flags
+// should export the result files to the path provided by this flag.
+func init() {
+	testSample := TestCase{
+		Name: "should export the result files to provided path [E2E-CLI-030]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--output-path", "output",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+		},
+		WantStatus: []int{40},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-031_scan_report-formats.go
+++ b/e2e/testcases/e2e-cli-031_scan_report-formats.go
@@ -1,0 +1,25 @@
+package testcases
+
+// E2E-CLI-031 - Kics  scan command with --report-formats and --output-path flags
+// should export the results based on the formats provided by this flag.
+func init() {
+	testSample := TestCase{
+		Name: "E2E-CLI-031",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_031_RESULT",
+					"--report-formats", "json,sarif,glsast,html",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
+			},
+			ExpectedResult: []ResultsValidation{
+				{
+					ResultsFile:    "E2E_CLI_031_RESULT",
+					ResultsFormats: []string{"json", "sarif", "glsast", "html"},
+				},
+			},
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-032_scan_output-path_validate_json.go
+++ b/e2e/testcases/e2e-cli-032_scan_output-path_validate_json.go
@@ -1,0 +1,25 @@
+package testcases
+
+// E2E-CLI-032 - KICS scan command with --output-path flag
+// should set the output path and check the results.json report format
+func init() {
+	testSample := TestCase{
+		Name: "should set the results output path [E2E-CLI-032]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-o", "output", "--output-name", "E2E_CLI_032_RESULT",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+				},
+			},
+			ExpectedResult: []ResultsValidation{
+				{
+					ResultsFile:    "E2E_CLI_032_RESULT",
+					ResultsFormats: []string{"json"},
+				},
+			},
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-033_scan_output-path_validate_payload.go
+++ b/e2e/testcases/e2e-cli-033_scan_output-path_validate_payload.go
@@ -1,0 +1,32 @@
+package testcases
+
+// E2E-CLI-033 - KICS scan command with --output-path and --payload-path flags
+// should perform a scan and create result file(s) and payload file
+func init() {
+	testSample := TestCase{
+		Name: " should perform a scan and create a result and payload file [E2E-CLI-033]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan",
+					"--output-path", "output",
+					"--output-name", "E2E_CLI_033_RESULT",
+					"--report-formats", "json,sarif,glsast",
+					"--payload-path", "output/E2E_CLI_033_PAYLOAD.json",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf",
+				},
+			},
+			ExpectedResult: []ResultsValidation{
+				{
+					ResultsFile:    "E2E_CLI_033_RESULT",
+					ResultsFormats: []string{"json", "sarif", "glsast"},
+				},
+			},
+			ExpectedPayload: []string{
+				"E2E_CLI_033_PAYLOAD.json",
+			},
+		},
+		WantStatus: []int{40},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-034_scan_log-format_no_verbose.go
+++ b/e2e/testcases/e2e-cli-034_scan_log-format_no_verbose.go
@@ -1,0 +1,28 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-034 - KICS scan command with --log-format without --verbose
+// should not output log messages in the CLI (json)
+func init() {
+	testSample := TestCase{
+		Name: "should not display messages in the CLI [E2E-CLI-034]",
+		Args: args{
+			Args: []cmdArgs{
+
+				[]string{"scan", "--log-format", "json",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+		},
+
+		Validation: func(outputText string) bool {
+			match1, _ := regexp.MatchString(`{"level":"info"`, outputText)
+			match2, _ := regexp.MatchString(`"message":"Inspector initialized, number of queries=\d+"`, outputText)
+			return !match1 && !match2
+		},
+
+		WantStatus: []int{40},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-035_scan_exclude-results.go
+++ b/e2e/testcases/e2e-cli-035_scan_exclude-results.go
@@ -1,0 +1,26 @@
+package testcases
+
+// E2E-CLI-035 - KICS scan command with --exclude-results
+// should not run/found results (similarityID) provided by this flag
+func init() {
+	testSample := TestCase{
+		Name: "should exclude provided results [E2E-CLI-035]",
+		Args: args{
+			Args: []cmdArgs{
+
+				[]string{"scan",
+					"--exclude-results",
+					"2abf26c3014fc445da69d8d5bb862c1c511e8e16ad3a6c6f6e14c28aa0adac1d," +
+						"4aa3f159f39767de53b49ed871977b8b499bf19b3b0865b1631042aa830598aa," +
+						"83461a5eac8fed2264fac68a6d352d1ed752867a9b0a131afa9ba7e366159b59",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+
+				[]string{"scan", "--exclude-results", "-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+		},
+
+		WantStatus: []int{20, 126},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-036_scan_include-queries.go
+++ b/e2e/testcases/e2e-cli-036_scan_include-queries.go
@@ -1,0 +1,59 @@
+package testcases
+
+// E2E-CLI-036 - KICS scan command with --include-queries
+// should perform a scan running only the provided queries
+func init() {
+	testSample := TestCase{
+		Name: "should perform a scan including only specific queries [E2E-CLI-036]",
+		Args: args{
+			Args: []cmdArgs{
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_036_RESULT",
+					"--include-queries", "275a3217-ca37-40c1-a6cf-bb57d245ab32,027a4b7a-8a59-4938-a04f-ed532512cf45," +
+						"e415f8d3-fc2b-4f52-88ab-1129e8c8d3f5,105ba098-1e34-48cd-b0f2-a8a43a51bf9b,ad21e616-5026-4b9d-990d-5b007bfe679c," +
+						"79d745f0-d5f3-46db-9504-bef73e9fd528,e200a6f3-c589-49ec-9143-7421d4a2c845,01d5a458-a6c4-452a-ac50-054d59275b7c," +
+						"7f384a5f-b5a2-4d84-8ca3-ee0a5247becb,87482183-a8e7-4e42-a566-7a23ec231c16,4a1e6b34-1008-4e61-a5f2-1f7c276f8d14," +
+						"d24389b4-b209-4ff0-8345-dc7a4569dcdd,5e6c9c68-8a82-408e-8749-ddad78cbb9c5"}, // Load Many Queries (13)
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_036_RESULT_2",
+					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec231c16"}, // Load 1 query
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec231c17"}, // Load 0 queries (valid, but doesn't exists)
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--include-queries", "87482183-a8e7-4e42-a566-7a23ec23KICS"}, // Invalid query ID
+
+				[]string{"scan", "--include-queries", "cfdcabb0-fc06-427c-865b-c59f13e898ce",
+					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
+
+				[]string{"scan", "--include-queries", "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10,15ffbacc-fa42-4f6f-a57d-2feac7365caa",
+					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
+
+				[]string{"scan", "--include-queries", "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
+					"-s", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
+
+				[]string{"scan", "--include-queries",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+				[]string{"scan", "--include-queries",
+					"--queries-path", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+			ExpectedResult: []ResultsValidation{
+				{
+					ResultsFile:    "E2E_CLI_036_RESULT",
+					ResultsFormats: []string{"json"},
+				},
+				{
+					ResultsFile:    "E2E_CLI_036_RESULT_2",
+					ResultsFormats: []string{"json"},
+				},
+			},
+		},
+
+		WantStatus: []int{50, 40, 0, 126, 50, 40, 20, 126, 126},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-037_scan_exclude-results_include-queries.go
+++ b/e2e/testcases/e2e-cli-037_scan_exclude-results_include-queries.go
@@ -1,0 +1,25 @@
+package testcases
+
+// E2E-CLI-037 - KICS scan command with --exclude-results and --include-queries
+// should run only provided queries and does not run results (similarityID) provided by this flag
+func init() {
+	testSample := TestCase{
+		Name: "should run only provided queries and exclude provided results [E2E-CLI-037]",
+		Args: args{
+			Args: []cmdArgs{
+
+				[]string{"scan", "--include-queries", "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
+					"--exclude-results", "406b71d9fd0edb656a4735df30dde77c5f8a6c4ec3caa3442f986a92832c653b",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+
+				[]string{"scan", "--include-queries", "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
+					"--exclude-results", "d1c5f6aec84fd91ed24f5f06ccb8b6662e26c0202bcb5d4a58a1458c16456d20",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+		},
+
+		WantStatus: []int{0, 20},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-038_scan_log-path.go
+++ b/e2e/testcases/e2e-cli-038_scan_log-path.go
@@ -1,0 +1,31 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-038 - KICS scan command with --log-path
+// should generate and save a log file for the scan
+func init() {
+	testSample := TestCase{
+		Name: "should generate and save a log file [E2E-CLI-038]",
+		Args: args{
+			Args: []cmdArgs{
+
+				[]string{"scan", "--log-path", "output/E2E_CLI_038_LOG",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+
+			ExpectedLog: LogValidation{
+				LogFile: "E2E_CLI_038_LOG",
+				ValidationFunc: func(logText string) bool {
+					match1, _ := regexp.MatchString("Scanning with Keeping Infrastructure as Code Secure", logText)
+					match2, _ := regexp.MatchString(`Files scanned: \d+`, logText)
+					match3, _ := regexp.MatchString(`Queries loaded: \d+`, logText)
+					return match1 && match2 && match3
+				},
+			},
+		},
+		WantStatus: []int{40},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-039_scan_log-path_log-level.go
+++ b/e2e/testcases/e2e-cli-039_scan_log-path_log-level.go
@@ -1,0 +1,32 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-039 - KICS scan command with --log-path and --log-level
+// should generate and save a log file based in the provided log-level
+func init() {
+	testSample := TestCase{
+		Name: " should generate and save a log file with log level [E2E-CLI-039]",
+		Args: args{
+			Args: []cmdArgs{
+
+				[]string{"scan", "--log-path", "output/E2E_CLI_039_LOG",
+					"--log-level", "TRACE",
+					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
+			},
+
+			ExpectedLog: LogValidation{
+				LogFile: "E2E_CLI_039_LOG",
+				ValidationFunc: func(logText string) bool {
+					match1, _ := regexp.MatchString("TRACE", logText)
+					match2, _ := regexp.MatchString(`Inspector executed with result`, logText)
+					match3, _ := regexp.MatchString(`Scan duration: \d+`, logText)
+					return match1 && match2 && match3
+				},
+			},
+		},
+		WantStatus: []int{40},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-040_scan_report-formats_validate_outputs.go
+++ b/e2e/testcases/e2e-cli-040_scan_report-formats_validate_outputs.go
@@ -1,0 +1,25 @@
+package testcases
+
+// E2E-CLI-040 - Kics  scan command with --report-formats and --output-path flags
+// should export the results based on the formats provided by this flag.
+func init() {
+	testSample := TestCase{
+		Name: "should export the results based on report formats [E2E-CLI-040]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_040_RESULT",
+					"--report-formats", "json,sarif,glsast,html",
+					"-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml"},
+			},
+			ExpectedResult: []ResultsValidation{
+				{
+					ResultsFile:    "E2E_CLI_040_RESULT",
+					ResultsFormats: []string{"json", "sarif", "glsast", "html"},
+				},
+			},
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-041_scan_remote_path_git.go
+++ b/e2e/testcases/e2e-cli-041_scan_remote_path_git.go
@@ -1,0 +1,25 @@
+package testcases
+
+// E2E-CLI-041 - Kics scan command with -p targeting remote path (git)
+// should download and scan the provided path.
+func init() {
+	testSample := TestCase{
+		Name: "should download and scan the provided git path [E2E-CLI-041]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_041_RESULT",
+					"--report-formats", "json,sarif,glsast", "-q", "../assets/queries",
+					"-p", "git::https://github.com/dockersamples/example-voting-app"},
+			},
+			ExpectedResult: []ResultsValidation{
+				{
+					ResultsFile:    "E2E_CLI_041_RESULT",
+					ResultsFormats: []string{"json", "sarif", "glsast"},
+				},
+			},
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-042_scan_remote_path_http.go
+++ b/e2e/testcases/e2e-cli-042_scan_remote_path_http.go
@@ -1,0 +1,25 @@
+package testcases
+
+// E2E-CLI-042 - Kics scan command with -p targeting remote path (http/https)
+// should download and scan the provided path/file.
+func init() {
+	testSample := TestCase{
+		Name: "should download and scan the provided http path/file [E2E-CLI-042]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_042_RESULT",
+					"--report-formats", "json,sarif,glsast", "-q", "../assets/queries",
+					"-p", "https://raw.githubusercontent.com/dockersamples/example-voting-app/master/docker-compose-simple.yml"},
+			},
+			ExpectedResult: []ResultsValidation{
+				{
+					ResultsFile:    "E2E_CLI_042_RESULT",
+					ResultsFormats: []string{"json", "sarif", "glsast"},
+				},
+			},
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-043_scan_cloud-provider.go
+++ b/e2e/testcases/e2e-cli-043_scan_cloud-provider.go
@@ -1,0 +1,24 @@
+package testcases
+
+// E2E-CLI-043 - Kics scan command with --cloud-provider
+// should execute only queries that have the same provider as given in the flag.
+func init() {
+	testSample := TestCase{
+		Name: "should execute only queries of specific cloud provider [E2E-CLI-043]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "", "fixtures/samples/positive.yaml",
+					"--cloud-provider", "none"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--cloud-provider"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--cloud-provider", "aws"},
+			},
+		},
+		WantStatus: []int{126, 126, 50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-044_scan_exclude-severities.go
+++ b/e2e/testcases/e2e-cli-044_scan_exclude-severities.go
@@ -1,0 +1,31 @@
+package testcases
+
+// E2E-CLI-044 - Kics scan command with --exclude-severities
+// should only execute query-ids provided in the flag.
+func init() {
+	testSample := TestCase{
+		Name: "should exclude queries by given severities [E2E-CLI-044]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities", "HIGH"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities", "HIGH,MEDIUM,LOW,INFO"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--output-path", "output", "--output-name", "E2E_CLI_044_RESULT",
+					"--exclude-severities", "HIGH,MEDIUM,LOW"},
+			},
+		},
+		WantStatus: []int{40, 0, 126, 20},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-045_scan_disable-secrets.go
+++ b/e2e/testcases/e2e-cli-045_scan_disable-secrets.go
@@ -1,0 +1,26 @@
+package testcases
+
+// E2E-CLI-045 - Kics scan command with --disable-secrets
+// should not execute secret based queries.
+func init() {
+	testSample := TestCase{
+		Name: "should not execute secret based queries [E2E-CLI-045]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08",
+					"--disable-secrets"},
+
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--include-queries", "487f4be7-3fd9-4506-a07a-eae252180c08,e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
+					"--disable-secrets"},
+			},
+		},
+		WantStatus: []int{50, 0, 20},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-046_scan_disable-full-descriptions.go
+++ b/e2e/testcases/e2e-cli-046_scan_disable-full-descriptions.go
@@ -1,0 +1,26 @@
+package testcases
+
+import "regexp"
+
+// E2E-CLI-046 - Kics scan command with --disable-full-descriptions
+// should fetch CIS descriptions from enviroment URL KICS_DESCRIPTIONS_ENDPOINT.
+func init() {
+	testSample := TestCase{
+		Name: "should fetch CIS descriptions from enviroment [E2E-CLI-046]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--no-color", "-v",
+					"--disable-full-descriptions"},
+			},
+		},
+		Validation: func(outputText string) bool {
+			uuidRegex := "Skipping CIS descriptions because provided disable flag is set"
+			match, _ := regexp.MatchString(uuidRegex, outputText)
+			return match
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/e2e-cli-047_scan_payload-lines.go
+++ b/e2e/testcases/e2e-cli-047_scan_payload-lines.go
@@ -1,0 +1,21 @@
+package testcases
+
+// E2E-CLI-047 - Kics scan command with --payload-lines
+// should display additional information lines in the payload file.
+func init() {
+	testSample := TestCase{
+		Name: "should display additional information lines in the payload file [E2E-CLI-047]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--silent", "-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf",
+					"--payload-path", "output/E2E_CLI_047_PAYLOAD.json", "--payload-lines"},
+			},
+			ExpectedPayload: []string{
+				"E2E_CLI_047_PAYLOAD.json",
+			},
+		},
+		WantStatus: []int{50},
+	}
+
+	Tests = append(Tests, testSample)
+}

--- a/e2e/testcases/general.go
+++ b/e2e/testcases/general.go
@@ -1,0 +1,37 @@
+package testcases
+
+type TestCase struct {
+	Name       string
+	Args       args
+	WantStatus []int
+	Validation Validation
+}
+
+type LogValidation struct {
+	LogFile        string
+	ValidationFunc Validation
+}
+
+type Validation func(string) bool
+
+type ResultsValidation struct {
+	ResultsFile    string
+	ResultsFormats []string
+}
+
+type args struct {
+	Args            []cmdArgs // args to pass to kics binary
+	ExpectedOut     []string  // path to file with expected output
+	ExpectedPayload []string
+	ExpectedResult  []ResultsValidation
+	ExpectedLog     LogValidation
+}
+
+type TestTemplates struct {
+	Help     string
+	ScanHelp string
+}
+
+type cmdArgs []string
+
+var Tests = make([]TestCase, 0)


### PR DESCRIPTION
Closes #

**Proposed Changes**
- Bring more readability to E2E Tests by splitting the test cases into single files (instead of creating a single array with dozens of tests).
- These changes allow us to find and identify tests more quickly.

I submit this contribution under the Apache-2.0 license.
