### PR TITLE
feat(e2e): added CycloneDX report schema

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -137,8 +137,14 @@ func checkExpectedOutput(t *testing.T, tt *testcases.TestCase, argIndex int) {
 	// Check result file (JUNIT - XML)
 	if utils.Contains(resultsFormats, "junit") {
 		filename := "junit-" + tt.Args.ExpectedResult[argIndex].ResultsFile + ".xml"
-		json := utils.XMLToJSON(t, filename)
+		json := utils.XMLToJSON(t, filename, "junit")
 		utils.JSONSchemaValidationFromData(t, json, "result-junit.json")
+	}
+	// Check result file (CYCLONEDX - XML)
+	if utils.Contains(resultsFormats, "cyclonedx") {
+		filename := "cyclonedx-" + tt.Args.ExpectedResult[argIndex].ResultsFile + ".xml"
+		json := utils.XMLToJSON(t, filename, "cyclonedx")
+		utils.JSONSchemaValidationFromData(t, json, "result-cyclonedx.json")
 	}
 }
 

--- a/e2e/fixtures/schemas/result-cyclonedx.json
+++ b/e2e/fixtures/schemas/result-cyclonedx.json
@@ -1,0 +1,269 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "XMLName",
+        "XMLNS",
+        "XMLNSV",
+        "SerialNumber",
+        "Version",
+        "Metadata",
+        "Components"
+    ],
+    "definitions": {
+        "uuid_pattern": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-4{1}[a-f0-9]{3}-[89ab]{1}[a-f0-9]{3}-[a-f0-9]{12}$"
+        },
+        "pkg_generic": {
+            "type": "string",
+            "pattern": "^pkg:generic\/(.)+@(.)*-[a-f0-9]+$"
+        },
+        "XMLName": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "Space",
+                "Local"
+            ],
+            "properties": {
+                "Space": {
+                    "type": "string",
+                    "format": "uri",
+                    "minLength": 1
+                },
+                "Local": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        }
+    },
+    "properties": {
+        "XMLName": {
+            "$ref": "#/definitions/XMLName"
+        },
+        "XMLNS": {
+            "type": "string",
+            "format": "uri",
+            "minLength": 1
+        },
+        "XMLNSV": {
+            "type": "string",
+            "format": "uri",
+            "minLength": 1
+        },
+        "SerialNumber": {
+            "type": "string",
+            "pattern": "^urn:uuid:[a-f0-9]{8}-[a-f0-9]{4}-4{1}[a-f0-9]{3}-[89ab]{1}[a-f0-9]{3}-[a-f0-9]{12}$"
+        },
+        "Version": {
+            "type": "string",
+            "pattern": "^\\d+$",
+            "minLength": 1
+        },
+        "Metadata": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "Timestamp",
+                "Tools"
+            ],
+            "properties": {
+                "Timestamp": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "Tools": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "Vendor",
+                            "Name",
+                            "Version"
+                        ],
+                        "properties": {
+                            "Vendor": {
+                                "type": "string",
+                                "const": "Checkmarx"
+                            },
+                            "Name": {
+                                "type": "string",
+                                "const": "KICS"
+                            },
+                            "Version": {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "Components": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "Components"
+            ],
+            "properties": {
+                "Components": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "Type",
+                            "BomRef",
+                            "Name",
+                            "Version",
+                            "Hashes",
+                            "Purl",
+                            "Vulnerabilities"
+                        ],
+                        "properties": {
+                            "Type": {
+                                "type": "string",
+                                "const": "file"
+                            },
+                            "BomRef": {
+                                "$ref": "#/definitions/pkg_generic"
+                            },
+                            "Name": {
+                                "type": "string",
+                                "pattern": "^([\\w\\-. ]+(\\\\|\\/))*([\\w\\-. ]+(\\\\|\\/).(.)*)$",
+                                "minLength": 1
+                            },
+                            "Version": {
+                                "type": "string",
+                                "pattern": "^(.)+-[a-f0-9]{12}$",
+                                "minLength": 1
+                            },
+                            "Hashes": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "Alg",
+                                        "Content"
+                                    ],
+                                    "properties": {
+                                        "Alg": {
+                                            "type": "string",
+                                            "const": "SHA-256"
+                                        },
+                                        "Content": {
+                                            "type": "string",
+                                            "pattern": "^[a-f0-9]{64}$"
+                                        }
+                                    }
+                                }
+                            },
+                            "Purl": {
+                                "$ref": "#/definitions/pkg_generic"
+                            },
+                            "Vulnerabilities": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "Ref",
+                                        "ID",
+                                        "Source",
+                                        "Ratings",
+                                        "Description",
+                                        "Recommendations"
+                                    ],
+                                    "properties": {
+                                        "Ref": {
+                                            "$ref": "#/definitions/pkg_generic" 
+                                        },
+                                        "ID": {
+                                            "$ref": "#/definitions/uuid_pattern"
+                                        },
+                                        "Source": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "required": [
+                                                "Name",
+                                                "URL"
+                                            ],
+                                            "properties": {
+                                                "Name": {
+                                                    "type": "string",
+                                                    "const": "KICS"
+                                                },
+                                                "URL": {
+                                                    "type": "string",
+                                                    "const": "https://kics.io/"
+                                                }
+                                            }
+                                        },
+                                        "Ratings": {
+                                            "type": "array",
+                                            "minItems": 1,
+                                            "items": {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "Severity",
+                                                    "Method"
+                                                ],
+                                                "properties": {
+                                                    "Severity": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "High",
+                                                            "Medium",
+                                                            "Low",
+                                                            "None"
+                                                        ]
+                                                    },
+                                                    "Method": {
+                                                        "type": "string",
+                                                        "const": "Other"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "Description": {
+                                            "type": "string",
+                                            "pattern": "^\\[(.)+\\]\\.\\[(.)+\\]:(.)+$",
+                                            "minLength": 1
+                                        },
+                                        "Recommendations": {
+                                            "type": "array",
+                                            "minItems": 1,
+                                            "items": {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "required": [
+                                                    "Recommendation"
+                                                ],
+                                                "properties": {
+                                                    "Recommendation": {
+                                                        "type": "string",
+                                                        "pattern": "In line \\d+, a result was found. '(.)+', but '(.)+'",
+                                                        "minLength": 1
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/e2e/testcases/e2e-cli-031_scan_report-formats.go
+++ b/e2e/testcases/e2e-cli-031_scan_report-formats.go
@@ -8,7 +8,7 @@ func init() { //nolint
 		Args: args{
 			Args: []cmdArgs{
 				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_031_RESULT",
-					"--report-formats", "json,SARIF,glsast,Html,SonarQUBE,Junit",
+					"--report-formats", "json,SARIF,glsast,Html,SonarQUBE,Junit,cyclonedx",
 					"-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
 
 				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_031_RESULT_CIS",
@@ -18,7 +18,7 @@ func init() { //nolint
 			ExpectedResult: []ResultsValidation{
 				{
 					ResultsFile:    "E2E_CLI_031_RESULT",
-					ResultsFormats: []string{"json", "sarif", "glsast", "html", "sonarqube", "junit"},
+					ResultsFormats: []string{"json", "sarif", "glsast", "html", "sonarqube", "junit", "cyclonedx"},
 				},
 				{
 					ResultsFile:    "E2E_CLI_031_RESULT_CIS",

--- a/e2e/utils/xml.go
+++ b/e2e/utils/xml.go
@@ -42,6 +42,7 @@ func readXMLasJSON(t *testing.T, fullPath, file string, data interface{}) []byte
 	return jsonData
 }
 
+// CycloneSchema is the struct used to unmarshal the cyclonedx xml
 type CycloneSchema struct {
 	XMLName      xml.Name `xml:"bom"`
 	XMLNS        string   `xml:"xmlns,attr"`

--- a/e2e/utils/xml.go
+++ b/e2e/utils/xml.go
@@ -12,7 +12,7 @@ import (
 )
 
 // XMLToJSON - converts XML to JSON Structure
-func XMLToJSON(t *testing.T, filename string) []byte {
+func XMLToJSON(t *testing.T, filename, model string) []byte {
 	cwd, _ := os.Getwd()
 	filePath := filepath.Join("output", filename)
 	fullPath := filepath.Join(cwd, filePath)
@@ -20,12 +20,69 @@ func XMLToJSON(t *testing.T, filename string) []byte {
 	file, err := ReadFixture(filePath, cwd)
 	require.NoError(t, err, "Error reading file: %s", fullPath)
 
-	data := reportModel.NewJUnitReport("")
-	err = xml.Unmarshal([]byte(file), &data)
+	switch model {
+	default:
+		return []byte{}
+	case "junit":
+		data := reportModel.NewJUnitReport("")
+		return readXMLasJSON(t, fullPath, file, data)
+	case "cyclonedx":
+		data := CycloneSchema{}
+		return readXMLasJSON(t, fullPath, file, &data)
+	}
+}
+
+func readXMLasJSON(t *testing.T, fullPath, file string, data interface{}) []byte {
+	err := xml.Unmarshal([]byte(file), &data)
 	require.NoError(t, err, "Error unmarshalling file: %s", fullPath)
 
 	jsonData, err := json.Marshal(data)
 	require.NoError(t, err, "Error marshaling file: %s", fullPath)
 
 	return jsonData
+}
+
+type CycloneSchema struct {
+	XMLName      xml.Name `xml:"bom"`
+	XMLNS        string   `xml:"xmlns,attr"`
+	XMLNSV       string   `xml:"v,attr"`
+	SerialNumber string   `xml:"serialNumber,attr"`
+	Version      string   `xml:"version,attr"`
+	Metadata     struct {
+		Timestamp string `xml:"timestamp"`
+		Tools     []struct {
+			Vendor  string `xml:"vendor"`
+			Name    string `xml:"name"`
+			Version string `xml:"version"`
+		} `xml:"tools>tool"`
+	} `xml:"metadata"`
+	Components struct {
+		Components []struct {
+			Type    string `xml:"type,attr"`
+			BomRef  string `xml:"bom-ref,attr"`
+			Name    string `xml:"name"`
+			Version string `xml:"version"`
+			Hashes  []struct {
+				Alg     string `xml:"alg,attr"`
+				Content string `xml:",chardata"`
+			} `xml:"hashes>hash"`
+			Purl            string `xml:"purl"`
+			Vulnerabilities []struct {
+				Ref    string `xml:"ref,attr"`
+				ID     string `xml:"id"`
+				Source struct {
+					Name string `xml:"name"`
+					URL  string `xml:"url"`
+				} `xml:"source"`
+				Ratings []struct {
+					Severity string `xml:"severity"`
+					Method   string `xml:"method"`
+				} `xml:"ratings>rating"`
+				Description     string `xml:"description"`
+				Recommendations []struct {
+					Recommendation string `xml:"Recommendation"`
+				} `xml:"recommendations>recommendation"`
+			} `xml:"vulnerabilities>vulnerability"`
+		} `xml:"component"`
+	} `xml:"components"`
 }


### PR DESCRIPTION
**Proposed Changes**

The aim of this PR is to validate the structure of CycloneDX reports generated by kics.
It includes a JSON-Schema validation that verifies all the fields of a CycloneDX report, applying many asserts, such as regex and enum on specific fields. The CycloneDX report is generated as XML, and the E2E converts it into JSON to validate using a schema.

I submit this contribution under the Apache-2.0 license.
