### PR TITLE
feat(e2e): Schema validation for ASFF Reports

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -126,6 +126,10 @@ func checkExpectedOutput(t *testing.T, tt *testcases.TestCase, argIndex int) {
 	if utils.Contains(resultsFormats, "sonarqube") {
 		utils.JSONSchemaValidationFromFile(t, "sonarqube-"+jsonFileName, "result-sonarqube.json")
 	}
+	// Check result file (ASFF)
+	if utils.Contains(resultsFormats, "asff") {
+		utils.JSONSchemaValidationFromFile(t, "asff-"+jsonFileName, "result-asff.json")
+	}
 	// Check result file (SARIF)
 	if utils.Contains(resultsFormats, "sarif") {
 		utils.JSONSchemaValidationFromFile(t, tt.Args.ExpectedResult[argIndex].ResultsFile+".sarif", "result-sarif.json")

--- a/e2e/fixtures/schemas/result-asff.json
+++ b/e2e/fixtures/schemas/result-asff.json
@@ -1,0 +1,158 @@
+{
+    "type": "array",
+    "minItems": 1,
+    "definitions": {
+        "aws_id_pattern": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^AWS_REGION\/AWS_ACCOUNT_ID\/[A-Fa-f0-9]{64}$"
+        },
+        "arn_pattern": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^arn:aws:securityhub:\\w+:\\w+:product\/\\w+\/default$"
+        },
+        "recommendation_text_pattern": {
+            "pattern": "^In line \\d+ of file (.)+, a result was found. (.)+, but (.)+$"
+        }
+    },
+    "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+            "AwsAccountId",
+            "Compliance",
+            "CreatedAt",
+            "Description",
+            "GeneratorId",
+            "Id",
+            "ProductArn",
+            "Remediation",
+            "Resources",
+            "SchemaVersion",
+            "Severity",
+            "Title",
+            "Types",
+            "UpdatedAt"
+        ],
+        "properties": {
+            "AwsAccountId": {
+                "type": "string",
+                "const": "AWS_ACCOUNT_ID"
+            },
+            "Compliance": {
+                "type": "object",
+                "properties": {
+                    "Status": {
+                        "type": "string",
+                        "const": "FAILED"
+                    }
+                }
+            },
+            "CreatedAt": {
+                "type": "string",
+                "format": "date-time",
+                "minLength": 1
+            },
+            "Description": {
+                "type": "string",
+                "minLength": 1
+            },
+            "GeneratorId": {
+                "type": "string",
+                "format": "uuid"
+            },
+            "Id": {
+                "$ref": "#/definitions/aws_id_pattern"
+            },
+            "ProductArn": {
+                "$ref": "#/definitions/arn_pattern"
+            },
+            "Remediation": {
+                "type": "object",
+                "properties": {
+                    "Recommendation": {
+                        "type": "object",
+                        "properties": {
+                            "Text": {
+                                "$ref": "#/definitions/recommendation_text_pattern"
+                            }
+                        }
+                    }
+                }
+            },
+            "Resources": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                        "Id",
+                        "Type"
+                    ],
+                    "properties": {
+                        "Id": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "Type": {
+                            "type": "string",
+                            "const": "Other"
+                        }
+                    }
+                }
+            },
+            "SchemaVersion": {
+                "type": "string",
+                "format": "date",
+                "minLength": 1
+            },
+            "Severity": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                    "Label",
+                    "Original"
+                ],
+                "properties": {
+                    "Label": {
+                        "type": "string",
+                        "enum": [
+                            "HIGH",
+                            "MEDIUM",
+                            "LOW",
+                            "INFORMATIONAL"
+                        ]
+                    },
+                    "Original": {
+                        "type": "string",
+                        "enum": [
+                            "HIGH",
+                            "MEDIUM",
+                            "LOW",
+                            "INFO"
+                        ]
+                    }
+                }
+            },
+            "Title": {
+                "type": "string",
+                "minLength": 1
+            },
+            "Types": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "string",
+                    "const": "Software and Configuration Checks/Vulnerabilities/KICS"
+                }
+            },
+            "UpdatedAt": {
+                "type": "string",
+                "format": "date-time",
+                "minLength": 1
+            }
+        }
+    }
+}

--- a/e2e/testcases/e2e-cli-031_scan_report-formats.go
+++ b/e2e/testcases/e2e-cli-031_scan_report-formats.go
@@ -8,7 +8,7 @@ func init() { //nolint
 		Args: args{
 			Args: []cmdArgs{
 				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_031_RESULT",
-					"--report-formats", "json,SARIF,glsast,Html,SonarQUBE,Junit,cyclonedx",
+					"--report-formats", "json,SARIF,glsast,Html,SonarQUBE,Junit,cyclonedx,asff",
 					"-q", "../assets/queries", "-p", "fixtures/samples/terraform.tf"},
 
 				[]string{"scan", "--output-path", "output", "--output-name", "E2E_CLI_031_RESULT_CIS",
@@ -18,7 +18,7 @@ func init() { //nolint
 			ExpectedResult: []ResultsValidation{
 				{
 					ResultsFile:    "E2E_CLI_031_RESULT",
-					ResultsFormats: []string{"json", "sarif", "glsast", "html", "sonarqube", "junit", "cyclonedx"},
+					ResultsFormats: []string{"json", "sarif", "glsast", "html", "sonarqube", "junit", "cyclonedx", "asff"},
 				},
 				{
 					ResultsFile:    "E2E_CLI_031_RESULT_CIS",


### PR DESCRIPTION
Closes #

**Proposed Changes**
- As Kics had received support for generating AWS Security Finding Format (ASFF), this PR introduces an E2E Test to validate reports in this format, ensuring correct information and formatting of generated ASFF reports.

I submit this contribution under the Apache-2.0 license.
