### PR TITLE
fix(query): Extend image_without_digest k8s rule to cover further resource kinds

### DIFF
--- a/assets/queries/k8s/image_without_digest/metadata.json
+++ b/assets/queries/k8s/image_without_digest/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Image Without Digest",
   "severity": "LOW",
   "category": "Insecure Configurations",
-  "descriptionText": "Sees if Kubernetes image has digest on",
+  "descriptionText": "Images should be specified together with their digests to ensure integrity",
   "descriptionUrl": "https://kubernetes.io/docs/concepts/containers/images/#updating-images",
   "platform": "Kubernetes",
   "descriptionID": "3f9f8d78"

--- a/assets/queries/k8s/image_without_digest/test/positive.yaml
+++ b/assets/queries/k8s/image_without_digest/test/positive.yaml
@@ -8,14 +8,3 @@ spec:
       image: $PRIVATE_IMAGE_NAME
       imagePullPolicy: Always
       command: [ "echo", "SUCCESS" ]
-
----
-
-apiVersion: v1
-kind: Pod
-metadata:
-  name: private-image-test-1.2
-spec:
-  containers:
-    - name: uses-private-image
-      command: [ "echo", "SUCCESS" ]

--- a/assets/queries/k8s/image_without_digest/test/positive_expected_result.json
+++ b/assets/queries/k8s/image_without_digest/test/positive_expected_result.json
@@ -3,10 +3,5 @@
     "queryName": "Image Without Digest",
     "severity": "LOW",
     "line": 8
-  },
-  {
-    "queryName": "Image Without Digest",
-    "severity": "LOW",
-    "line": 19
   }
 ]


### PR DESCRIPTION
**Proposed Changes**

- Extend the rule to cover additional resource kinds, e.g., Deployment, DaemonSet, etc.
- Remove `MissingAttribute` check for `image` + adapt the testcase
  - For a container to be deployable, specifying an image is indispensible (see `type Container struct` [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go)).
  - Trying to deploy a pod without an image attribute yields an error: `The Pod "private-image-test-1.2" is invalid: spec.containers[0].image: Required value`
  - Note: `image` can be empty (= null) though, e.g., if `command` is also used
- More comprehensive metadata description

I submit this contribution under the Apache-2.0 license.
