### PR TITLE
feat(query): add allow rule for ansible-vault

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -284,6 +284,10 @@
     {
       "description": "Avoiding TF file function",
       "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*=\\s*['\"]?(file\\()['\"]?"
+    },
+    {
+      "description": "Avoiding ansible-vault encrypted variables",
+      "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*[=:]\\s*['\"]?(!vault \\|)['\"]?"
     }
   ]
 }


### PR DESCRIPTION
**Proposed Changes**
- kics reports passwords encrypted with ansible-vault (in the Passwords And Secrets - Generic Password query). However since these passwords are encrypted, they should not be reported

I submit this contribution under the Apache-2.0 license.
