### PR TITLE
fix(query): Extend image_pull_policy_of_container_is_not_always k8s rule to cover additional resource kinds

### DIFF
--- a/assets/queries/k8s/image_pull_policy_of_container_is_not_always/test/positive1.yaml
+++ b/assets/queries/k8s/image_pull_policy_of_container_is_not_always/test/positive1.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   containers:
     - name: uses-private-image
-      image: $PRIVATE_IMAGE_NAME
+      image: $PRIVATE_IMAGE_NAME:1.2
       imagePullPolicy: Never
       command: [ "echo", "SUCCESS" ]

--- a/assets/queries/k8s/image_pull_policy_of_container_is_not_always/test/positive2.yaml
+++ b/assets/queries/k8s/image_pull_policy_of_container_is_not_always/test/positive2.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-with-image-pull-policy
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: library/nginx:1.20.0
+          imagePullPolicy: IfNotPresent

--- a/assets/queries/k8s/image_pull_policy_of_container_is_not_always/test/positive3.yaml
+++ b/assets/queries/k8s/image_pull_policy_of_container_is_not_always/test/positive3.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-with-image-pull-policy1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: library/nginx:1.20.0

--- a/assets/queries/k8s/image_pull_policy_of_container_is_not_always/test/positive_expected_result.json
+++ b/assets/queries/k8s/image_pull_policy_of_container_is_not_always/test/positive_expected_result.json
@@ -2,6 +2,19 @@
 	{
 		"queryName": "Image Pull Policy Of The Container Is Not Set To Always",
 		"severity": "LOW",
-		"line": 9
+		"line": 9,
+		"fileName": "positive1.yaml"
+	},
+	{
+		"queryName": "Image Pull Policy Of The Container Is Not Set To Always",
+		"severity": "LOW",
+		"line": 18,
+		"fileName": "positive2.yaml"
+	},
+	{
+		"queryName": "Image Pull Policy Of The Container Is Not Set To Always",
+		"severity": "LOW",
+		"line": 16,
+		"fileName": "positive3.yaml"
 	}
 ]


### PR DESCRIPTION
The rule intends to address the problem that image tags are mutable and it is not guaranteed that the version of an image that is cached on a node equals the one with the same tag in a registry. This potential security issue can be prevented by any of the following conditions:

- Explicitly setting `imagePullPolicy` to "Always" to ensure the kubelet downloads the image anew every time it launches the container
- By not specifying `imagePullPolicy` but by providing an image in one the following ways:
  - With tag "latest"
  - By not specifying a tag at all. From the [docs](https://kubernetes.io/docs/concepts/containers/images/#image-names):
    > If you don't specify a tag, Kubernetes assumes you mean the tag latest
  - By specifying a digest with the image

Except for the last sub-item, Kubernetes will apply `imagePullPolicy: Always`. When an image is provided together with a digest, caching by a node is legit and does not trigger the potential security risk this rule strives to detect. Also, this is analogous to what is done by the kubelet with policy "Always" (see [here](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy). In other words, since the digest associated with an image is immutable, it unambiguously refers to a specific image locally and/or in the registry.

**Problem**

- The rule only covers "Pod" and works with the assumption that `imagePullPolicy` is always defined. Otherwise, the rule aborts early as a statement evalutes to false. This is an issue as the default pull policy is `IfNotPresent` and not `Always`
- The rule does not cover the case that no tag is used or an image is specified with a digest

**Proposed Changes**

- Extend the rule to cover additional resource kinds, e.g., Deployment, DaemonSet, etc.
- Cover the possibilites described above
- New positive test cases:
  - `imagePullPolicy != "Always"` in a Deployment
  - `imagePullPolicy` not specified but a tag

I submit this contribution under the Apache-2.0 license.
