### PR TITLE
feat(parser): Enabled parsers ignore comment by line

### DIFF
--- a/docs/running-kics.md
+++ b/docs/running-kics.md
@@ -160,11 +160,13 @@ resource "google_storage_bucket" "example" {
 ```
 
 KICS currently supports five commands:
-- `ignore`: Will ignore file when running a scan;
-- `enable=<query_id>,<query_id>`: Will get results on this file **only** for listed queries;
-- `disable=<query_id>,<query_id>`: Will ignore results on this file for listed queries;
-- `ignore-line`: Will ignore the line beneath the comment on the results
-- `ignore-block`: Will ignore the block and all its key-value pairs on the results
+- Must be in file's start:
+    - `ignore`: Will ignore file when running a scan;
+    - `enable=<query_id>,<query_id>`: Will get results on this file **only** for listed queries;
+    - `disable=<query_id>,<query_id>`: Will ignore results on this file for listed queries;
+- Can be used in all file extension:
+    - `ignore-line`: Will ignore the line beneath the comment on the results
+    - `ignore-block`: Will ignore the block and all its key-value pairs on the results
 
 The order of prescendence in above commands are:
 1. ignore

--- a/pkg/kics/resolver_sink.go
+++ b/pkg/kics/resolver_sink.go
@@ -56,6 +56,7 @@ func (s *Service) resolverSink(ctx context.Context, filename, scanID string) ([]
 				Content:          string(rfile.Content),
 				HelmID:           rfile.SplitID,
 				IDInfo:           rfile.IDInfo,
+				LinesIgnore:      documents.IgnoreLines,
 			}
 			s.saveToFile(ctx, &file)
 		}

--- a/pkg/model/comment_yaml_test.go
+++ b/pkg/model/comment_yaml_test.go
@@ -240,7 +240,7 @@ func Test_ignoreCommentsYAML(t *testing.T) {
 		},
 		{
 			name: "test_3: regular-comment",
-			want: []int{},
+			want: nil,
 			args: args{
 				&yaml.Node{
 					Kind: yaml.MappingNode,

--- a/pkg/model/comment_yaml_test.go
+++ b/pkg/model/comment_yaml_test.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Test_ignoreCommentsYAML tests the YAML marshalling of the ignoreComments type.
 func Test_ignoreCommentsYAML(t *testing.T) {
 	type args struct {
 		node *yaml.Node
@@ -35,7 +36,7 @@ func Test_ignoreCommentsYAML(t *testing.T) {
 						},
 						{
 							Kind:        yaml.ScalarNode,
-							HeadComment: "# kics ignore-block",
+							HeadComment: "# kics-scan ignore-block",
 							Value:       "key_object",
 							Line:        2,
 						},
@@ -136,7 +137,7 @@ func Test_ignoreCommentsYAML(t *testing.T) {
 					Content: []*yaml.Node{
 						{
 							Kind:        yaml.ScalarNode,
-							HeadComment: "# kics ignore-line",
+							HeadComment: "# kics-scan ignore-line",
 							Value:       "key",
 							Line:        1,
 						},
@@ -247,7 +248,7 @@ func Test_ignoreCommentsYAML(t *testing.T) {
 					Content: []*yaml.Node{
 						{
 							Kind:        yaml.ScalarNode,
-							HeadComment: "# kics regular comment",
+							HeadComment: "# kics-scan regular comment",
 							Value:       "key",
 							Line:        1,
 						},
@@ -355,7 +356,7 @@ func Test_ignoreCommentsYAML(t *testing.T) {
 			args: args{
 				&yaml.Node{
 					Kind:        yaml.MappingNode,
-					HeadComment: "# kics ignore-block",
+					HeadComment: "# kics-scan ignore-block",
 					Content: []*yaml.Node{
 						{
 							Kind:  yaml.ScalarNode,
@@ -479,7 +480,7 @@ func Test_ignoreCommentsYAML(t *testing.T) {
 						},
 						{
 							Kind:        yaml.ScalarNode,
-							HeadComment: "# kics ignore-block",
+							HeadComment: "# kics-scan ignore-block",
 							Value:       "seq_object",
 							Line:        5,
 						},

--- a/pkg/model/comments.go
+++ b/pkg/model/comments.go
@@ -1,0 +1,39 @@
+package model
+
+// RemoveDuplicates removes duplicate lines from a slice of lines.
+func RemoveDuplicates(lines []int) []int {
+	seen := make(map[int]bool)
+	var result []int
+	for _, line := range lines {
+		if !seen[line] {
+			result = append(result, line)
+			seen[line] = true
+		}
+	}
+	return result
+}
+
+// ProcessCommands processes a slice of commands.
+func ProcessCommands(commands []string) CommentCommand {
+	for _, command := range commands {
+		switch com := CommentCommand(command); com {
+		case IgnoreLine:
+			return IgnoreLine
+		case IgnoreBlock:
+			return IgnoreBlock
+		default:
+			continue
+		}
+	}
+
+	return CommentCommand(commands[0])
+}
+
+// Range returns a slice of lines between the start and end line numbers.
+func Range(start, end int) (lines []int) {
+	lines = make([]int, end-start+1)
+	for i := range lines {
+		lines[i] = start + i
+	}
+	return
+}

--- a/pkg/model/comments_test.go
+++ b/pkg/model/comments_test.go
@@ -1,0 +1,108 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveDuplicates(t *testing.T) {
+	type args struct {
+		lines []int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []int
+	}{
+		{
+			name: "remove duplicates",
+			args: args{
+				lines: []int{1, 1, 2, 3, 4, 5},
+			},
+			want: []int{1, 2, 3, 4, 5},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RemoveDuplicates(tt.args.lines); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RemoveDuplicates() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProcessCommands(t *testing.T) {
+	type args struct {
+		commands []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want CommentCommand
+	}{
+		{
+			name: "process commands: ignore-line",
+			args: args{
+				commands: []string{"ignore-line"},
+			},
+			want: IgnoreLine,
+		},
+		{
+			name: "process commands: ignore-block",
+			args: args{
+				commands: []string{"ignore-block"},
+			},
+			want: IgnoreBlock,
+		},
+		{
+			name: "process commands: regular-command",
+			args: args{
+				commands: []string{"regular-command"},
+			},
+			want: CommentCommand("regular-command"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProcessCommands(tt.args.commands); got != tt.want {
+				t.Errorf("ProcessCommands() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRange(t *testing.T) {
+	type args struct {
+		start int
+		end   int
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantLines []int
+	}{
+		{
+			name: "range: start=1, end=5",
+			args: args{
+				start: 1,
+				end:   5,
+			},
+			wantLines: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name: "range: start=1, end=1",
+			args: args{
+				start: 1,
+				end:   1,
+			},
+			wantLines: []int{1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotLines := Range(tt.args.start, tt.args.end); !reflect.DeepEqual(gotLines, tt.wantLines) {
+				t.Errorf("Range() = %v, want %v", gotLines, tt.wantLines)
+			}
+		})
+	}
+}

--- a/pkg/model/comments_test.go
+++ b/pkg/model/comments_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 )
 
+// TestRemoveDuplicates tests the RemoveDuplicates function.
 func TestRemoveDuplicates(t *testing.T) {
 	type args struct {
 		lines []int
@@ -31,6 +32,7 @@ func TestRemoveDuplicates(t *testing.T) {
 	}
 }
 
+// TestProcessCommands tests the ProcessCommands function.
 func TestProcessCommands(t *testing.T) {
 	type args struct {
 		commands []string
@@ -71,6 +73,7 @@ func TestProcessCommands(t *testing.T) {
 	}
 }
 
+// TestRange tests the Range function.
 func TestRange(t *testing.T) {
 	type args struct {
 		start int

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -62,7 +62,7 @@ var (
 
 var (
 	// KICSCommentRgxp is the regexp to identify if a comment is a KICS comment
-	KICSCommentRgxp = regexp.MustCompile(`^((/{2})|#)*\s*kics\s*`)
+	KICSCommentRgxp = regexp.MustCompile(`^((/{2})|#)*\s*kics-scan\s*`)
 )
 
 // Version - is the model for the version response

--- a/pkg/parser/docker/comments.go
+++ b/pkg/parser/docker/comments.go
@@ -29,26 +29,13 @@ func (i *ignore) setIgnore(from string) {
 // ignoreBlock adds block lines to be ignored to the ignore struct.
 func (i *ignore) ignoreBlock(node *parser.Node, from string) {
 	if _, ok := i.from[from]; ok {
-		i.lines = append(i.lines, commentRange(node.StartLine, node.EndLine)...)
+		i.lines = append(i.lines, model.Range(node.StartLine, node.EndLine)...)
 	}
 }
 
 // getIgnoreLines returns the lines that are being ignored.
-func (i *ignore) getIgnoreLines() []int { // nolint
-	return removeDups(i.lines)
-}
-
-// removeDups removes duplicates from a slice of ints.
-func removeDups(lines []int) []int { // nolint
-	seen := make(map[int]bool)
-	var result []int
-	for _, line := range lines {
-		if !seen[line] {
-			result = append(result, line)
-			seen[line] = true
-		}
-	}
-	return result
+func (i *ignore) getIgnoreLines() []int {
+	return model.RemoveDuplicates(i.lines)
 }
 
 // getIgnoreComments returns lines to be ignored for each node of the dockerfile
@@ -60,7 +47,7 @@ func (i *ignore) getIgnoreComments(node *parser.Node) (ignore bool) {
 	for idx, comment := range node.PrevComment {
 		switch processComment(comment) {
 		case model.IgnoreLine:
-			i.lines = append(i.lines, commentRange(node.StartLine-(idx+1), node.EndLine)...)
+			i.lines = append(i.lines, model.Range(node.StartLine-(idx+1), node.EndLine)...)
 		case model.IgnoreBlock:
 			i.lines = append(i.lines, node.StartLine-(idx+1))
 			ignore = true
@@ -79,33 +66,8 @@ func processComment(comment string) (value model.CommentCommand) {
 	if model.KICSCommentRgxp.MatchString(commentLower) {
 		commentLower = model.KICSCommentRgxp.ReplaceAllString(commentLower, "")
 		commands := strings.Split(strings.Trim(commentLower, "\n"), " ")
-		value = processCommands(commands)
+		value = model.ProcessCommands(commands)
 		return
 	}
 	return model.CommentCommand(comment)
-}
-
-// processCommands goes over kics commands in a line and returns the type of command given
-func processCommands(commands []string) model.CommentCommand {
-	for _, command := range commands {
-		switch com := model.CommentCommand(command); com {
-		case model.IgnoreLine:
-			return model.IgnoreLine
-		case model.IgnoreBlock:
-			return model.IgnoreBlock
-		default:
-			continue
-		}
-	}
-
-	return model.CommentCommand(commands[0])
-}
-
-// commentRange returns the range of the comment between the start and end lines.
-func commentRange(start, end int) (lines []int) {
-	lines = make([]int, end-start+1)
-	for i := range lines {
-		lines[i] = start + i
-	}
-	return
 }

--- a/pkg/parser/docker/comments_test.go
+++ b/pkg/parser/docker/comments_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test_newIgnore tests the newIgnore function to ensure it returns a new ignore struct with the correct values set.
 func Test_newIgnore(t *testing.T) {
 	tests := []struct {
 		name string
@@ -30,6 +31,7 @@ func Test_newIgnore(t *testing.T) {
 	}
 }
 
+// Test_ignore_setIgnore tests the setIgnore function to ensure it sets the correct values.
 func Test_ignore_setIgnore(t *testing.T) {
 	type fields struct {
 		from  map[string]bool
@@ -67,6 +69,7 @@ func Test_ignore_setIgnore(t *testing.T) {
 	}
 }
 
+// Test_ignore_ignoreBlock tests the ignoreBlock function to ensure it sets the correct values.
 func Test_ignore_ignoreBlock(t *testing.T) {
 	type fields struct {
 		from  map[string]bool
@@ -130,6 +133,7 @@ func Test_ignore_ignoreBlock(t *testing.T) {
 	}
 }
 
+// Test_ignore_getIgnoreLines tests the getIgnoreLines function to ensure it returns the correct values.
 func Test_ignore_getIgnoreLines(t *testing.T) {
 	type fields struct {
 		from  map[string]bool
@@ -170,6 +174,7 @@ func Test_ignore_getIgnoreLines(t *testing.T) {
 	}
 }
 
+// Test_ignore_getIgnoreComments tests the getIgnoreComments function to ensure it returns the correct values.
 func Test_ignore_getIgnoreComments(t *testing.T) {
 	type fields struct {
 		from  map[string]bool
@@ -193,7 +198,7 @@ func Test_ignore_getIgnoreComments(t *testing.T) {
 			},
 			args: args{
 				node: &parser.Node{
-					PrevComment: []string{"kics ignore-line"},
+					PrevComment: []string{"kics-scan ignore-line"},
 					StartLine:   3,
 					EndLine:     3,
 				},
@@ -209,7 +214,7 @@ func Test_ignore_getIgnoreComments(t *testing.T) {
 			},
 			args: args{
 				node: &parser.Node{
-					PrevComment: []string{"kics ignore-line"},
+					PrevComment: []string{"kics-scan ignore-line"},
 					StartLine:   3,
 					EndLine:     6,
 				},
@@ -225,7 +230,7 @@ func Test_ignore_getIgnoreComments(t *testing.T) {
 			},
 			args: args{
 				node: &parser.Node{
-					PrevComment: []string{"kics ignore-line", "kics regular command"},
+					PrevComment: []string{"kics-scan ignore-line", "kics-scan regular command"},
 					StartLine:   3,
 					EndLine:     6,
 				},
@@ -257,7 +262,7 @@ func Test_ignore_getIgnoreComments(t *testing.T) {
 			},
 			args: args{
 				node: &parser.Node{
-					PrevComment: []string{"kics ignore-block"},
+					PrevComment: []string{"kics-scan ignore-block"},
 					StartLine:   3,
 					EndLine:     6,
 				},

--- a/pkg/parser/docker/parser.go
+++ b/pkg/parser/docker/parser.go
@@ -98,9 +98,9 @@ func (p *Parser) Parse(_ string, fileContent []byte) ([]model.Document, []int, e
 
 	documents = append(documents, *doc)
 
-	// ignoreLines := ignoreStruct.getIgnoreLines() nolint
+	ignoreLines := ignoreStruct.getIgnoreLines()
 
-	return documents, []int{}, nil
+	return documents, ignoreLines, nil
 }
 
 // GetKind returns the kind of the parser

--- a/pkg/parser/docker/parser_test.go
+++ b/pkg/parser/docker/parser_test.go
@@ -43,7 +43,7 @@ func TestParser_Parse(t *testing.T) {
 		`
 		FROM ubuntu:xenial
 		RUN echo hi > /etc/hi.conf
-		# kics ignore-line
+		# kics-scan ignore-line
 		CMD ["echo"]
 		HEALTHCHECK --retries=5 CMD echo hi
 		ONBUILD ADD foo bar
@@ -54,7 +54,7 @@ func TestParser_Parse(t *testing.T) {
 		CMD ["echo"]
 		`,
 		`
-		# kics ignore-block
+		# kics-scan ignore-block
 		FROM golang:alpine
 		ENV CGO_ENABLED=0
 		WORKDIR /app

--- a/pkg/parser/docker/parser_test.go
+++ b/pkg/parser/docker/parser_test.go
@@ -68,7 +68,7 @@ func TestParser_Parse(t *testing.T) {
 	}
 
 	for idx, sampleFile := range sample {
-		doc, _, err := p.Parse("Dockerfile", []byte(sampleFile))
+		doc, igLines, err := p.Parse("Dockerfile", []byte(sampleFile))
 		switch idx {
 		case 0:
 			require.NoError(t, err)
@@ -78,6 +78,7 @@ func TestParser_Parse(t *testing.T) {
 			docJDk := doc[0]["command"].(map[string]interface{})["openjdk:11-jdk"]
 			require.Len(t, docJDk, 7)
 			require.Contains(t, docJDk.([]interface{})[5].(map[string]interface{})["Value"].([]interface{})[0], "${JAR_FILE}")
+			// require.Equal(t, nil, igLines)
 		case 1:
 			require.NoError(t, err)
 			require.Len(t, doc, 1)
@@ -90,6 +91,7 @@ func TestParser_Parse(t *testing.T) {
 			require.Len(t, docXec2, 3)
 			require.Contains(t, docXec.([]interface{})[3].(map[string]interface{})["Flags"].([]interface{})[0], "--retries=5")
 			require.Contains(t, docXec.([]interface{})[4].(map[string]interface{})["SubCmd"], "add")
+			require.Equal(t, []int{4, 5}, igLines)
 		case 2:
 			require.NoError(t, err)
 			require.Len(t, doc, 1)
@@ -98,6 +100,7 @@ func TestParser_Parse(t *testing.T) {
 			docGoALP := doc[0]["command"].(map[string]interface{})["golang:alpine"]
 			require.Len(t, docGoALP, 5)
 			require.Contains(t, docGoALP.([]interface{})[4].(map[string]interface{})["Value"].([]interface{})[0], "${GIT_USER}")
+			require.Equal(t, []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, igLines)
 		}
 	}
 }

--- a/pkg/parser/terraform/comment/comment_test.go
+++ b/pkg/parser/terraform/comment/comment_test.go
@@ -63,6 +63,7 @@ func TestComment_ParseComments(t *testing.T) {
 			want: Ignore{
 				model.IgnoreBlock: []hcl.Pos{
 					{Line: 3, Column: 11, Byte: 34},
+					{Line: 2, Column: 0, Byte: 0},
 				},
 				model.IgnoreLine:    []hcl.Pos{},
 				model.IgnoreComment: []hcl.Pos{},
@@ -77,6 +78,7 @@ func TestComment_ParseComments(t *testing.T) {
 				model.IgnoreBlock: []hcl.Pos{},
 				model.IgnoreLine: []hcl.Pos{
 					{Line: 5, Column: 16, Byte: 130},
+					{Line: 4, Column: 0, Byte: 0},
 				},
 				model.IgnoreComment: []hcl.Pos{},
 			},
@@ -90,8 +92,8 @@ func TestComment_ParseComments(t *testing.T) {
 				model.IgnoreBlock: []hcl.Pos{},
 				model.IgnoreLine:  []hcl.Pos{},
 				model.IgnoreComment: []hcl.Pos{
-					{Line: 5, Column: 1, Byte: 117},
-					{Line: 7, Column: 1, Byte: 179},
+					{Line: 4, Column: 0, Byte: 0},
+					{Line: 6, Column: 0, Byte: 0},
 				},
 			},
 			wantErr: false,
@@ -103,6 +105,7 @@ func TestComment_ParseComments(t *testing.T) {
 			want: Ignore{
 				model.IgnoreBlock: []hcl.Pos{
 					{Line: 5, Column: 9, Byte: 124},
+					{Line: 4, Column: 0, Byte: 0},
 				},
 				model.IgnoreLine:    []hcl.Pos{},
 				model.IgnoreComment: []hcl.Pos{},
@@ -143,13 +146,13 @@ func TestComment_GetIgnoreLines(t *testing.T) {
 			name:     "TestComment_GetIgnoreLines: ignore-line",
 			content:  samples["ignore-line"],
 			filename: "",
-			want:     []int{5},
+			want:     []int{5, 4},
 		},
 		{
 			name:     "TestComment_GetIgnoreLines: regular-comment",
 			content:  samples["regular-comment"],
 			filename: "",
-			want:     []int{5, 7},
+			want:     []int{4, 6},
 		},
 		{
 			name:     "TestComment_GetIgnoreLines: ignore inner-block",

--- a/pkg/parser/terraform/comment/comment_test.go
+++ b/pkg/parser/terraform/comment/comment_test.go
@@ -13,7 +13,7 @@ import (
 var (
 	samples = map[string][]byte{
 		"ignore-block": []byte(`
-		// kics ignore-block
+		// kics-scan ignore-block
 		resource "aws_api_gateway_stage" "positive2" {
 			deployment_id = "some deployment id"
 			rest_api_id   = "some rest api id"
@@ -22,14 +22,14 @@ var (
 		"ignore-line": []byte(`
 		resource "aws_api_gateway_stage" "positive2" {
 		  deployment_id = "some deployment id"
-		  // kics ignore-line
+		  // kics-scan ignore-line
 		  rest_api_id   = "some rest api id"
 		  stage_name    = "development"
 		}`),
 		"regular-comment": []byte(`
 		resource "aws_api_gateway_stage" "positive2" {
 		  deployment_id = "some deployment id"
-		  // kics do-not-ignore
+		  // kics-scan do-not-ignore
 		  rest_api_id   = "some rest api id"
 		  // regular comment
 		  stage_name    = "development"
@@ -37,7 +37,7 @@ var (
 		"ignore-inner-block": []byte(`
 		resource "aws_api_gateway_stage" "positive2" {
 		  deployment_id = "some deployment id"
-		  // kics ignore-block
+		  // kics-scan ignore-block
 		  tags = {
 			Terraform   = "true"
 			Environment = "dev"
@@ -62,7 +62,7 @@ func TestComment_ParseComments(t *testing.T) {
 			filename: "",
 			want: Ignore{
 				model.IgnoreBlock: []hcl.Pos{
-					{Line: 3, Column: 11, Byte: 34},
+					{Line: 3, Column: 11, Byte: 39},
 					{Line: 2, Column: 0, Byte: 0},
 				},
 				model.IgnoreLine:    []hcl.Pos{},
@@ -77,7 +77,7 @@ func TestComment_ParseComments(t *testing.T) {
 			want: Ignore{
 				model.IgnoreBlock: []hcl.Pos{},
 				model.IgnoreLine: []hcl.Pos{
-					{Line: 5, Column: 16, Byte: 130},
+					{Line: 5, Column: 16, Byte: 135},
 					{Line: 4, Column: 0, Byte: 0},
 				},
 				model.IgnoreComment: []hcl.Pos{},
@@ -104,7 +104,7 @@ func TestComment_ParseComments(t *testing.T) {
 			filename: "",
 			want: Ignore{
 				model.IgnoreBlock: []hcl.Pos{
-					{Line: 5, Column: 9, Byte: 124},
+					{Line: 5, Column: 9, Byte: 129},
 					{Line: 4, Column: 0, Byte: 0},
 				},
 				model.IgnoreLine:    []hcl.Pos{},

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -13,10 +13,10 @@ var (
 	have = `
 resource "aws_s3_bucket" "b" {
   bucket = "S3B_541"
-  // kics ignore-line
+  // kics-scan ignore-line
   acl    = "public-read"
   // regular comment
-  // kics ignore-block
+  // kics-scan ignore-block
   tags = {
     Name        = "My bucket"
     Environment = "Dev"

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -13,8 +13,10 @@ var (
 	have = `
 resource "aws_s3_bucket" "b" {
   bucket = "S3B_541"
+  // kics ignore-line
   acl    = "public-read"
-
+  // regular comment
+  // kics ignore-block
   tags = {
     Name        = "My bucket"
     Environment = "Dev"
@@ -71,8 +73,9 @@ func TestParser_SupportedExtensions(t *testing.T) {
 // Test_Parser tests the functions [Parser()] and all the methods called by them
 func Test_Parser(t *testing.T) {
 	parser := NewDefault()
-	document, _, err := parser.Parse("test.tf", []byte(have))
+	document, linesToIgnore, err := parser.Parse("test.tf", []byte(have))
 
+	require.Equal(t, []int{8, 9, 10, 11, 5, 4, 6}, linesToIgnore)
 	require.NoError(t, err)
 	require.Len(t, document, 1)
 	require.Contains(t, document[0], "resource")

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -35,7 +35,10 @@ func (p *Parser) Parse(filePath string, fileContent []byte) ([]model.Document, [
 		return nil, []int{}, errors.Wrap(errors.New("invalid yaml"), "failed to parse yaml")
 	}
 
-	return convertKeysToString(addExtraInfo(documents, filePath)), []int{}, nil
+	linesToIgnore := model.NewIgnore.GetLines()
+	model.NewIgnore.Reset()
+
+	return convertKeysToString(addExtraInfo(documents, filePath)), linesToIgnore, nil
 }
 
 // convertKeysToString goes through every document to convert map[interface{}]interface{}

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -32,7 +32,7 @@ func TestParser_SupportedTypes(t *testing.T) {
 func TestParser_Parse(t *testing.T) { //nolint
 	p := &Parser{}
 	have := []string{`
-# kics ignore-block
+# kics-scan ignore-block
 martin:
   name: test
 ---
@@ -40,7 +40,7 @@ martin2:
   name: test2
 `, `
 ---
-# kics ignore-block
+# kics-scan ignore-block
 - name: Create an empty bucket2
   amazon.aws.aws_s3:
     bucket: mybucket
@@ -51,7 +51,7 @@ martin2:
 test:
   - &test_anchor
     group:
-      # kics ignore-line
+      # kics-scan ignore-line
       name: "cx"
 test_2:
   perm:

--- a/pkg/parser/yaml/parser_test.go
+++ b/pkg/parser/yaml/parser_test.go
@@ -32,6 +32,7 @@ func TestParser_SupportedTypes(t *testing.T) {
 func TestParser_Parse(t *testing.T) { //nolint
 	p := &Parser{}
 	have := []string{`
+# kics ignore-block
 martin:
   name: test
 ---
@@ -39,6 +40,7 @@ martin2:
   name: test2
 `, `
 ---
+# kics ignore-block
 - name: Create an empty bucket2
   amazon.aws.aws_s3:
     bucket: mybucket
@@ -49,6 +51,7 @@ martin2:
 test:
   - &test_anchor
     group:
+      # kics ignore-line
       name: "cx"
 test_2:
   perm:
@@ -72,8 +75,9 @@ downscaler_enabled: "false"
 	}
 
 	type wantExpect struct {
-		want    string
-		wantErr bool
+		want              string
+		wantErr           bool
+		wantLinesToIgnore []int
 	}
 
 	want := []wantExpect{
@@ -85,16 +89,16 @@ downscaler_enabled: "false"
 				  "_kics_line": 0
 				},
 				"_kics_martin": {
-				  "_kics_line": 2
+				  "_kics_line": 3
 				}
 			  },
 			  "martin": {
 				"_kics_lines": {
 				  "_kics__default": {
-					"_kics_line": 2
+					"_kics_line": 3
 				  },
 				  "_kics_name": {
-					"_kics_line": 3
+					"_kics_line": 4
 				  }
 				},
 				"name": "test"
@@ -106,16 +110,16 @@ downscaler_enabled: "false"
 				  "_kics_line": 0
 				},
 				"_kics_martin2": {
-				  "_kics_line": 5
+				  "_kics_line": 6
 				}
 			  },
 			  "martin2": {
 				"_kics_lines": {
 				  "_kics__default": {
-					"_kics_line": 5
+					"_kics_line": 6
 				  },
 				  "_kics_name": {
-					"_kics_line": 6
+					"_kics_line": 7
 				  }
 				},
 				"name": "test2"
@@ -123,7 +127,8 @@ downscaler_enabled: "false"
 			}
 		  ]
 		  `,
-			wantErr: false,
+			wantErr:           false,
+			wantLinesToIgnore: []int{3, 2, 4},
 		},
 		{
 			want: `[
@@ -133,13 +138,13 @@ downscaler_enabled: "false"
 				  "_kics_arr": [
 					{
 					  "_kics__default": {
-						"_kics_line": 3
-					  },
-					  "_kics_amazon.aws.aws_s3": {
 						"_kics_line": 4
 					  },
+					  "_kics_amazon.aws.aws_s3": {
+						"_kics_line": 5
+					  },
 					  "_kics_name": {
-						"_kics_line": 3
+						"_kics_line": 4
 					  }
 					}
 				  ],
@@ -151,16 +156,16 @@ downscaler_enabled: "false"
 				  "amazon.aws.aws_s3": {
 					"_kics_lines": {
 					  "_kics__default": {
-						"_kics_line": 4
-					  },
-					  "_kics_bucket": {
 						"_kics_line": 5
 					  },
-					  "_kics_mode": {
+					  "_kics_bucket": {
 						"_kics_line": 6
 					  },
-					  "_kics_permission": {
+					  "_kics_mode": {
 						"_kics_line": 7
+					  },
+					  "_kics_permission": {
+						"_kics_line": 8
 					  }
 					},
 					"bucket": "mybucket",
@@ -173,7 +178,8 @@ downscaler_enabled: "false"
 			}
 		  ]
 		  `,
-			wantErr: false,
+			wantErr:           false,
+			wantLinesToIgnore: []int{4, 3, 5, 6, 7, 8},
 		},
 		{
 			want: `[
@@ -196,7 +202,7 @@ downscaler_enabled: "false"
 				  "_kics_line": 2
 				},
 				"_kics_test_2": {
-				  "_kics_line": 6
+				  "_kics_line": 7
 				}
 			  },
 			  "test": [
@@ -207,7 +213,7 @@ downscaler_enabled: "false"
 						"_kics_line": 4
 					  },
 					  "_kics_name": {
-						"_kics_line": 5
+						"_kics_line": 6
 					  }
 					},
 					"name": "cx"
@@ -217,20 +223,20 @@ downscaler_enabled: "false"
 			  "test_2": {
 				"_kics_lines": {
 				  "_kics__default": {
-					"_kics_line": 6
+					"_kics_line": 7
 				  },
 				  "_kics_perm": {
 					"_kics_arr": [
 					  {
 						"_kics_<<": {
-						  "_kics_line": 8
+						  "_kics_line": 9
 						},
 						"_kics__default": {
-						  "_kics_line": 8
+						  "_kics_line": 9
 						}
 					  }
 					],
-					"_kics_line": 7
+					"_kics_line": 8
 				  }
 				},
 				"perm": [
@@ -240,20 +246,23 @@ downscaler_enabled: "false"
 			}
 		  ]
 		  `,
-			wantErr: false,
+			wantErr:           false,
+			wantLinesToIgnore: []int{5, 6},
 		},
 		{
-			want:    "{}",
-			wantErr: true,
+			want:              "{}",
+			wantErr:           true,
+			wantLinesToIgnore: []int{},
 		},
 	}
 
 	for idx, tt := range have {
 		t.Run(fmt.Sprintf("test_parse_case_%d", idx), func(t *testing.T) {
-			doc, _, err := p.Parse("test.yaml", []byte(tt))
+			doc, linesToIgnore, err := p.Parse("test.yaml", []byte(tt))
 			if want[idx].wantErr {
 				require.Error(t, err)
 			} else {
+				require.Equal(t, want[idx].wantLinesToIgnore, linesToIgnore)
 				require.NoError(t, err)
 				compareJSONLine(t, doc, want[idx].want)
 			}


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #4420

**Proposed Changes**
- Enabled Ignore Line By comments for YAML, Dockerfile, and Terraform Parsers
- Added Unit Tests to parsers for ignoring comments
- Enabled feature for Helm
- Added Helper comment Library to be used by all parsers
- Add Documentation
- changed `kics ignore-...` to `kics-scan ignore-...` for consistency 


I submit this contribution under the Apache-2.0 license.
