### PR TITLE
fix(query): deleting searchLine in "Resource Not Using Tags" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/resource_not_using_tags/query.rego
+++ b/assets/queries/terraform/aws/resource_not_using_tags/query.rego
@@ -16,7 +16,6 @@ CxPolicy[result] {
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s[{{%s}}].tags is defined and not null", [res, name]),
 		"keyActualValue": sprintf("%s[{{%s}}].tags is undefined or null", [res, name]),
-		"searchLine": common_lib.build_search_line(["resource", res, name], []),
 	}
 }
 
@@ -33,7 +32,6 @@ CxPolicy[result] {
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("%s[{{%s}}].tags has tags defined other than 'Name'", [res, name]),
 		"keyActualValue": sprintf("%s[{{%s}}].tags has no tags defined", [res, name]),
-		"searchLine": common_lib.build_search_line(["resource", res, name, "tags"], []),
 	}
 }
 

--- a/e2e/fixtures/E2E_CLI_032_RESULT.json
+++ b/e2e/fixtures/E2E_CLI_032_RESULT.json
@@ -226,7 +226,7 @@
       "files": [
         {
           "file_name": "fixtures/samples/terraform.tf",
-          "similarity_id": "ff26328ed857afb92e2be8b946b4dd28fb0e5125fae679653e0117e5b9359554",
+          "similarity_id": "b44463ffd0f5c1eadc04ce6649982da68658349ad880daef470250661d3d1512",
           "line": 1,
           "issue_type": "MissingAttribute",
           "search_key": "aws_redshift_cluster[{{default}}]",
@@ -237,7 +237,7 @@
         },
         {
           "file_name": "fixtures/samples/terraform.tf",
-          "similarity_id": "fa5d403b0ee5702d19523b159dfe830584ac506471647bbfb94d101d258cb3c8",
+          "similarity_id": "406b71d9fd0edb656a4735df30dde77c5f8a6c4ec3caa3442f986a92832c653b",
           "line": 10,
           "issue_type": "MissingAttribute",
           "search_key": "aws_redshift_cluster[{{default1}}]",

--- a/e2e/fixtures/E2E_CLI_033_RESULT.json
+++ b/e2e/fixtures/E2E_CLI_033_RESULT.json
@@ -91,7 +91,7 @@
       "files": [
         {
           "file_name": "../../e2e/fixtures/samples/terraform-single.tf",
-          "similarity_id": "ff26328ed857afb92e2be8b946b4dd28fb0e5125fae679653e0117e5b9359554",
+          "similarity_id": "406b71d9fd0edb656a4735df30dde77c5f8a6c4ec3caa3442f986a92832c653b",
           "line": 1,
           "issue_type": "MissingAttribute",
           "search_key": "aws_redshift_cluster[{{default1}}]",

--- a/e2e/testcases/e2e-cli-037_scan_exclude-results_include-queries.go
+++ b/e2e/testcases/e2e-cli-037_scan_exclude-results_include-queries.go
@@ -9,7 +9,7 @@ func init() { //nolint
 			Args: []cmdArgs{
 
 				[]string{"scan", "--include-queries", "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",
-					"--exclude-results", "ff26328ed857afb92e2be8b946b4dd28fb0e5125fae679653e0117e5b9359554",
+					"--exclude-results", "406b71d9fd0edb656a4735df30dde77c5f8a6c4ec3caa3442f986a92832c653b",
 					"-q", "../assets/queries", "-p", "fixtures/samples/terraform-single.tf"},
 
 				[]string{"scan", "--include-queries", "e38a8e0a-b88b-4902-b3fe-b0fcb17d5c10",


### PR DESCRIPTION
**Proposed Changes**
- Deleting searchLine in "Resource Not Using Tags" for Terraform

I submit this contribution under the Apache-2.0 license.
