### PR TITLE
Feat(query): Added Ram Account Password Policy not Required Numbers for Terraform

### DIFF
--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/metadata.json
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/metadata.json
@@ -4,7 +4,7 @@
   "severity": "MEDIUM",
   "category": "Secret Management",
   "descriptionText": "Ram Account Password Policy should have 'require_numbers' set to true",
-  "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_account_password_policy",
+  "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_account_password_policy#require_numbers",
   "platform": "Terraform",
   "descriptionID": "0ee40b1d",
   "cloudProvider": "alicloud"

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/metadata.json
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Ram Account Password Policy Not Required Numbers",
   "severity": "MEDIUM",
   "category": "Secret Management",
-  "descriptionText": "Ram Account Password Policy Require Numbers should be true",
+  "descriptionText": "Ram Account Password Policy should have 'require_numbers' set to true",
   "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_account_password_policy",
   "platform": "Terraform",
   "descriptionID": "0ee40b1d",

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/metadata.json
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "063234c0-91c0-4ab5-bbd0-47ddb5f23786",
+  "queryName": "Ram Account Password Policy Not Required Numbers",
+  "severity": "MEDIUM",
+  "category": "Secret Management",
+  "descriptionText": "Ram Account Password Policy Numbers should be true",
+  "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_account_password_policy",
+  "platform": "Terraform",
+  "descriptionID": "0ee40b1d",
+  "cloudProvider": "alicloud"
+}

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/metadata.json
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Ram Account Password Policy Not Required Numbers",
   "severity": "MEDIUM",
   "category": "Secret Management",
-  "descriptionText": "Ram Account Password Policy Numbers should be true",
+  "descriptionText": "Ram Account Password Policy Require Numbers should be true",
   "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_account_password_policy",
   "platform": "Terraform",
   "descriptionID": "0ee40b1d",

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/query.rego
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	some i
+	resource := input.document[i].resource.alicloud_ram_account_password_policy[name]
+    resource.require_numbers == false 
+    
+    result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("alicloud_ram_account_password_policy[%s].require_numbers", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'require_numbers' is defined and set to true",
+		"keyActualValue": "'require_numbers' is false",
+		"searchLine": common_lib.build_search_line(["resource", "alicloud_ram_account_password_policy", name, "require_numbers"], []),
+	}
+}

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/test/negative1.tf
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/test/negative1.tf
@@ -1,0 +1,11 @@
+resource "alicloud_ram_account_password_policy" "corporate" {
+  minimum_password_length      = 9
+  require_lowercase_characters = false
+  require_uppercase_characters = false
+  require_numbers              = true
+  require_symbols              = false
+  hard_expiry                  = true
+  max_password_age             = 12
+  password_reuse_prevention    = 5
+  max_login_attempts           = 3
+}

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/test/negative2.tf
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/test/negative2.tf
@@ -1,0 +1,10 @@
+resource "alicloud_ram_account_password_policy" "corporate" {
+  minimum_password_length      = 9
+  require_lowercase_characters = false
+  require_uppercase_characters = false
+  require_symbols              = false
+  hard_expiry                  = true
+  max_password_age             = 12
+  password_reuse_prevention    = 5
+  max_login_attempts           = 3
+}

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/test/positive1.tf
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/test/positive1.tf
@@ -1,0 +1,11 @@
+resource "alicloud_ram_account_password_policy" "corporate" {
+  minimum_password_length      = 9
+  require_lowercase_characters = false
+  require_uppercase_characters = false
+  require_numbers              = false
+  require_symbols              = false
+  hard_expiry                  = true
+  max_password_age             = 12
+  password_reuse_prevention    = 5
+  max_login_attempts           = 3
+}

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_numbers/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+    {
+      "queryName": "Ram Account Password Policy Not Required Numbers",
+      "severity": "MEDIUM",
+      "line": 5,
+      "fileName": "positive1.tf"
+    }
+]


### PR DESCRIPTION

**Proposed Changes**
- Added Ram Account Password Policy not Required Numbers for Terraform 

I submit this contribution under the Apache-2.0 license.
