### PR TITLE
fix(query): updated "S3 Bucket Without Enabled MFA Delete" for Terraform

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "S3 Bucket Without Enabled MFA Delete",
   "severity": "HIGH",
   "category": "Insecure Configurations",
-  "descriptionText": "S3 bucket without MFA Delete Enabled. MFA delete cannot be enabled through Terraform, it can be done by adding a MFA device (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable.html) and enabling versioning and MFA delete by using AWS CLI: 'aws s3api put-bucket-versioning --versioning-configuration=Status=Enabled,MFADelete=Enabled --bucket=<BUCKET_NAME> --mfa=<MFA_SERIAL_NUMBER>'",
+  "descriptionText": "S3 bucket without MFA Delete Enabled. MFA delete cannot be enabled through Terraform, it can be done by adding a MFA device (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable.html) and enabling versioning and MFA delete by using AWS CLI: 'aws s3api put-bucket-versioning --versioning-configuration=Status=Enabled,MFADelete=Enabled --bucket=<BUCKET_NAME> --mfa=<MFA_SERIAL_NUMBER>'. Please, also notice that MFA delete can not be used with lifecycle configurations",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#mfa_delete",
   "platform": "Terraform",
   "descriptionID": "e1699d08",

--- a/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/query.rego
@@ -4,6 +4,7 @@ import data.generic.common as common_lib
 
 CxPolicy[result] {
 	bucket := input.document[i].resource.aws_s3_bucket[name]
+	not common_lib.valid_key(bucket, "lifecycle_rule")
 	not common_lib.valid_key(bucket, "versioning")
 
 	result := {
@@ -22,8 +23,9 @@ checkedFields = {
 }
 
 CxPolicy[result] {
-	ver := input.document[i].resource.aws_s3_bucket[name].versioning
-	not common_lib.valid_key(ver, checkedFields[j])
+	bucket := input.document[i].resource.aws_s3_bucket[name]
+	not common_lib.valid_key(bucket, "lifecycle_rule")
+	not common_lib.valid_key(bucket.versioning, checkedFields[j])
 
 	result := {
 		"documentId": input.document[i].id,
@@ -36,8 +38,9 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	ver := input.document[i].resource.aws_s3_bucket[name].versioning
-	ver[checkedFields[j]] != true
+	bucket := input.document[i].resource.aws_s3_bucket[name]
+	not common_lib.valid_key(bucket, "lifecycle_rule")
+	bucket.versioning[checkedFields[j]] != true
 
 	result := {
 		"documentId": input.document[i].id,
@@ -53,6 +56,7 @@ CxPolicy[result] {
 	module := input.document[i].module[name]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_s3_bucket", "versioning")
 
+	not common_lib.valid_key(module, "lifecycle_rule")
 	not common_lib.valid_key(module, keyToCheck)
 
 	result := {
@@ -69,6 +73,7 @@ CxPolicy[result] {
 	module := input.document[i].module[name]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_s3_bucket", "versioning")
 
+	not common_lib.valid_key(module, "lifecycle_rule")
 	not common_lib.valid_key(module[keyToCheck],  checkedFields[c])
 
 	result := {
@@ -85,6 +90,7 @@ CxPolicy[result] {
 	module := input.document[i].module[name]
 	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_s3_bucket", "versioning")
 
+	not common_lib.valid_key(module, "lifecycle_rule")
 	module[keyToCheck][checkedFields[c]] != true
 
 	result := {

--- a/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/test/negative3.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/test/negative3.tf
@@ -1,0 +1,17 @@
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+  version = "3.7.0"
+
+  bucket = "my-s3-bucket"
+  acl    = "private"
+
+  lifecycle_rule {
+    id      = "tmp"
+    prefix  = "tmp/"
+    enabled = true
+
+    expiration {
+      date = "2016-01-12"
+    }
+  }
+}

--- a/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/test/negative4.tf
+++ b/assets/queries/terraform/aws/s3_bucket_without_enabled_mfa_delete/test/negative4.tf
@@ -1,0 +1,19 @@
+resource "aws_s3_bucket" "negative4" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
+  }
+
+  lifecycle_rule {
+    id      = "tmp"
+    prefix  = "tmp/"
+    enabled = true
+
+    expiration {
+      date = "2016-01-12"
+    }
+  }
+}


### PR DESCRIPTION
Closes #4576

**Proposed Changes**
- Updated "S3 Bucket Without Enabled MFA Delete" for Terraform: excluded `s3_bucket` with lifecycle configurations

I submit this contribution under the Apache-2.0 license.
