### PR TITLE
feat(e2e): added negative tests for queries-path

### DIFF
--- a/e2e/fixtures/samples/queries/invalid/invalid_metadata/terraform/athena_database_not_encrypted/metadata.json
+++ b/e2e/fixtures/samples/queries/invalid/invalid_metadata/terraform/athena_database_not_encrypted/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "b2315cae-b110-4426-81e0-80bb8640cddZ"
+  "queryName": "Athena Database Not Encrypted"
+  "severity": "high"
+  "category": "Encryption",
+  "descriptionText": "AWS Athena Database data in S3 should be encrypted",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_database#encryption_configuration",
+  "platform": "Terraform",
+  "descriptionID": "c90feea8"
+}

--- a/e2e/fixtures/samples/queries/invalid/invalid_metadata/terraform/athena_database_not_encrypted/query.rego
+++ b/e2e/fixtures/samples/queries/invalid/invalid_metadata/terraform/athena_database_not_encrypted/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_athena_database[name]
+	not common_lib.valid_key(resource, "encryption_configuration")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_athena_database[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_athena_database[{{%s}}] encryption_configuration is defined", [name]),
+		"keyActualValue": sprintf("aws_athena_database[{{%s}}] encryption_configuration is missing", [name]),
+	}
+}

--- a/e2e/fixtures/samples/queries/invalid/missing_metadata/terraform/athena_database_not_encrypted/query.rego
+++ b/e2e/fixtures/samples/queries/invalid/missing_metadata/terraform/athena_database_not_encrypted/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_athena_database[name]
+	not common_lib.valid_key(resource, "encryption_configuration")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_athena_database[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_athena_database[{{%s}}] encryption_configuration is defined", [name]),
+		"keyActualValue": sprintf("aws_athena_database[{{%s}}] encryption_configuration is missing", [name]),
+	}
+}

--- a/e2e/fixtures/samples/queries/valid/single_query/terraform/athena_database_not_encrypted/metadata.json
+++ b/e2e/fixtures/samples/queries/valid/single_query/terraform/athena_database_not_encrypted/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "b2315cae-b110-4426-81e0-80bb8640cddZ",
+  "queryName": "Athena Database Not Encrypted",
+  "severity": "high",
+  "category": "Encryption",
+  "descriptionText": "AWS Athena Database data in S3 should be encrypted",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_database#encryption_configuration",
+  "platform": "Terraform",
+  "descriptionID": "c90feea8"
+}

--- a/e2e/fixtures/samples/queries/valid/single_query/terraform/athena_database_not_encrypted/query.rego
+++ b/e2e/fixtures/samples/queries/valid/single_query/terraform/athena_database_not_encrypted/query.rego
@@ -1,0 +1,16 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_athena_database[name]
+	not common_lib.valid_key(resource, "encryption_configuration")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_athena_database[{{%s}}]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("aws_athena_database[{{%s}}] encryption_configuration is defined", [name]),
+		"keyActualValue": sprintf("aws_athena_database[{{%s}}] encryption_configuration is missing", [name]),
+	}
+}

--- a/e2e/testcases/e2e-cli-018_scan_exclude-categories.go
+++ b/e2e/testcases/e2e-cli-018_scan_exclude-categories.go
@@ -9,12 +9,9 @@ func init() { //nolint
 			Args: []cmdArgs{
 				[]string{"scan", "--exclude-categories", "Observability,Insecure Configurations", "-s",
 					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
-
-				[]string{"scan", "-s",
-					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
 			},
 		},
-		WantStatus: []int{20, 40},
+		WantStatus: []int{20},
 	}
 
 	Tests = append(Tests, testSample)

--- a/e2e/testcases/e2e-cli-031_scan_report-formats.go
+++ b/e2e/testcases/e2e-cli-031_scan_report-formats.go
@@ -8,7 +8,7 @@ func init() { //nolint
 		Args: args{
 			Args: []cmdArgs{
 				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_031_RESULT",
-					"--report-formats", "json,sarif,glsast,html",
+					"--report-formats", "json,SARIF,glsast,Html",
 					"-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
 			},
 			ExpectedResult: []ResultsValidation{

--- a/e2e/testcases/e2e-cli-039_scan_log-path_log-level.go
+++ b/e2e/testcases/e2e-cli-039_scan_log-path_log-level.go
@@ -11,7 +11,7 @@ func init() { //nolint
 			Args: []cmdArgs{
 
 				[]string{"scan", "--log-path", "output/E2E_CLI_039_LOG",
-					"--log-level", "TRACE",
+					"--log-level", "Trace",
 					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
 			},
 

--- a/e2e/testcases/e2e-cli-043_scan_cloud-provider.go
+++ b/e2e/testcases/e2e-cli-043_scan_cloud-provider.go
@@ -14,7 +14,7 @@ func init() { //nolint
 					"--cloud-provider"},
 
 				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml",
-					"--cloud-provider", "aws"},
+					"--cloud-provider", "aWs"},
 			},
 		},
 		WantStatus: []int{126, 126, 50},

--- a/e2e/testcases/e2e-cli-051_scan_custom-queries-path.go
+++ b/e2e/testcases/e2e-cli-051_scan_custom-queries-path.go
@@ -1,0 +1,20 @@
+package testcases
+
+// E2E-CLI-051 - Kics scan command with --queries-path
+// should load and execute queries found in the provided path
+func init() { //nolint
+	testSample := TestCase{
+		Name: "should load and execute queries from a custom path [E2E-CLI-051]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "--queries-path", "fixtures/samples/queries/valid/single_query", "-p", "fixtures/samples/bom-positive.tf"},
+				[]string{"scan", "--queries-path", "fixtures/samples/queries/invalid/invalid_metadata", "-p", "fixtures/samples/bom-positive.tf"},
+				[]string{"scan", "--queries-path", "fixtures/samples/queries/invalid/missing_metadata", "-p", "fixtures/samples/bom-positive.tf"},
+				[]string{"scan", "--queries-path", "fixtures/samples/invalid_path", "-p", "fixtures/samples/bom-positive.tf"},
+			},
+		},
+		WantStatus: []int{50, 0, 0, 126},
+	}
+
+	Tests = append(Tests, testSample)
+}


### PR DESCRIPTION
Closes #

**Proposed Changes**
- This PR introduces a new E2E Test case related to negative tests for queries-path (-q) flag. The purpose of these tests is to cover custom inputs from the user, mainly focused on bad inputs, such as invalid or badly formatted queries.
- Moreover, to increase the coverage of testing samples, some tests had new inputs, using them as case insensitive (to catch errors related to case sensitivity).

I submit this contribution under the Apache-2.0 license.
