### PR TITLE
fix(library): fixed "Generic:354: rego_type_error: rule named engines redeclared at Common:354"

### DIFF
--- a/assets/libraries/common.rego
+++ b/assets/libraries/common.rego
@@ -351,7 +351,7 @@ get_encryption_if_exists(resource) = encryption {
 	encryption := "unencrypted"
 }
 
-engines := {
+engines = {
 	"aurora": 3306,
 	"aurora-mysql": 3306,
 	"aurora-postgresql": 3306,

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -93,7 +93,7 @@ You can also run the command `cdktf synth --json` to display it in the terminal.
 ### Limitations
 
 #### Ansible
-At the moment, KICS does not support a robust approach to identifying Ansible samples. The identification of these samples is done through exclusion. When a YAML sample is not a CloudFormation, Helm, Kubernetes or OpenAPI sample, KICS recognize it as Ansible.
+At the moment, KICS does not support a robust approach to identifying Ansible samples. The identification of these samples is done through exclusion. When a YAML sample is not a CloudFormation, Google Deployment Manager, Helm, Kubernetes or OpenAPI sample, KICS recognize it as Ansible.
 
 Thus, KICS recognize other YAML samples (that are not Ansible) as Ansible, e.g. GitHub Actions samples. However, you can ignore these samples by writing `#kics-scan ignore` on the top of the file. For more details, please read this [documentation](https://github.com/Checkmarx/kics/blob/25b6b703e924ed42067d9ab7772536864aee900b/docs/running-kics.md#using-commands-on-scanned-files-as-comments).
 

--- a/test/fixtures/common_query_test/metadata.json
+++ b/test/fixtures/common_query_test/metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "4a3aa2b5-9c87-452c-a3ea-f3e9e3573874",
+  "queryName": "Common Query Test",
+  "severity": "HIGH",
+  "category": "Best Practices",
+  "descriptionText": "",
+  "descriptionUrl": "",
+  "platform": "Common"
+}

--- a/test/fixtures/common_query_test/query.rego
+++ b/test/fixtures/common_query_test/query.rego
@@ -1,0 +1,13 @@
+package Cx
+
+CxPolicy[result] {
+	input.document[i]
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": "",
+		"issueType": "RedundantAttribute",
+		"keyExpectedValue": "",
+		"keyActualValue": "",
+	}
+}

--- a/test/fixtures/get_queries_test/common_query.rego
+++ b/test/fixtures/get_queries_test/common_query.rego
@@ -1,0 +1,13 @@
+package Cx
+
+CxPolicy[result] {
+	input.document[i]
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": "",
+		"issueType": "RedundantAttribute",
+		"keyExpectedValue": "",
+		"keyActualValue": "",
+	}
+}


### PR DESCRIPTION
**Proposed Changes**
- When using a custom common query (platform: "Common" in query metadata), KICS inspector reports the error `Generic:354: rego_type_error: rule named engines redeclared at Common:354` and does not load the query. That happens due to the declaration of engines `engines := {` in common.rego. So, this PR changes it to  `engines : {`

I submit this contribution under the Apache-2.0 license.
