### PR TITLE
fix(report): added space between description and results in pdf report

### DIFF
--- a/pkg/report/pdf.go
+++ b/pkg/report/pdf.go
@@ -151,6 +151,9 @@ func createDescription(m pdf.Maroto, description string) {
 			})
 		})
 	})
+	m.Row(colFive, func() {
+		m.ColSpace(0)
+	})
 }
 
 func createCISRows(m pdf.Maroto, query *model.QueryResult) {


### PR DESCRIPTION
**Proposed Changes**
- Added space between description and results in pdf report

I submit this contribution under the Apache-2.0 license.
