### PR TITLE
feat(Query): Added Alicloud RAM Security Preference Not Enforce MFA Login for Terraform

### DIFF
--- a/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/metadata.json
+++ b/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/metadata.json
@@ -1,0 +1,11 @@
+{
+    "id": "dcda2d32-e482-43ee-a926-75eaabeaa4e0",
+    "queryName": "RAM Security Preference Not Enforce MFA Login",
+    "severity": "HIGH",
+    "category": "Access Control",
+    "descriptionText": "RAM Security preferences should enforce MFA login for RAM users",
+    "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_security_preference#enforce_mfa_for_login",
+    "platform": "Terraform",
+    "descriptionID": "6131e90d",
+    "cloudProvider": "alicloud"
+  }

--- a/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/query.rego
+++ b/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/query.rego
@@ -1,0 +1,55 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	ram_users := [ram_users | docs := input.document; docs[i].resource.alicloud_ram_user[name]; ram_users := {"id": docs[i].id, "name": name}]
+	count(ram_users) > 0
+    ram_user := ram_users[0]
+    not has_preference(input.document) 
+	#resource alicloud_ram_user
+	result := {
+    	"documentId": ram_user.id,
+		"searchKey": sprintf("alicloud_ram_user[%s]", [ram_user.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "alicloud_ram_security_preference resource should be defined",
+		"keyActualValue": "alicloud_ram_security_preference resource is not defined",        
+		"searchLine": common_lib.build_search_line(["resource", "alicloud_ram_user", ram_user.name], []),
+	}
+}
+
+has_preference(doc){
+	doc[_].resource["alicloud_ram_security_preference"]
+}
+
+has_ram_user(doc){
+	doc[_].resource["alicloud_ram_user"]
+}
+
+CxPolicy[result] {
+	has_ram_user(input.document)
+	resource := input.document[id].resource.alicloud_ram_security_preference[name]
+    not common_lib.valid_key(resource,"enforce_mfa_for_login")
+	result := {
+    	"documentId": input.document[id].id,
+		"searchKey": sprintf("alicloud_ram_security_preference[%s]", [name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'enforce_mfa_for_login' should be defined and set to true",
+		"keyActualValue": "'enforce_mfa_for_login' is not defined",
+		"searchLine": common_lib.build_search_line(["resource", "alicloud_ram_security_preference", name], []),
+	}
+}
+
+CxPolicy[result] {
+	has_ram_user(input.document)
+	resource := input.document[id].resource.alicloud_ram_security_preference[name]
+    resource.enforce_mfa_for_login == false
+	result := {
+    	"documentId": input.document[id].id,
+		"searchKey": sprintf("alicloud_ram_security_preference[%s]", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'enforce_mfa_for_login' should be set to true",
+		"keyActualValue": "'enforce_mfa_for_login' is set to 'false'",
+		"searchLine": common_lib.build_search_line(["resource", "alicloud_ram_security_preference", name, "enforce_mfa_for_login" ], []),
+	}
+}

--- a/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/query.rego
+++ b/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/query.rego
@@ -7,7 +7,7 @@ CxPolicy[result] {
 	count(ram_users) > 0
     ram_user := ram_users[0]
     not has_preference(input.document) 
-	#resource alicloud_ram_user
+
 	result := {
     	"documentId": ram_user.id,
 		"searchKey": sprintf("alicloud_ram_user[%s]", [ram_user.name]),
@@ -30,6 +30,7 @@ CxPolicy[result] {
 	has_ram_user(input.document)
 	resource := input.document[id].resource.alicloud_ram_security_preference[name]
     not common_lib.valid_key(resource,"enforce_mfa_for_login")
+
 	result := {
     	"documentId": input.document[id].id,
 		"searchKey": sprintf("alicloud_ram_security_preference[%s]", [name]),
@@ -44,6 +45,7 @@ CxPolicy[result] {
 	has_ram_user(input.document)
 	resource := input.document[id].resource.alicloud_ram_security_preference[name]
     resource.enforce_mfa_for_login == false
+	
 	result := {
     	"documentId": input.document[id].id,
 		"searchKey": sprintf("alicloud_ram_security_preference[%s]", [name]),

--- a/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/test/negative1.tf
+++ b/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/test/negative1.tf
@@ -1,0 +1,15 @@
+# Create a new RAM user.
+resource "alicloud_ram_user" "user0" {
+  name         = "user_test"
+  display_name = "user_display_name"
+  mobile       = "86-18688888888"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
+}
+
+resource "alicloud_ram_security_preference" "example0" {
+  enable_save_mfa_ticket        = false
+  allow_user_to_change_password = true
+  enforce_mfa_for_login = true
+}

--- a/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/test/positive1.tf
+++ b/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/test/positive1.tf
@@ -1,0 +1,14 @@
+# Create a new RAM user.
+resource "alicloud_ram_user" "user1" {
+  name         = "user_test"
+  display_name = "user_display_name"
+  mobile       = "86-18688888888"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
+}
+
+resource "alicloud_ram_security_preference" "example1" {
+  enable_save_mfa_ticket        = false
+  allow_user_to_change_password = true
+}

--- a/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/test/positive2.tf
+++ b/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/test/positive2.tf
@@ -1,0 +1,15 @@
+# Create a new RAM user.
+resource "alicloud_ram_user" "user2" {
+  name         = "user_test"
+  display_name = "user_display_name"
+  mobile       = "86-18688888888"
+  email        = "hello.uuu@aaa.com"
+  comments     = "yoyoyo"
+  force        = true
+}
+
+resource "alicloud_ram_security_preference" "example2" {
+  enable_save_mfa_ticket        = false
+  allow_user_to_change_password = true
+  enforce_mfa_for_login = false
+}

--- a/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/test/positive3.tf
+++ b/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/test/positive3.tf
@@ -1,0 +1,11 @@
+# this file does not return any result because inside the test folder exists at least one resource "alicloud_ram_security_preference" in the samples
+#resource "alicloud_ram_user" "user3" {
+#  name         = "user_test"
+#  display_name = "user_display_name"
+#  mobile       = "86-18688888888"
+#  email        = "hello.uuu@aaa.com"
+#  comments     = "yoyoyo"
+#  force        = true
+#}
+
+

--- a/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/ram_security_preference_not_enforce_mfa/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "RAM Security Preference Not Enforce MFA Login",
+    "severity": "HIGH",
+    "line": 11,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "RAM Security Preference Not Enforce MFA Login",
+    "severity": "HIGH",
+    "line": 14,
+    "fileName": "positive2.tf"
+  }
+]


### PR DESCRIPTION
**Proposed Changes**
-Added Alicloud RAM Security Preference Not Enforce MFA Login for Terraform

I submit this contribution under the Apache-2.0 license.
