### PR TITLE
feat(report): update gitlab sast report schema version

### DIFF
--- a/pkg/report/model/gitlab_sast.go
+++ b/pkg/report/model/gitlab_sast.go
@@ -85,7 +85,7 @@ type GitlabSASTReport interface {
 func NewGitlabSASTReport(start, end time.Time) GitlabSASTReport {
 	return &gitlabSASTReport{
 		Schema:          "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v13.1.0/dist/sast-report-format.json",
-		SchemaVersion:   "13.1.0",
+		SchemaVersion:   "14.0.1",
 		Scan:            initGitlabSASTScan(start, end),
 		Vulnerabilities: make([]gitlabSASTVulnerability, 0),
 	}

--- a/pkg/report/model/gitlab_sast_test.go
+++ b/pkg/report/model/gitlab_sast_test.go
@@ -19,7 +19,7 @@ func TestNewGitlabSASTReport(t *testing.T) {
 		"https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v13.1.0/dist/sast-report-format.json",
 		glSAST.Schema,
 	)
-	require.Equal(t, "13.1.0", glSAST.SchemaVersion)
+	require.Equal(t, "14.0.1", glSAST.SchemaVersion)
 	require.Equal(t, constants.Fullname, glSAST.Scan.Scanner.Name)
 	require.Equal(t, constants.URL, glSAST.Scan.Scanner.URL)
 	require.Equal(t, end.Format(timeFormat), glSAST.Scan.EndTime)


### PR DESCRIPTION
Closes #4700 

**Proposed Changes**
Updates schema version field, since schema fields used by KICS are the same, this change just updates version number on `SchemaVersion` field on gitlab sast model. The chosen version was 14.0.1, since this is the last version available to check on validator.

This change was validated by [gitlab schema validator][1] and using this [sample generated by KICS on this branch][2].

Signed-off-by: Felipe Avelar <felipe.avelar@outlook.com>

I submit this contribution under the Apache-2.0 license.

[1]:  https://gitlab-org-security-products-secure-schema-validator.34.127.22.151.sslip.io/
[2]: https://gist.github.com/lipeavelar/7bed6400eea9a29ac8d378ec98f674b1