### PR TITLE
Feat(query): Alicloud Terraform Ram Policy Admin Access Not Attached to Users Groups Roles

### DIFF
--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/metadata.json
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "e8e62026-da63-4904-b402-65adfe3ca975",
+  "queryName": "Ram Policy Admin Access Not Attached to Users Groups Roles",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "Ram policies with admin access should not be associated to users, groups or roles",
+  "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_policy",
+  "platform": "Terraform",
+  "descriptionID": "d529825f",
+  "cloudProvider": "alicloud"
+}

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/query.rego
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+
+    ram_policy := input.document[i].resource.alicloud_ram_policy[name]
+    
+    is_admin_policy(ram_policy.document)
+    
+    policy_attachment_possibilities := {"alicloud_ram_user_policy_attachment", "alicloud_ram_group_policy_attachment", "alicloud_ram_role_policy_attachment"}
+    attachment := policy_attachment_possibilities[pap]
+    attach := input.document[_].resource[attachment][n]
+    
+    target_policy_name := split(attach.policy_name, ".")[1]
+    
+    target_policy_name == name 
+    
+    
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("%s.%s.policy_name",[pap, n]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("alicloud_ram_policy[%s] is not attached to any user, group or role",[name]),
+		"keyActualValue": sprintf("alicloud_ram_policy[%s] is attached to a user, group or role and gives admin access",[name]),
+        "searchline":common_lib.build_search_line([pap, n ,"policy_name"], []),
+	}
+}
+
+
+is_admin_policy(ram_policy)
+{
+	u_policy := common_lib.json_unmarshal(ram_policy)
+	statement := common_lib.get_statement(u_policy)
+    st:=statement[_]
+	st.Effect == "Allow"
+    common_lib.containsOrInArrayContains(st.Resource, "*")
+    common_lib.containsOrInArrayContains(st.Action, "*")
+}

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/query.rego
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/query.rego
@@ -21,9 +21,9 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("%s.%s.policy_name",[pap, n]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("alicloud_ram_policy[%s] is not attached to any user, group or role",[name]),
+		"keyExpectedValue": sprintf("alicloud_ram_policy[%s] does not give admin access to any user, group or role",[name]),
 		"keyActualValue": sprintf("alicloud_ram_policy[%s] is attached to a user, group or role and gives admin access",[name]),
-        "searchline":common_lib.build_search_line([pap, n ,"policy_name"], []),
+        "searchKey": sprintf("%s[%s].policy_name",[attachment, n]),
 	}
 }
 

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/query.rego
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/query.rego
@@ -19,11 +19,11 @@ CxPolicy[result] {
     
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("%s[%s].policy_name",[attachment, n]),
+		"searchline":common_lib.build_search_line(["resource", attachment, n ,"policy_name"], []),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("alicloud_ram_policy[%s] does not give admin access to any user, group or role",[name]),
 		"keyActualValue": sprintf("alicloud_ram_policy[%s] is attached to a user, group or role and gives admin access",[name]),
-        "searchline":common_lib.build_search_line([pap, n ,"policy_name"], []),
+        "searchKey": sprintf("%s[%s].policy_name",[attachment, n]),
 	}
 }
 

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/query.rego
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/query.rego
@@ -19,11 +19,11 @@ CxPolicy[result] {
     
 	result := {
 		"documentId": input.document[i].id,
-		"searchKey": sprintf("%s.%s.policy_name",[pap, n]),
+		"searchKey": sprintf("%s[%s].policy_name",[attachment, n]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("alicloud_ram_policy[%s] does not give admin access to any user, group or role",[name]),
 		"keyActualValue": sprintf("alicloud_ram_policy[%s] is attached to a user, group or role and gives admin access",[name]),
-        "searchKey": sprintf("%s[%s].policy_name",[attachment, n]),
+        "searchline":common_lib.build_search_line([pap, n ,"policy_name"], []),
 	}
 }
 

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/query.rego
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/query.rego
@@ -19,11 +19,11 @@ CxPolicy[result] {
     
 	result := {
 		"documentId": input.document[i].id,
-		"searchline":common_lib.build_search_line(["resource", attachment, n ,"policy_name"], []),
+        "searchKey": sprintf("%s[%s].policy_name",[attachment, n]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("alicloud_ram_policy[%s] does not give admin access to any user, group or role",[name]),
 		"keyActualValue": sprintf("alicloud_ram_policy[%s] is attached to a user, group or role and gives admin access",[name]),
-        "searchKey": sprintf("%s[%s].policy_name",[attachment, n]),
+        "searchline":common_lib.build_search_line(["resource", attachment, n ,"policy_name"], []),        
 	}
 }
 

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/negative1.tf
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/negative1.tf
@@ -1,0 +1,39 @@
+# Create a RAM User Policy attachment.
+resource "alicloud_ram_user" "user1" {
+  name         = "userName"
+  display_name = "user_display_name"
+  mobile       = "86-18688888888"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
+}
+
+resource "alicloud_ram_policy" "policy1" {
+  name        = "policyName"
+  document    = <<EOF
+  {
+    "Statement": [
+      {
+        "Action": [
+          "oss:ListObjects",
+          "oss:GetObject"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+          "acs:oss:*:*:mybucket",
+          "acs:oss:*:*:mybucket/*"
+        ]
+      }
+    ],
+      "Version": "1"
+  }
+  EOF
+  description = "this is a policy test"
+  force       = true
+}
+
+resource "alicloud_ram_user_policy_attachment" "attach" {
+  policy_name = alicloud_ram_policy.policy1.name
+  policy_type = alicloud_ram_policy.policy1.type
+  user_name   = alicloud_ram_user.user1.name
+}

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/negative2.tf
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/negative2.tf
@@ -1,0 +1,36 @@
+# Create a RAM Group Policy attachment.
+resource "alicloud_ram_group" "group2" {
+  name     = "groupName"
+  comments = "this is a group comments."
+  force    = true
+}
+
+resource "alicloud_ram_policy" "policy2" {
+  name        = "policyName"
+  document    = <<EOF
+    {
+      "Statement": [
+        {
+          "Action": [
+            "oss:ListObjects",
+            "oss:GetObject"
+          ],
+          "Effect": "Allow",
+          "Resource": [
+            "acs:oss:*:*:mybucket",
+            "acs:oss:*:*:mybucket/*"
+          ]
+        }
+      ],
+        "Version": "1"
+    }
+  EOF
+  description = "this is a policy test"
+  force       = true
+}
+
+resource "alicloud_ram_group_policy_attachment" "attach" {
+  policy_name = alicloud_ram_policy.policy2.name
+  policy_type = alicloud_ram_policy.policy2.type
+  group_name  = alicloud_ram_group.group2.name
+}

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/negative3.tf
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/negative3.tf
@@ -1,0 +1,53 @@
+# Create a RAM Role Policy attachment.
+resource "alicloud_ram_role" "role3" {
+  name        = "roleName"
+  document    = <<EOF
+    {
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": [
+              "apigateway.aliyuncs.com", 
+              "ecs.aliyuncs.com"
+            ]
+          }
+        }
+      ],
+      "Version": "1"
+    }
+    EOF
+  description = "this is a role test."
+  force       = true
+}
+
+resource "alicloud_ram_policy" "policy3" {
+  name        = "policyName"
+  document    = <<EOF
+  {
+    "Statement": [
+      {
+        "Action": [
+          "oss:ListObjects",
+          "oss:GetObject"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+          "acs:oss:*:*:mybucket",
+          "acs:oss:*:*:mybucket/*"
+        ]
+      }
+    ],
+      "Version": "1"
+  }
+  EOF
+  description = "this is a policy test"
+  force       = true
+}
+
+resource "alicloud_ram_role_policy_attachment" "attach" {
+  policy_name = alicloud_ram_policy.policy3.name
+  policy_type = alicloud_ram_policy.policy3.type
+  role_name   = alicloud_ram_role.role3.name
+}

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/positive1.tf
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/positive1.tf
@@ -1,0 +1,38 @@
+# Create a RAM User Policy attachment.
+resource "alicloud_ram_user" "user4" {
+  name         = "userName"
+  display_name = "user_display_name"
+  mobile       = "86-18688888888"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
+}
+
+resource "alicloud_ram_policy" "policy4" {
+  name        = "policyName"
+  document    = <<EOF
+  {
+    "Statement": [
+      {
+        "Action": [
+          "oss:*"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+          "acs:oss:*:*:mybucket",
+          "acs:oss:*:*:mybucket/*"
+        ]
+      }
+    ],
+      "Version": "1"
+  }
+  EOF
+  description = "this is a policy test"
+  force       = true
+}
+
+resource "alicloud_ram_user_policy_attachment" "attach" {
+  policy_name = alicloud_ram_policy.policy4.name
+  policy_type = alicloud_ram_policy.policy4.type
+  user_name   = alicloud_ram_user.user4.name
+}

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/positive2.tf
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/positive2.tf
@@ -1,0 +1,35 @@
+# Create a RAM Group Policy attachment.
+resource "alicloud_ram_group" "group5" {
+  name     = "groupName"
+  comments = "this is a group comments."
+  force    = true
+}
+
+resource "alicloud_ram_policy" "policy5" {
+  name        = "policyName"
+  document    = <<EOF
+    {
+      "Statement": [
+        {
+          "Action": [
+            "oss:*"
+          ],
+          "Effect": "Allow",
+          "Resource": [
+            "acs:oss:*:*:mybucket",
+            "acs:oss:*:*:mybucket/*"
+          ]
+        }
+      ],
+        "Version": "1"
+    }
+  EOF
+  description = "this is a policy test"
+  force       = true
+}
+
+resource "alicloud_ram_group_policy_attachment" "attach" {
+  policy_name = alicloud_ram_policy.policy5.name
+  policy_type = alicloud_ram_policy.policy5.type
+  group_name  = alicloud_ram_group.group5.name
+}

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/positive3.tf
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/positive3.tf
@@ -1,0 +1,52 @@
+# Create a RAM Role Policy attachment.
+resource "alicloud_ram_role" "role6" {
+  name        = "roleName"
+  document    = <<EOF
+    {
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": [
+              "apigateway.aliyuncs.com", 
+              "ecs.aliyuncs.com"
+            ]
+          }
+        }
+      ],
+      "Version": "1"
+    }
+    EOF
+  description = "this is a role test."
+  force       = true
+}
+
+resource "alicloud_ram_policy" "policy6" {
+  name        = "policyName"
+  document    = <<EOF
+  {
+    "Statement": [
+      {
+        "Action": [
+          "oss:*"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+          "acs:oss:*:*:mybucket",
+          "acs:oss:*:*:mybucket/*"
+        ]
+      }
+    ],
+      "Version": "1"
+  }
+  EOF
+  description = "this is a policy test"
+  force       = true
+}
+
+resource "alicloud_ram_role_policy_attachment" "attach" {
+  policy_name = alicloud_ram_policy.policy6.name
+  policy_type = alicloud_ram_policy.policy6.type
+  role_name   = alicloud_ram_role.role6.name
+}

--- a/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/ram_policy_admin_access_not_attached_to_users_groups_roles/test/positive_expected_result.json
@@ -1,0 +1,20 @@
+[
+  {
+    "queryName": "Ram Policy Admin Access Not Attached to Users Groups Roles",
+    "severity": "HIGH",
+    "line": 35,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "Ram Policy Admin Access Not Attached to Users Groups Roles",
+    "severity": "HIGH",
+    "line": 32,
+    "fileName": "positive2.tf"
+  },
+  {
+    "queryName": "Ram Policy Admin Access Not Attached to Users Groups Roles",
+    "severity": "HIGH",
+    "line": 49,
+    "fileName": "positive3.tf"
+  }
+]


### PR DESCRIPTION
**Proposed Changes**
- Query: Ram Policy Admin Access Not Attached to Users Groups Roles


I submit this contribution under the Apache-2.0 license.
