### PR TITLE
ci(kics): Remove comments from KICS Github Actions

### DIFF
--- a/.github/workflows/kics-gh-action.yaml
+++ b/.github/workflows/kics-gh-action.yaml
@@ -13,10 +13,10 @@ jobs:
       - name: Run KICS Scan
         uses: checkmarx/kics-action@v1.4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+#           token: ${{ secrets.GITHUB_TOKEN }}
           path: "./Dockerfile"
           ignore_on_exit: results
-          enable_comments: true
+#           enable_comments: true
           output_path: ./results
           output_formats: json,html
           type: dockerfile


### PR DESCRIPTION
**Proposed Changes**
- Remove KICS GitHub Actions Comments so it doesn't fail with forks

I submit this contribution under the Apache-2.0 license.
