### PR TITLE
add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,19 @@
+---
+
+# For use with pre-commit.
+# See usage instructions at http://pre-commit.com
+
+-   id: kics
+    name:  Checkmarx Kics
+    description: This hook runs kics.
+    entry: kics scan -p .
+    language: golang
+    pass_filenames: false
+    always_run: false
+    types_or:
+      - terraform
+      - dockerfile
+      - yaml
+      - json
+    exclude: '^.*\.terraform.*$'
+    require_serial: true

--- a/docs/integrations_pre_commit.md
+++ b/docs/integrations_pre_commit.md
@@ -1,0 +1,24 @@
+# Running Kics with pre-commmit
+
+To use `kics` with [pre-commit](https://pre-commit.com) add the following hook to your local repo's `.pre-commit-config.yaml` file. 
+
+```yaml
+- repo: https://github.com/Checkmarx/kics
+  rev: '' # change to correct tag or sha
+  hooks:
+    - id: kics
+```
+
+## How to pass extra arguments
+
+You can provide arguments to `kics` by providing the pre-commit `args` [property](https://pre-commit.com/#passing-arguments-to-hooks). The following example will print the `kics scan` output, but will not block regardless of success/failure.
+
+```yaml
+repos:
+- repo: https://github.com/Checkmarx/kics
+  rev: '' # change to correct tag or sha
+  hooks:
+  - id: kics
+    verbose: true
+    args: [--ignore-on-exit, 'all']
+```


### PR DESCRIPTION
Closes #

I use `pre-commit` a lot to check for stuff before pushing it to the repo, and I was missing `kics` integration.

One thing that I noticed is that even though I'm excluding `.terraform`, I think `kics` itself is scanning them because it scans [terraform modules](https://github.com/Checkmarx/kics/issues/4493) by default, but I'm not sure.  Any thoughts?

**Proposed Changes**
- Add pre-commit integration

I submit this contribution under the Apache-2.0 license.
