### PR TITLE
fix(scan): not reporting error when progress bar fails to close

### DIFF
--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -106,7 +106,9 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 		return nil, err
 	}
 
-	progressBar.Close()
+	if err := progressBar.Close(); err != nil {
+		log.Debug().Msgf("Failed to close progress bar: %s", err.Error())
+	}
 
 	return &executeScanParameters{
 		services:       services,


### PR DESCRIPTION
Signed-off-by: Felipe Avelar <felipe.avelar@checkmarx.com>

**Proposed Changes**
- Added a log when progress bar fails to close

I submit this contribution under the Apache-2.0 license.
