### PR TITLE
fix(query): fixed "Service Control Policies Disabled" query

### DIFF
--- a/assets/queries/terraform/aws/service_control_policies_disabled/metadata.json
+++ b/assets/queries/terraform/aws/service_control_policies_disabled/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Service Control Policies Disabled",
   "severity": "MEDIUM",
   "category": "Insecure Configurations",
-  "descriptionText": "Check if the Amazon Organizations' policies ensure that all features are enabled to achieve full control over the use of AWS services and actions across multiple AWS accounts using Service Control Policies (SCPs).",
+  "descriptionText": "Check if the Amazon Organizations ensure that all features are enabled to achieve full control over the use of AWS services and actions across multiple AWS accounts using Service Control Policies (SCPs).",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy",
   "platform": "Terraform",
   "descriptionID": "0fbcc152",

--- a/assets/queries/terraform/aws/service_control_policies_disabled/query.rego
+++ b/assets/queries/terraform/aws/service_control_policies_disabled/query.rego
@@ -3,33 +3,16 @@ package Cx
 import data.generic.common as common_lib
 
 CxPolicy[result] {
-	org_policy := input.document[i].resource.aws_organizations_policy[name]
+	org := input.document[i].resource.aws_organizations_organization[name]
 
-	serviceControlPolicy(object.get(org_policy, "type", "undefined"))
-
-	content := common_lib.json_unmarshal(org_policy.content)
-
-	st := common_lib.get_statement(content)
-	statement := st[_]
-
-	not policy_check(statement)
+	org.feature_set == "CONSOLIDATED_BILLING"
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("aws_organizations_policy[%s].content", [name]),
+		"searchKey": sprintf("aws_organizations_organization[%s].feature_set", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Statements allow all policy actions in all resources",
-		"keyActualValue": "Some or all statements don't allow all policy actions in all resources",
-		"searchLine": common_lib.build_search_line(["resource", "aws_organizations_policy", name, "content"], []),
+		"keyExpectedValue": "'feature_set' is set to 'ALL' or undefined",
+		"keyActualValue": "'feature_set' is set to 'CONSOLIDATED_BILLING'",
+		"searchLine": common_lib.build_search_line(["resource", "aws_organizations_organization", name, "feature_set"], []),
 	}
-}
-
-serviceControlPolicy("SERVICE_CONTROL_POLICY") = true
-
-serviceControlPolicy("undefined") = true
-
-policy_check(statement) {
-	common_lib.is_allow_effect(statement)
-	common_lib.equalsOrInArray(statement.Action, "*")
-	common_lib.equalsOrInArray(statement.Resource, "*")
 }

--- a/assets/queries/terraform/aws/service_control_policies_disabled/test/negative.tf
+++ b/assets/queries/terraform/aws/service_control_policies_disabled/test/negative.tf
@@ -1,31 +1,8 @@
-resource "aws_organizations_policy" "negative1" {
-  name = "example"
+resource "aws_organizations_organization" "negative1" {
+  aws_service_access_principals = [
+    "cloudtrail.amazonaws.com",
+    "config.amazonaws.com",
+  ]
 
-  content = <<CONTENT
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "*",
-    "Resource": "*"
-  }
-}
-CONTENT
-}
-
-resource "aws_organizations_policy" "all_features_allowed" {
-  name = "example"
-
-  content = <<CONTENT
-{
-  "Version": "2012-10-17",
-  "Statement": [
-      {
-        "Effect": "Allow",
-        "Action": "*",
-        "Resource": "*"
-        }
-    ]
-}
-CONTENT
+  feature_set = "ALL"
 }

--- a/assets/queries/terraform/aws/service_control_policies_disabled/test/positive.tf
+++ b/assets/queries/terraform/aws/service_control_policies_disabled/test/positive.tf
@@ -1,46 +1,8 @@
-resource "aws_organizations_policy" "positive1" {
-  name = "example"
+resource "aws_organizations_organization" "positive1" {
+  aws_service_access_principals = [
+    "cloudtrail.amazonaws.com",
+    "config.amazonaws.com",
+  ]
 
-  content = <<CONTENT
-{
-  "Version": "2012-10-17",
-  "Statement": [
-      {
-        "Effect": "Allow",
-        "Action": "iam",
-        "Resource": "*"
-        }
-    ]
-}
-CONTENT
-}
-
-resource "aws_organizations_policy" "positive2" {
-  name = "example"
-  type = "SERVICE_CONTROL_POLICY"
-  content = <<CONTENT
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "*",
-    "Resource": ["some-resource"]
-  }
-}
-CONTENT
-}
-
-resource "aws_organizations_policy" "positive3" {
-  name = "example"
-
-  content = <<CONTENT
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Deny",
-    "Action": "*",
-    "Resource": "*"
-  }
-}
-CONTENT
+  feature_set = "CONSOLIDATED_BILLING"
 }

--- a/assets/queries/terraform/aws/service_control_policies_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/service_control_policies_disabled/test/positive_expected_result.json
@@ -2,16 +2,7 @@
   {
     "queryName": "Service Control Policies Disabled",
     "severity": "MEDIUM",
-    "line": 4
-  },
-  {
-    "queryName": "Service Control Policies Disabled",
-    "severity": "MEDIUM",
-    "line": 21
-  },
-  {
-    "queryName": "Service Control Policies Disabled",
-    "severity": "MEDIUM",
-    "line": 36
+    "line": 7,
+    "fileName": "positive.tf"
   }
 ]


### PR DESCRIPTION
Closes #4828

**Proposed Changes**
- Fixed "Service Control Policies Disabled" query: since Service Control Policies (SCPs)  are available only if all features of the AWS Organizations are enabled, this query should check if all features are enabled in AWS Organizations.

I submit this contribution under the Apache-2.0 license.
