### PR TITLE
feat(query): Added Alicloud Public Security Group Rule Unknown Port for Terraform

### DIFF
--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/query.rego
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/query.rego
@@ -18,9 +18,9 @@ CxPolicy[result] {
 		"documentId": id,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rules", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("ec2_group.rules[%d].from_port is known", [index]),
-		"keyActualValue": sprintf("ec2_group.rules[%d].from_port is unknown and is exposed to the entire Internet", [index]),
-		"searchLine": commonLib.build_search_line(["playbooks", t, modules[m], "rules"], []),
+		"keyExpectedValue": sprintf("ec2_group.rules[%d] port_range does not contain unknown  ports and are not exposed to the entire Internet", [index]),
+		"keyActualValue": sprintf("ec2_group.rules[%d] port_range contains unknown ports and are exposed to the entire Internet", [index]),
+		"searchLine": commonLib.build_search_line(["playbooks", t, modules[m], "rules", index, "from_port"], []),
 	}
 }
 

--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/query.rego
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 	ansLib.checkState(ec2_group)
 	rule := ec2_group.rules[index]
 
-	not portIsKnown(rule.from_port)
+	unknownPort(rule.from_port,rule.to_port)
 	isEntireNetwork(rule)
 
 	result := {
@@ -20,19 +20,14 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("ec2_group.rules[%d].from_port is known", [index]),
 		"keyActualValue": sprintf("ec2_group.rules[%d].from_port is unknown and is exposed to the entire Internet", [index]),
+		"searchLine": commonLib.build_search_line(["playbooks", t, modules[m], "rules"], []),
 	}
 }
 
-portIsKnown(port) {
-	knownPorts := [
-		0, 20, 21, 22, 23, 25, 53, 57, 80, 88, 110, 119, 123, 135, 143, 137, 138, 139,
-		161, 162, 163, 164, 194, 318, 443, 514, 563, 636, 989, 990, 1433, 1434,
-		2382, 2383, 2484, 3000, 3020, 3306, 3389, 4505, 4506, 5060, 5353, 5432,
-		5500, 5900, 7001, 8000, 8080, 8140, 9000, 9200, 9300, 11214, 11215, 27017,
-		27018, 61621,
-	]
 
-	commonLib.inArray(knownPorts, port)
+unknownPort(from_port,to_port) {
+	port := numbers.range(from_port, to_port)[i]
+	not commonLib.valid_key(commonLib.tcpPortsMap, port)
 }
 
 isEntireNetwork(rule) {

--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/test/positive.yaml
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/test/positive.yaml
@@ -6,10 +6,10 @@
     region: eu-west-1
     rules:
       - proto: tcp
-        from_port: 800000000000
-        to_port: 80
+        from_port: 8001
+        to_port: 8002
         cidr_ip: 0.0.0.0/0
       - proto: tcp
-        from_port: 222222
-        to_port: 22
+        from_port: 2222
+        to_port: 2226
         cidr_ipv6: ::/0

--- a/assets/queries/ansible/aws/unknown_port_exposed_to_internet/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/unknown_port_exposed_to_internet/test/positive_expected_result.json
@@ -2,11 +2,11 @@
 	{
 		"queryName": "Unknown Port Exposed To Internet",
 		"severity": "HIGH",
-		"line": 7
+		"line": 9
 	},
 	{
 		"queryName": "Unknown Port Exposed To Internet",
 		"severity": "HIGH",
-		"line": 7
+		"line": 13
 	}
 ]

--- a/assets/queries/cloudFormation/aws/unknown_port_exposed_to_internet/query.rego
+++ b/assets/queries/cloudFormation/aws/unknown_port_exposed_to_internet/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d] doesn't open unknown ports to the Internet", [name, index]),
 		"keyActualValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d] opens unknown ports to the Internet", [name, index]),
-		"searchLine": commonLib.build_search_line(["Resources", name, "Properties", "SecurityGroupIngress"], []),
+		"searchLine": commonLib.build_search_line(["Resources", name, "Properties", "SecurityGroupIngress", index], []),
 	}
 }
 

--- a/assets/queries/cloudFormation/aws/unknown_port_exposed_to_internet/query.rego
+++ b/assets/queries/cloudFormation/aws/unknown_port_exposed_to_internet/query.rego
@@ -17,25 +17,18 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d] doesn't open unknown ports to the Internet", [name, index]),
 		"keyActualValue": sprintf("Resources.%s.Properties.SecurityGroupIngress[%d] opens unknown ports to the Internet", [name, index]),
+		"searchLine": commonLib.build_search_line(["Resources", name, "Properties", "SecurityGroupIngress"], []),
 	}
 }
 
-knownPorts := [
-	0, 20, 21, 22, 23, 25, 53, 57, 80, 88, 110, 119, 123, 135, 143, 137, 138, 139,
-	161, 162, 163, 164, 194, 318, 443, 514, 563, 636, 989, 990, 1433, 1434,
-	2382, 2383, 2484, 3000, 3020, 3306, 3389, 4505, 4506, 5060, 5353, 5432,
-	5500, 5900, 7001, 8000, 8080, 8140, 9000, 9200, 9300, 11214, 11215, 27017,
-	27018, 61621,
-]
-
 containsUnknownPort(rule) {
-	not commonLib.inArray(knownPorts, rule.FromPort)
+	not commonLib.valid_key(commonLib.tcpPortsMap, rule.FromPort)
 } else {
-	not commonLib.inArray(knownPorts, rule.ToPort)
+	not commonLib.valid_key(commonLib.tcpPortsMap, rule.ToPort)
 } else {
 	some i
 	port := numbers.range(rule.FromPort, rule.ToPort)[i]
-	not commonLib.inArray(knownPorts, port)
+	not commonLib.valid_key(commonLib.tcpPortsMap, port)
 }
 
 entireNetwork(rule) {

--- a/assets/queries/cloudFormation/aws/unknown_port_exposed_to_internet/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/aws/unknown_port_exposed_to_internet/test/positive_expected_result.json
@@ -2,13 +2,13 @@
   {
     "queryName": "Unknown Port Exposed To Internet",
     "severity": "HIGH",
-    "line": 8,
+    "line": 9,
     "fileName": "positive1.yaml"
   },
   {
     "fileName": "positive2.json",
     "queryName": "Unknown Port Exposed To Internet",
     "severity": "HIGH",
-    "line": 10
+    "line": 12
   }
 ]

--- a/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/metadata.json
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/metadata.json
@@ -1,0 +1,11 @@
+{
+    "id": "dd706080-b7a8-47dc-81fb-3e8184430ec0",
+    "queryName": "Public Security Group Rule Unknown Port",
+    "severity": "MEDIUM",
+    "category": "Networking and Firewall",
+    "descriptionText": "A unknown port, such as port 24 or port 111, is open to the public in either TCP or UDP or ALL protocol/protocols mentioned",
+    "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/security_group_rule#port_range",
+    "platform": "Terraform",
+    "descriptionID": "a2097952",
+    "cloudProvider": "alicloud"
+  }

--- a/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/query.rego
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/query.rego
@@ -13,8 +13,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("alicloud_security_group_rule[%s].port_range", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "port_range does not contain ports unknown and are not exposed to the entire Internet",
-		"keyActualValue": "port_range contains ports unknown and are exposed to the entire Internet",
+		"keyExpectedValue": "port_range does not contain unknown ports and are not exposed to the entire Internet",
+		"keyActualValue": "port_range contains unknown ports and are exposed to the entire Internet",
 		"searchLine": common_lib.build_search_line(["resource", "alicloud_security_group_rule", name, "port_range"], []),
 	}
 }

--- a/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/query.rego
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/query.rego
@@ -1,0 +1,59 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.terraform as terraform_lib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.alicloud_security_group_rule[name]
+	resource.cidr_ip == "0.0.0.0/0"
+	isTCPorUDP(resource.ip_protocol)
+    containsUnknownPort(resource)	
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("alicloud_security_group_rule[%s].port_range", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "port_range does not contain ports unknown and are not exposed to the entire Internet",
+		"keyActualValue": "port_range contains ports unknown and are exposed to the entire Internet",
+		"searchLine": common_lib.build_search_line(["resource", "alicloud_security_group_rule", name, "port_range"], []),
+	}
+}
+
+isTCPorUDP("tcp") = true
+
+isTCPorUDP("udp") = true
+
+
+CxPolicy[result] {
+	resource := input.document[i].resource.alicloud_security_group_rule[name]
+	resource.cidr_ip == "0.0.0.0/0"
+	resource.ip_protocol == "all"
+	resource.port_range == "-1/-1"
+    containsUnknownPortForAll(resource)	
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("alicloud_security_group_rule[%s].port_range", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "port_range does not contain ports unknown and are not exposed to the entire Internet",
+		"keyActualValue": "port_range contains ports unknown and are exposed to the entire Internet",
+		"searchLine": common_lib.build_search_line(["resource", "alicloud_security_group_rule", name, "port_range"], []),
+	}
+}
+
+
+containsUnknownPort(rule){
+    sublist := split(rule.port_range, "/")
+    from_port :=  to_number(sublist[0])
+    to_port := to_number(sublist[1])
+    port := numbers.range(from_port, to_port)[i]
+    not common_lib.valid_key(common_lib.tcpPortsMap,port)
+}
+
+containsUnknownPortForAll(rule){
+    rule.port_range == "-1/-1"
+    from_port :=  1
+    to_port := 65535
+    port := numbers.range(from_port, to_port)[i]
+    not common_lib.valid_key(common_lib.tcpPortsMap,port)
+}

--- a/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/test/negative1.tf
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/test/negative1.tf
@@ -1,0 +1,14 @@
+resource "alicloud_security_group" "default" {
+  name = "default"
+}
+
+resource "alicloud_security_group_rule" "allow_all_tcp" {
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "internet"
+  policy            = "accept"
+  port_range        = "1/65535"
+  priority          = 1
+  security_group_id = alicloud_security_group.default.id
+  cidr_ip           = "10.159.6.18/12"
+}

--- a/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/test/negative2.tf
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/test/negative2.tf
@@ -1,0 +1,14 @@
+resource "alicloud_security_group" "default" {
+  name = "default"
+}
+
+resource "alicloud_security_group_rule" "allow_all_tcp" {
+  type              = "ingress"
+  ip_protocol       = "icmp"
+  nic_type          = "internet"
+  policy            = "accept"
+  port_range        = "-1/-1"
+  priority          = 1
+  security_group_id = alicloud_security_group.default.id
+  cidr_ip           = "10.159.6.18/12"
+}

--- a/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/test/positive1.tf
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/test/positive1.tf
@@ -1,0 +1,14 @@
+resource "alicloud_security_group" "default" {
+  name = "default"
+}
+
+resource "alicloud_security_group_rule" "allow_all_tcp" {
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "internet"
+  policy            = "accept"
+  port_range        = "54/60"
+  priority          = 1
+  security_group_id = alicloud_security_group.default.id
+  cidr_ip           = "0.0.0.0/0"
+}

--- a/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/test/positive2.tf
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/test/positive2.tf
@@ -1,0 +1,14 @@
+resource "alicloud_security_group" "default" {
+  name = "default"
+}
+
+resource "alicloud_security_group_rule" "allow_all_tcp" {
+  type              = "ingress"
+  ip_protocol       = "all"
+  nic_type          = "internet"
+  policy            = "accept"
+  port_range        = "-1/-1"
+  priority          = 1
+  security_group_id = alicloud_security_group.default.id
+  cidr_ip           = "0.0.0.0/0"
+}

--- a/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+    {
+        "queryName": "Public Security Group Rule Unknown Port",
+        "severity": "MEDIUM",
+        "line": 10,
+        "fileName": "positive1.tf"
+    },
+    {
+        "queryName": "Public Security Group Rule Unknown Port",
+        "severity": "MEDIUM",
+        "line": 10,
+        "fileName": "positive2.tf"
+    }
+]

--- a/assets/queries/terraform/aws/unknown_port_exposed_to_internet/query.rego
+++ b/assets/queries/terraform/aws/unknown_port_exposed_to_internet/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("aws_security_group[%s].ingress ports are known", [name]),
 		"keyActualValue": sprintf("aws_security_group[%s].ingress ports are unknown and exposed to the entire Internet", [name]),
-		"searchLine": commonLib.build_search_line(["resource", "aws_security_group", name, "ingress","cidr_blocks"], []),
+		"searchLine": commonLib.build_search_line(["resource", "aws_security_group", name, "ingress", j, "cidr_blocks"], []),
 	}
 }
 


### PR DESCRIPTION
Closes #

**Proposed Changes**
-Added Alicloud Public Security Group Rule Unknown Port for Terraform
- Fix bugs in:
&emsp; - Unknown Port Exposed To Internet AWS for Ansible
&emsp; - Unknown Port Exposed To Internet AWS for CloudFormation
&emsp; - Unknown Port Exposed To Internet AWS for Terraform

I submit this contribution under the Apache-2.0 license.
