### PR TITLE
fix(query): add a missing SSE way for SQS

### DIFF
--- a/assets/queries/terraform/aws/sqs_with_sse_disabled/query.rego
+++ b/assets/queries/terraform/aws/sqs_with_sse_disabled/query.rego
@@ -20,8 +20,8 @@ CxPolicy[result] {
 
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("aws_sqs_queue[%s]", [name]),
-		"issueType": "MissingAttribute",
+		"searchKey": sprintf("aws_sqs_queue[%s].sqs_managed_sse_enabled", [name]),
+		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_sqs_queue[%s].sqs_managed_sse_enabled must be set to true", [name]),
 		"keyActualValue": sprintf("aws_sqs_queue[%s].sqs_managed_sse_enabled is set to false", [name]),
 		"searchLine": common_lib.build_search_line(["resource", "aws_sqs_queue", name, "sqs_managed_sse_enabled"], []),

--- a/assets/queries/terraform/aws/sqs_with_sse_disabled/test/negative3.tf
+++ b/assets/queries/terraform/aws/sqs_with_sse_disabled/test/negative3.tf
@@ -1,0 +1,4 @@
+resource "aws_sqs_queue" "negative3" {
+  name                    = "terraform-example-queue"
+  sqs_managed_sse_enabled = true
+}

--- a/assets/queries/terraform/aws/sqs_with_sse_disabled/test/positive7.tf
+++ b/assets/queries/terraform/aws/sqs_with_sse_disabled/test/positive7.tf
@@ -1,0 +1,4 @@
+resource "aws_sqs_queue" "positive7" {
+  name                    = "terraform-example-queue"
+  sqs_managed_sse_enabled = false
+}

--- a/assets/queries/terraform/aws/sqs_with_sse_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sqs_with_sse_disabled/test/positive_expected_result.json
@@ -34,5 +34,11 @@
     "severity": "HIGH",
     "line": 1,
     "fileName": "positive6.tf"
+  },
+  {
+    "queryName": "SQS With SSE Disabled",
+    "severity": "HIGH",
+    "line": 3,
+    "fileName": "positive7.tf"
   }
 ]


### PR DESCRIPTION
## Context

From [the documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue#server-side-encryption-sse), there are 2 way to add SSE on a AWS SQS : 
1)  SSE-SQS
2)  SSE-KMS

Currently, the query `terraform/aws/sqs_with_sse_disabled` check only SSE-KMS.

## Proposed Changes
- Update the query `terraform/aws/sqs_with_sse_disabled` to check if one of the 2 ways is set and not null

I submit this contribution under the Apache-2.0 license.
