### PR TITLE
fix(engine): Fixed comments commands on windows

### DIFF
--- a/docs/running-kics.md
+++ b/docs/running-kics.md
@@ -222,6 +222,17 @@ in this case only lines from 1 to 3 will be ignored.
 
 `ignore-line` will ignore all lines of a multi-line command in Docker.
 
+**NOTE**: For YAML when trying to ignore the whole resource this file should start with `---` and then the KICS comment command as you can see on the following example:
+```yaml
+1: ---
+2: # kics-scan ignore-block
+3: apiVersion: v1
+4: kind: Pod
+5: metadata:
+6:  name: memory-demo-1
+7:  namespace: mem-example
+```
+
 This feature is supported by all extensions that supports comments. Currently, KICS supports this feature for:
 - Dockerfile;
 - HCL (Terraform);

--- a/pkg/model/comment_yaml.go
+++ b/pkg/model/comment_yaml.go
@@ -46,6 +46,9 @@ func ignoreCommentsYAML(node *yaml.Node) {
 	}
 	// check if comment is in the content
 	for i, content := range node.Content {
+		if content.FootComment != "" && i+2 < len(node.Content) {
+			linesIgnore = append(linesIgnore, processCommentYAML((*comment)(&content.FootComment), i+2, node, node.Kind)...) //nolint
+		}
 		if content.HeadComment == "" {
 			continue
 		}
@@ -117,14 +120,13 @@ func getNodeLastLine(node *yaml.Node) (lastLine int) {
 // value returns the value of the comment
 func (c *comment) value() (value CommentCommand) {
 	comment := strings.ToLower(string(*c))
-
 	// check if we are working with kics command
 	if KICSCommentRgxp.MatchString(comment) {
 		comment = KICSCommentRgxp.ReplaceAllString(comment, "")
-		commands := strings.Split(strings.Trim(comment, "\n"), " ")
+		comment = strings.Trim(comment, "\n")
+		commands := strings.Split(strings.Trim(comment, "\r"), " ")
 		value = ProcessCommands(commands)
 		return
 	}
-
 	return CommentCommand(comment)
 }

--- a/pkg/parser/terraform/comment/comment.go
+++ b/pkg/parser/terraform/comment/comment.go
@@ -22,11 +22,11 @@ func (c *comment) value() (value model.CommentCommand) {
 	// check if we are working with kics command
 	if model.KICSCommentRgxp.MatchString(comment) {
 		comment = model.KICSCommentRgxp.ReplaceAllString(comment, "")
-		commands := strings.Split(strings.Trim(comment, "\n"), " ")
+		comment = strings.Trim(comment, "\n")
+		commands := strings.Split(strings.Trim(comment, "\r"), " ")
 		value = model.ProcessCommands(commands)
 		return
 	}
-
 	return model.CommentCommand(comment)
 }
 


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- There was a problem with YAML parser that [it confuses head comments with footer comments](https://github.com/go-yaml/yaml/issues/695), this is fixed by this PR
- Also removed carriage character to prevent errors on windows system

I submit this contribution under the Apache-2.0 license.
