### PR TITLE
update(terraformer): added timestamp to generated import folder

### DIFF
--- a/pkg/terraformer/terraformer.go
+++ b/pkg/terraformer/terraformer.go
@@ -2,11 +2,13 @@ package terraformer
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tfLogger "log"
 
@@ -70,7 +72,9 @@ func Import(terraformerPath, destinationPath string) (string, error) {
 		}
 	}
 
-	destination := filepath.Join(destinationPath, "kics-extract-terraformer")
+	destFolderName := fmt.Sprintf("kics-extract-terraformer-%s", time.Now().Format("01-02-2006"))
+
+	destination := filepath.Join(destinationPath, destFolderName)
 
 	var provider CloudProvider
 

--- a/pkg/terraformer/terraformer_test.go
+++ b/pkg/terraformer/terraformer_test.go
@@ -3,6 +3,7 @@ package terraformer
 import (
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Checkmarx/kics/pkg/terraformer/aws"
@@ -113,7 +114,7 @@ func TestImport(t *testing.T) {
 				t.Errorf("Import() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if filepath.Base(got) != filepath.Base(tt.want) {
+			if !strings.Contains(filepath.Base(got), filepath.Base(tt.want)) {
 				t.Errorf("Import() = %v, want %v", filepath.Base(got), filepath.Base(tt.want))
 			}
 		})


### PR DESCRIPTION
Signed-off-by: João Reigota <joao.reigota@checkmarx.com>

**Proposed Changes**
- generated folder kics-extract-terraformer now has the current timestamp in the folder name

I submit this contribution under the Apache-2.0 license.
