### PR TITLE
feat(query): Added Protect Kernel Defaults Is Not Set To False for Kubernetes

### DIFF
--- a/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/metadata.json
+++ b/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/metadata.json
@@ -1,0 +1,11 @@
+{
+    "id": "6cf42c97-facd-4fda-b8af-ea4529123355",
+    "queryName": "Protect Kernel Defaults Is Not Set To False",
+    "severity": "MEDIUM",
+    "category": "Insecure Configurations",
+    "descriptionText": "--protect-kernel-defaults should be set to true when defined",
+    "descriptionUrl": "https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/",
+    "platform": "Kubernetes",
+    "descriptionID": "e3a4b35d"
+  }
+  

--- a/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/query.rego
+++ b/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/query.rego
@@ -1,0 +1,25 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.k8s as k8sLib
+
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	specInfo := k8sLib.getSpecInfo(resource)
+	types := {"initContainers", "containers"}
+	container := specInfo.spec[types[x]][j]
+
+	common_lib.inArray(container.command, "kubelet")
+	k8sLib.hasFlag(container, "--protect-kernel-defaults=false")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.command", [metadata.name, specInfo.path, types[x], container.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "--protect-kernel-defaults flag should not be set to false",
+		"keyActualValue": "--protect-kernel-defaults flag is set to false",
+		"searchLine":common_lib.build_search_line(split(specInfo.path, "."), ["command"] ),
+	}
+}
+

--- a/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/test/negative1.yaml
+++ b/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/test/negative1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: joaodanielrufino/kubelet
+      command: ["kubelet"]
+      args: ["--protect-kernel-defaults=true"]
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/test/negative2.yaml
+++ b/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/test/negative2.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: joaodanielrufino/kubelet
+      command: ["kubelet"]
+      args: []
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/test/positive1.yaml
+++ b/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/test/positive1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: joaodanielrufino/kubelet
+      command: ["kubelet"]
+      args: ["--protect-kernel-defaults=false"]
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/test/positive2.yaml
+++ b/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/test/positive2.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: joaodanielrufino/kubelet
+      command: ["kubelet","--protect-kernel-defaults=false"]
+      args: []
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/test/positive_expected_result.json
+++ b/assets/queries/k8s/protect_kernel_defaults_is_not_set_to_false/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+	{
+		"queryName": "Protect Kernel Defaults Is Not Set To False",
+		"severity": "MEDIUM",
+		"line": 11,
+		"fileName": "positive1.yaml"
+	},
+	{
+		"queryName": "Protect Kernel Defaults Is Not Set To False",
+		"severity": "MEDIUM",
+		"line": 11,
+		"fileName": "positive2.yaml"
+	}
+]


### PR DESCRIPTION
**Proposed Changes**
- Added Protect Kernel Defaults Is Not Set To False for Kubernetes

I submit this contribution under the Apache-2.0 license.
