### PR TITLE
feat(query): Added Namespace Lifecycle Admission Control Plugin Disabled for Kubernetes

### DIFF
--- a/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/metadata.json
+++ b/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "9587c890-0524-40c2-9ce2-663af7c2f063",
+  "queryName": "Namespace Lifecycle Admission Control Plugin Disabled",
+  "severity": "LOW",
+  "category": "Build Process",
+  "descriptionText": "When using kube-apiserver command, the '--disable-admission-plugins' flag should not have 'NamespaceLifecycle' plugin",
+  "descriptionUrl": "https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/",
+  "platform": "Kubernetes",
+  "descriptionID": "3649a726"
+}

--- a/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/query.rego
+++ b/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/query.rego
@@ -1,0 +1,23 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.k8s as k8sLib
+
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	specInfo := k8sLib.getSpecInfo(resource)
+	types := {"initContainers", "containers"}
+	container := specInfo.spec[types[x]][j]
+	common_lib.inArray(container.command, "kube-apiserver")
+	k8sLib.hasFlagWithValue(container, "--disable-admission-plugins", "NamespaceLifecycle")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.command", [metadata.name, specInfo.path, types[x], container.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "--disable-admission-plugins flag should not contain 'NamespaceLifecycle' plugin",
+		"keyActualValue": "--disable-admission-plugins flag contains 'NamespaceLifecycle' plugin",
+		"searchLine": common_lib.build_search_line(split(specInfo.path, "."), [types[x], j, "command"]),
+	}
+}

--- a/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/negative1.yaml
+++ b/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/negative1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      command: ["kube-apiserver"]
+      args: ["--enable-admission-plugins=NamespaceLifecycle", "--admission-control-config-file=path/to/plugin/config/file.yaml"]
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/negative2.yaml
+++ b/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/negative2.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      command: ["kube-apiserver"]
+      args: []
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/positive1.yaml
+++ b/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/positive1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      command: ["kube-apiserver"]
+      args: ["--disable-admission-plugins=NamespaceLifecycle"]
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/positive2.yaml
+++ b/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/positive2.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      command: ["kube-apiserver","--disable-admission-plugins=NamespaceLifecycle"]
+      args: []
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/positive_expected_result.json
+++ b/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/positive_expected_result.json
@@ -3,12 +3,12 @@
 		"queryName": "Namespace Lifecycle Admission Control Plugin Disabled",
 		"severity": "LOW",
 		"line": 11,
-        "file": "positive1.yaml"
+        "fileName": "positive1.yaml"
 	},
 	{
 		"queryName": "Namespace Lifecycle Admission Control Plugin Disabled",
 		"severity": "LOW",
 		"line": 11,
-        "file": "positive2.yaml"
+        "fileName": "positive2.yaml"
 	}	
 ]

--- a/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/positive_expected_result.json
+++ b/assets/queries/k8s/namespace_lifecycle_admission_control_plugin_disabled/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+	{
+		"queryName": "Namespace Lifecycle Admission Control Plugin Disabled",
+		"severity": "LOW",
+		"line": 11,
+        "file": "positive1.yaml"
+	},
+	{
+		"queryName": "Namespace Lifecycle Admission Control Plugin Disabled",
+		"severity": "LOW",
+		"line": 11,
+        "file": "positive2.yaml"
+	}	
+]


### PR DESCRIPTION
**Proposed Changes**
- Added Namespace Lifecycle Admission Control Plugin Disabled for Kubernetes

I submit this contribution under the Apache-2.0 license.
