### PR TITLE
fix(query): Extend container_requests_not_equal_to_its_limits k8s rule to cover further resource kinds and remove redundant checks

### DIFF
--- a/assets/queries/k8s/container_requests_not_equal_to_its_limits/metadata.json
+++ b/assets/queries/k8s/container_requests_not_equal_to_its_limits/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Container Requests Not Equal To It's Limits",
   "severity": "LOW",
   "category": "Resource Management",
-  "descriptionText": "A Pod's Containers must have the same requests as limits set, which is recommended to avoid resource DDOS of the node during spikes. This means the 'requests.memory' and 'requests.cpu' must equal 'limits.memory' and 'limits.cpu', respectively, and all four must be defined.",
+  "descriptionText": "Containers must have the same resource requests set as limits. This is recommended to avoid resource DDoS of the node during spikes and means that 'requests.memory' and 'requests.cpu' must equal 'limits.memory' and 'limits.cpu', respectively",
   "descriptionUrl": "https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
   "platform": "Kubernetes",
   "descriptionID": "39aeed84"

--- a/assets/queries/k8s/container_requests_not_equal_to_its_limits/test/positive_expected_result.json
+++ b/assets/queries/k8s/container_requests_not_equal_to_its_limits/test/positive_expected_result.json
@@ -2,27 +2,7 @@
   {
     "queryName": "Container Requests Not Equal To It's Limits",
     "severity": "LOW",
-    "line": 11
-  },
-  {
-    "queryName": "Container Requests Not Equal To It's Limits",
-    "severity": "LOW",
-    "line": 22
-  },
-  {
-    "queryName": "Container Requests Not Equal To It's Limits",
-    "severity": "LOW",
     "line": 26
-  },
-  {
-    "queryName": "Container Requests Not Equal To It's Limits",
-    "severity": "LOW",
-    "line": 36
-  },
-  {
-    "queryName": "Container Requests Not Equal To It's Limits",
-    "severity": "LOW",
-    "line": 47
   },
   {
     "queryName": "Container Requests Not Equal To It's Limits",


### PR DESCRIPTION
**Proposed Changes**

- Extend the rule to cover additional resource kinds, e.g., Deployment, DaemonSet, etc.
- Remove redundant `MissingAttribute` checks that are covered by other rules. While this rule has a LOW severity rating, checks for missing cpu and memory attributes are rated MEDIUM. 
  - The concerning rules are:
    - [cpu_requests_not_set](https://github.com/Checkmarx/kics/blob/master/assets/queries/k8s/cpu_requests_not_set/query.rego)
    - [cpu_limits_not_set](https://github.com/Checkmarx/kics/blob/master/assets/queries/k8s/cpu_limits_not_set/query.rego)
    - [memory_requests_not_defined](https://github.com/Checkmarx/kics/blob/master/assets/queries/k8s/memory_requests_not_defined/query.rego)
    - [memory_limits_not_defined](https://github.com/Checkmarx/kics/blob/master/assets/queries/k8s/memory_limits_not_defined/query.rego)
  - When kics is run with the full rule set (or better said: together with these 4 rules), it will produce search hits on the same result lines as the ones I removed from `positive_expected_result.json` here.

I submit this contribution under the Apache-2.0 license.