### PR TITLE
fix(analyzer): overriding k8s match for arm sample

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -36,6 +36,7 @@ var (
 const (
 	yml  = ".yml"
 	yaml = ".yaml"
+	json = ".json"
 )
 
 // Analyze will go through the slice paths given and determine what type of queries should be loaded
@@ -107,7 +108,7 @@ func worker(path string, results, unwanted chan<- string, wg *sync.WaitGroup) {
 	case ".tf", "tfvars":
 		results <- "terraform"
 	// Cloud Formation, Ansible, OpenAPI
-	case yaml, yml, ".json":
+	case yaml, yml, json:
 		checkContent(path, results, unwanted, ext)
 	}
 }
@@ -146,6 +147,14 @@ var types = map[string]regexSlice{
 	},
 }
 
+// overrides k8s match when all regexs passes for azureresourcemanager key and extension is set to json
+func needsOverride(check bool, returnType, key, ext string) bool {
+	if check && returnType == "kubernetes" && key == "azureresourcemanager" && ext == ".json" {
+		return true
+	}
+	return false
+}
+
 // checkContent will determine the file type by content when worker was unable to
 // determine by ext, if no type was determined checkContent adds it to unwanted channel
 func checkContent(path string, results, unwanted chan<- string, ext string) {
@@ -177,10 +186,7 @@ func checkContent(path string, results, unwanted chan<- string, ext string) {
 		// If all regexs passed and there wasn't a type already assigned
 		if check && returnType == "" {
 			returnType = key
-		}
-
-		// overrides k8s match when all regexs passes for azureresourcemanager key
-		if check && returnType == "kubernetes" && key == "azureresourcemanager" {
+		} else if needsOverride(check, returnType, key, ext) {
 			returnType = key
 		}
 	}


### PR DESCRIPTION
Closes #4345 

**Proposed Changes**
- Since ARM sample with the following fields defined: kind, metadata and apiVersion is recognized as a Kubernetes sample, we need to override k8s match

I submit this contribution under the Apache-2.0 license.
