### PR TITLE
fix(parser): fixed YAML parser panic with wrong type for interface (#4521)

### DIFF
--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Checkmarx/kics/pkg/model"
 	"github.com/Checkmarx/kics/pkg/parser/utils"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 )
 
@@ -132,6 +133,7 @@ func addExtraInfo(documents []model.Document, filePath string) []model.Document 
 func processPlaybooks(playbooks interface{}, filePath string) {
 	sliceResources, ok := playbooks.([]interface{})
 	if !ok { // prevent panic if playbooks is not a slice
+		log.Warn().Msgf("Failed to parse playbooks: %s", filePath)
 		return
 	}
 	for _, resources := range sliceResources { // iterate over playbooks
@@ -141,14 +143,17 @@ func processPlaybooks(playbooks interface{}, filePath string) {
 
 func processPlaybooksElements(resources interface{}, filePath string) {
 	mapResources, ok := resources.(map[string]interface{})
-	if !ok { // prevent panic if playbooks is not a map
+	if !ok {
+		log.Warn().Msgf("Failed to parse playbooks elements: %s", filePath)
 		return
 	}
 	for _, value := range mapResources {
 		mapValue, ok := value.(map[string]interface{})
-		if ok {
-			processElements(mapValue, filePath)
+		if !ok {
+			log.Warn().Msgf("Failed to parse playbooks values: %s", filePath)
+			continue
 		}
+		processElements(mapValue, filePath)
 	}
 }
 

--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -122,18 +122,34 @@ func processElements(elements map[string]interface{}, filePath string) {
 func addExtraInfo(documents []model.Document, filePath string) []model.Document {
 	for _, documentPlaybooks := range documents { // iterate over documents
 		if playbooks, ok := documentPlaybooks["playbooks"]; ok {
-			for _, resources := range playbooks.([]interface{}) { // iterate over playbooks
-				for _, v := range resources.(map[string]interface{}) {
-					_, ok := v.(map[string]interface{})
-					if ok {
-						processElements(v.(map[string]interface{}), filePath)
-					}
-				}
-			}
+			processPlaybooks(playbooks, filePath)
 		}
 	}
 
 	return documents
+}
+
+func processPlaybooks(playbooks interface{}, filePath string) {
+	sliceResources, ok := playbooks.([]interface{})
+	if !ok { // prevent panic if playbooks is not a slice
+		return
+	}
+	for _, resources := range sliceResources { // iterate over playbooks
+		processPlaybooksElements(resources, filePath)
+	}
+}
+
+func processPlaybooksElements(resources interface{}, filePath string) {
+	mapResources, ok := resources.(map[string]interface{})
+	if !ok { // prevent panic if playbooks is not a map
+		return
+	}
+	for _, value := range mapResources {
+		mapValue, ok := value.(map[string]interface{})
+		if ok {
+			processElements(mapValue, filePath)
+		}
+	}
 }
 
 // GetCommentToken return the comment token of YAML - #


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #4521

**Proposed Changes**
- Added Type check to prevent panic in YAML parser for Ansible files


I submit this contribution under the Apache-2.0 license.
