### PR TITLE
fix(passwords and secrets): excluded TF file function reference in results

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -276,6 +276,10 @@
     {
       "description": "Avoiding arn",
       "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*[=:]\\s*['\"]?(arn:)['\"]?"
+    },
+    {
+      "description": "Avoiding TF file function",
+      "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*=\\s*['\"]?(file\\()['\"]?"
     }
   ]
 }

--- a/assets/queries/common/passwords_and_secrets/test/negative46.tf
+++ b/assets/queries/common/passwords_and_secrets/test/negative46.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "instance" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+
+  connection {
+    user        = "ubuntu"
+    private_key = file(var.private_key_path)
+  }
+}


### PR DESCRIPTION
**Proposed Changes**
- Exclude the results that point to Terraform file function

I submit this contribution under the Apache-2.0 license.
