### PR TITLE
fix(query): Fix path to spec in root_container_not_mounted_as_read_only k8s rule

### DIFF
--- a/assets/queries/k8s/root_container_not_mounted_as_read_only/metadata.json
+++ b/assets/queries/k8s/root_container_not_mounted_as_read_only/metadata.json
@@ -1,9 +1,9 @@
 {
   "id": "a9c2f49d-0671-4fc9-9ece-f4e261e128d0",
-  "queryName": "Root Container Not Mounted As Read-only",
+  "queryName": "Root Container Not Mounted Read-only",
   "severity": "LOW",
   "category": "Build Process",
-  "descriptionText": "Check if the root container filesystem is not being mounted as read-only.",
+  "descriptionText": "Check if the root container filesystem is not being mounted read-only.",
   "descriptionUrl": "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
   "platform": "Kubernetes",
   "descriptionID": "0d2df1e5"

--- a/assets/queries/k8s/root_container_not_mounted_as_read_only/query.rego
+++ b/assets/queries/k8s/root_container_not_mounted_as_read_only/query.rego
@@ -1,57 +1,43 @@
 package Cx
 
 import data.generic.common as common_lib
+import data.generic.k8s as k8sLib
 
 types := {"initContainers", "containers"}
 
 CxPolicy[result] {
 	document := input.document[i]
-
-	some j
-	container := document.spec[types[x]][j]
-	not common_lib.valid_key(container, "securityContext")
-
 	metadata := document.metadata
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}", [metadata.name, types[x], container.name]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'spec.%s.name={{%s}}.securityContext' is set", [types[x], container.name]),
-		"keyActualValue": sprintf("'spec.%s.name={{%s}}.securityContext' is undefined", [types[x], container.name]),
-	}
-}
 
-CxPolicy[result] {
-	document := input.document[i]
+	specInfo := k8sLib.getSpecInfo(document)
+	container := specInfo.spec[types[x]][_]
 
-	some j
-	container := document.spec[types[x]][j]
-	securityContext := container.securityContext
-	not common_lib.valid_key(securityContext, "readOnlyRootFilesystem")
-
-	metadata := document.metadata
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}.securityContext", [metadata.name, types[x], container.name]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'spec.%s.name={{%s}}.securityContext.readOnlyRootFilesystem' is set and is true", [types[x], container.name]),
-		"keyActualValue": sprintf("'spec.%s.name={{%s}}.securityContext.readOnlyRootFilesystem' is undefined", [types[x], container.name]),
-	}
-}
-
-CxPolicy[result] {
-	document := input.document[i]
-
-	some j
-	container := document.spec[types[x]][j]
 	container.securityContext.readOnlyRootFilesystem == false
 
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.readOnlyRootFilesystem", [metadata.name, specInfo.path, types[x], container.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.readOnlyRootFilesystem is true", [metadata.name, specInfo.path, types[x], container.name]),
+		"keyActualValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.readOnlyRootFilesystem is false", [metadata.name, specInfo.path, types[x], container.name]),
+	}
+}
+
+CxPolicy[result] {
+	document := input.document[i]
 	metadata := document.metadata
+
+	specInfo := k8sLib.getSpecInfo(document)
+	container := specInfo.spec[types[x]][_]
+
+	containerCtx := object.get(container, "securityContext", {})
+	not common_lib.valid_key(containerCtx, "readOnlyRootFilesystem")
+
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name={{%s}}.spec.%s.name={{%s}}.securityContext.readOnlyRootFilesystem", [metadata.name, types[x], container.name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'spec.%s.name={{%s}}.securityContext.readOnlyRootFilesystem' is true", [types[x], container.name]),
-		"keyActualValue": sprintf("'spec.%s.name={{%s}}.securityContext.readOnlyRootFilesystem' is false", [types[x], container.name]),
+		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext", [metadata.name, specInfo.path, types[x], container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.readOnlyRootFilesystem is set and is true", [metadata.name, specInfo.path, types[x], container.name]),
+		"keyActualValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.readOnlyRootFilesystem is undefined", [metadata.name, specInfo.path, types[x], container.name]),
 	}
 }

--- a/assets/queries/k8s/root_container_not_mounted_as_read_only/query.rego
+++ b/assets/queries/k8s/root_container_not_mounted_as_read_only/query.rego
@@ -28,16 +28,17 @@ CxPolicy[result] {
 	metadata := document.metadata
 
 	specInfo := k8sLib.getSpecInfo(document)
-	container := specInfo.spec[types[x]][_]
+	container := specInfo.spec[types[x]][c]
 
 	containerCtx := object.get(container, "securityContext", {})
 	not common_lib.valid_key(containerCtx, "readOnlyRootFilesystem")
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext", [metadata.name, specInfo.path, types[x], container.name]),
+		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}", [metadata.name, specInfo.path, types[x], container.name]),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.readOnlyRootFilesystem is set and is true", [metadata.name, specInfo.path, types[x], container.name]),
 		"keyActualValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.readOnlyRootFilesystem is undefined", [metadata.name, specInfo.path, types[x], container.name]),
+		"searchLine": common_lib.build_search_line(split(specInfo.path, "."), [types[x], c, "securityContext"])
 	}
 }

--- a/assets/queries/k8s/root_container_not_mounted_as_read_only/test/positive_expected_result.json
+++ b/assets/queries/k8s/root_container_not_mounted_as_read_only/test/positive_expected_result.json
@@ -1,11 +1,11 @@
 [
 	{
-		"queryName": "Root Container Not Mounted As Read-only",
+		"queryName": "Root Container Not Mounted Read-only",
 		"severity": "LOW",
 		"line": 12
 	},
 	{
-		"queryName": "Root Container Not Mounted As Read-only",
+		"queryName": "Root Container Not Mounted Read-only",
 		"severity": "LOW",
 		"line": 24
 	}


### PR DESCRIPTION
**Proposed Changes**

- Fold the check for the existence of `container.securityContext` with the check for `readOnlyRootFilesystem`
- Correct the spec reference `searchKey` to the actual path

I submit this contribution under the Apache-2.0 license.
