### PR TITLE
feat(query): Added Image Policy Webhook Not Defined for Kubernetes

### DIFF
--- a/assets/queries/k8s/image_policy_webhook_not_defined/metadata.json
+++ b/assets/queries/k8s/image_policy_webhook_not_defined/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "14abda69-8e91-4acb-9931-76e2bee90284",
+  "queryName": "Image Policy Webhook Not Defined",
+  "severity": "LOW",
+  "category": "Build Process",
+  "descriptionText": "Image Policy Webhook should be defined Defined",
+  "descriptionUrl": "https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#imagepolicywebhook",
+  "platform": "Kubernetes",
+  "descriptionID": "7e7fe5b6"
+}

--- a/assets/queries/k8s/image_policy_webhook_not_defined/query.rego
+++ b/assets/queries/k8s/image_policy_webhook_not_defined/query.rego
@@ -1,0 +1,23 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.k8s as k8sLib
+
+
+CxPolicy[result] {
+	resource:= input.document[i]
+    resource.kind == "AdmissionConfiguration"
+	not hasImagePolicyWebhook(resource.plugins)
+    
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("kind={{AdmissionConfiguration}}.plugins", []),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "'ImagePolicyWebhook' should be defined in the AdmissionConfiguration plugins",
+		"keyActualValue":  "'ImagePolicyWebhook' is not defined in the AdmissionConfiguration plugins",
+	}
+}
+
+hasImagePolicyWebhook(plugins){
+	plugins[_].name == "ImagePolicyWebhook"
+}

--- a/assets/queries/k8s/image_policy_webhook_not_defined/test/negative1.yaml
+++ b/assets/queries/k8s/image_policy_webhook_not_defined/test/negative1.yaml
@@ -1,0 +1,5 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: ImagePolicyWebhook
+  path: imagepolicyconfig.yaml

--- a/assets/queries/k8s/image_policy_webhook_not_defined/test/negative2.yaml
+++ b/assets/queries/k8s/image_policy_webhook_not_defined/test/negative2.yaml
@@ -1,0 +1,11 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: ImagePolicyWebhook
+  configuration:
+    imagePolicy:
+      kubeConfigFile: /path/to/cert.pem
+      allowTTL: 50
+      denyTTL: 50
+      retryBackoff: 500
+      defaultAllow: true

--- a/assets/queries/k8s/image_policy_webhook_not_defined/test/positive1.yaml
+++ b/assets/queries/k8s/image_policy_webhook_not_defined/test/positive1.yaml
@@ -1,0 +1,3 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:

--- a/assets/queries/k8s/image_policy_webhook_not_defined/test/positive_expected_result.json
+++ b/assets/queries/k8s/image_policy_webhook_not_defined/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+	{
+		"queryName": "Image Policy Webhook Not Defined",
+		"severity": "LOW",
+		"line": 3,
+		"fileName": "positive1.yaml"
+	}
+]


### PR DESCRIPTION
**Proposed Changes**
- Added Image Policy Webhook Not Defined for Kubernetes

I submit this contribution under the Apache-2.0 license.
