### PR TITLE
fix(query): Corrected tag flagging invalid_image k8s rule

### DIFF
--- a/assets/queries/k8s/invalid_image/metadata.json
+++ b/assets/queries/k8s/invalid_image/metadata.json
@@ -1,9 +1,9 @@
 {
   "id": "583053b7-e632-46f0-b989-f81ff8045385",
-  "queryName": "Invalid Image",
+  "queryName": "Invalid Image Tag",
   "severity": "LOW",
   "category": "Supply-Chain",
-  "descriptionText": "Image must be defined and not be empty or equal to latest.",
+  "descriptionText": "Image tag must be defined and not be empty or equal to latest.",
   "descriptionUrl": "https://kubernetes.io/docs/concepts/containers/images/#updating-images",
   "platform": "Kubernetes",
   "descriptionID": "30154626"

--- a/assets/queries/k8s/invalid_image/test/negative.yaml
+++ b/assets/queries/k8s/invalid_image/test/negative.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   containers:
     - name: uses-private-image
-      image: "$PRIVATE_IMAGE_NAME"
+      image: nginx:1.21
       imagePullPolicy: Always
       command: [ "echo", "SUCCESS" ]

--- a/assets/queries/k8s/invalid_image/test/positive.yaml
+++ b/assets/queries/k8s/invalid_image/test/positive.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: uses-private-image-container
-      image: ""
+      image: nginx
       imagePullPolicy: Always
       command: [ "echo", "SUCCESS" ]
 ---
@@ -16,17 +16,6 @@ metadata:
 spec:
   containers:
     - name: uses-private-image-container
-      image:
-      imagePullPolicy: Always
-      command: [ "echo", "SUCCESS" ]
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: private-image-test-3344
-spec:
-  containers:
-    - name: uses-private-image-container
-      image: "latest"
+      image: nginx:latest
       imagePullPolicy: Always
       command: [ "echo", "SUCCESS" ]

--- a/assets/queries/k8s/invalid_image/test/positive_expected_result.json
+++ b/assets/queries/k8s/invalid_image/test/positive_expected_result.json
@@ -7,11 +7,6 @@
   {
     "queryName": "Invalid Image",
     "severity": "LOW",
-    "line": 18
-  },
-  {
-    "queryName": "Invalid Image",
-    "severity": "LOW",
-    "line": 30
+    "line": 19
   }
 ]


### PR DESCRIPTION
**Problem**

- The logic to check whether a tag is provided seems flawed. Specifying an empty image is fine, e.g., with `Cronjob` where an empty image tag is provided but shell commands are provided in `command`.
  What this rule most likely wanted to target in the first place is whether the **image tag** is empty (or latest), rather than the image itself.

**Proposed Changes**

- Extend the rule to cover additional resource kinds, e.g., Deployment, DaemonSet, etc.
- Remove `MissingAttribute` check for `image`
  - For a container to be deployable, specifying an image is indispensible (see `type Container struct` [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/types.go)).
  - Trying to deploy a pod without an image attribute yields an error: `The Pod "private-image-test-1.2" is invalid: spec.containers[0].image: Required value`
  - `image` can be empty (= null) though, e.g., if `command` is also used

I submit this contribution under the Apache-2.0 license.
