### PR TITLE
feat(e2e): add tests to validate sonaqube reports

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -122,6 +122,10 @@ func checkExpectedOutput(t *testing.T, tt *testcases.TestCase, argIndex int) {
 	if utils.Contains(resultsFormats, "glsast") {
 		utils.JSONSchemaValidation(t, "gl-sast-"+jsonFileName, "result-gl-sast.json")
 	}
+	// Check result file (SONARQUBE)
+	if utils.Contains(resultsFormats, "sonarqube") {
+		utils.JSONSchemaValidation(t, "sonarqube-"+jsonFileName, "result-sonarqube.json")
+	}
 	// Check result file (SARIF)
 	if utils.Contains(resultsFormats, "sarif") {
 		utils.JSONSchemaValidation(t, tt.Args.ExpectedResult[argIndex].ResultsFile+".sarif", "result-sarif.json")

--- a/e2e/fixtures/schemas/result-sonarqube.json
+++ b/e2e/fixtures/schemas/result-sonarqube.json
@@ -1,0 +1,58 @@
+{
+    "type": "object",
+    "required": [
+        "issues"
+    ],
+    "properties": {
+        "issues": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": [
+                    "engineId",
+                    "ruleId",
+                    "severity",
+                    "type",
+                    "primaryLocation"
+                ],
+                "properties": {
+                    "engineId": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "ruleId": {
+                        "type": "string",
+                        "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-4{1}[a-f0-9]{3}-[89ab]{1}[a-f0-9]{3}-[a-f0-9]{12}$"
+                    },
+                    "severity": {
+                        "type": "string",
+                        "enum": [
+                            "INFO",
+                            "MINOR",
+                            "MAJOR",
+                            "CRITICAL"
+                        ]
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "VULNERABILITY",
+                            "CODE_SMELL"
+                        ]
+                    },
+                    "primaryLocation": {
+                        "$ref" : "sonarqubeLocations.json"
+                    },
+                    "secondaryLocations": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "$ref": "sonarqubeLocations.json"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/e2e/fixtures/schemas/sonarqubeLocations.json
+++ b/e2e/fixtures/schemas/sonarqubeLocations.json
@@ -1,0 +1,30 @@
+{
+    "type": "object",
+    "required": [
+        "message",
+        "filePath",
+        "textRange"
+    ],
+    "properties": {
+        "message": {
+            "type": "string",
+            "minLength": 1
+        },
+        "filePath": {
+            "type": "string",
+            "pattern": "^([\\w\\-. ]+(\\\\|\\/))*([\\w\\-. ]+(\\\\|\\/).(.)*)$"
+        },
+        "textRange": {
+            "type": "object",
+            "required": [
+                "startLine"
+            ],
+            "properties": {
+                "startLine": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        }
+    }
+}

--- a/e2e/testcases/e2e-cli-031_scan_report-formats.go
+++ b/e2e/testcases/e2e-cli-031_scan_report-formats.go
@@ -8,13 +8,13 @@ func init() { //nolint
 		Args: args{
 			Args: []cmdArgs{
 				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_031_RESULT",
-					"--report-formats", "json,SARIF,glsast,Html",
+					"--report-formats", "json,SARIF,glsast,Html,SonarQUBE",
 					"-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
 			},
 			ExpectedResult: []ResultsValidation{
 				{
 					ResultsFile:    "E2E_CLI_031_RESULT",
-					ResultsFormats: []string{"json", "sarif", "glsast", "html"},
+					ResultsFormats: []string{"json", "sarif", "glsast", "html", "sonarqube"},
 				},
 			},
 		},

--- a/e2e/testcases/e2e-cli-040_scan_report-formats_validate_outputs.go
+++ b/e2e/testcases/e2e-cli-040_scan_report-formats_validate_outputs.go
@@ -8,13 +8,13 @@ func init() { //nolint
 		Args: args{
 			Args: []cmdArgs{
 				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_040_RESULT",
-					"--report-formats", "json,sarif,glsast,html",
+					"--report-formats", "json,sarif,glsast,html,sonarqube",
 					"-q", "../assets/queries", "-p", "fixtures/samples/positive.yaml"},
 			},
 			ExpectedResult: []ResultsValidation{
 				{
 					ResultsFile:    "E2E_CLI_040_RESULT",
-					ResultsFormats: []string{"json", "sarif", "glsast", "html"},
+					ResultsFormats: []string{"json", "sarif", "glsast", "html", "sonarqube"},
 				},
 			},
 		},


### PR DESCRIPTION
**Proposed Changes**
- This PR introduces a JSON Schema to validate sonarqube reports generated by kics.
- It also includes the sonarqube report validation in 2 tests.

I submit this contribution under the Apache-2.0 license.
