### PR TITLE
fix(query): Added kubelet config file to Kubelet Read Only Port is Not Set To Zero query

### DIFF
--- a/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/query.rego
+++ b/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/query.rego
@@ -21,3 +21,33 @@ CxPolicy[result] {
 		"keyActualValue": "--read-only-port flag does not exists or is not set to '0' in container",
 	}
 }
+
+CxPolicy[result] {
+	resource := input.document[i]
+	resource.kind == "KubeletConfiguration"
+
+	not common_lib.valid_key(resource, "readOnlyPort")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": "kind",
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "readOnlyPort attribute to exists and have value of 0",
+		"keyActualValue": "readOnlyPort attribute does not exist",
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i]
+	resource.kind == "KubeletConfiguration"
+
+	resource.readOnlyPort != 0
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": "readOnlyPort",
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "readOnlyPort attribute to have value of 0",
+		"keyActualValue": sprintf("readOnlyPort attribute has value of %d", [resource.readOnlyPort]),
+	}
+}

--- a/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/negative3.yaml
+++ b/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/negative3.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+address: "192.168.0.8"
+port: 20250
+serializeImagePulls: false
+evictionHard:
+  memory.available: "200Mi"
+readOnlyPort: 0

--- a/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/negative4.json
+++ b/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/negative4.json
@@ -1,0 +1,6 @@
+{
+    "kind": "KubeletConfiguration",
+    "apiVersion": "kubelet.config.k8s.io/v1beta1",
+    "address": "192.168.0.8",
+    "readOnlyPort": 0
+  }

--- a/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/negative6.json
+++ b/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/negative6.json
@@ -1,0 +1,5 @@
+{
+    "kind": "KubeletConfiguration",
+    "apiVersion": "kubelet.config.k8s.io/v1beta1",
+    "address": "192.168.0.8"
+  }

--- a/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/positive4.yaml
+++ b/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/positive4.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+address: "192.168.0.8"
+port: 20250
+serializeImagePulls: false
+evictionHard:
+  memory.available: "200Mi"

--- a/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/positive5.yaml
+++ b/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/positive5.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+address: "192.168.0.8"
+port: 20250
+serializeImagePulls: false
+evictionHard:
+  memory.available: "200Mi"
+readOnlyPort: 1

--- a/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/positive6.json
+++ b/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/positive6.json
@@ -1,0 +1,5 @@
+{
+    "kind": "KubeletConfiguration",
+    "apiVersion": "kubelet.config.k8s.io/v1beta1",
+    "address": "192.168.0.8"
+  }

--- a/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/positive7.json
+++ b/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/positive7.json
@@ -1,0 +1,6 @@
+{
+    "kind": "KubeletConfiguration",
+    "apiVersion": "kubelet.config.k8s.io/v1beta1",
+    "address": "192.168.0.8",
+    "readOnlyPort": 1
+  }

--- a/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/positive_expected_result.json
+++ b/assets/queries/k8s/kubelet_read_only_port_is_not_set_to_zero/test/positive_expected_result.json
@@ -16,5 +16,17 @@
     "severity": "MEDIUM",
     "line": 11,
     "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Kubelet Read Only Port Is Not Set To Zero",
+    "severity": "MEDIUM",
+    "line": 2,
+    "filename": "positive4.yaml"
+  },
+  {
+    "queryName": "Kubelet Read Only Port Is Not Set To Zero",
+    "severity": "MEDIUM",
+    "line": 8,
+    "filename": "positive5.yaml"
   }
 ]


### PR DESCRIPTION
Signed-off-by: joaorufi <joao.rufino@checkmarx.com>

**Proposed Changes**
- Added kubelet config file to Kubelet Read Only Port is Not Set To Zero query

I submit this contribution under the Apache-2.0 license.
