### PR TITLE
fix(ci): removing arm64 platform for ubi7 images

### DIFF
--- a/.github/workflows/release-dkr-image-for-tag.yml
+++ b/.github/workflows/release-dkr-image-for-tag.yml
@@ -103,6 +103,7 @@ jobs:
           context: .
           file: ./Dockerfile.ubi7
           push: true
+          platforms: linux/amd64
           tags: ${{ steps.prep.outputs.ubi7_tags }}
           build-args: |
             VERSION=${{ github.event.inputs.tag }}

--- a/.github/workflows/release-dkr-image.yml
+++ b/.github/workflows/release-dkr-image.yml
@@ -82,7 +82,7 @@ jobs:
           file: ./Dockerfile.ubi7
           push: true
           tags: checkmarx/kics:ubi7,checkmarx/kics:${{ steps.get-version.outputs.version }}-ubi7
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           build-args: |
             VERSION=${{ steps.get-version.outputs.version }}
             COMMIT=${{ github.sha }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -191,7 +191,7 @@ jobs:
           file: ./Dockerfile.ubi7
           push: true
           tags: checkmarx/kics:nightly-ubi7
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           build-args: |
             VERSION=nightly-${{ needs.pre_release_job.outputs.sha8 }}
             COMMIT=${{ github.sha }}


### PR DESCRIPTION


I submit this contribution under the Apache-2.0 license.
