### PR TITLE
add allow rule for mysql password hashes

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -288,6 +288,10 @@
     {
       "description": "Avoiding ansible-vault encrypted variables",
       "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*[=:]\\s*['\"]?(!vault \\|)['\"]?"
+    },
+    {
+      "description": "Avoiding sha-hashed mysql native passwords",
+      "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*[=:]\\s*['\"]?(\\*[0-9A-F]{40})['\"]?"
     }
   ]
 }


### PR DESCRIPTION
**Proposed Changes**
MySQL-password are twiced hashed.
They are always 41 bytes long with the fist byte being an asterisk.

I submit this contribution under the Apache-2.0 license.
