### PR TITLE
fix(query): resource not using tags FP

### DIFF
--- a/assets/queries/terraform/aws/resource_not_using_tags/query.rego
+++ b/assets/queries/terraform/aws/resource_not_using_tags/query.rego
@@ -1,10 +1,11 @@
 package Cx
 
-import data.generic.terraform as terraform_lib
 import data.generic.common as common_lib
+import data.generic.terraform as terraform_lib
 
 CxPolicy[result] {
 	resource := input.document[i].resource[res][name]
+	check_default_tags == false
 	terraform_lib.check_resource_tags(res)
 	not common_lib.valid_key(resource, "tags")
 
@@ -19,6 +20,7 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	resource := input.document[i].resource[res][name]
+	check_default_tags == false
 	terraform_lib.check_resource_tags(res)
 	tags := remove_name_tag(resource.tags)
 	count(tags) == 0
@@ -37,4 +39,11 @@ remove_name_tag(tags) = res_tags {
 	res_tags := tags
 } else = res_tags {
 	res_tags := object.remove(tags, {"Name"})
+}
+
+check_default_tags {
+	def_tags := input.document[_].provider[_].default_tags.tags
+	def_tags != {}
+} else = false {
+	true
 }


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- Added a check for default_tags inside the provider

Note: Can't add a negative sample for this issue, since we must look in multiple documents for the provider,
	meaning, that if we have a default_tags defined in the negative cases the positives will pick up
	these tags


I submit this contribution under the Apache-2.0 license.
