### PR TITLE
feat(passwords and secrets mechanism): a88baa34-e2ad-44ea-ad6f-8cac87bc7c71 trigger all the rules defined inside the regex_rules.json

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -64,5 +64,14 @@ Moreover, to exclude scenarios like `automountServiceAccountToken: false`, we ca
 
 
 #### Flags
-It is important to mention that you can disable this query through flag `--disable-secrets`.
-Furthermore, if you want to add new rules, you can point the path through the flag `--secrets-regexes-path`.
+
+##### Passwords And Secrets Exclusion
+It is important to mention that you can disable this query through flag `--disable-secrets`. Furthermore, you also can disable it through flag `--exclude-queries`, which should point to its query ID.
+
+##### Passwords And Secrets Inclusion
+When the flag `--include-queries` is not used, the Password and Secrets query is included for default. However, when this flag is used, the Password and Secrets query is not included for default. So, to include this query, you can use the flag `--include-queries`, which should point to the Password and Secrets query ID.
+
+##### New Rules Addition
+If you want to use your own rules, you can point the path through the flag `--secrets-regexes-path`. KICS is prepared for two cases:
+- only the use of the user's rule (through the flag `--secrets-regexes-path`)
+- the use of the user's rules plus all KICS rules (through the flag `--secrets-regexes-path` and `--include-queries`, which should point to the Passwords and Secrets query ID)

--- a/pkg/engine/secrets/inspector.go
+++ b/pkg/engine/secrets/inspector.go
@@ -199,8 +199,10 @@ func compileRegexQueries(queryFilter *source.QueryInspectorParameters, allRegexQ
 
 	for i := range allRegexQueries {
 		includeSpecificSecretQuery = isValueInArray(allRegexQueries[i].ID, queryFilter.IncludeQueries.ByIDs)
-		if len(queryFilter.IncludeQueries.ByIDs) > 0 && !allSecretsQueryAndCustom && (includeAllSecretsQuery || includeSpecificSecretQuery) {
-			regexQueries = append(regexQueries, allRegexQueries[i])
+		if len(queryFilter.IncludeQueries.ByIDs) > 0 && !allSecretsQueryAndCustom {
+			if includeAllSecretsQuery || includeSpecificSecretQuery {
+				regexQueries = append(regexQueries, allRegexQueries[i])
+			}
 		} else {
 			if !shouldExecuteQuery(
 				allRegexQueries[i].ID,

--- a/pkg/engine/secrets/inspector.go
+++ b/pkg/engine/secrets/inspector.go
@@ -181,8 +181,9 @@ func (c *Inspector) Inspect(ctx context.Context, basePaths []string,
 
 func compileRegexQueries(queryFilter *source.QueryInspectorParameters, allRegexQueries []RegexQuery, isCustom bool) ([]RegexQuery, error) {
 	var regexQueries []RegexQuery
+	var includeSpecificSecretQuery bool
 
-	onlyKicsSecretsRegexes := true
+	allSecretsQueryAndCustom := false
 
 	includeAllSecretsQuery := isValueInArray("a88baa34-e2ad-44ea-ad6f-8cac87bc7c71", queryFilter.IncludeQueries.ByIDs)
 
@@ -192,16 +193,14 @@ func compileRegexQueries(queryFilter *source.QueryInspectorParameters, allRegexQ
 		if err != nil {
 			return nil, err
 		}
-		onlyKicsSecretsRegexes = false
+		allSecretsQueryAndCustom = true
 		regexQueries = kicsRegexQueries.Rules
 	}
 
 	for i := range allRegexQueries {
-		if len(queryFilter.IncludeQueries.ByIDs) > 0 && onlyKicsSecretsRegexes {
-			includeSpecificSecretQuery := isValueInArray(allRegexQueries[i].ID, queryFilter.IncludeQueries.ByIDs)
-			if includeAllSecretsQuery || includeSpecificSecretQuery {
-				regexQueries = append(regexQueries, allRegexQueries[i])
-			}
+		includeSpecificSecretQuery = isValueInArray(allRegexQueries[i].ID, queryFilter.IncludeQueries.ByIDs)
+		if len(queryFilter.IncludeQueries.ByIDs) > 0 && !allSecretsQueryAndCustom && (includeAllSecretsQuery || includeSpecificSecretQuery) {
+			regexQueries = append(regexQueries, allRegexQueries[i])
 		} else {
 			if !shouldExecuteQuery(
 				allRegexQueries[i].ID,

--- a/pkg/engine/secrets/inspector.go
+++ b/pkg/engine/secrets/inspector.go
@@ -96,7 +96,8 @@ func NewInspector(
 	executionTimeout int,
 	regexRulesContent string,
 ) (*Inspector, error) {
-	if disableSecretsQuery {
+	excludeSecretsQuery := isValueInArray("a88baa34-e2ad-44ea-ad6f-8cac87bc7c71", queryFilter.ExcludeQueries.ByIDs)
+	if disableSecretsQuery || excludeSecretsQuery {
 		return &Inspector{
 			ctx:                   ctx,
 			tracker:               tracker,
@@ -182,7 +183,12 @@ func compileRegexQueries(queryFilter *source.QueryInspectorParameters, allRegexQ
 
 	for i := range allRegexQueries {
 		if len(queryFilter.IncludeQueries.ByIDs) > 0 {
-			if isValueInArray(allRegexQueries[i].ID, queryFilter.IncludeQueries.ByIDs) {
+			includeAllSecretsQuery := isValueInArray("a88baa34-e2ad-44ea-ad6f-8cac87bc7c71", queryFilter.IncludeQueries.ByIDs)
+			includeSpecificSecretQuery := isValueInArray(allRegexQueries[i].ID, queryFilter.IncludeQueries.ByIDs)
+			if includeAllSecretsQuery {
+				regexQueries = append(regexQueries, allRegexQueries[i])
+				break
+			} else if includeSpecificSecretQuery {
 				regexQueries = append(regexQueries, allRegexQueries[i])
 			}
 		} else {

--- a/pkg/engine/secrets/inspector_test.go
+++ b/pkg/engine/secrets/inspector_test.go
@@ -495,7 +495,7 @@ func TestEntropyInterval(t *testing.T) {
 
 func TestCompileRegexQueries(t *testing.T) {
 	for _, in := range testCompileRegexesInput {
-		got, err := compileRegexQueries(in.inspectorParams, in.allRegexQueries, in.isCustomSecretsRegexes)
+		got, err := compileRegexQueries(in.inspectorParams, in.allRegexQueries, in.isCustomSecretsRegexes, "")
 		require.NoError(t, err, "test[%s] compileRegexQueries(%+v, %+v) error", in.name, in.inspectorParams, in.allRegexQueries)
 		require.Len(t,
 			got,

--- a/pkg/engine/secrets/inspector_test.go
+++ b/pkg/engine/secrets/inspector_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 var testCompileRegexesInput = []struct {
-	name            string
-	inspectorParams *source.QueryInspectorParameters
-	allRegexQueries []RegexQuery
-	wantIDs         []string
+	name                   string
+	inspectorParams        *source.QueryInspectorParameters
+	allRegexQueries        []RegexQuery
+	wantIDs                []string
+	isCustomSecretsRegexes bool
 }{
 	{
 		name: "empty_query",
@@ -27,8 +28,9 @@ var testCompileRegexesInput = []struct {
 			ExcludeQueries: source.ExcludeQueries{ByIDs: []string{}, ByCategories: []string{}},
 			InputDataPath:  "",
 		},
-		allRegexQueries: []RegexQuery{},
-		wantIDs:         []string{},
+		allRegexQueries:        []RegexQuery{},
+		wantIDs:                []string{},
+		isCustomSecretsRegexes: false,
 	},
 	{
 		name: "one_query",
@@ -44,7 +46,8 @@ var testCompileRegexesInput = []struct {
 				RegexStr: `['|"]?[p|P][a|A][s|S][s|S][w|W][o|O][r|R][d|D]['|\"]?\s*[:|=]\s*['|"]?([A-Za-z0-9/~^_!@&%()=?*+-]{4,})['|"]?`,
 			},
 		},
-		wantIDs: []string{"487f4be7-3fd9-4506-a07a-eae252180c08"},
+		wantIDs:                []string{"487f4be7-3fd9-4506-a07a-eae252180c08"},
+		isCustomSecretsRegexes: false,
 	},
 	{
 		name: "three_queries",
@@ -73,7 +76,8 @@ var testCompileRegexesInput = []struct {
 				RegexStr: `[a-zA-Z]{3,10}://[^/\s:@]*?:[^/\s:@]*?@[^/\s:@]*`,
 			},
 		},
-		wantIDs: []string{"487f4be7-3fd9-4506-a07a-eae252180c08", "4b2b5fd3-364d-4093-bac2-17391b2a5297", "c4d3b58a-e6d4-450f-9340-04f1e702eaae"},
+		wantIDs:                []string{"487f4be7-3fd9-4506-a07a-eae252180c08", "4b2b5fd3-364d-4093-bac2-17391b2a5297", "c4d3b58a-e6d4-450f-9340-04f1e702eaae"},
+		isCustomSecretsRegexes: false,
 	},
 	{
 		name: "include_one",
@@ -102,7 +106,8 @@ var testCompileRegexesInput = []struct {
 				RegexStr: `[a-zA-Z]{3,10}://[^/\s:@]*?:[^/\s:@]*?@[^/\s:@]*`,
 			},
 		},
-		wantIDs: []string{"487f4be7-3fd9-4506-a07a-eae252180c08"},
+		wantIDs:                []string{"487f4be7-3fd9-4506-a07a-eae252180c08"},
+		isCustomSecretsRegexes: false,
 	},
 	{
 		name: "exclude_one",
@@ -131,7 +136,8 @@ var testCompileRegexesInput = []struct {
 				RegexStr: `[a-zA-Z]{3,10}://[^/\s:@]*?:[^/\s:@]*?@[^/\s:@]*`,
 			},
 		},
-		wantIDs: []string{"487f4be7-3fd9-4506-a07a-eae252180c08", "4b2b5fd3-364d-4093-bac2-17391b2a5297"},
+		wantIDs:                []string{"487f4be7-3fd9-4506-a07a-eae252180c08", "4b2b5fd3-364d-4093-bac2-17391b2a5297"},
+		isCustomSecretsRegexes: false,
 	},
 }
 
@@ -489,7 +495,7 @@ func TestEntropyInterval(t *testing.T) {
 
 func TestCompileRegexQueries(t *testing.T) {
 	for _, in := range testCompileRegexesInput {
-		got, err := compileRegexQueries(in.inspectorParams, in.allRegexQueries)
+		got, err := compileRegexQueries(in.inspectorParams, in.allRegexQueries, in.isCustomSecretsRegexes)
 		require.NoError(t, err, "test[%s] compileRegexQueries(%+v, %+v) error", in.name, in.inspectorParams, in.allRegexQueries)
 		require.Len(t,
 			got,
@@ -537,6 +543,7 @@ func TestNewInspector(t *testing.T) {
 			in.disableSecrets,
 			60,
 			in.assetsSecretsQueryRegexRulesJSON,
+			false,
 		)
 		if in.wantErr {
 			require.Error(t,
@@ -587,6 +594,7 @@ func TestInspect(t *testing.T) {
 			false,
 			60,
 			assets.SecretsQueryRegexRulesJSON,
+			false,
 		)
 		require.NoError(t, err, "NewInspector() should not return error")
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -72,6 +72,8 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		return nil, err
 	}
 
+	isCustomSecretsRegexes := len(c.ScanParams.SecretsRegexesPath) > 0
+
 	secretsInspector, err := secrets.NewInspector(
 		ctx,
 		c.ExcludeResultsMap,
@@ -80,6 +82,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		c.ScanParams.DisableSecrets,
 		c.ScanParams.QueryExecTimeout,
 		secretsRegexRulesContent,
+		isCustomSecretsRegexes,
 	)
 	if err != nil {
 		log.Err(err)

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -91,6 +91,7 @@ func createServices(types, cloudProviders []string) (serviceSlice, *storage.Memo
 		false,
 		60,
 		assets.SecretsQueryRegexRulesJSON,
+		false,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/test/secrets_test.go
+++ b/test/secrets_test.go
@@ -56,6 +56,7 @@ func testSecretsInspector(t *testing.T, samplePaths []string, expectedVulnerabil
 		false,
 		60,
 		assets.SecretsQueryRegexRulesJSON,
+		false,
 	)
 	require.NoError(t, err, "unable to create secrets inspector")
 


### PR DESCRIPTION
**Proposed Changes**
- **Exclude Passwords and Secrets query (a88baa34-e2ad-44ea-ad6f-8cac87bc7c71) through --exclude-queries**: this approach took advantage of disableSecretsQuery verification. It was added verification to not include the Password and Secrets mechanism when the --exclude-queries points to Passwords and Secrets query (a88baa34-e2ad-44ea-ad6f-8cac87bc7c71) and --secrets-regexes-path is not used

- **Include Passwords and Secrets query (a88baa34-e2ad-44ea-ad6f-8cac87bc7c71) through --include-queries**: if --include-queries points to the Passwords and Secrets query (a88baa34-e2ad-44ea-ad6f-8cac87bc7c71), it should trigger all the rules defined inside the regex_rules.json. For that, we have some cases:
  - --include-queries points to the Passwords and Secrets query (a88baa34-e2ad-44ea-ad6f-8cac87bc7c71) and --secrets-regexes-path is used. This is, the user wants to merge all KICS regexes with the ones pointed by --secrets-regexes-path
  - --include-queries points to the Passwords and Secrets query (a88baa34-e2ad-44ea-ad6f-8cac87bc7c71) and --secrets-regexes-path is not used. This is, the user only wants to include the KICS regexes

I submit this contribution under the Apache-2.0 license.
