### PR TITLE
feat(query): added "Elasticsearch Without IAM Authentication" for CloudFormation and Terraform

### DIFF
--- a/assets/libraries/common.rego
+++ b/assets/libraries/common.rego
@@ -426,6 +426,8 @@ any_principal(statement) {
 } else {
 	is_array(statement.Principal.AWS)
 	contains(statement.Principal.AWS[_], "*")
+} else {
+	not valid_key(statement, "Principal")
 }
 
 is_recommended_tls(field) {

--- a/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/metadata.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "5c666ed9-b586-49ab-9873-c495a833b705",
+  "queryName": "Elasticsearch Without IAM Authentication",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "AWS Elasticsearch should ensure IAM Authentication",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html#cfn-elasticsearch-domain-accesspolicies",
+  "platform": "CloudFormation",
+  "descriptionID": "af727c29",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/query.rego
+++ b/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/query.rego
@@ -1,0 +1,24 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	document := input.document
+	resource = document[i].Resources[name]
+	resource.Type == "AWS::Elasticsearch::Domain"
+	properties := resource.Properties
+
+	policy := properties.AccessPolicies
+	st := policy.Statement[idx]
+
+	common_lib.any_principal(st)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("Resources.%s.Properties.AccessPolicies.Statement", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Elasticsearch Domain ensure IAM Authentication",
+		"keyActualValue": "Elasticsearch Domain does not ensure IAM Authentication",
+		"searchLine": common_lib.build_search_line(["Resource", name, "Properties", "AccessPolicies", "Statement", idx], []),
+	}
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/test/negative1.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/test/negative1.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Creates ES
+Resources:
+  ElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: "test"
+      ElasticsearchVersion: "7.10"
+      ElasticsearchClusterConfig:
+        DedicatedMasterEnabled: true
+        InstanceCount: "2"
+        ZoneAwarenessEnabled: true
+        InstanceType: "m3.medium.elasticsearch"
+        DedicatedMasterType: "m3.medium.elasticsearch"
+        DedicatedMasterCount: "3"
+      EBSOptions:
+        EBSEnabled: true
+        Iops: "0"
+        VolumeSize: "20"
+        VolumeType: "gp2"
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: "arn:aws:iam::123456789012:user/es-user"
+            Action: "es:*"
+            Resource: "arn:aws:es:us-east-1:846973539254:domain/test/*"
+      LogPublishingOptions:
+        ES_APPLICATION_LOGS:
+          CloudWatchLogsLogGroupArn: "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-application-logs"
+          Enabled: true
+        SEARCH_SLOW_LOGS:
+          CloudWatchLogsLogGroupArn: "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs"
+          Enabled: true
+        INDEX_SLOW_LOGS:
+          CloudWatchLogsLogGroupArn: "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs"
+          Enabled: true
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: true

--- a/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/test/negative2.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/test/negative2.json
@@ -1,0 +1,57 @@
+{
+  "Resources": {
+    "ElasticsearchDomain": {
+      "Type": "AWS::Elasticsearch::Domain",
+      "Properties": {
+        "DomainName": "test",
+        "ElasticsearchVersion": "7.10",
+        "ElasticsearchClusterConfig": {
+          "DedicatedMasterEnabled": true,
+          "InstanceCount": "2",
+          "ZoneAwarenessEnabled": true,
+          "InstanceType": "m3.medium.elasticsearch",
+          "DedicatedMasterType": "m3.medium.elasticsearch",
+          "DedicatedMasterCount": "3"
+        },
+        "EBSOptions": {
+          "EBSEnabled": true,
+          "Iops": "0",
+          "VolumeSize": "20",
+          "VolumeType": "gp2"
+        },
+        "AccessPolicies": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::123456789012:user/es-user"
+              },
+              "Action": "es:*",
+              "Resource": "arn:aws:es:us-east-1:123456789012:domain/test/*"
+            }
+          ]
+        },
+        "LogPublishingOptions": {
+          "ES_APPLICATION_LOGS": {
+            "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-application-logs",
+            "Enabled": true
+          },
+          "SEARCH_SLOW_LOGS": {
+            "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs",
+            "Enabled": true
+          },
+          "INDEX_SLOW_LOGS": {
+            "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs",
+            "Enabled": true
+          }
+        },
+        "AdvancedOptions": {
+          "rest.action.multi.allow_explicit_index": true
+        }
+      }
+    }
+  },
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Creates RDS Cluster"
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/test/positive1.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/test/positive1.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Creates ES
+Resources:
+  ElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: "test"
+      ElasticsearchVersion: "7.10"
+      ElasticsearchClusterConfig:
+        DedicatedMasterEnabled: true
+        InstanceCount: "2"
+        ZoneAwarenessEnabled: true
+        InstanceType: "m3.medium.elasticsearch"
+        DedicatedMasterType: "m3.medium.elasticsearch"
+        DedicatedMasterCount: "3"
+      EBSOptions:
+        EBSEnabled: true
+        Iops: "0"
+        VolumeSize: "20"
+        VolumeType: "gp2"
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: "arn:aws:es:us-east-1:846973539254:domain/test/*"
+      LogPublishingOptions:
+        ES_APPLICATION_LOGS:
+          CloudWatchLogsLogGroupArn: "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-application-logs"
+          Enabled: true
+        SEARCH_SLOW_LOGS:
+          CloudWatchLogsLogGroupArn: "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs"
+          Enabled: true
+        INDEX_SLOW_LOGS:
+          CloudWatchLogsLogGroupArn: "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs"
+          Enabled: true
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: true

--- a/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/test/positive2.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/test/positive2.json
@@ -1,0 +1,57 @@
+{
+  "Resources": {
+    "ElasticsearchDomain": {
+      "Type": "AWS::Elasticsearch::Domain",
+      "Properties": {
+        "DomainName": "test",
+        "ElasticsearchVersion": "7.10",
+        "ElasticsearchClusterConfig": {
+          "DedicatedMasterEnabled": true,
+          "InstanceCount": "2",
+          "ZoneAwarenessEnabled": true,
+          "InstanceType": "m3.medium.elasticsearch",
+          "DedicatedMasterType": "m3.medium.elasticsearch",
+          "DedicatedMasterCount": "3"
+        },
+        "EBSOptions": {
+          "EBSEnabled": true,
+          "Iops": "0",
+          "VolumeSize": "20",
+          "VolumeType": "gp2"
+        },
+        "AccessPolicies": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Action": "es:*",
+              "Resource": "arn:aws:es:us-east-1:123456789012:domain/test/*"
+            }
+          ]
+        },
+        "LogPublishingOptions": {
+          "ES_APPLICATION_LOGS": {
+            "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-application-logs",
+            "Enabled": true
+          },
+          "SEARCH_SLOW_LOGS": {
+            "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs",
+            "Enabled": true
+          },
+          "INDEX_SLOW_LOGS": {
+            "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs",
+            "Enabled": true
+          }
+        },
+        "AdvancedOptions": {
+          "rest.action.multi.allow_explicit_index": true
+        }
+      }
+    }
+  },
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Creates RDS Cluster"
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_without_iam_authentication/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Elasticsearch Without IAM Authentication",
+    "severity": "MEDIUM",
+    "line": 23,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Without IAM Authentication",
+    "severity": "MEDIUM",
+    "line": 24,
+    "fileName": "positive2.json"
+  }
+]

--- a/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/metadata.json
+++ b/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "e7530c3c-b7cf-4149-8db9-d037a0b5268e",
+  "queryName": "Elasticsearch Without IAM Authentication",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "AWS Elasticsearch should ensure IAM Authentication",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain",
+  "platform": "Terraform",
+  "descriptionID": "7677c71c",
+  "cloudProvider": "aws"
+}

--- a/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/query.rego
+++ b/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/query.rego
@@ -1,0 +1,48 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	input.document[i].resource.aws_elasticsearch_domain[name]
+
+	not has_policy(name)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticsearch_domain[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Elasticsearch Domain has a policy associated",
+		"keyActualValue": "Elasticsearch Domain does not have a policy associated",
+		"searchLine": common_lib.build_search_line(["resource", "aws_elasticsearch_domain", name], []),
+	}
+}
+
+CxPolicy[result] {
+	input.document[i].resource.aws_elasticsearch_domain[name]
+
+	without_iam_auth(name)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_elasticsearch_domain[%s]", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Elasticsearch Domain ensure IAM Authentication",
+		"keyActualValue": "Elasticsearch Domain does not ensure IAM Authentication",
+		"searchLine": common_lib.build_search_line(["resource", "aws_elasticsearch_domain", name], []),
+	}
+}
+
+has_policy(name) {
+	policy := input.document[i].resource.aws_elasticsearch_domain_policy[_]
+	split(policy.domain_name, ".")[1] == name
+}
+
+without_iam_auth(name) {
+	policy := input.document[i].resource.aws_elasticsearch_domain_policy[_]
+	split(policy.domain_name, ".")[1] == name
+
+	p := common_lib.json_unmarshal(policy.access_policies)
+	st := p.Statement[_]
+	st.Effect == "Allow"
+	common_lib.any_principal(st)
+}

--- a/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/test/negative.tf
+++ b/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/test/negative.tf
@@ -1,0 +1,30 @@
+resource "aws_elasticsearch_domain" "negativee" {
+  domain_name           = "tf-test"
+  elasticsearch_version = "2.3"
+}
+
+resource "aws_elasticsearch_domain_policy" "main8" {
+  domain_name = aws_elasticsearch_domain.negativee.domain_name
+
+  access_policies = <<POLICIES
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "es:*",
+            "Principal" : {
+              "AWS": [
+                "arn:aws:iam::123456789012:root",
+                "arn:aws:iam::555555555555:root"
+                ]
+            },
+            "Effect": "Allow",
+            "Condition": {
+                "IpAddress": {"aws:SourceIp": "127.0.0.1/32"}
+            },
+            "Resource": "${aws_elasticsearch_domain.negativee.arn}/*"
+        }
+    ]
+}
+POLICIES
+}

--- a/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/test/positive1.tf
+++ b/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/test/positive1.tf
@@ -1,0 +1,25 @@
+resource "aws_elasticsearch_domain" "example" {
+  domain_name           = "tf-test"
+  elasticsearch_version = "2.3"
+}
+
+resource "aws_elasticsearch_domain_policy" "main" {
+  domain_name = aws_elasticsearch_domain.example.domain_name
+
+  access_policies = <<POLICIES
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "es:*",
+            "Principal": "*",
+            "Effect": "Allow",
+            "Condition": {
+                "IpAddress": {"aws:SourceIp": "127.0.0.1/32"}
+            },
+            "Resource": "${aws_elasticsearch_domain.example.arn}/*"
+        }
+    ]
+}
+POLICIES
+}

--- a/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/test/positive2.tf
+++ b/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/test/positive2.tf
@@ -1,0 +1,24 @@
+resource "aws_elasticsearch_domain" "example2" {
+  domain_name           = "tf-test"
+  elasticsearch_version = "2.3"
+}
+
+resource "aws_elasticsearch_domain_policy" "main2" {
+  domain_name = aws_elasticsearch_domain.example2.domain_name
+
+  access_policies = <<POLICIES
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "es:*",
+            "Effect": "Allow",
+            "Condition": {
+                "IpAddress": {"aws:SourceIp": "127.0.0.1/32"}
+            },
+            "Resource": "${aws_elasticsearch_domain.example2.arn}/*"
+        }
+    ]
+}
+POLICIES
+}

--- a/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/elasticsearch_without_iam_authentication/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Elasticsearch Without IAM Authentication",
+    "severity": "MEDIUM",
+    "line": 1,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "Elasticsearch Without IAM Authentication",
+    "severity": "MEDIUM",
+    "line": 1,
+    "fileName": "positive2.tf"
+  }
+]


### PR DESCRIPTION
**Proposed Changes**
- Added "Elasticsearch Without IAM Authentication" for CloudFormation and Terraform

🚨 SEVERITY AND CATEGORY NEED REVIEW 🚨

I submit this contribution under the Apache-2.0 license.
