### PR TITLE
fix(ci): Fixed docs version regex of prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -23,7 +23,7 @@ jobs:
           echo "Date :: ${{ steps.cdate.outputs.date }}"
       - name: Replace lines
         run: |
-          sed -E -i "s/<h4>Version [0-9]+\.[0-9]+\.[0-9]+<\/h4>/<h4>Version ${{ github.event.inputs.version }}<\/h4>/" docs/index.md
+          sed -E -i "s/<h4>Version \d+(\.\d+)*<\/h4>/<h4>Version ${{ github.event.inputs.version }}<\/h4>/" docs/index.md
           sed -E -i "s/(<p.*>)[0-9]{4}\.[0-9]{2}\.[0-9]{2}<p>/\1${{ steps.cdate.outputs.date }}<p>/" docs/index.md
           sed -E -i "s/(<a.*href=\"https:\/\/github.com\/Checkmarx\/kics\/releases\/download\/).*(\/kics_).*(_[a-z]+_.*>)/\1v${{ github.event.inputs.version }}\2${{ github.event.inputs.version }}\3/g" docs/index.md
       - name: Create pull request


### PR DESCRIPTION
**Proposed Changes**
- Fix the regex to identify any valid version in kics docs (the current regex didn't identify version 1.4.6.1).

I submit this contribution under the Apache-2.0 license.
