### PR TITLE
fix: generic secret regex

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -30,6 +30,10 @@
         {
           "description": "Avoiding Square OAuth Secret",
           "regex": "(?i)['\"]?secret[_]?(key)?['\"]?\\s*(:|=)\\s*['\"]?(sq0csp-[0-9A-Za-z\\-_]{43})['\"]?"
+        },
+        {
+          "description": "Avoiding TF resource access",
+          "regex": "(?i)['\"]?secret[_]?(key)?['\"]?\\s*=\\s*([a-zA-z_]+(.))?[a-zA-z_]+(.)[a-zA-z_]+(.)[a-zA-z_]+"
         }
       ]
     },

--- a/assets/queries/common/passwords_and_secrets/test/negative44.tf
+++ b/assets/queries/common/passwords_and_secrets/test/negative44.tf
@@ -1,0 +1,5 @@
+locals {
+  secrets = {
+    my_secret = random_password.my_password.result
+  }
+}

--- a/assets/queries/common/passwords_and_secrets/test/positive40.tf
+++ b/assets/queries/common/passwords_and_secrets/test/positive40.tf
@@ -1,0 +1,5 @@
+locals {
+  secrets = {
+    clientSecret = "C98D9F6O-1273-4E8A-B8D9-551F7F3OC41"
+  }
+}

--- a/assets/queries/common/passwords_and_secrets/test/positive_expected_result.json
+++ b/assets/queries/common/passwords_and_secrets/test/positive_expected_result.json
@@ -328,5 +328,11 @@
     "severity": "HIGH",
     "line": 10,
     "fileName": "positive39.yaml"
+  },
+  {
+    "queryName": "Passwords And Secrets - Generic Secret",
+    "severity": "HIGH",
+    "line": 3,
+    "fileName": "positive40.tf"
   }
 ]


### PR DESCRIPTION
**Proposed Changes**
- Generic secret regex was forcing the beginning of a secret word or some word followed by `_`, which resulted in KICS not catching secrets like `clientSecret: C98D9F6O-1273-4E8A-B8D9-551F7F3OC41`
- Furthermore, this regex was also catching TF resource access cases


I submit this contribution under the Apache-2.0 license.
