### PR TITLE
fix(query): fixed query Multiple RUN, ADD, COPY, Instructions Listed (#4567)

### DIFF
--- a/assets/queries/dockerfile/multiple_run_add_copy_instructions_listed/query.rego
+++ b/assets/queries/dockerfile/multiple_run_add_copy_instructions_listed/query.rego
@@ -5,9 +5,14 @@ CxPolicy[result] {
 	instructions := {"copy", "add", "run"}
 	some j
 	cmdInst := [x | resource[j].Cmd == instructions[y]; x := resource[j]]
+	typeCMD := [x | cmd := cmdInst[_]; x := {"cmd": cmd.Cmd, "dest": cmd.Value[minus(count(cmd.Value), 1)]}]
+	newCmdInst := [x | cmd := cmdInst[_]; check_dest(typeCMD, cmd); x := cmd]
 
 	some n, m
-	lineCounter := [x | cmdInst[n]._kics_line - cmdInst[m]._kics_line == -1; x := cmdInst[n]]
+	lineCounter := [x |
+		newCmdInst[n]._kics_line - newCmdInst[m]._kics_line == -1
+		x := newCmdInst[n]
+	]
 
 	upperName := upper(instructions[y])
 	countCmdInst := count(lineCounter)
@@ -20,4 +25,15 @@ CxPolicy[result] {
 		"keyExpectedValue": sprintf("There isn´t any %s instruction that could be grouped", [upperName]),
 		"keyActualValue": sprintf("There are %s instructions that could be grouped", [upperName]),
 	}
+}
+
+check_dest(typeCMD, cmd) {
+	types := {"copy", "add"}
+	cmd.Cmd == types[y]
+	cmdCheck = [x | cmd.Value[minus(count(cmd.Value), 1)] == typeCMD[z].dest; x := typeCMD[z]]
+	count(cmdCheck) > 1
+} else {
+	cmd.Cmd == "run"
+} else = false {
+	true
 }

--- a/assets/queries/dockerfile/multiple_run_add_copy_instructions_listed/test/negative4.dockerfile
+++ b/assets/queries/dockerfile/multiple_run_add_copy_instructions_listed/test/negative4.dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu
+COPY README.md ./one
+COPY package.json ./two
+COPY gulpfile.js ./three
+COPY __BUILD_NUMBER ./four
+
+FROM ubuntu:1.2
+ADD README.md ./one
+ADD package.json ./two
+ADD gulpfile.js ./three
+ADD __BUILD_NUMBER ./four


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

Closes #4567

**Proposed Changes**
- Query now looks if the destinations are identical for `COPY` and `ADD` commands
I submit this contribution under the Apache-2.0 license.
