### PR TITLE
docs(logo): changed kics logo in README.md to colored logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Go Coverage](https://raw.githubusercontent.com/Checkmarx/kics/gh-pages/coverage.svg)](https://docs.kics.io/coverage.html)
 
 
-<img alt="KICS - Keep Infrastructure as Code Secure" src="docs/img/logo/kics_hat_white_new.png" width="250">
+<img alt="KICS - Keep Infrastructure as Code Secure" src="docs/img/logo/kics_hat_color_new.png" width="250">
 
 ---
 


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- changed kics logo in README.md to colored logo

I submit this contribution under the Apache-2.0 license.
