### PR TITLE
fix(query): containers-run-with-low-uid k8s query should consider statement precedence

### DIFF
--- a/assets/queries/k8s/containers_run_with_low_uid/test/negative2.yaml
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/negative2.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: securitydemo
+  labels:
+    app: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      securityContext:
+        runAsUser: 65532
+      containers:
+        - name: frontend
+          image: nginx
+          ports:
+            - containerPort: 80
+          securityContext:
+            readOnlyRootFilesystem: true
+        - name: echoserver
+          image: k8s.gcr.io/echoserver:1.4
+          ports:
+            - containerPort: 8080

--- a/assets/queries/k8s/containers_run_with_low_uid/test/negative3.yaml
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/negative3.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: securitydemo
+  labels:
+    app: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      securityContext:
+        runAsUser: 19000
+      containers:
+        - name: frontend
+          image: nginx
+          ports:
+            - containerPort: 80
+          securityContext:
+            runAsUser: 12000
+            readOnlyRootFilesystem: true
+        - name: echoserver
+          image: k8s.gcr.io/echoserver:1.4
+          ports:
+            - containerPort: 8080
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/assets/queries/k8s/containers_run_with_low_uid/test/positive4.yaml
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/positive4.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: securitydemo
+  labels:
+    app: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      securityContext:
+        runAsUser: 1200
+      containers:
+        - name: frontend
+          image: nginx
+          ports:
+            - containerPort: 80
+          securityContext:
+            readOnlyRootFilesystem: true
+        - name: echoserver
+          image: k8s.gcr.io/echoserver:1.4
+          ports:
+            - containerPort: 8080
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/assets/queries/k8s/containers_run_with_low_uid/test/positive5.yaml
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/positive5.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: securitydemo
+  labels:
+    app: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: frontend
+          image: nginx
+          ports:
+            - containerPort: 80
+          securityContext:
+            readOnlyRootFilesystem: true
+        - name: echoserver
+          image: k8s.gcr.io/echoserver:1.4
+          ports:
+            - containerPort: 8080
+          securityContext:
+            readOnlyRootFilesystem: true

--- a/assets/queries/k8s/containers_run_with_low_uid/test/positive6.yaml
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/positive6.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: securitydemo
+  labels:
+    app: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      securityContext:
+        runAsUser: 12000
+      containers:
+        - name: frontend
+          image: nginx
+          ports:
+            - containerPort: 80
+          securityContext:
+            runAsUser: 1234
+            readOnlyRootFilesystem: true
+        - name: echoserver
+          image: k8s.gcr.io/echoserver:1.4
+          ports:
+            - containerPort: 8080
+          securityContext:
+            runAsUser: 5678
+            readOnlyRootFilesystem: true

--- a/assets/queries/k8s/containers_run_with_low_uid/test/positive7.yaml
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/positive7.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: securitydemo
+  labels:
+    app: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: frontend
+          image: nginx
+          ports:
+            - containerPort: 80
+          securityContext:
+            runAsUser: 1234
+            readOnlyRootFilesystem: true
+        - name: echoserver
+          image: k8s.gcr.io/echoserver:1.4
+          ports:
+            - containerPort: 8080

--- a/assets/queries/k8s/containers_run_with_low_uid/test/positive_expected_result.json
+++ b/assets/queries/k8s/containers_run_with_low_uid/test/positive_expected_result.json
@@ -2,20 +2,8 @@
   {
     "queryName": "Container Running With Low UID",
     "severity": "MEDIUM",
-    "line": 7,
-    "fileName": "positive1.yaml"
-  },
-  {
-    "queryName": "Container Running With Low UID",
-    "severity": "MEDIUM",
     "line": 12,
     "fileName": "positive1.yaml"
-  },
-  {
-    "queryName": "Container Running With Low UID",
-    "severity": "MEDIUM",
-    "line": 7,
-    "fileName": "positive2.yaml"
   },
   {
     "queryName": "Container Running With Low UID",
@@ -32,13 +20,49 @@
   {
     "queryName": "Container Running With Low UID",
     "severity": "MEDIUM",
-    "line": 6,
+    "line": 12,
     "fileName": "positive3.yaml"
   },
   {
     "queryName": "Container Running With Low UID",
     "severity": "MEDIUM",
-    "line": 12,
-    "fileName": "positive3.yaml"
+    "line": 18,
+    "fileName": "positive4.yaml"
+  },
+  {
+    "queryName": "Container Running With Low UID",
+    "severity": "MEDIUM",
+    "line": 22,
+    "fileName": "positive5.yaml"
+  },
+  {
+    "queryName": "Container Running With Low UID",
+    "severity": "MEDIUM",
+    "line": 28,
+    "fileName": "positive5.yaml"
+  },
+  {
+    "queryName": "Container Running With Low UID",
+    "severity": "MEDIUM",
+    "line": 25,
+    "fileName": "positive6.yaml"
+  },
+  {
+    "queryName": "Container Running With Low UID",
+    "severity": "MEDIUM",
+    "line": 32,
+    "fileName": "positive6.yaml"
+  },
+  {
+    "queryName": "Container Running With Low UID",
+    "severity": "MEDIUM",
+    "line": 23,
+    "fileName": "positive7.yaml"
+  },
+  {
+    "queryName": "Container Running With Low UID",
+    "severity": "MEDIUM",
+    "line": 25,
+    "fileName": "positive7.yaml"
   }
 ]


### PR DESCRIPTION
**Problem**

The K8s rule _containers-run-with-low-uid_ traverses documents recursively, searching for `runAsUser` defintions. By doing so, the implementation disregards hierarchical inheritance, in which a `runAsUser` statement can occur. If defined in the SecurityContext of a pod, it is inherited by all containers, unless redefined in the SecurityContext of a container. More information about precedence is provided [here](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).

The current rule shows false positive alerts for each SecurityContext definition, which does not include `runAsUser`.

**Proposed Changes**

- Change the current implementation to check for possible definitions at multiple locations:
  - Does a container explicitly define `runAsUser`?
  - Does a container inherit `runAsUser` from the pod SecurityContext?
  - Do neither pod nor container define `runAsUser`?

- Additional tests
  * _negative2.yaml_: `runAsUser` defined in `spec.template.spec.securityContext`
    *  Existing rule: 1 false positive match
  * _negative3.yaml_: `runAsUser` defined in `spec.template.spec.securityContext` and SecurityContext of one container
    *  Existing rule: 1 false positive match
  * _positive4.yaml_: IncorrectValue in `spec.template.spec.securityContext.runAsUser`
    * Existing rule: 3 false positive matches
  * _positive5.yaml_: MissingAttribute in SecurityContext of containers
  * _positive6.yaml_: IncorrectValue in SecurityContext of containers
  * _positive7.yaml_: IncorrectValue and MissingAttribute in SecurityContext of containers
    * Existing rule:
      * Does not recognize missing `runAsUser` statement in second container
      * Missing `runAsUser` attribute for second container is not recognized

I submit this contribution under the Apache-2.0 license.
