### PR TITLE
update(queries): KICS Docker queries multi-staged aware

### DIFF
--- a/assets/libraries/dockerfile.rego
+++ b/assets/libraries/dockerfile.rego
@@ -28,3 +28,13 @@ withVersion(pack) {
 arrayContains(array, list) {
 	contains(array[_], list[_])
 }
+
+check_multi_stage(imageName, images) {
+    unsortedIndex := {x |
+        images[name][i].Cmd == "from"
+        x := {"Name": name, "Line": images[name][i].EndLine}
+    }
+
+    sortedIndex := sort(unsortedIndex)
+    imageName == sortedIndex[minus(count(sortedIndex), 1)].Name
+} 

--- a/assets/queries/dockerfile/healthcheck_instruction_missing/query.rego
+++ b/assets/queries/dockerfile/healthcheck_instruction_missing/query.rego
@@ -1,13 +1,17 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	resource := input.document[i].command[name]
+	dockerLib.check_multi_stage(name, input.document[i].command)
+
 	not contains(resource, "healthcheck")
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}", [name]),
-		"issueType": "MissingAttribute", #"MissingAttribute" / "RedundantAttribute"
+		"issueType": "MissingAttribute",
 		"keyExpectedValue": "Dockerfile contains instruction 'HEALTHCHECK'",
 		"keyActualValue": "Dockerfile doesn't contain instruction 'HEALTHCHECK'",
 	}

--- a/assets/queries/dockerfile/healthcheck_instruction_missing/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/healthcheck_instruction_missing/test/negative2.dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.16 AS builder
+WORKDIR /go/src/github.com/alexellis/href-counter/
+RUN go get -d -v golang.org/x/net/html  
+COPY app.go    ./
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick
+HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1 

--- a/assets/queries/dockerfile/healthcheck_instruction_missing/test/positive2.dockerfile
+++ b/assets/queries/dockerfile/healthcheck_instruction_missing/test/positive2.dockerfile
@@ -1,12 +1,14 @@
-FROM golang:1.7.3
+FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go .
+COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick

--- a/assets/queries/dockerfile/healthcheck_instruction_missing/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/healthcheck_instruction_missing/test/positive_expected_result.json
@@ -2,6 +2,13 @@
 	{
 		"queryName": "Healthcheck Instruction Missing",
 		"severity": "LOW",
-		"line": 1
+		"line": 1,
+		"fileName": "positive.dockerfile"
+	},
+	{
+		"queryName": "Healthcheck Instruction Missing",
+		"severity": "LOW",
+		"line": 7,
+		"fileName": "positive2.dockerfile"
 	}
 ]

--- a/assets/queries/dockerfile/last_user_is_root/query.rego
+++ b/assets/queries/dockerfile/last_user_is_root/query.rego
@@ -1,7 +1,11 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	resource := input.document[i].command[name]
+	dockerLib.check_multi_stage(name, input.document[i].command)
+
 	userCmd := [x | resource[j].Cmd == "user"; x := resource[j]]
 	userCmd[minus(count(userCmd), 1)].Value[0] == "root"
 

--- a/assets/queries/dockerfile/last_user_is_root/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/last_user_is_root/test/negative2.dockerfile
@@ -1,12 +1,15 @@
-FROM golang:1.7.3
+FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go .
+COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+USER root
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick

--- a/assets/queries/dockerfile/maintainer_instruction_being_used/query.rego
+++ b/assets/queries/dockerfile/maintainer_instruction_being_used/query.rego
@@ -7,7 +7,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.MAINTAINER={{%s}}", [name, resource.Value[0]]),
-		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"issueType": "IncorrectValue", 
 		"keyExpectedValue": sprintf("Maintainer instruction being used in Label 'LABEL maintainer=%s'", [resource.Value[0]]),
 		"keyActualValue": sprintf("Maintainer instruction not being used in Label 'MAINTAINER %s'", [resource.Value[0]]),
 	}

--- a/assets/queries/dockerfile/missing_dnf_clean_all/query.rego
+++ b/assets/queries/dockerfile/missing_dnf_clean_all/query.rego
@@ -1,7 +1,11 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	resource := input.document[i].command[name][_]
+	dockerLib.check_multi_stage(name, input.document[i].command)
+
 	resource.Cmd == "run"
 	command := resource.Value[0]
 

--- a/assets/queries/dockerfile/missing_dnf_clean_all/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/missing_dnf_clean_all/test/negative2.dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.16 AS builder
+WORKDIR /go/src/github.com/alexellis/href-counter/
+RUN go get -d -v golang.org/x/net/html  
+COPY app.go    ./
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+RUN set -uex && \
+    dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo && \
+    sed -i 's/\$releasever/26/g' /etc/yum.repos.d/docker-ce.repo && \
+    dnf install -vy docker-ce
+
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick

--- a/assets/queries/dockerfile/missing_user_instruction/query.rego
+++ b/assets/queries/dockerfile/missing_user_instruction/query.rego
@@ -1,10 +1,13 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	resource := input.document[i].command[name]
+	dockerLib.check_multi_stage(name, input.document[i].command)
 
 	not name == "scratch"
-	not hasUserInstruction(resource)
+	not has_user_instruction(resource)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -15,7 +18,6 @@ CxPolicy[result] {
 	}
 }
 
-hasUserInstruction(resource) {
-	some j
-	resource[j].Cmd == "user"
+has_user_instruction(resource) {
+	resource[_].Cmd == "user"
 }

--- a/assets/queries/dockerfile/missing_user_instruction/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/missing_user_instruction/test/negative2.dockerfile
@@ -1,12 +1,14 @@
-FROM golang:1.7.3
+FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go .
+COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick

--- a/assets/queries/dockerfile/missing_user_instruction/test/negative3.dockerfile
+++ b/assets/queries/dockerfile/missing_user_instruction/test/negative3.dockerfile
@@ -1,0 +1,7 @@
+FROM python:2.7
+RUN pip install Flask==0.11.1
+RUN useradd -ms /bin/bash patrick
+COPY --chown=patrick:patrick app /app
+WORKDIR /app
+USER patrick
+CMD ["python", "app.py"]

--- a/assets/queries/dockerfile/missing_user_instruction/test/positive2.dockerfile
+++ b/assets/queries/dockerfile/missing_user_instruction/test/positive2.dockerfile
@@ -1,12 +1,11 @@
-FROM golang:1.7.3
+FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go .
+COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"] 

--- a/assets/queries/dockerfile/missing_user_instruction/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/missing_user_instruction/test/positive_expected_result.json
@@ -2,6 +2,13 @@
 	{
 		"queryName": "Missing User Instruction",
 		"severity": "HIGH",
-		"line": 1
+		"line": 1,
+		"fileName": "positive.dockerfile"
+	},
+	{
+		"queryName": "Missing User Instruction",
+		"severity": "HIGH",
+		"line": 7,
+		"fileName": "positive2.dockerfile"
 	}
 ]

--- a/assets/queries/dockerfile/missing_zypper_clean/query.rego
+++ b/assets/queries/dockerfile/missing_zypper_clean/query.rego
@@ -1,13 +1,14 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	document := input.document[i]
 	commands = document.command
-	some img
-	some c
+	
 	commands[img][c].Cmd == "run"
+	dockerLib.check_multi_stage(img, commands)
 
-	some j
 	command := commands[img][c].Value[j]
 
 	commandHasZypperUsage(command)

--- a/assets/queries/dockerfile/missing_zypper_clean/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/missing_zypper_clean/test/negative2.dockerfile
@@ -1,12 +1,15 @@
-FROM golang:1.7.3
+FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go .
+COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+RUN zypper install
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick

--- a/assets/queries/dockerfile/missing_zypper_non_interactive_switch/query.rego
+++ b/assets/queries/dockerfile/missing_zypper_non_interactive_switch/query.rego
@@ -1,13 +1,14 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	document := input.document[i]
 	commands = document.command
-	some img
-	some c
-	commands[img][c].Cmd == "run"
 
-	some j
+	commands[img][c].Cmd == "run"
+	dockerLib.check_multi_stage(img, commands)
+
 	command := commands[img][c].Value[j]
 
 	commandHasZypperUsage(command)

--- a/assets/queries/dockerfile/missing_zypper_non_interactive_switch/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/missing_zypper_non_interactive_switch/test/negative2.dockerfile
@@ -1,12 +1,15 @@
-FROM golang:1.7.3
+FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go .
+COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+RUN zypper install httpd && zypper clean
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick

--- a/assets/queries/dockerfile/multiple_cmd_instructions_listed/query.rego
+++ b/assets/queries/dockerfile/multiple_cmd_instructions_listed/query.rego
@@ -1,7 +1,11 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	resource := input.document[i].command[name]
+	dockerLib.check_multi_stage(name, input.document[i].command)
+	
 	cmdInst := [x | resource[j].Cmd == "cmd"; x := resource[j]]
 	count(cmdInst) > 1
 

--- a/assets/queries/dockerfile/multiple_cmd_instructions_listed/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/multiple_cmd_instructions_listed/test/negative2.dockerfile
@@ -1,12 +1,16 @@
-FROM golang:1.7.3
+FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go .
+COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+CMD ["./app"] 
+CMD ["./apps"] 
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick

--- a/assets/queries/dockerfile/multiple_cmd_instructions_listed/test/positive.dockerfile
+++ b/assets/queries/dockerfile/multiple_cmd_instructions_listed/test/positive.dockerfile
@@ -3,11 +3,10 @@ WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
 COPY app.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
-CMD ["./app"] 
-CMD ["./apps"] 
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
 CMD ["./app"] 
+CMD ["./apps"] 

--- a/assets/queries/dockerfile/multiple_cmd_instructions_listed/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/multiple_cmd_instructions_listed/test/positive_expected_result.json
@@ -2,6 +2,7 @@
 	{
 		"queryName": "Multiple CMD Instructions Listed",
 		"severity": "MEDIUM",
-		"line": 6
+		"line": 11,
+		"fileName": "positive.dockerfile"
 	}
 ]

--- a/assets/queries/dockerfile/multiple_entrypoint_instructions_listed/query.rego
+++ b/assets/queries/dockerfile/multiple_entrypoint_instructions_listed/query.rego
@@ -1,14 +1,18 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	resource := input.document[i].command[name]
+	dockerLib.check_multi_stage(name, input.document[i].command)
+
 	cmdInst := [x | resource[j].Cmd == "entrypoint"; x := resource[j]]
 	count(cmdInst) > 1
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, cmdInst[0].Original]),
-		"issueType": "RedundantAttribute", #"MissingAttribute" / "RedundantAttribute"
+		"issueType": "RedundantAttribute", 
 		"keyExpectedValue": "There is only one ENTRYPOINT instruction",
 		"keyActualValue": sprintf("There are %d ENTRYPOINT instructions", [count(cmdInst)]),
 	}

--- a/assets/queries/dockerfile/multiple_entrypoint_instructions_listed/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/multiple_entrypoint_instructions_listed/test/negative2.dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.16 AS builder
+WORKDIR /go/src/github.com/alexellis/href-counter/
+RUN go get -d -v golang.org/x/net/html  
+COPY app.go    ./
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
+ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
+
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick

--- a/assets/queries/dockerfile/multiple_entrypoint_instructions_listed/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/multiple_entrypoint_instructions_listed/test/positive_expected_result.json
@@ -2,6 +2,7 @@
 	{
 		"queryName": "Multiple ENTRYPOINT Instructions Listed",
 		"severity": "HIGH",
-		"line": 6
+		"line": 11,
+		"fileName": "positive.dockerfile"
 	}
 ]

--- a/assets/queries/dockerfile/multiple_run_add_copy_instructions_listed/query.rego
+++ b/assets/queries/dockerfile/multiple_run_add_copy_instructions_listed/query.rego
@@ -1,7 +1,11 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	resource := input.document[i].command[name]
+	dockerLib.check_multi_stage(name, input.document[i].command)
+	
 	instructions := {"copy", "add", "run"}
 	some j
 	cmdInst := [x | resource[j].Cmd == instructions[y]; x := resource[j]]

--- a/assets/queries/dockerfile/multiple_run_add_copy_instructions_listed/test/negative5.dockerfile
+++ b/assets/queries/dockerfile/multiple_run_add_copy_instructions_listed/test/negative5.dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.16 AS builder
+WORKDIR /go/src/github.com/alexellis/href-counter/
+RUN go get -d -v golang.org/x/net/html  
+COPY app.go    ./
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+ADD cairo.spec /rpmbuild/SOURCES
+ADD cairo-1.13.1.tar.xz /rpmbuild/SOURCES
+
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick

--- a/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/query.rego
+++ b/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/query.rego
@@ -1,7 +1,11 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	resource := input.document[i].command[name][_]
+	dockerLib.check_multi_stage(name, input.document[i].command)
+	
 	resource.Cmd == "cmd"
 	resource.JSON == false
 
@@ -16,6 +20,8 @@ CxPolicy[result] {
 
 CxPolicy[result] {
 	resource := input.document[i].command[name][_]
+	dockerLib.check_multi_stage(name, input.document[i].command)
+	
 	resource.Cmd == "entrypoint"
 	resource.JSON == false
 

--- a/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/test/negative2.dockerfile
@@ -1,12 +1,16 @@
-FROM golang:1.7.3
+FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go .
+COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+CMD [python, /usr/src/app/app.py] 
+ENTRYPOINT [top, -b]
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick

--- a/assets/queries/dockerfile/same_alias_in_different_froms/query.rego
+++ b/assets/queries/dockerfile/same_alias_in_different_froms/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}", [aliasResource.Value[idx_2]]),
-		"issueType": "IncorrectValue", #"MissingAttribute" / "RedundantAttribute"
+		"issueType": "IncorrectValue", 
 		"keyExpectedValue": "Different FROM commands don't have the same alias defined",
 		"keyActualValue": sprintf("Different FROM commands with with the same alias '%s' defined", [aliasResource.Value[idx_2]]),
 	}

--- a/assets/queries/dockerfile/yum_clean_all_missing/query.rego
+++ b/assets/queries/dockerfile/yum_clean_all_missing/query.rego
@@ -1,7 +1,11 @@
 package Cx
 
+import data.generic.dockerfile as dockerLib
+
 CxPolicy[result] {
 	resource := input.document[i].command[name][_]
+	dockerLib.check_multi_stage(name, input.document[i].command)
+	
 	resource.Cmd == "run"
 
 	command := resource.Value[0]

--- a/assets/queries/dockerfile/yum_clean_all_missing/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/yum_clean_all_missing/test/negative2.dockerfile
@@ -1,12 +1,16 @@
-FROM golang:1.7.3
+FROM golang:1.16 AS builder
 WORKDIR /go/src/github.com/alexellis/href-counter/
 RUN go get -d -v golang.org/x/net/html  
-COPY app.go .
+COPY app.go    ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+RUN yum clean all \
+    yum -y install
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=0 /go/src/github.com/alexellis/href-counter/app .
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8080" ]
-ENTRYPOINT [ "/opt/app/run.sh", "--port", "8000" ]
+COPY --from=builder /go/src/github.com/alexellis/href-counter/app ./
+CMD ["./app"]
+RUN useradd -ms /bin/bash patrick
+
+USER patrick


### PR DESCRIPTION
Closes #4850

**Proposed Changes**
- Updated KICS Docker queries to be multi-staged aware:
  - Missing User Instruction
  - Multiple ENTRYPOINT Instructions Listed
  - Healthcheck Instruction Missing
  - Multiple RUN, ADD, COPY, Instructions Listed
  - Last User Is 'root'
  - Missing Dnf Clean All
  - Missing Zypper Clean
  - Missing Zypper Non-interactive Switch
  - Multiple CMD Instructions Listed
  - Not Using JSON In CMD And ENTRYPOINT Arguments
  - Yum Clean All Missing

Work done with @joaoReigota1 

I submit this contribution under the Apache-2.0 license.
