### PR TITLE
fix(ci): fixed wrong path to common.json

### DIFF
--- a/.github/workflows/alert-update-terraform-modules.yaml
+++ b/.github/workflows/alert-update-terraform-modules.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           pip3 install -r .github/scripts/watchers/requirements.txt
           python3 -u .github/scripts/watchers/terraform-modules-update.py \
-            -c internal/console/assets/libraries/common.json \
+            -c assets/libraries/common.json \
             -u https://registry.terraform.io/v1/modules
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3.10.1


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Path for common.json was wrong on `alert-update-terraform-modules` GitHub Action

I submit this contribution under the Apache-2.0 license.
