### PR TITLE
fix(query): be able to check default_tags on multiple providers

### DIFF
--- a/assets/queries/terraform/aws/resource_not_using_tags/query.rego
+++ b/assets/queries/terraform/aws/resource_not_using_tags/query.rego
@@ -41,7 +41,9 @@ check_different_tag(tags) {
 }
 
 check_default_tags {
-	common_lib.valid_key(input.document[_].provider[_].default_tags, "tags")
+	common_lib.valid_key(input.document[_].provider["aws"].default_tags, "tags")
+} else {
+	common_lib.valid_key(input.document[_].provider["aws"][_].default_tags, "tags")
 } else = false {
 	true
 }


### PR DESCRIPTION
## Context

In the query `aws/resource_not_using_tags`, the query contains the following function

```rego
check_default_tags {
	common_lib.valid_key(input.document[_].provider[_].default_tags, "tags")
} else = false {
	true
}
```

This function is only able to test if there's a single provider.

```terraform
provider "aws" {
  region  = "eu-west-3"
  alias   = "foobar"
  profile = "foobar"
  default_tags {
    tags = {
      foo = "bar"
    }
  }
}
```

the payload

```json
{
	"document": [
		{
			"file": "/Users/jycamier/workspace/terraform/00_network_tgw/toto/provider.tf",
			"id": "012c8e85-a9ee-405b-9294-2b589e389330",
			"provider": {
				"aws": {
					"alias": "foobar",
					"default_tags": {
						"tags": {
							"foo": "bar"
						}
					},
					"profile": "foobar",
					"region": "eu-west-3"
				}
			}
		}
	]
}
```
`input.document.provider.aws` is a struct so all is fine.

If you're using more than one provider : 

```terraform
provider "aws" {
  region  = "eu-west-3"
  alias   = "foobar"
  profile = "foobar"
  default_tags {
    tags = {
      foo = "bar"
    }
  }
}

provider "aws" {
  region  = "eu-west-3"
  alias   = "foobar2"
  profile = "foobar2"
  default_tags {
    tags = {
      foo = "foobar2"
    }
  }
}
```

```json
{
	"document": [
		{
			"file": "/Users/jycamier/workspace/terraform/00_network_tgw/toto/provider.tf",
			"id": "796949ef-7c5b-479d-a99c-eb660eedd5bc",
			"provider": {
				"aws": [
					{
						"alias": "foobar",
						"default_tags": {
							"tags": {
								"foo": "bar"
							}
						},
						"profile": "foobar",
						"region": "eu-west-3"
					},
					{
						"alias": "foobar2",
						"default_tags": {
							"tags": {
								"foo": "foobar2"
							}
						},
						"profile": "foobar2",
						"region": "eu-west-3"
					}
				]
			}
		}
	]
}
```

`input.document.provider.aws` become an array of struct in this case and the rego function isn't able to access to `default_tags`.
 
## Proposed Changes

- we can use with the `input.document.provider.aws` as our rules is impact only aws resources
- we check `default_tags` if we've more than one aws providers

I submit this contribution under the Apache-2.0 license.
