### PR TITLE
feat(query): added "Google Compute Network Using Firewall Rule that Allows Port Range" for Ansible and Terraform

### DIFF
--- a/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/metadata.json
+++ b/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "7289eebd-a477-4064-8ad4-3c044bd70b00",
+  "queryName": "Google Compute Network Using Firewall Rule that Allows Port Range",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Google Compute Network should not use a firewall rule that allows port range",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_firewall_module.html#parameter-allowed",
+  "platform": "Ansible",
+  "descriptionID": "2b7880b0",
+  "cloudProvider": "gcp"
+}

--- a/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/query.rego
+++ b/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/query.rego
@@ -1,0 +1,36 @@
+package Cx
+
+import data.generic.ansible as ans_lib
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	task := ans_lib.tasks[_][_]
+	modulesFirewall := {"google.cloud.gcp_compute_firewall", "gcp_compute_firewall"}
+	firewall := task[modulesFirewall[_]]
+	ans_lib.checkState(firewall)
+
+	is_ingress(firewall)
+	regex.match("[0-9]+-[0-9]+", firewall.allowed[_].ports[_])
+	firewall.allowed[_].ports[_] != "0-65535"
+
+	tk := ans_lib.tasks[id][_]
+	modulesCompute := {"google.cloud.gcp_compute_network", "gcp_compute_network"}
+	computeNetwork := tk[modulesCompute[m]]
+	ans_lib.checkState(computeNetwork)
+	firewall.network == sprintf("{{ %s }}", [tk.register])
+
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}", [tk.name, modulesCompute[m]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s' is not using a firewall rule that allows access to port range", [modulesCompute[m]]),
+		"keyActualValue": sprintf("'%s' is using a firewall rule that allows access to port range", [modulesCompute[m]]),
+	}
+}
+
+is_ingress(firewall) {
+	not common_lib.valid_key(firewall, "direction")
+} else {
+	firewall.direction == "INGRESS"
+}

--- a/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/test/negative.yaml
+++ b/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/test/negative.yaml
@@ -1,0 +1,26 @@
+- name: create a firewall
+  google.cloud.gcp_compute_firewall:
+    name: test_object
+    allowed:
+    - ip_protocol: tcp
+      ports:
+      - '22'
+    target_tags:
+    - test-ssh-server
+    - staging-ssh-server
+    source_tags:
+    - test-ssh-clients
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    network: "{{ my_network }}"
+- name: create a network
+  google.cloud.gcp_compute_network:
+    name: test_object
+    auto_create_subnetworks: 'true'
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+  register: my_network

--- a/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/test/positive.yaml
+++ b/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/test/positive.yaml
@@ -1,0 +1,26 @@
+- name: create a firewall2
+  google.cloud.gcp_compute_firewall:
+    name: test_object
+    allowed:
+    - ip_protocol: tcp
+      ports:
+      - '20-1000'
+    target_tags:
+    - test-ssh-server
+    - staging-ssh-server
+    source_tags:
+    - test-ssh-clients
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+    network: "{{ my_network2 }}"
+- name: create a network2
+  google.cloud.gcp_compute_network:
+    name: test_object
+    auto_create_subnetworks: 'true'
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+  register: my_network2

--- a/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/test/positive_expected_result.json
+++ b/assets/queries/ansible/gcp/google_compute_network_using_firewall_allows_port_range/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Google Compute Network Using Firewall Rule that Allows Port Range",
+    "severity": "MEDIUM",
+    "line": 19,
+    "fileName": "positive.yaml"
+  }
+]

--- a/assets/queries/terraform/gcp/google_compute_network_using_firewall_rule_allows_port_range/metadata.json
+++ b/assets/queries/terraform/gcp/google_compute_network_using_firewall_rule_allows_port_range/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "e6f61c37-106b-449f-a5bb-81bfcaceb8b4",
+  "queryName": "Google Compute Network Using Firewall Rule that Allows Port Range",
+  "severity": "MEDIUM",
+  "category": "Networking and Firewall",
+  "descriptionText": "Google Compute Network should not use a firewall rule that allows port range",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall#allow",
+  "platform": "Terraform",
+  "descriptionID": "7289eebd",
+  "cloudProvider": "gcp"
+}

--- a/assets/queries/terraform/gcp/google_compute_network_using_firewall_rule_allows_port_range/query.rego
+++ b/assets/queries/terraform/gcp/google_compute_network_using_firewall_rule_allows_port_range/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	
+	computeNetwork := input.document[i].resource.google_compute_network[name]
+	
+	firewall := input.document[_].resource.google_compute_firewall[_]
+
+	split(firewall.network, ".")[1] == name
+	is_ingress(firewall)
+	is_port_range(firewall.allow)
+	
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("google_compute_network[%s]", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'google_compute_network[%s]' is not using a firewall rule that allows access to port range", [name]),
+		"keyActualValue": sprintf("'google_compute_network[%s]' is using a firewall rule that allows access to port range", [name]),
+		"searchLine": common_lib.build_search_line(["resource", "google_compute_network", name], []),
+	}
+}
+
+is_ingress(firewall) {
+	not common_lib.valid_key(firewall, "direction")
+} else {
+	firewall.direction == "INGRESS"
+}
+
+is_port_range(allow) {
+	is_array(allow)
+	regex.match("[0-9]+-[0-9]+", allow[_].ports[_])
+	allow[_].ports[_] != "0-65535"
+} else {
+	is_object(allow)
+	regex.match("[0-9]+-[0-9]+", allow.ports[_])
+	allow.ports[_] != "0-65535"
+}

--- a/assets/queries/terraform/gcp/google_compute_network_using_firewall_rule_allows_port_range/test/negative.tf
+++ b/assets/queries/terraform/gcp/google_compute_network_using_firewall_rule_allows_port_range/test/negative.tf
@@ -1,0 +1,19 @@
+resource "google_compute_firewall" "negative1" {
+  name    = "test-firewall"
+  network = google_compute_network.negative1.name
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "8080"]
+  }
+
+  source_tags = ["web"]
+}
+
+resource "google_compute_network" "negative1" {
+  name = "test-network"
+}

--- a/assets/queries/terraform/gcp/google_compute_network_using_firewall_rule_allows_port_range/test/positive.tf
+++ b/assets/queries/terraform/gcp/google_compute_network_using_firewall_rule_allows_port_range/test/positive.tf
@@ -1,0 +1,19 @@
+resource "google_compute_firewall" "positive1" {
+  name    = "test-firewall"
+  network = google_compute_network.positive1.name
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "8080", "1000-2000"]
+  }
+
+  source_tags = ["web"]
+}
+
+resource "google_compute_network" "positive1" {
+  name = "test-network"
+}

--- a/assets/queries/terraform/gcp/google_compute_network_using_firewall_rule_allows_port_range/test/positive_expected_result.json
+++ b/assets/queries/terraform/gcp/google_compute_network_using_firewall_rule_allows_port_range/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+	{
+		"queryName": "Google Compute Network Using Firewall Rule that Allows Port Range",
+		"severity": "MEDIUM",
+		"line": 17,
+		"fileName": "positive.tf"
+	}
+]


### PR DESCRIPTION
**Proposed Changes**
- Added "Google Compute Network Using Firewall Rule that Allows Port Range" for Ansible and Terraform

🚨 SEVERITY AND CATEGORY NEED REVIEW 🚨

I submit this contribution under the Apache-2.0 license.
