### PR TITLE
fix(password and secrets): fixed MS Teams regex hardcoded team_name (#4528)

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -100,7 +100,7 @@
     {
       "id": "d6214dca-a31b-425f-bcf7-f4faa772a1c0",
       "name": "MSTeams Webhook",
-      "regex": "https://team_name.webhook.office.com/webhook(b2)?/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/IncomingWebhook/[a-z0-9]+/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+      "regex": "https://[a-zA-Z0-9_]{1,24}.webhook.office.com/webhook(b2)?/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}@[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/IncomingWebhook/[a-z0-9]+/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
     },
     {
       "id": "7908a9e3-5cac-41b1-b514-5f6d82ce02d5",


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #4528

**Proposed Changes**
- Removed hardcoded team name from MS Teams Regex

I submit this contribution under the Apache-2.0 license.
