### PR TITLE
feat(cli): added contribution appeal when the user includes external queries

### DIFF
--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -46,13 +46,15 @@ var reportGenerators = map[string]func(path, filename string, body interface{}) 
 // Line is the color to print the line with the vulnerability
 // minVersion is a bool that if true will print the results output in a minimum version
 type Printer struct {
-	Medium  color.RGBColor
-	High    color.RGBColor
-	Low     color.RGBColor
-	Info    color.RGBColor
-	Success color.RGBColor
-	Line    color.RGBColor
-	minimal bool
+	Medium              color.RGBColor
+	High                color.RGBColor
+	Low                 color.RGBColor
+	Info                color.RGBColor
+	Success             color.RGBColor
+	Line                color.RGBColor
+	VersionMessage      color.RGBColor
+	ContributionMessage color.RGBColor
+	minimal             bool
 }
 
 // WordWrap Wraps text at the specified number of words
@@ -277,13 +279,15 @@ func ListReportFormats() []string {
 // NewPrinter initializes a new Printer
 func NewPrinter(minimal bool) *Printer {
 	return &Printer{
-		Medium:  color.HEX("#ff7213"),
-		High:    color.HEX("#bb2124"),
-		Low:     color.HEX("#edd57e"),
-		Success: color.HEX("#22bb33"),
-		Info:    color.HEX("#5bc0de"),
-		Line:    color.HEX("#f0ad4e"),
-		minimal: minimal,
+		Medium:              color.HEX("#ff7213"),
+		High:                color.HEX("#bb2124"),
+		Low:                 color.HEX("#edd57e"),
+		Success:             color.HEX("#22bb33"),
+		Info:                color.HEX("#5bc0de"),
+		Line:                color.HEX("#f0ad4e"),
+		VersionMessage:      color.HEX("#ff9913"),
+		ContributionMessage: color.HEX("ffe313"),
+		minimal:             minimal,
 	}
 }
 

--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -125,7 +125,6 @@ func PrintResult(summary *model.Summary, failedQueries map[string]error, printer
 	log.Info().Msgf("Queries failed to execute: %d", summary.FailedToExecuteQueries)
 	log.Info().Msg("Inspector stopped")
 
-	summary.PrintVersionCheck()
 	return nil
 }
 

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -9,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gookit/color"
 	"github.com/rs/zerolog/log"
 )
 
@@ -251,15 +249,5 @@ func CreateSummary(counters Counters, vulnerabilities []Vulnerability,
 		SeveritySummary: severitySummary,
 		ScannedPaths:    removeAllURLCredentials(pathExtractionMap),
 		LatestVersion:   version,
-	}
-}
-
-// PrintVersionCheck - Prints and logs warning if not using KICS latest version
-func (s *Summary) PrintVersionCheck() {
-	if !s.LatestVersion.Latest {
-		message := fmt.Sprintf("A new version 'v%s' of KICS is available, please consider updating", s.LatestVersion.LatestVersionTag)
-		orange := 214
-		color.C256(uint8(orange)).Println(message)
-		log.Warn().Msgf(message)
 	}
 }

--- a/pkg/model/summary.go
+++ b/pkg/model/summary.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gookit/color"
 	"github.com/rs/zerolog/log"
 )
 
@@ -257,7 +258,8 @@ func CreateSummary(counters Counters, vulnerabilities []Vulnerability,
 func (s *Summary) PrintVersionCheck() {
 	if !s.LatestVersion.Latest {
 		message := fmt.Sprintf("A new version 'v%s' of KICS is available, please consider updating", s.LatestVersion.LatestVersionTag)
-		fmt.Println(message)
+		orange := 214
+		color.C256(uint8(orange)).Println(message)
 		log.Warn().Msgf(message)
 	}
 }

--- a/pkg/scan/path_utils.go
+++ b/pkg/scan/path_utils.go
@@ -3,12 +3,14 @@ package scan
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	consoleHelpers "github.com/Checkmarx/kics/internal/console/helpers"
 	"github.com/Checkmarx/kics/pkg/analyzer"
 	"github.com/Checkmarx/kics/pkg/engine/provider"
 	"github.com/Checkmarx/kics/pkg/model"
+	"github.com/gookit/color"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -133,5 +135,13 @@ func deleteExtractionFolder(extractionMap map[string]model.ExtractedPathObject) 
 		if err != nil {
 			log.Err(err).Msg("Failed to delete KICS extraction folder")
 		}
+	}
+}
+
+func contributionAppeal(queriesPath string) {
+	if !strings.Contains(queriesPath, filepath.Join("assets", "queries")) {
+		msg := "\nAre you using a custom query? If so, feel free to contribute to KICS!\n"
+		contributionPage := "Check out how to do it: https://github.com/Checkmarx/kics/blob/master/docs/CONTRIBUTING.md\n\n"
+		color.Yellow.Print(msg + contributionPage)
 	}
 }

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -115,9 +115,9 @@ func (c *Client) postScan(scanResults *Results) error {
 
 	consolePrinter.PrintScanDuration(time.Since(c.ScanStartTime))
 
-	summary.PrintVersionCheck()
+	printVersionCheck(c.Printer, &summary)
 
-	contributionAppeal(c.ScanParams.QueriesPath)
+	contributionAppeal(c.Printer, c.ScanParams.QueriesPath)
 
 	exitCode := consoleHelpers.ResultsExitCode(&summary)
 	if consoleHelpers.ShowError("results") && exitCode != 0 {

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -115,6 +115,10 @@ func (c *Client) postScan(scanResults *Results) error {
 
 	consolePrinter.PrintScanDuration(time.Since(c.ScanStartTime))
 
+	summary.PrintVersionCheck()
+
+	contributionAppeal(c.ScanParams.QueriesPath)
+
 	exitCode := consoleHelpers.ResultsExitCode(&summary)
 	if consoleHelpers.ShowError("results") && exitCode != 0 {
 		os.Exit(exitCode)

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Checkmarx/kics/pkg/analyzer"
 	"github.com/Checkmarx/kics/pkg/engine/provider"
 	"github.com/Checkmarx/kics/pkg/model"
-	"github.com/gookit/color"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -138,10 +137,21 @@ func deleteExtractionFolder(extractionMap map[string]model.ExtractedPathObject) 
 	}
 }
 
-func contributionAppeal(queriesPath string) {
+func contributionAppeal(printer *consoleHelpers.Printer, queriesPath string) {
 	if !strings.Contains(queriesPath, filepath.Join("assets", "queries")) {
 		msg := "\nAre you using a custom query? If so, feel free to contribute to KICS!\n"
-		contributionPage := "Check out how to do it: https://github.com/Checkmarx/kics/blob/master/docs/CONTRIBUTING.md\n\n"
-		color.Yellow.Print(msg + contributionPage)
+		contributionPage := "Check out how to do it: https://github.com/Checkmarx/kics/blob/master/docs/CONTRIBUTING.md\n"
+
+		fmt.Println(printer.ContributionMessage.Sprintf(msg + contributionPage))
+	}
+}
+
+// printVersionCheck - Prints and logs warning if not using KICS latest version
+func printVersionCheck(printer *consoleHelpers.Printer, s *model.Summary) {
+	if !s.LatestVersion.Latest {
+		message := fmt.Sprintf("A new version 'v%s' of KICS is available, please consider updating", s.LatestVersion.LatestVersionTag)
+
+		fmt.Println(printer.VersionMessage.Sprintf(message))
+		log.Warn().Msgf(message)
 	}
 }


### PR DESCRIPTION
Closes #2224

**Proposed Changes**
- Added contribution appeal when the user includes external queries (the queries path do not follow assets/queries structure)
- Changed `PrintVersionCheck` location and colour

I submit this contribution under the Apache-2.0 license.
