### PR TITLE
Feat(query): Added RAM Account Password Policy Not Required Symbols for Terraform.

### DIFF
--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_symbols/metadata.json
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_symbols/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "41a38329-d81b-4be4-aef4-55b2615d3282",
+  "queryName": "RAM Account Password Policy Not Required Symbols",
+  "severity": "MEDIUM",
+  "category": "Secret Management",
+  "descriptionText": "RAM account password security should require at least one symbol",
+  "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_account_password_policy#require_symbols",
+  "platform": "Terraform",
+  "descriptionID": "f3616c34",
+  "cloudProvider": "alicloud"
+}

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_symbols/query.rego
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_symbols/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	document := input.document[i]
+	resource := document.resource.alicloud_ram_account_password_policy[name]
+    resource["require_symbols"] == false
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("resource.alicloud_ram_account_password_policy[%s].require_symbols", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("resource.alicloud_ram_account_password_policy[%s].require_symbols is set to 'true'", [name]),
+		"keyActualValue": sprintf("resource.alicloud_ram_account_password_policy[%s].require_symbols is configured as 'false'", [name]),
+		"searchLine": common_lib.build_search_line(["resource", "alicloud_ram_account_password_policy", name, "require_symbols"], []),
+	}
+}

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_symbols/test/negative1.tf
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_symbols/test/negative1.tf
@@ -1,0 +1,11 @@
+resource "alicloud_ram_account_password_policy" "corporate1" {
+  minimum_password_length      = 9
+  require_lowercase_characters = false
+  require_uppercase_characters = false
+  require_numbers              = false
+  require_symbols              = true
+  hard_expiry                  = true
+  max_password_age             = 12
+  password_reuse_prevention    = 5
+  max_login_attempts           = 3
+}

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_symbols/test/positive1.tf
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_symbols/test/positive1.tf
@@ -1,0 +1,11 @@
+resource "alicloud_ram_account_password_policy" "corporate2" {
+  minimum_password_length      = 9
+  require_lowercase_characters = false
+  require_uppercase_characters = false
+  require_numbers              = false
+  require_symbols              = false
+  hard_expiry                  = true
+  max_password_age             = 12
+  password_reuse_prevention    = 5
+  max_login_attempts           = 3
+}

--- a/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_symbols/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/ram_account_password_policy_not_required_symbols/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "RAM Account Password Policy Not Required Symbols",
+    "severity": "MEDIUM",
+    "line": 6,
+    "fileName": "positive1.tf"
+  }
+]


### PR DESCRIPTION
**Proposed Changes**
- Added RAM Account Password Policy Not Required Symbols

I submit this contribution under the Apache-2.0 license.
