### PR TITLE
fix(query): refine missing_app_armor_config k8s rule to operate on specific containers

### DIFF
--- a/assets/queries/k8s/missing_app_armor_config/metadata.json
+++ b/assets/queries/k8s/missing_app_armor_config/metadata.json
@@ -1,9 +1,9 @@
 {
   "id": "8b36775e-183d-4d46-b0f7-96a6f34a723f",
-  "queryName": "Missing App Armor Config",
+  "queryName": "Missing AppArmor Profile",
   "severity": "LOW",
   "category": "Access Control",
-  "descriptionText": "Containers should be configured with AppArmor for any application to reduce its potential attack",
+  "descriptionText": "Containers should be configured with an AppArmor profile to enforce fine-grained access control over low-level system resources",
   "descriptionUrl": "https://kubernetes.io/docs/tutorials/clusters/apparmor/",
   "platform": "Kubernetes",
   "descriptionID": "59c17c0a"

--- a/assets/queries/k8s/missing_app_armor_config/query.rego
+++ b/assets/queries/k8s/missing_app_armor_config/query.rego
@@ -39,9 +39,10 @@ CxPolicy[result] {
 	annotationsPath := trim_left(sprintf("%s.annotations", [metadataInfo.path]), ".")
 	result := {
 		"documentId": document.id,
-		"searchKey": sprintf("metadata.name={{%s}}.%s[%s]", [metadata.name, annotationsPath, expectedKey]),
+		"searchKey": sprintf("metadata.name={{%s}}.%s", [metadata.name, annotationsPath]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s[%s] should be set to 'runtime/default' or 'localhost'", [metadata.name, annotationsPath, expectedKey])
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s[%s] should be set to 'runtime/default' or 'localhost'", [metadata.name, annotationsPath, expectedKey]),
+		"keyActualValue": sprintf("metadata.name={{%s}}.%s[%s] does not specify a valid AppArmor profile", [metadata.name, annotationsPath, expectedKey]),
 	}
 }
 

--- a/assets/queries/k8s/missing_app_armor_config/query.rego
+++ b/assets/queries/k8s/missing_app_armor_config/query.rego
@@ -61,9 +61,10 @@ CxPolicy[result] {
 	annotationsPath := trim_left(sprintf("%s.annotations", [metadataInfo.path]), ".")
 	result := {
 		"documentId": document.id,
-		"searchKey": sprintf("metadata.name={{%s}}.%s", [metadata.name, annotationsPath]),
+		"searchKey": trim_right(sprintf("metadata.name={{%s}}.%s", [metadata.name, metadataInfo.path]), "."),
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s should specify an AppArmor profile for container {{%s}}", [metadata.name, annotationsPath, container]),
 		"keyActualValue": sprintf("metadata.name={{%s}}.%s does not specify an AppArmor profile for container {{%s}}", [metadata.name, annotationsPath, container]),
+		"searchLine": common_lib.build_search_line(split(annotationsPath, "."), [])
 	}
 }

--- a/assets/queries/k8s/missing_app_armor_config/query.rego
+++ b/assets/queries/k8s/missing_app_armor_config/query.rego
@@ -1,49 +1,45 @@
 package Cx
 
-CxPolicy[result] {
-	document := input.document[i]
-	metadata := document.metadata
-	document.kind == "Pod"
-	metadata.annotations[key]
-	expectedKey := "container.apparmor.security.beta.kubernetes.io"
-	not startswith(key, expectedKey)
+import data.generic.k8s as k8sLib
 
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name={{%s}}.annotations", [metadata.name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name[%s].annotations should contain key: '%s'", [metadata.name, expectedKey]),
-		"keyActualValue": sprintf("metadata.name[%s].annotations doesn't contain key: '%s'", [metadata.name, expectedKey]),
-	}
+types := {"initContainers", "containers"}
+
+getMetadataInfo(document) = metadataInfo {
+	templates := {"job_template", "jobTemplate"}
+	metadata := document.spec[templates[t]].spec.template.metadata
+	metadataInfo := {"metadata": metadata, "path": sprintf("spec.%s.spec.template.metadata", [templates[t]])}
+} else = metadataInfo {
+	metadata := document.spec.template.metadata
+	metadataInfo := {"metadata": metadata, "path": "spec.template.metadata"}
+} else = metadataInfo {
+	metadata := document.metadata
+	metadataInfo := {"metadata": metadata, "path": ""}
+}
+
+isValidAppArmorProfile(profile) {
+	profile == "runtime/default"
+} else {
+	startswith(profile, "localhost/")
 }
 
 CxPolicy[result] {
 	document := input.document[i]
 	metadata := document.metadata
-	document.kind == "Pod"
-	expectedKey := "container.apparmor.security.beta.kubernetes.io"
-	metadata.annotations == null
 
+	specInfo := k8sLib.getSpecInfo(document)
+	container := specInfo.spec[types[x]][_].name
+
+	metadataInfo := getMetadataInfo(document)
+	annotations := object.get(metadataInfo.metadata, "annotations", {})
+	expectedKey := sprintf("container.apparmor.security.beta.kubernetes.io/%s", [container])
+
+	not isValidAppArmorProfile(annotations[expectedKey])
+
+	annotationsPath := trim_left(sprintf("%s.annotations", [metadataInfo.path]), ".")
 	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name={{%s}}.annotations", [metadata.name]),
+		"documentId": document.id,
+		"searchKey": sprintf("metadata.name={{%s}}.%s[%s]", [metadata.name, annotationsPath, expectedKey]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name[%s].annotations should contain AppArmor profile config: '%s'", [metadata.name, expectedKey]),
-		"keyActualValue": sprintf("metadata.name[%s].annotations doesn't contain AppArmor profile config: '%s'", [metadata.name, expectedKey]),
-	}
-}
-
-CxPolicy[result] {
-	document := input.document[i]
-	document.kind == "Pod"
-	metadata := document.metadata
-	not metadata.annotations
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name=%s", [metadata.name]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("metadata.name[%s] should include annotations for AppArmor profile config", [metadata.name]),
-		"keyActualValue": sprintf("metadata.name[%s] doesn't contain AppArmor profile config in annotations", [metadata.name]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s[%s] should be set to 'runtime/default' or 'localhost'", [metadata.name, annotationsPath, expectedKey])
 	}
 }

--- a/assets/queries/k8s/missing_app_armor_config/test/positive.yaml
+++ b/assets/queries/k8s/missing_app_armor_config/test/positive.yaml
@@ -3,41 +3,39 @@ kind: Pod
 metadata:
   name: hello-apparmor-1
   annotations:
-    container.apparmor/hello1: localhost/k8s-apparmor-example-allow-write
+    container.apparmor.security.beta.kubernetes.io/hello1: dummy
+    container.apparmor.security.beta.kubernetes.io/hello2: dummy
 spec:
   containers:
   - name: hello1
     image: busybox
     command: [ "sh", "-c", "echo 'Hello AppArmor!' && sleep 1h" ]
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: hello-apparmor-2
-spec:
-  containers:
   - name: hello2
     image: busybox
     command: [ "sh", "-c", "echo 'Hello AppArmor!' && sleep 1h" ]
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: hello-apparmor4
-  annotations:
-    ingress-whitelist: "qa.acmecorp.internal.acmecorp.com"
-spec:
-  containers:
-  - name: hello4
+  - name: hello3
     image: busybox
     command: [ "sh", "-c", "echo 'Hello AppArmor!' && sleep 1h" ]
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: hello-apparmor5
+  name: ubuntu-test1
+  namespace: testns
+  labels:
+    deployment: ubuntu-1
 spec:
-  containers:
-  - name: hello5
-    image: busybox
-    command: [ "sh", "-c", "echo 'Hello AppArmor!' && sleep 1h" ]
+  replicas: 1
+  selector:
+    matchLabels:
+      container: ubuntu-1
+  template:
+    metadata:
+      labels:
+        container: ubuntu-1
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/ubuntu-1-container: dummy
+    spec:
+      containers:
+      - name: ubuntu-1-container
+        image: 0x010/ubuntu-w-utils:latest

--- a/assets/queries/k8s/missing_app_armor_config/test/positive_expected_result.json
+++ b/assets/queries/k8s/missing_app_armor_config/test/positive_expected_result.json
@@ -12,6 +12,11 @@
 	{
 		"queryName": "Missing App Armor Config",
 		"severity": "LOW",
+		"line": 5
+	},
+	{
+		"queryName": "Missing App Armor Config",
+		"severity": "LOW",
 		"line": 33
 	}
 ]

--- a/assets/queries/k8s/missing_app_armor_config/test/positive_expected_result.json
+++ b/assets/queries/k8s/missing_app_armor_config/test/positive_expected_result.json
@@ -7,7 +7,7 @@
 	{
 		"queryName": "Missing AppArmor Profile",
 		"severity": "LOW",
-		"line": 4
+		"line": 5
 	},
 	{
 		"queryName": "Missing AppArmor Profile",
@@ -17,6 +17,6 @@
 	{
 		"queryName": "Missing AppArmor Profile",
 		"severity": "LOW",
-		"line": 33
+		"line": 36
 	}
 ]

--- a/assets/queries/k8s/missing_app_armor_config/test/positive_expected_result.json
+++ b/assets/queries/k8s/missing_app_armor_config/test/positive_expected_result.json
@@ -2,21 +2,16 @@
 	{
 		"queryName": "Missing App Armor Config",
 		"severity": "LOW",
-		"line": 5
+		"line": 4
 	},
 	{
 		"queryName": "Missing App Armor Config",
 		"severity": "LOW",
-		"line": 27
+		"line": 4
 	},
 	{
 		"queryName": "Missing App Armor Config",
 		"severity": "LOW",
-		"line": 38
-	},
-	{
-		"queryName": "Missing App Armor Config",
-		"severity": "LOW",
-		"line": 16
+		"line": 33
 	}
 ]

--- a/assets/queries/k8s/missing_app_armor_config/test/positive_expected_result.json
+++ b/assets/queries/k8s/missing_app_armor_config/test/positive_expected_result.json
@@ -1,21 +1,21 @@
 [
 	{
-		"queryName": "Missing App Armor Config",
+		"queryName": "Missing AppArmor Profile",
 		"severity": "LOW",
 		"line": 4
 	},
 	{
-		"queryName": "Missing App Armor Config",
+		"queryName": "Missing AppArmor Profile",
 		"severity": "LOW",
 		"line": 4
 	},
 	{
-		"queryName": "Missing App Armor Config",
+		"queryName": "Missing AppArmor Profile",
 		"severity": "LOW",
 		"line": 5
 	},
 	{
-		"queryName": "Missing App Armor Config",
+		"queryName": "Missing AppArmor Profile",
 		"severity": "LOW",
 		"line": 33
 	}


### PR DESCRIPTION
**Problem**

- The current rule only works on pods
- There is no check whether AppArmor is configured for each container
- There is no check whether the provided AppArmor profile is reasonable

**Proposed Changes**

- An implementation that addresses the issues described above.

I submit this contribution under the Apache-2.0 license.
