### PR TITLE
feat(query): added "Project-wide SSH Keys Are Enabled In VM Instances" for Google Deployment Manager

### DIFF
--- a/assets/queries/ansible/gcp/project_wide_ssh_keys_are_enabled_in_vm_instances/metadata.json
+++ b/assets/queries/ansible/gcp/project_wide_ssh_keys_are_enabled_in_vm_instances/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Project-wide SSH Keys Are Enabled In VM Instances",
   "severity": "MEDIUM",
   "category": "Secret Management",
-  "descriptionText": "Check if the VM Instance doesn't block project-wide SSH keys.",
+  "descriptionText": "VM Instance should block project-wide SSH keys",
   "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_instance_module.html",
   "platform": "Ansible",
   "descriptionID": "bf6076f0",

--- a/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/metadata.json
+++ b/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Project-wide SSH Keys Are Enabled In VM Instances",
   "severity": "MEDIUM",
   "category": "Secret Management",
-  "descriptionText": "Check if the VM Instance doesn't block project-wide SSH keys",
+  "descriptionText": "VM Instance should block project-wide SSH keys",
   "descriptionUrl": "https://cloud.google.com/compute/docs/reference/rest/v1/instances",
   "platform": "GoogleDeploymentManager",
   "descriptionID": "5e36c46d",

--- a/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/metadata.json
+++ b/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "6e2b1ec1-1eca-4eb7-9d4d-2882680b4811",
+  "queryName": "Project-wide SSH Keys Are Enabled In VM Instances",
+  "severity": "MEDIUM",
+  "category": "Secret Management",
+  "descriptionText": "Check if the VM Instance doesn't block project-wide SSH keys",
+  "descriptionUrl": "https://cloud.google.com/compute/docs/reference/rest/v1/instances",
+  "platform": "GoogleDeploymentManager",
+  "descriptionID": "5e36c46d",
+  "cloudProvider": "gcp"
+}

--- a/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/query.rego
+++ b/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/query.rego
@@ -1,0 +1,56 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i].resources[idx]
+	resource.type == "compute.v1.instance"
+
+	not common_lib.valid_key(resource.properties, "metadata")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("resources.name={{%s}}.properties", [resource.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'metadata' to be defined and not null",
+		"keyActualValue": "'metadata' is undefined or null", 
+		"searchLine": common_lib.build_search_line(["resources", idx, "properties"], []),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resources[idx]
+	resource.type == "compute.v1.instance"
+
+	not haveField(resource.properties.metadata.items, "block-project-ssh-keys")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("resources.name={{%s}}.properties.metadata.items", [resource.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'metadata.items' should have 'block-project-ssh-keys'",
+		"keyActualValue": "'metadata.items' does not have 'block-project-ssh-keys'", 
+		"searchLine": common_lib.build_search_line(["resources", idx, "properties", "metadata", "items"], []),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resources[idx]
+	resource.type == "compute.v1.instance"
+
+	resource.properties.metadata.items[j].key == "block-project-ssh-keys"
+	resource.properties.metadata.items[j].value == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("resources.name={{%s}}.properties.metadata.items[%d].key", [resource.name, j]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'metadata.items[%d].value' should be true", [j]),
+		"keyActualValue": sprintf("'metadata.items[%d].value' is false", [j]), 
+		"searchLine": common_lib.build_search_line(["resources", idx, "properties", "metadata", "items", j, "value"], []),
+	}
+}
+
+haveField(items, field) {
+	items[i].key == field
+}

--- a/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/test/negative1.yaml
+++ b/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/test/negative1.yaml
@@ -1,0 +1,12 @@
+resources:
+  - name: vm
+    type: compute.v1.instance
+    properties:
+      description: my-vm
+      metadata:
+        fingerprint: fingerprint
+        items:
+          - key: my-key
+            value: true
+          - key: block-project-ssh-keys
+            value: true

--- a/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/test/positive1.yaml
+++ b/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/test/positive1.yaml
@@ -1,0 +1,5 @@
+resources:
+  - name: vm
+    type: compute.v1.instance
+    properties:
+      description: my-vm

--- a/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/test/positive2.yaml
+++ b/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/test/positive2.yaml
@@ -1,0 +1,12 @@
+resources:
+  - name: vm
+    type: compute.v1.instance
+    properties:
+      description: my-vm
+      metadata:
+        fingerprint: fingerprint
+        items:
+          - key: my-key
+            value: true
+          - key: my-key-2
+            value: false

--- a/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/test/positive3.yaml
+++ b/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/test/positive3.yaml
@@ -1,0 +1,12 @@
+resources:
+  - name: vm
+    type: compute.v1.instance
+    properties:
+      description: my-vm
+      metadata:
+        fingerprint: fingerprint
+        items:
+          - key: my-key
+            value: true
+          - key: block-project-ssh-keys
+            value: false

--- a/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/test/positive_expected_result.json
+++ b/assets/queries/googleDeploymentManager/project_wide_ssh_keys_are_enabled_in_vm_instances/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+  {
+    "queryName": "Project-wide SSH Keys Are Enabled In VM Instances",
+    "severity": "MEDIUM",
+    "line": 4,
+    "filename": "positive1.yaml"
+  },
+  {
+    "queryName": "Project-wide SSH Keys Are Enabled In VM Instances",
+    "severity": "MEDIUM",
+    "line": 8,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Project-wide SSH Keys Are Enabled In VM Instances",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive3.yaml"
+  }
+]

--- a/assets/queries/terraform/gcp/project_wide_ssh_keys_are_enabled_in_vm_instances/metadata.json
+++ b/assets/queries/terraform/gcp/project_wide_ssh_keys_are_enabled_in_vm_instances/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Project-wide SSH Keys Are Enabled In VM Instances",
   "severity": "MEDIUM",
   "category": "Insecure Configurations",
-  "descriptionText": "Check if SSH keys are enabled project-wide in VM instances",
+  "descriptionText": "VM Instance should block project-wide SSH keys",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance",
   "platform": "Terraform",
   "descriptionID": "4b9307cd",


### PR DESCRIPTION
Signed-off-by: JoaoDanielRufino <joaodaniel0405@gmail.com>

**Proposed Changes**
- Added "Project-wide SSH Keys Are Enabled In VM Instances" for Google Deployment Manager

I submit this contribution under the Apache-2.0 license.
