### PR TITLE
feat(docs & passwords and secrets): consideration of kics-scan ignore command and LinesIgnore 

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -64,6 +64,13 @@ terraform show -json plan-sample.tfplan > plan-sample.tfplan.json
 
 ### Limitations
 
+#### Ansible
+At the moment, KICS does not support a robust approach to identifying Ansible samples. The identification of these samples is done through exclusion. When a YAML sample is not a CloudFormation, Helm, Kubernetes or OpenAPI sample, KICS recognize it as Ansible. 
+
+Thus, KICS recognize other YAML samples (that are not Ansible) as Ansible, e.g. GitHub Actions samples. However, you can ignore these samples by writing `#kics-scan ignore` on the top of the file. For more details, please read this [documentation](https://github.com/Checkmarx/kics/blob/25b6b703e924ed42067d9ab7772536864aee900b/docs/running-kics.md#using-commands-on-scanned-files-as-comments). 
+
+
+#### Terraform
 Although KICS support variables and interpolations, KICS does not support functions and enviroment variables. In case of variables used as function parameters, it will parse as wrapped expression, so the following function call:
 
 ```hcl

--- a/pkg/engine/secrets/inspector.go
+++ b/pkg/engine/secrets/inspector.go
@@ -173,18 +173,7 @@ func (c *Inspector) Inspect(ctx context.Context, basePaths []string,
 				case <-timeoutCtx.Done():
 					return c.vulnerabilities, timeoutCtx.Err()
 				default:
-					// check file content line by line
-					if c.regexQueries[i].Multiline == (MultilineResult{}) {
-						lines := c.detector.SplitLines(&files[idx])
-
-						for lineNumber, currentLine := range lines {
-							c.checkLineByLine(&c.regexQueries[i], basePaths, &files[idx], lineNumber, currentLine)
-						}
-						continue
-					}
-
-					// check file content as a whole
-					c.checkFileContent(&c.regexQueries[i], basePaths, &files[idx])
+					c.checkContent(i, idx, basePaths, files)
 				}
 			}
 		}
@@ -559,4 +548,19 @@ func validateCustomSecretsQueriesID(allRegexQueries []RegexQuery) error {
 		}
 	}
 	return nil
+}
+
+func (c *Inspector) checkContent(i, idx int, basePaths []string, files model.FileMetadatas) {
+	// check file content line by line
+	if c.regexQueries[i].Multiline == (MultilineResult{}) {
+		lines := c.detector.SplitLines(&files[idx])
+
+		for lineNumber, currentLine := range lines {
+			c.checkLineByLine(&c.regexQueries[i], basePaths, &files[idx], lineNumber, currentLine)
+		}
+		return
+	}
+
+	// check file content as a whole
+	c.checkFileContent(&c.regexQueries[i], basePaths, &files[idx])
 }

--- a/pkg/engine/secrets/inspector_test.go
+++ b/pkg/engine/secrets/inspector_test.go
@@ -312,6 +312,35 @@ master_auth {
 		wantVuln: []model.Vulnerability{},
 		wantErr:  false,
 	},
+	{
+		name: "valid_no_results",
+		files: model.FileMetadatas{
+			{
+				ID:          "853012ab-cc05-4c1c-b517-9c3552085ee8",
+				LinesIgnore: []int{9},
+				Document:    model.Document{},
+				OriginalData: `
+resource "google_container_cluster" "primary3" {
+name               = "marcellus-wallace"
+location           = "us-central1-a"
+initial_node_count = 3
+
+master_auth {
+	username = "1234567890qwertyuiopasdfghjklçzxcvbnm"
+  # password = "password123456"
+
+	client_certificate_config {
+		issue_client_certificate = true
+	}
+}
+}`,
+				Kind:     "TF",
+				FilePath: "assets/queries/common/passwords_and_secrets/test/negative7.tf",
+			},
+		},
+		wantVuln: []model.Vulnerability{},
+		wantErr:  false,
+	},
 }
 
 var testNewInspectorInputs = []struct {

--- a/pkg/engine/secrets/inspector_test.go
+++ b/pkg/engine/secrets/inspector_test.go
@@ -154,20 +154,20 @@ var testInspectInput = []struct {
 				ID:       "853012ab-cc05-4c1c-b517-9c3552085ee8",
 				Document: model.Document{},
 				OriginalData: `
-resource "google_container_cluster" "primary3" {
-name               = "marcellus-wallace"
-location           = "us-central1-a"
-initial_node_count = 3
+	resource "google_container_cluster" "primary3" {
+	name               = "marcellus-wallace"
+	location           = "us-central1-a"
+	initial_node_count = 3
 
-master_auth {
-	username = "1234567890qwertyuiopasdfghjklçzxcvbnm"
-	password = ""
+	master_auth {
+		username = "1234567890qwertyuiopasdfghjklçzxcvbnm"
+		password = ""
 
-	client_certificate_config {
-		issue_client_certificate = true
+		client_certificate_config {
+			issue_client_certificate = true
+		}
 	}
-}
-}`,
+	}`,
 				Kind:     "TF",
 				FilePath: "assets/queries/common/passwords_and_secrets/test/negative7.tf",
 			},
@@ -182,13 +182,13 @@ master_auth {
 				ID:       "b032c51d-2e7c-4ffc-8a81-41405c166bc8",
 				Document: model.Document{},
 				OriginalData: `
-apiVersion: v1
-kind: Secret
-metadata:
-name: secret-basic-auth
-type: kubernetes.io/basic-auth
-stringData:
-password: "root"`,
+	apiVersion: v1
+	kind: Secret
+	metadata:
+	name: secret-basic-auth
+	type: kubernetes.io/basic-auth
+	stringData:
+	password: "root"`,
 				Kind:     "K8S",
 				FilePath: "assets/queries/common/passwords_and_secrets/test/positive1.yaml",
 			},
@@ -211,21 +211,21 @@ password: "root"`,
 				ID:       "d274e272-a4af-497e-a900-a277500e4182",
 				Document: model.Document{},
 				OriginalData: `
-resource "aws_transfer_ssh_key" "example" {
-server_id = aws_transfer_server.example.id
-user_name = aws_transfer_user.example.user_name
-body      = <<EOT
------BEGIN OPENSSH PRIVATE KEY-----
-b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS
-1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQTTD+Q+10oNWDzXxx9x2bOobcXAA4rd
-jGaQoqJjcXRWR2TS1ioKvML1fI5KLP4kuF3TlyPTLgJxlfrJtYYEfGHwAAAA0FjbkWRY25
-FkAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNMP5D7XSg1YPNfH
-H3HZs6htxcADit2MZpCiomNxdFZHZNLWKgq8wvV8jkos/iS4XdOXI9MuAnGV+sm1hgR8Yf
-AAAAAgHI23o+KRbewZJJxFExEGwiOPwM7gonjATdzLP+YT/6sAAAA0cm9nZXJpb3AtbWFj
-Ym9va0BSb2dlcmlvUC1NYWNCb29rcy1NYWNCb29rLVByby5sb2NhbAECAwQ=
------END OPENSSH PRIVATE KEY-----
-EOT
-}`,
+	resource "aws_transfer_ssh_key" "example" {
+	server_id = aws_transfer_server.example.id
+	user_name = aws_transfer_user.example.user_name
+	body      = <<EOT
+	-----BEGIN OPENSSH PRIVATE KEY-----
+	b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS
+	1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQTTD+Q+10oNWDzXxx9x2bOobcXAA4rd
+	jGaQoqJjcXRWR2TS1ioKvML1fI5KLP4kuF3TlyPTLgJxlfrJtYYEfGHwAAAA0FjbkWRY25
+	FkAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNMP5D7XSg1YPNfH
+	H3HZs6htxcADit2MZpCiomNxdFZHZNLWKgq8wvV8jkos/iS4XdOXI9MuAnGV+sm1hgR8Yf
+	AAAAAgHI23o+KRbewZJJxFExEGwiOPwM7gonjATdzLP+YT/6sAAAA0cm9nZXJpb3AtbWFj
+	Ym9va0BSb2dlcmlvUC1NYWNCb29rcy1NYWNCb29rLVByby5sb2NhbAECAwQ=
+	-----END OPENSSH PRIVATE KEY-----
+	EOT
+	}`,
 				Kind:     "TF",
 				FilePath: "assets/queries/common/passwords_and_secrets/test/positive13.tf",
 			},
@@ -248,24 +248,24 @@ EOT
 				ID:       "",
 				Document: model.Document{},
 				OriginalData: `
-resource "aws_lambda_function" "analysis_lambda2" {
-  # lambda have plain text secrets in environment variables
-  filename      = "resources/lambda_function_payload.zip"
-  function_name = "${local.resource_prefix.value}-analysis"
-  role          = "${aws_iam_role.iam_for_lambda.arn}"
-  handler       = "exports.test"
+	resource "aws_lambda_function" "analysis_lambda2" {
+	  # lambda have plain text secrets in environment variables
+	  filename      = "resources/lambda_function_payload.zip"
+	  function_name = "${local.resource_prefix.value}-analysis"
+	  role          = "${aws_iam_role.iam_for_lambda.arn}"
+	  handler       = "exports.test"
 
-  source_code_hash = "${filebase64sha256("resources/lambda_function_payload.zip")}"
+	  source_code_hash = "${filebase64sha256("resources/lambda_function_payload.zip")}"
 
-  runtime = "nodejs12.x"
+	  runtime = "nodejs12.x"
 
-  environment {
-    variables = {
-      secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-    }
-  }
-}
-`,
+	  environment {
+	    variables = {
+	      secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	    }
+	  }
+	}
+	`,
 				Kind:     "TF",
 				FilePath: "assets/queries/common/passwords_and_secrets/test/positive37.tf",
 			},
@@ -285,10 +285,12 @@ resource "aws_lambda_function" "analysis_lambda2" {
 		name: "valid_no_results",
 		files: model.FileMetadatas{
 			{
-				ID:       "853012ab-cc05-4c1c-b517-9c3552085ee8",
+				ID: "853012ab-cc05-4c1c-b517-9c3552085ee8",
+				Commands: model.CommentsCommands{
+					"ignore": "",
+				},
 				Document: model.Document{},
-				OriginalData: `
-# kics-scan ignore
+				OriginalData: `# kics-scan ignore
 resource "google_container_cluster" "primary3" {
 name               = "marcellus-wallace"
 location           = "us-central1-a"

--- a/pkg/engine/secrets/inspector_test.go
+++ b/pkg/engine/secrets/inspector_test.go
@@ -281,6 +281,35 @@ resource "aws_lambda_function" "analysis_lambda2" {
 		},
 		wantErr: false,
 	},
+	{
+		name: "valid_no_results",
+		files: model.FileMetadatas{
+			{
+				ID:       "853012ab-cc05-4c1c-b517-9c3552085ee8",
+				Document: model.Document{},
+				OriginalData: `
+# kics-scan ignore
+resource "google_container_cluster" "primary3" {
+name               = "marcellus-wallace"
+location           = "us-central1-a"
+initial_node_count = 3
+
+master_auth {
+	username = "1234567890qwertyuiopasdfghjklçzxcvbnm"
+	password = "password123456"
+
+	client_certificate_config {
+		issue_client_certificate = true
+	}
+}
+}`,
+				Kind:     "TF",
+				FilePath: "assets/queries/common/passwords_and_secrets/test/negative7.tf",
+			},
+		},
+		wantVuln: []model.Vulnerability{},
+		wantErr:  false,
+	},
 }
 
 var testNewInspectorInputs = []struct {

--- a/pkg/scan/path_utils.go
+++ b/pkg/scan/path_utils.go
@@ -32,6 +32,10 @@ func (c *Client) prepareAndAnalyzePaths() (extractedPaths provider.ExtractedPath
 		return extractedPaths, errAnalyze
 	}
 
+	if len(newTypeFlagValue) == 0 {
+		return provider.ExtractedPath{}, nil
+	}
+
 	c.ScanParams.Platform = newTypeFlagValue
 	c.ScanParams.ExcludePaths = newExcludePathsFlagValue
 
@@ -106,8 +110,17 @@ func analyzePaths(paths, types, exclude []string) (typesRes, excludeRes []string
 			log.Err(err)
 			return []string{}, []string{}, err
 		}
-		log.Info().Msgf("Loading queries of type: %s", strings.Join(types, ", "))
+		logLoadingQueriesType(types)
 	}
 	exclude = append(exclude, exc...)
 	return types, exclude, nil
+}
+
+func logLoadingQueriesType(types []string) {
+	if len(types) == 0 {
+		log.Info().Msg("No queries were loaded")
+		return
+	}
+
+	log.Info().Msgf("Loading queries of type: %s", strings.Join(types, ", "))
 }

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	_ "embed" // Embed kics CLI img and scan-flags
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,6 +92,12 @@ func printOutput(outputPath, filename string, body interface{}, formats []string
 
 // postScan is responsible for the output results
 func (c *Client) postScan(scanResults *Results) error {
+	if scanResults == nil {
+		log.Info().Msg("No files were scanned")
+		fmt.Println("No files were scanned")
+		return nil
+	}
+
 	summary := c.getSummary(scanResults.Results, time.Now(), model.PathParameters{
 		ScannedPaths:      c.ScanParams.Path,
 		PathExtractionMap: scanResults.ExtractedPaths.ExtractionMap,

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -47,6 +47,10 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		return nil, err
 	}
 
+	if len(extractedPaths.Path) == 0 {
+		return nil, nil
+	}
+
 	querySource := source.NewFilesystemSource(
 		c.ScanParams.QueriesPath,
 		c.ScanParams.Platform,
@@ -117,6 +121,10 @@ func (c *Client) executeScan(ctx context.Context) (*Results, error) {
 	if err != nil {
 		log.Err(err)
 		return nil, err
+	}
+
+	if executeScanParameters == nil {
+		return nil, nil
 	}
 
 	if err = scanner.PrepareAndScan(ctx, c.ScanParams.ScanID, *c.ProBarBuilder, executeScanParameters.services); err != nil {


### PR DESCRIPTION
Closes #4485
Closes #4419

**Proposed Changes**
- Added documentation about Ansible identification limitation
- Added consideration of `kics-scan ignore` command in passwords and secrets inspector
- Added consideration of LinesIgnore in passwords and secrets inspector (Fix bug #4419)
- Fix bug #4485

I submit this contribution under the Apache-2.0 license.
