### PR TITLE
feat(query): added "SQL DB Instance Backup Disabled" for Google Deployment Manager

### DIFF
--- a/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/metadata.json
+++ b/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "a5bf1a1c-92c7-401c-b4c6-ebdc8b686c01",
+  "queryName": "SQL DB Instance Backup Disabled",
+  "severity": "HIGH",
+  "category": "Backup",
+  "descriptionText": "Checks if backup configuration is enabled for all Cloud SQL Database instances",
+  "descriptionUrl": "https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances",
+  "platform": "GoogleDeploymentManager",
+  "descriptionID": "45790b7e",
+  "cloudProvider": "gcp"
+}

--- a/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/query.rego
+++ b/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/query.rego
@@ -1,0 +1,54 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i].resources[idx]
+	resource.type == "sqladmin.v1beta4.instance"
+	settings := resource.properties.settings
+
+	not common_lib.valid_key(settings, "backupConfiguration")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("resources.name={{%s}}.properties.settings.backupConfiguration", [resource.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'settings.backupConfiguration' is defined and not null",
+		"keyActualValue": "'settings.backupConfiguration' is not defined or null", 
+		"searchLine": common_lib.build_search_line(["resources", idx, "properties", "settings", "backupConfiguration"], []),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resources[idx]
+	resource.type == "sqladmin.v1beta4.instance"
+	settings := resource.properties.settings
+
+	not common_lib.valid_key(settings.backupConfiguration, "enabled")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("resources.name={{%s}}.properties.settings.backupConfiguration.enabled", [resource.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'settings.backupConfiguration.enabled' is defined and not null",
+		"keyActualValue": "'settings.backupConfiguration.enabled' is undefined or null", 
+		"searchLine": common_lib.build_search_line(["resources", idx, "properties", "settings", "backupConfiguration", "enabled"], []),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resources[idx]
+	resource.type == "sqladmin.v1beta4.instance"
+	settings := resource.properties.settings
+
+	settings.backupConfiguration.enabled == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("resources.name={{%s}}.properties.settings.backupConfiguration.enabled", [resource.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'settings.backupConfiguration.enabled' to be true",
+		"keyActualValue": "'settings.backupConfiguration.enabled' is false", 
+		"searchLine": common_lib.build_search_line(["resources", idx, "properties", "settings", "backupConfiguration", "enabled"], []),
+	}
+}

--- a/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/query.rego
+++ b/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("resources.name={{%s}}.properties.settings.backupConfiguration", [resource.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'settings.backupConfiguration' is defined and not null",
-		"keyActualValue": "'settings.backupConfiguration' is not defined or null", 
+		"keyActualValue": "'settings.backupConfiguration' is undefined or null", 
 		"searchLine": common_lib.build_search_line(["resources", idx, "properties", "settings", "backupConfiguration"], []),
 	}
 }

--- a/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/query.rego
+++ b/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/query.rego
@@ -11,11 +11,11 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("resources.name={{%s}}.properties.settings.backupConfiguration", [resource.name]),
+		"searchKey": sprintf("resources.name={{%s}}.properties.settings", [resource.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'settings.backupConfiguration' is defined and not null",
 		"keyActualValue": "'settings.backupConfiguration' is undefined or null", 
-		"searchLine": common_lib.build_search_line(["resources", idx, "properties", "settings", "backupConfiguration"], []),
+		"searchLine": common_lib.build_search_line(["resources", idx, "properties", "settings"], []),
 	}
 }
 
@@ -28,11 +28,11 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("resources.name={{%s}}.properties.settings.backupConfiguration.enabled", [resource.name]),
+		"searchKey": sprintf("resources.name={{%s}}.properties.settings.backupConfiguration", [resource.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "'settings.backupConfiguration.enabled' is defined and not null",
 		"keyActualValue": "'settings.backupConfiguration.enabled' is undefined or null", 
-		"searchLine": common_lib.build_search_line(["resources", idx, "properties", "settings", "backupConfiguration", "enabled"], []),
+		"searchLine": common_lib.build_search_line(["resources", idx, "properties", "settings", "backupConfiguration"], []),
 	}
 }
 

--- a/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/test/negative1.yaml
+++ b/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/test/negative1.yaml
@@ -1,0 +1,8 @@
+resources:
+  - name: sql-instance
+    type: sqladmin.v1beta4.instance
+    properties:
+      settings:
+        tier: db-custom-1-3840
+        backupConfiguration:
+          enabled: true

--- a/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/test/positive1.yaml
+++ b/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/test/positive1.yaml
@@ -1,0 +1,6 @@
+resources:
+  - name: sql-instance
+    type: sqladmin.v1beta4.instance
+    properties:
+      settings:
+        tier: db-custom-1-3840

--- a/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/test/positive2.yaml
+++ b/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/test/positive2.yaml
@@ -1,0 +1,8 @@
+resources:
+  - name: sql-instance
+    type: sqladmin.v1beta4.instance
+    properties:
+      settings:
+        tier: db-custom-1-3840
+        backupConfiguration:
+          binaryLogEnabled: true

--- a/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/test/positive3.yaml
+++ b/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/test/positive3.yaml
@@ -1,0 +1,8 @@
+resources:
+  - name: sql-instance
+    type: sqladmin.v1beta4.instance
+    properties:
+      settings:
+        tier: db-custom-1-3840
+        backupConfiguration:
+          enabled: false

--- a/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/test/positive_expected_result.json
+++ b/assets/queries/googleDeploymentManager/sql_db_instance_backup_disable/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+  {
+    "queryName": "SQL DB Instance Backup Disabled",
+    "severity": "HIGH",
+    "line": 5,
+    "filename": "positive1.yaml"
+  },
+  {
+    "queryName": "SQL DB Instance Backup Disabled",
+    "severity": "HIGH",
+    "line": 7,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "SQL DB Instance Backup Disabled",
+    "severity": "HIGH",
+    "line": 8,
+    "filename": "positive3.yaml"
+  }
+]


### PR DESCRIPTION
Signed-off-by: joaorufi <joao.rufino@checkmarx.com>

**Proposed Changes**
- Added "SQL DB Instance Backup Disabled" for Google Deployment Manager

I submit this contribution under the Apache-2.0 license.
