### PR TITLE
fix(query) Wrong detection of unused security group

### DIFF
--- a/assets/queries/terraform/aws/security_groups_not_used/query.rego
+++ b/assets/queries/terraform/aws/security_groups_not_used/query.rego
@@ -27,3 +27,10 @@ is_used(securityGroupName, doc) {
 	securityGroupUsed := value.security_group_id
 	contains(securityGroupUsed, sprintf("aws_security_group.%s", [securityGroupName]))
 }
+
+# check security groups assigned to aws_instance resources
+is_used(securityGroupName, doc) {
+	[path, value] := walk(doc)
+	securityGroupUsed := value.vpc_security_group_ids[_]
+	contains(securityGroupUsed, sprintf("aws_security_group.%s", [securityGroupName]))
+}

--- a/assets/queries/terraform/aws/security_groups_not_used/test/negative3.tf
+++ b/assets/queries/terraform/aws/security_groups_not_used/test/negative3.tf
@@ -1,0 +1,41 @@
+# given:
+#  - used security group
+#  - aws_instance
+# when:
+#  - used security group attached to aws_instance
+# then:
+#  - do not detect any unused security group
+
+resource "aws_security_group" "used_sg" {
+  name        = "used-sg"
+  description = "Used security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description      = "Some port"
+    from_port        = 43
+    to_port          = 43
+    protocol         = "tcp"
+    cidr_blocks      = [aws_vpc.main.cidr_block]
+    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+}
+
+resource "aws_instance" "negative3" {
+  ami = "ami-003634241a8fcdec0"
+
+  instance_type = "t2.micro"
+
+  vpc_security_group_ids = [ "${aws_security_group.used_sg.id}" ]
+  
+}
+

--- a/assets/queries/terraform/aws/security_groups_not_used/test/positive2.tf
+++ b/assets/queries/terraform/aws/security_groups_not_used/test/positive2.tf
@@ -1,0 +1,37 @@
+# given:
+#  - unused security group
+#  - aws_instance
+# when:
+#  - no security group attached to aws_instance
+# then:
+#  - detect unused security group as unused
+
+resource "aws_instance" "positive1" {
+  ami = "ami-003634241a8fcdec0"
+
+  instance_type = "t2.micro"
+}
+
+resource "aws_security_group" "unused-sg" {
+  name        = "unused-sg"
+  description = "Unused security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description      = "Some port"
+    from_port        = 42
+    to_port          = 42
+    protocol         = "tcp"
+    cidr_blocks      = [aws_vpc.main.cidr_block]
+    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+}

--- a/assets/queries/terraform/aws/security_groups_not_used/test/positive3.tf
+++ b/assets/queries/terraform/aws/security_groups_not_used/test/positive3.tf
@@ -1,0 +1,65 @@
+# given:
+#  - unused security group
+#  - used security group
+#  - aws_instance
+# when:
+#  - used security group attached to aws_instance
+#  - unused security group not attached to aws_instance
+# then:
+#  - detect only unused security group as unused
+
+resource "aws_instance" "positive1" {
+  ami = "ami-003634241a8fcdec0"
+
+  instance_type = "t2.micro"
+
+  vpc_security_group_ids = [ aws_security_group.used_sg.id ]
+}
+
+resource "aws_security_group" "unused_sg" {
+  name        = "unused-sg"
+  description = "Unused security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description      = "Some port"
+    from_port        = 42
+    to_port          = 42
+    protocol         = "tcp"
+    cidr_blocks      = [aws_vpc.main.cidr_block]
+    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+}
+
+resource "aws_security_group" "used_sg" {
+  name        = "used-sg"
+  description = "Used security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description      = "Some port"
+    from_port        = 43
+    to_port          = 43
+    protocol         = "tcp"
+    cidr_blocks      = [aws_vpc.main.cidr_block]
+    ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+}

--- a/assets/queries/terraform/aws/security_groups_not_used/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/security_groups_not_used/test/positive_expected_result.json
@@ -4,5 +4,17 @@
     "severity": "INFO",
     "line": 8,
     "filename": "positive1.tf"
+  },
+  {
+    "queryName": "Security Group Not Used",
+    "severity": "INFO",
+    "line": 15,
+    "filename": "positive2.tf"
+  },
+  {
+    "queryName": "Security Group Not Used",
+    "severity": "INFO",
+    "line": 19,
+    "filename": "positive3.tf"
   }
 ]


### PR DESCRIPTION
Closes #4501

**Proposed Changes**
- Add check against vpc_security_group_ids
- Add test cases:
  - Negative: 
    - security group attached to aws_instance should not be detected as unused security group
  - Positive:
    - unused security group declared and no security group attached to aws_instance
    - unused security group declared and other security group attached to aws_instance

I submit this contribution under the Apache-2.0 license.
