### PR TITLE
feat(e2e): E2E Tests for kics comments commands

### DIFF
--- a/e2e/fixtures/samples/scan-ignore/disable.tf
+++ b/e2e/fixtures/samples/scan-ignore/disable.tf
@@ -1,0 +1,5 @@
+# kics-scan disable=0a494a6a-ebe2-48a0-9d77-cf9d5125e1b3,15ffbacc-fa42-4f6f-a57d-2feac7365caa
+resource "aws_redshift_cluster" "default1" {
+  publicly_accessible = false
+  encrypted=true
+}

--- a/e2e/fixtures/samples/scan-ignore/enable.tf
+++ b/e2e/fixtures/samples/scan-ignore/enable.tf
@@ -1,0 +1,19 @@
+# kics-scan enable=0a494a6a-ebe2-48a0-9d77-cf9d5125e1b3,15ffbacc-fa42-4f6f-a57d-2feac7365caa
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "Mustbe8characters"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+}
+
+resource "aws_redshift_cluster" "default1" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "Mustbe8characters"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+  publicly_accessible = true
+}

--- a/e2e/fixtures/samples/scan-ignore/ignore-block.dockerfile
+++ b/e2e/fixtures/samples/scan-ignore/ignore-block.dockerfile
@@ -1,0 +1,12 @@
+# kics-scan ignore-block
+FROM debian
+RUN wget http://google.com
+RUN curl http://bing.com
+
+FROM python:3.7
+RUN pip install Flask==0.11.1
+RUN useradd -ms /bin/bash patrick
+COPY --chown=patrick:patrick app /app
+WORKDIR /app
+USER patrick
+CMD ["python", "app.py"]

--- a/e2e/fixtures/samples/scan-ignore/ignore-lines.yaml
+++ b/e2e/fixtures/samples/scan-ignore/ignore-lines.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: liveness
+  name: liveness-exec
+spec:
+  hostAliases:
+  - ip: "127.0.0.1"
+    hostnames:
+    - "foo.local"
+    - "bar.local"
+  containers:
+  # kics-scan ignore-line
+  - name: liveness
+    image: k8s.gcr.io/busybox
+    args:
+    - /bin/sh
+    - -c
+    - touch /tmp/healthy; sleep 30; rm -rf /tmp/healthy; sleep 600

--- a/e2e/fixtures/samples/scan-ignore/ignore/sample.dockerfile
+++ b/e2e/fixtures/samples/scan-ignore/ignore/sample.dockerfile
@@ -1,0 +1,12 @@
+# kics-scan ignore
+FROM debian
+RUN wget http://google.com
+RUN curl http://bing.com
+
+FROM python:3.7
+RUN pip install Flask==0.11.1
+RUN useradd -ms /bin/bash patrick
+COPY --chown=patrick:patrick app /app
+WORKDIR /app
+USER patrick
+CMD ["python", "app.py"]

--- a/e2e/fixtures/samples/scan-ignore/ignore/sample.tf
+++ b/e2e/fixtures/samples/scan-ignore/ignore/sample.tf
@@ -1,0 +1,19 @@
+# kics-scan ignore
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "Mustbe8characters"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+}
+
+resource "aws_redshift_cluster" "default1" {
+  cluster_identifier = "tf-redshift-cluster"
+  database_name      = "mydb"
+  master_username    = "foo"
+  master_password    = "Mustbe8characters"
+  node_type          = "dc1.large"
+  cluster_type       = "single-node"
+  publicly_accessible = true
+}

--- a/e2e/fixtures/samples/scan-ignore/ignore/sample.yaml
+++ b/e2e/fixtures/samples/scan-ignore/ignore/sample.yaml
@@ -1,0 +1,21 @@
+# kics-scan ignore
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    test: liveness
+  name: liveness-exec
+spec:
+  hostAliases:
+  - ip: "127.0.0.1"
+    hostnames:
+    - "foo.local"
+    - "bar.local"
+  containers:
+  # kics-scan ignore-line
+  - name: liveness
+    image: k8s.gcr.io/busybox
+    args:
+    - /bin/sh
+    - -c
+    - touch /tmp/healthy; sleep 30; rm -rf /tmp/healthy; sleep 600

--- a/e2e/testcases/e2e-cli-053_kics_scan_ignore.go
+++ b/e2e/testcases/e2e-cli-053_kics_scan_ignore.go
@@ -1,0 +1,20 @@
+package testcases
+
+// E2E-CLI-053 - Kics scan can ignore entire files, blocks and lines based in kics-ignore comments
+func init() { //nolint
+	testSample := TestCase{
+		Name: "should ignore files/code-blocks/code-lines during the scan [E2E-CLI-053]",
+		Args: args{
+			Args: []cmdArgs{
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/scan-ignore/enable.tf"},
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/scan-ignore/disable.tf"},
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/scan-ignore/ignore-block.dockerfile"},
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/scan-ignore/ignore-lines.yaml"},
+				[]string{"scan", "-q", "../assets/queries", "-p", "fixtures/samples/scan-ignore/ignore"},
+			},
+		},
+		WantStatus: []int{50, 20, 40, 40, 0},
+	}
+
+	Tests = append(Tests, testSample)
+}


### PR DESCRIPTION
Closes #

**Proposed Changes**
- Added E2E Tests for kics comments commands that cover many supported formats (.yaml, .dockerfile & .tf) and all the available commands (ignore, ignore-block, ignore-lines, enable, disable)

I submit this contribution under the Apache-2.0 license.
