### PR TITLE
Feat(query): Added RAM Account Password Policy Not Required Uppercase Characters for Terraform

### DIFF
--- a/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/metadata.json
+++ b/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "5e0fb613-ba9b-44c3-88f0-b44188466bfd",
+  "queryName": "Ram Account Password Policy Not Required Uppercase Characters",
+  "severity": "MEDIUM",
+  "category": "Secret Management",
+  "descriptionText": "Ram Account Password Policy Require Uppercase Characters should be true",
+  "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_account_password_policy",
+  "platform": "Terraform",
+  "descriptionID": "5adbc73e",
+  "cloudProvider": "alicloud"
+}

--- a/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/metadata.json
+++ b/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/metadata.json
@@ -3,8 +3,8 @@
   "queryName": "Ram Account Password Policy Not Required Uppercase Characters",
   "severity": "MEDIUM",
   "category": "Secret Management",
-  "descriptionText": "Ram Account Password Policy Require Uppercase Characters should be true",
-  "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_account_password_policy",
+  "descriptionText": "Ram Account Password Policy should have 'require_uppercase_characters' set to true",
+  "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_account_password_policy#require_uppercase_characters",
   "platform": "Terraform",
   "descriptionID": "5adbc73e",
   "cloudProvider": "alicloud"

--- a/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/metadata.json
+++ b/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "5e0fb613-ba9b-44c3-88f0-b44188466bfd",
-  "queryName": "Ram Account Password Policy Not Required Uppercase Characters",
+  "queryName": "RAM Account Password Policy Not Require at Least one Uppercase Character",
   "severity": "MEDIUM",
   "category": "Secret Management",
   "descriptionText": "Ram Account Password Policy should have 'require_uppercase_characters' set to true",

--- a/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/query.rego
+++ b/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	some i
+	resource := input.document[i].resource.alicloud_ram_account_password_policy[name]
+    resource.require_uppercase_characters == false
+    
+    result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("alicloud_ram_account_password_policy[%s].require_uppercase_characters", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'require_uppercase_characters' is defined and set to true",
+		"keyActualValue": "'require_uppercase_characters' is false",
+		"searchLine": common_lib.build_search_line(["resource", "alicloud_ram_account_password_policy", name, "require_uppercase_characters"], []),		
+	}
+}

--- a/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/test/negative1.tf
+++ b/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/test/negative1.tf
@@ -1,0 +1,11 @@
+resource "alicloud_ram_account_password_policy" "corporate" {
+  minimum_password_length      = 9
+  require_lowercase_characters = false
+  require_uppercase_characters = true
+  require_numbers              = false
+  require_symbols              = false
+  hard_expiry                  = true
+  max_password_age             = 12
+  password_reuse_prevention    = 5
+  max_login_attempts           = 3
+}

--- a/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/test/negative2.tf
+++ b/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/test/negative2.tf
@@ -1,0 +1,10 @@
+resource "alicloud_ram_account_password_policy" "corporate" {
+  minimum_password_length      = 9
+  require_lowercase_characters = false
+  require_numbers              = false
+  require_symbols              = false
+  hard_expiry                  = true
+  max_password_age             = 12
+  password_reuse_prevention    = 5
+  max_login_attempts           = 3
+}

--- a/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/test/positive1.tf
+++ b/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/test/positive1.tf
@@ -1,0 +1,11 @@
+resource "alicloud_ram_account_password_policy" "corporate" {
+  minimum_password_length      = 9
+  require_lowercase_characters = false
+  require_uppercase_characters = false
+  require_numbers              = false
+  require_symbols              = false
+  hard_expiry                  = true
+  max_password_age             = 12
+  password_reuse_prevention    = 5
+  max_login_attempts           = 3
+}

--- a/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
   {
-    "queryName": "Ram Account Password Policy Not Required Uppercase Characters",
+    "queryName": "RAM Account Password Policy Not Require at Least one Uppercase Character",
     "severity": "MEDIUM",
     "line": 4,
     "fileName": "positive1.tf"

--- a/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/ram_password_security_policy_not_require_at_least_one_uppercase_character/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Ram Account Password Policy Not Required Uppercase Characters",
+    "severity": "MEDIUM",
+    "line": 4,
+    "fileName": "positive1.tf"
+  }
+]


### PR DESCRIPTION
**Proposed Changes**
- Added RAM Account Password Policy Not Required Uppercase Characters for Terraform

I submit this contribution under the Apache-2.0 license.
