### PR TITLE
feat(query): added "API Gateway without WAF" for Ansible, CloudFormation, and Terraform

### DIFF
--- a/assets/queries/ansible/aws/api_gateway_without_waf/metadata.json
+++ b/assets/queries/ansible/aws/api_gateway_without_waf/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "f5f38943-664b-4acc-ab11-f292fa10ed0b",
+  "queryName": "API Gateway without WAF",
+	"severity": "MEDIUM",
+  "category": "Networking and Firewall",
+	"descriptionText": "API Gateway should have WAF (Web Application Firewall) enabled",
+  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/wafv2_resources_module.html#parameter-arn",
+  "platform": "Ansible",
+  "descriptionID": "8e789062",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/ansible/aws/api_gateway_without_waf/query.rego
+++ b/assets/queries/ansible/aws/api_gateway_without_waf/query.rego
@@ -1,0 +1,34 @@
+package Cx
+
+import data.generic.ansible as ans_lib
+import data.generic.common as common_lib
+
+modules := {"community.aws.aws_api_gateway", "aws_api_gateway"}
+
+CxPolicy[result] {
+	task := ans_lib.tasks[id][t]
+	api := task[modules[m]]
+	ans_lib.checkState(api)
+
+	not has_waf_associated(api.stage)
+
+	result := {
+		"documentId": id,
+		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "API Gateway Stage is associated with a Web Application Firewall",
+		"keyActualValue": "API Gateway Stage is not associated with a Web Application Firewall",
+		"searchLine": common_lib.build_search_line(["playbooks", t, modules[m]], []),
+	}
+}
+
+has_waf_associated(stage) {
+	waf := {"community.aws.wafv2_resources", "wafv2_resources"}
+    
+    task2 := ans_lib.tasks[_][_]
+	wafResource := task2[waf[_]]
+    ans_lib.checkState(wafResource)
+    contains(wafResource.arn, "arn:aws:apigateway:")
+    associatedStage := split(wafResource.arn, "/")
+    associatedStage[4] == stage
+}

--- a/assets/queries/ansible/aws/api_gateway_without_waf/test/negative.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_waf/test/negative.yaml
@@ -1,0 +1,15 @@
+- name: add test alb to waf string03
+  community.aws.wafv2_resources:
+    name: string03
+    scope: REGIONAL
+    state: present
+    arn: "arn:aws:apigateway:region::/restapis/api-id/stages/produ"
+- name: Setup AWS API Gateway setup on AWS and deploy API definition
+  community.aws.aws_api_gateway:
+    swagger_file: my_api.yml
+    stage: produ
+    cache_enabled: true
+    cache_size: '1.6'
+    tracing_enabled: true
+    endpoint_type: EDGE
+    state: present

--- a/assets/queries/ansible/aws/api_gateway_without_waf/test/positive.yaml
+++ b/assets/queries/ansible/aws/api_gateway_without_waf/test/positive.yaml
@@ -1,0 +1,15 @@
+- name: add test alb to waf string032
+  community.aws.wafv2_resources:
+    name: string03
+    scope: REGIONAL
+    state: present
+    arn: "arn:aws:apigateway:region::/restapis/api-id/stages/prod"
+- name: Setup AWS API Gateway setup on AWS and deploy API definition2
+  community.aws.aws_api_gateway:
+    swagger_file: my_api.yml
+    stage: production
+    cache_enabled: true
+    cache_size: '1.6'
+    tracing_enabled: true
+    endpoint_type: EDGE
+    state: present

--- a/assets/queries/ansible/aws/api_gateway_without_waf/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/api_gateway_without_waf/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+	{
+		"queryName": "API Gateway without WAF",
+		"severity": "MEDIUM",
+		"line": 8,
+		"fileName": "positive.yaml"
+	}
+]

--- a/assets/queries/cloudFormation/api_gateway_without_waf/metadata.json
+++ b/assets/queries/cloudFormation/api_gateway_without_waf/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "fcbf9019-566c-4832-a65c-af00d8137d2b",
+  "queryName": "API Gateway without WAF",
+	"severity": "MEDIUM",
+  "category": "Networking and Firewall",
+	"descriptionText": "API Gateway should have WAF (Web Application Firewall) enabled",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-wafv2-webaclassociation.html#cfn-wafv2-webaclassociation-resourcearn",
+  "platform": "CloudFormation",
+  "descriptionID": "774d759c",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/cloudFormation/api_gateway_without_waf/query.rego
+++ b/assets/queries/cloudFormation/api_gateway_without_waf/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::ApiGateway::Stage"
+	
+	not has_waf_associated(resource.Properties.StageName)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.StageName", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "API Gateway Stage is associated with a Web Application Firewall",
+		"keyActualValue": "API Gateway Stage is not associated with a Web Application Firewall",
+		"searchLine": common_lib.build_search_line(["Resources", name, "Properties", "StageName"], []),
+	}
+}
+
+has_waf_associated(stage) {
+	resource := input.document[i].Resources[name]
+	resource.Type == "AWS::WAFv2::WebACLAssociation"
+
+    contains(resource.Properties.ResourceArn, "arn:aws:apigateway:")
+    associatedStage := split(resource.Properties.ResourceArn, "/")
+    associatedStage[4] == stage
+}

--- a/assets/queries/cloudFormation/api_gateway_without_waf/test/negative1.yaml
+++ b/assets/queries/cloudFormation/api_gateway_without_waf/test/negative1.yaml
@@ -1,0 +1,34 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "BatchJobDefinition"
+Resources:
+  Production:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      StageName: Production
+      Description: Prod Stage
+      RestApiId: !Ref MyRestApi
+      DeploymentId: !Ref TestDeployment
+      DocumentationVersion: !Ref MyDocumentationVersion
+      ClientCertificateId: !Ref ClientCertificate
+      Variables:
+        Stack: Production
+      MethodSettings:
+        - ResourcePath: /
+          HttpMethod: GET
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+        - ResourcePath: /stack
+          HttpMethod: POST
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+          ThrottlingBurstLimit: '999'
+        - ResourcePath: /stack
+          HttpMethod: GET
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+          ThrottlingBurstLimit: '555'
+  SampleWebACLAssociation:
+    Type: 'AWS::WAFv2::WebACLAssociation'
+    Properties:
+      WebACLArn: ExampleARNForWebACL
+      ResourceArn: arn:aws:apigateway:region::/restapis/api-id/stages/Production

--- a/assets/queries/cloudFormation/api_gateway_without_waf/test/negative2.json
+++ b/assets/queries/cloudFormation/api_gateway_without_waf/test/negative2.json
@@ -1,0 +1,48 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Production": {
+      "Properties": {
+        "ClientCertificateId": "ClientCertificate",
+        "DeploymentId": "TestDeployment",
+        "Description": "Prod Stage",
+        "DocumentationVersion": "MyDocumentationVersion",
+        "MethodSettings": [
+          {
+            "DataTraceEnabled": "false",
+            "HttpMethod": "GET",
+            "MetricsEnabled": "true",
+            "ResourcePath": "/"
+          },
+          {
+            "DataTraceEnabled": "false",
+            "HttpMethod": "POST",
+            "MetricsEnabled": "true",
+            "ResourcePath": "/stack",
+            "ThrottlingBurstLimit": "999"
+          },
+          {
+            "DataTraceEnabled": "false",
+            "HttpMethod": "GET",
+            "MetricsEnabled": "true",
+            "ResourcePath": "/stack",
+            "ThrottlingBurstLimit": "555"
+          }
+        ],
+        "RestApiId": "MyRestApi",
+        "StageName": "Production",
+        "Variables": {
+          "Stack": "Production"
+        }
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "SampleWebACLAssociation": {
+      "Properties": {
+        "ResourceArn": "arn:aws:apigateway:region::/restapis/api-id/stages/Production",
+        "WebACLArn": "ExampleARNForWebACL"
+      },
+      "Type": "AWS::WAFv2::WebACLAssociation"
+    }
+  }
+}

--- a/assets/queries/cloudFormation/api_gateway_without_waf/test/positive1.yaml
+++ b/assets/queries/cloudFormation/api_gateway_without_waf/test/positive1.yaml
@@ -1,0 +1,34 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "BatchJobDefinition"
+Resources:
+  Prod:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      StageName: Prod
+      Description: Prod Stage
+      RestApiId: !Ref MyRestApi
+      DeploymentId: !Ref TestDeployment
+      DocumentationVersion: !Ref MyDocumentationVersion
+      ClientCertificateId: !Ref ClientCertificate
+      Variables:
+        Stack: Prod
+      MethodSettings:
+        - ResourcePath: /
+          HttpMethod: GET
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+        - ResourcePath: /stack
+          HttpMethod: POST
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+          ThrottlingBurstLimit: '999'
+        - ResourcePath: /stack
+          HttpMethod: GET
+          MetricsEnabled: 'true'
+          DataTraceEnabled: 'false'
+          ThrottlingBurstLimit: '555'
+  SampleWebACLAssociation:
+    Type: 'AWS::WAFv2::WebACLAssociation'
+    Properties:
+      WebACLArn: ExampleARNForWebACL
+      ResourceArn: arn:aws:apigateway:region::/restapis/api-id/stages/stage

--- a/assets/queries/cloudFormation/api_gateway_without_waf/test/positive2.json
+++ b/assets/queries/cloudFormation/api_gateway_without_waf/test/positive2.json
@@ -1,0 +1,48 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "Prod": {
+      "Properties": {
+        "ClientCertificateId": "ClientCertificate",
+        "DeploymentId": "TestDeployment",
+        "Description": "Prod Stage",
+        "DocumentationVersion": "MyDocumentationVersion",
+        "MethodSettings": [
+          {
+            "DataTraceEnabled": "false",
+            "HttpMethod": "GET",
+            "MetricsEnabled": "true",
+            "ResourcePath": "/"
+          },
+          {
+            "DataTraceEnabled": "false",
+            "HttpMethod": "POST",
+            "MetricsEnabled": "true",
+            "ResourcePath": "/stack",
+            "ThrottlingBurstLimit": "999"
+          },
+          {
+            "DataTraceEnabled": "false",
+            "HttpMethod": "GET",
+            "MetricsEnabled": "true",
+            "ResourcePath": "/stack",
+            "ThrottlingBurstLimit": "555"
+          }
+        ],
+        "RestApiId": "MyRestApi",
+        "StageName": "Prod",
+        "Variables": {
+          "Stack": "Prod"
+        }
+      },
+      "Type": "AWS::ApiGateway::Stage"
+    },
+    "SampleWebACLAssociation": {
+      "Properties": {
+        "ResourceArn": "arn:aws:apigateway:region::/restapis/api-id/stages/stage",
+        "WebACLArn": "ExampleARNForWebACL"
+      },
+      "Type": "AWS::WAFv2::WebACLAssociation"
+    }
+  }
+}

--- a/assets/queries/cloudFormation/api_gateway_without_waf/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/api_gateway_without_waf/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "API Gateway without WAF",
+	  "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "API Gateway without WAF",
+    "severity": "MEDIUM",
+    "line": 33,
+    "fileName": "positive2.json"
+  }
+]

--- a/assets/queries/terraform/aws/api_gateway_without_waf/metadata.json
+++ b/assets/queries/terraform/aws/api_gateway_without_waf/metadata.json
@@ -1,0 +1,11 @@
+{
+	"id": "a186e82c-1078-4a7b-85d8-579561fde884",
+	"queryName": "API Gateway without WAF",
+	"severity": "MEDIUM",
+  	"category": "Networking and Firewall",
+	"descriptionText": "API Gateway should have WAF (Web Application Firewall) enabled",
+	"descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafregional_web_acl_association#resource_arn",
+	"platform": "Terraform",
+	"descriptionID": "bfefa118",
+	"cloudProvider": "aws"
+}

--- a/assets/queries/terraform/aws/api_gateway_without_waf/query.rego
+++ b/assets/queries/terraform/aws/api_gateway_without_waf/query.rego
@@ -1,0 +1,28 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+
+    apiGateway := input.document[i].resource.aws_api_gateway_stage[name]
+
+    not has_waf_associated(name)
+
+    result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_api_gateway_stage[%s]", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "API Gateway Stage is associated with a Web Application Firewall",
+		"keyActualValue": "API Gateway Stage is not associated with a Web Application Firewall",
+        "searchLine": common_lib.build_search_line(["resource", "aws_api_gateway_stage", name], []),
+	}
+}
+
+has_waf_associated(apiGatewayName) {
+    resource := input.document[_].resource.aws_wafregional_web_acl_association[_]
+   
+    associatedResource := split(resource.resource_arn, ".")
+   
+    associatedResource[0] == "${aws_api_gateway_stage"
+    associatedResource[1] == apiGatewayName
+}

--- a/assets/queries/terraform/aws/api_gateway_without_waf/test/negative.tf
+++ b/assets/queries/terraform/aws/api_gateway_without_waf/test/negative.tf
@@ -1,0 +1,84 @@
+resource "aws_wafregional_ipset" "ipset" {
+  name = "tfIPSet"
+
+  ip_set_descriptor {
+    type  = "IPV4"
+    value = "192.0.7.0/24"
+  }
+}
+
+resource "aws_wafregional_rule" "foo" {
+  name        = "tfWAFRule"
+  metric_name = "tfWAFRule"
+
+  predicate {
+    data_id = aws_wafregional_ipset.ipset.id
+    negated = false
+    type    = "IPMatch"
+  }
+}
+
+resource "aws_wafregional_web_acl" "foo" {
+  name        = "foo"
+  metric_name = "foo"
+
+  default_action {
+    type = "ALLOW"
+  }
+
+  rule {
+    action {
+      type = "BLOCK"
+    }
+
+    priority = 1
+    rule_id  = aws_wafregional_rule.foo.id
+  }
+}
+
+resource "aws_api_gateway_rest_api" "example" {
+  body = jsonencode({
+    openapi = "3.0.1"
+    info = {
+      title   = "example"
+      version = "1.0"
+    }
+    paths = {
+      "/path1" = {
+        get = {
+          x-amazon-apigateway-integration = {
+            httpMethod           = "GET"
+            payloadFormatVersion = "1.0"
+            type                 = "HTTP_PROXY"
+            uri                  = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+          }
+        }
+      }
+    }
+  })
+
+  name = "example"
+}
+
+resource "aws_api_gateway_deployment" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+
+  triggers = {
+    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.example.body))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "negative1" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "example"
+}
+
+resource "aws_wafregional_web_acl_association" "association" {
+  resource_arn = aws_api_gateway_stage.negative1.arn
+  web_acl_id   = aws_wafregional_web_acl.foo.id
+}

--- a/assets/queries/terraform/aws/api_gateway_without_waf/test/positive.tf
+++ b/assets/queries/terraform/aws/api_gateway_without_waf/test/positive.tf
@@ -1,0 +1,84 @@
+resource "aws_wafregional_ipset" "ipset" {
+  name = "tfIPSet"
+
+  ip_set_descriptor {
+    type  = "IPV4"
+    value = "192.0.7.0/24"
+  }
+}
+
+resource "aws_wafregional_rule" "foo" {
+  name        = "tfWAFRule"
+  metric_name = "tfWAFRule"
+
+  predicate {
+    data_id = aws_wafregional_ipset.ipset.id
+    negated = false
+    type    = "IPMatch"
+  }
+}
+
+resource "aws_wafregional_web_acl" "foo" {
+  name        = "foo"
+  metric_name = "foo"
+
+  default_action {
+    type = "ALLOW"
+  }
+
+  rule {
+    action {
+      type = "BLOCK"
+    }
+
+    priority = 1
+    rule_id  = aws_wafregional_rule.foo.id
+  }
+}
+
+resource "aws_api_gateway_rest_api" "example" {
+  body = jsonencode({
+    openapi = "3.0.1"
+    info = {
+      title   = "example"
+      version = "1.0"
+    }
+    paths = {
+      "/path1" = {
+        get = {
+          x-amazon-apigateway-integration = {
+            httpMethod           = "GET"
+            payloadFormatVersion = "1.0"
+            type                 = "HTTP_PROXY"
+            uri                  = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+          }
+        }
+      }
+    }
+  })
+
+  name = "example"
+}
+
+resource "aws_api_gateway_deployment" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+
+  triggers = {
+    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.example.body))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "positive1" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "example"
+}
+
+resource "aws_wafregional_web_acl_association" "association" {
+  resource_arn = aws_api_gateway_stage.positive.arn
+  web_acl_id   = aws_wafregional_web_acl.foo.id
+}

--- a/assets/queries/terraform/aws/api_gateway_without_waf/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/api_gateway_without_waf/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+	{
+		"queryName": "API Gateway without WAF",
+		"severity": "MEDIUM",
+		"line": 75,
+		"fileName": "positive.tf"
+	}
+]


### PR DESCRIPTION
**Proposed Changes**
- Added "API Gateway without WAF" for Ansible, CloudFormation, and Terraform

 🚨 SEVERITY AND CATEGORY NEED REVIEW 🚨

I submit this contribution under the Apache-2.0 license.
