### PR TITLE
fix(cli): report-formats panics with uppercase input closes #4455

### DIFF
--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -218,6 +218,7 @@ func GenerateReport(path, filename string, body interface{}, formats []string, p
 	defer progressBar.Close()
 
 	for _, format := range formats {
+		format = strings.ToLower(format)
 		if err = reportGenerators[format](path, filename, body); err != nil {
 			log.Error().Msgf("Failed to generate %s report", format)
 			break

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/Checkmarx/kics/internal/console/flags"
@@ -99,7 +100,7 @@ func run(cmd *cobra.Command) error {
 
 func updateReportFormats() {
 	for _, format := range flags.GetMultiStrFlag(flags.ReportFormatsFlag) {
-		if format == "all" {
+		if strings.EqualFold(format, "all") {
 			flags.SetMultiStrFlag(flags.ReportFormatsFlag, consoleHelpers.ListReportFormats())
 			break
 		}


### PR DESCRIPTION
Closes #4455

I submit this contribution under the Apache-2.0 license.
