### PR TITLE
update(analyzer): removed metadata regex for k8s

### DIFF
--- a/assets/queries/terraform/alicloud/actiontrail_trail_oss_bucket_is_publicly_accessible/query.rego
+++ b/assets/queries/terraform/alicloud/actiontrail_trail_oss_bucket_is_publicly_accessible/query.rego
@@ -1,5 +1,7 @@
 package Cx
+
 import data.generic.common as common_lib
+
 CxPolicy[result] {
     some i
     actiontrail := input.document[i].resource.alicloud_actiontrail_trail[name]

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -33,7 +33,6 @@ var (
 	cloudRegex                                      = regexp.MustCompile("\\s*\"?Resources\"?\\s*:")
 	k8sRegex                                        = regexp.MustCompile("\\s*\"?apiVersion\"?\\s*:")
 	k8sRegexKind                                    = regexp.MustCompile("\\s*\"?kind\"?\\s*:")
-	k8sRegexMetadata                                = regexp.MustCompile("\\s*\"?metadata\"?\\s*:")
 	ansibleVaultRegex                               = regexp.MustCompile(`^\s*\$ANSIBLE_VAULT.*`)
 	tfPlanRegexPV                                   = regexp.MustCompile("\\s*\"planned_values\"\\s*:")
 	tfPlanRegexRC                                   = regexp.MustCompile("\\s*\"resource_changes\"\\s*:")
@@ -101,7 +100,6 @@ var types = map[string]regexSlice{
 		regex: []*regexp.Regexp{
 			k8sRegex,
 			k8sRegexKind,
-			k8sRegexMetadata,
 		},
 	},
 	"cloudformation": {


### PR DESCRIPTION
**Proposed Changes**
- removed metadata regex for k8s to be possible to identify KubeletConfiguration

I submit this contribution under the Apache-2.0 license.
