### PR TITLE
Add blank line so mkdocs displays correctly the bulletpoints

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -22,6 +22,7 @@ The pipelines examples can be found in our [GitHub Repository](https://github.co
 ### MegaLinter
 
 KICS is natively embedded in [MegaLinter](https://megalinter.github.io/), a 100% Open-Source tool for CI/CD workflows that analyzes consistency and quality of:
+
 - 48 languages
 - 22 formats
 - 20 tooling formats 


### PR DESCRIPTION
Add blank line so mkdocs displays correctly the bulletpoints

![image](https://user-images.githubusercontent.com/17500430/141279295-7686ef4f-aea5-4715-b376-2a1fa1bd20c3.png)
