### PR TITLE
fix(ci): added 'e2e/testcases' path exclusion to sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=checkmarx
 sonar.language=go
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=.
-sonar.exclusions=**/*_test.go, **/vendor/**, pkg/model/sarif_categories.go, **/e2e/fixtures/**, assets/queries/**/*, test/fixtures/**/*, cmd/builder/**/*
+sonar.exclusions=**/*_test.go, **/vendor/**, pkg/model/sarif_categories.go, **/e2e/fixtures/**, assets/queries/**/*, test/fixtures/**/*, cmd/builder/**/*, **/e2e/testcases/*
 
 
 sonar.tests=.


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Added 'e2e/testcases' path exclusion to sonar

I submit this contribution under the Apache-2.0 license.
