### PR TITLE
Fix(report): Update GL-SAST reports version/schema

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -323,8 +323,8 @@ Gitlab SAST reports are sorted by severity (from high to info), following [Gitla
 
 ```json
 {
-	"schema": "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v13.1.0/dist/sast-report-format.json",
-	"version": "13.1.0",
+	"schema": "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v14.1.0/dist/sast-report-format.json",
+	"version": "14.1.0",
 	"scan": {
 		"start_time": "2021-05-26T17:22:13",
 		"end_time": "2021-05-26T17:22:13",

--- a/pkg/report/model/gitlab_sast.go
+++ b/pkg/report/model/gitlab_sast.go
@@ -84,7 +84,7 @@ type GitlabSASTReport interface {
 // NewGitlabSASTReport initializes a new instance of GitlabSASTReport to be uses
 func NewGitlabSASTReport(start, end time.Time) GitlabSASTReport {
 	return &gitlabSASTReport{
-		Schema:          "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v13.1.0/dist/sast-report-format.json",
+		Schema:          "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v14.1.0/dist/sast-report-format.json",
 		SchemaVersion:   "14.0.1",
 		Scan:            initGitlabSASTScan(start, end),
 		Vulnerabilities: make([]gitlabSASTVulnerability, 0),

--- a/pkg/report/model/gitlab_sast_test.go
+++ b/pkg/report/model/gitlab_sast_test.go
@@ -16,7 +16,7 @@ func TestNewGitlabSASTReport(t *testing.T) {
 	glSAST := NewGitlabSASTReport(start, end).(*gitlabSASTReport)
 	require.Equal(
 		t,
-		"https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v13.1.0/dist/sast-report-format.json",
+		"https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v14.1.0/dist/sast-report-format.json",
 		glSAST.Schema,
 	)
 	require.Equal(t, "14.0.1", glSAST.SchemaVersion)


### PR DESCRIPTION
**Proposed Changes**
- This PR introduces small fixes related to `gl-sast` reports, by replacing the old version & schema from 13.1.0 to 14.0.1.


I submit this contribution under the Apache-2.0 license.
