### PR TITLE
fix(query): covered additional deprecated API versions in k8s rule

### DIFF
--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/query.rego
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/query.rego
@@ -10,25 +10,39 @@ CxPolicy[result] {
 		"extensions/v1beta1": {
 			"Deployment": "apps/v1",
 			"DaemonSet": "apps/v1",
-			"Ingress": "apps/v1",
+			"ReplicaSet": "apps/v1",
+			"Ingress": "networking.k8s.io/v1",
+			"NetworkPolicy": "networking.k8s.io/v1",
 		},
 		"apps/v1beta1": {
 			"Deployment": "apps/v1",
+			"ReplicaSet": "apps/v1",
 			"StatefulSet": "apps/v1",
 		},
 		"apps/v1beta2": {
 			"Deployment": "apps/v1",
 			"DaemonSet": "apps/v1",
+			"ReplicaSet": "apps/v1",
 			"StatefulSet": "apps/v1",
+		},
+		"networking.k8s.io/v1beta1": {
+			"Ingress": "networking.k8s.io/v1",
+			"IngressClass": "networking.k8s.io/v1",
+		},
+		"rbac.authorization.k8s.io/v1beta1": {
+			"ClusterRole": "rbac.authorization.k8s.io/v1",
+			"ClusterRoleBinding": "rbac.authorization.k8s.io/v1",
+			"Role": "rbac.authorization.k8s.io/v1",
+			"RoleBinding": "rbac.authorization.k8s.io/v1",
 		},
 	}
 
 	common_lib.valid_key(recommendedVersions[document.apiVersion], document.kind)
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("apiVersion=%s", [document.apiVersion]),
+		"documentId": document.id,
+		"searchKey": sprintf("apiVersion={{%s}}", [document.apiVersion]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'apiVersion' should be %s", [recommendedVersions[document.apiVersion][document.kind]]),
-		"keyActualValue": sprintf("'apiVersion' is deprecated and is %s", [document.apiVersion]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.apiVersion should be {{%s}}", [metadata.name, recommendedVersions[document.apiVersion][document.kind]]),
+		"keyActualValue": sprintf("metadata.name={{%s}}.apiVersion is deprecated and is {{%s}}", [metadata.name, document.apiVersion]),
 	}
 }

--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/negative.yaml
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/negative.yaml
@@ -54,21 +54,3 @@ spec:
         - name: optmount
           hostPath:
             path: /opt
----
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: minimal-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-spec:
-  rules:
-  - http:
-      paths:
-      - path: /testpath
-        pathType: Prefix
-        backend:
-          service:
-            name: test
-            port:
-              number: 80

--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/positive.yaml
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/positive.yaml
@@ -72,3 +72,21 @@ spec:
             name: test
             port:
               number: 80
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: minimal-ingress1
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        pathType: Prefix
+        backend:
+          service:
+            name: test
+            port:
+              number: 80

--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/positive_expected_result.json
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/positive_expected_result.json
@@ -13,5 +13,10 @@
 		"queryName": "Object Is Using A Deprecated API Version",
 		"severity": "HIGH",
 		"line": 58
+	},
+	{
+		"queryName": "Object Is Using A Deprecated API Version",
+		"severity": "HIGH",
+		"line": 76
 	}
 ]


### PR DESCRIPTION
**Problem**

- `Ingress` in `extensions/v1beta1` recommends `apps/v1` but correct would be `networking.k8s.io/v1`
- `negative.yaml` includes an Ingress with `networking.k8s.io/v1beta1` but this API version is also deprecated
- All findings of a particular type are shown only once in results, even if they appear multiple times in a scanned *.yaml file
- The existing checks do not cover deprecations in K8s > v1.16

**Proposed Changes**

- Improvements for all items mentioned above
- Additional checks for commonly defined resource APIs that were [deprecated with K8s v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22)

I submit this contribution under the Apache-2.0 license.
