### PR TITLE
feat(query): Added Node Restriction Admission Control Plugin Not Set for Kubernetes

### DIFF
--- a/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/metadata.json
+++ b/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "33fc6923-6553-4fe6-9d3a-4efa51eb874b",
+  "queryName": "Node Restriction Admission Control Plugin Not Set",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "When using kube-apiserver command, the --enable-admission-plugins flag should have 'NodeRestriction' plugin and the plugin should be correctly configured in AdmissionControl Config file",
+  "descriptionUrl": "https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/",
+  "platform": "Kubernetes",
+  "descriptionID": "2a03f1ec"
+}

--- a/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/query.rego
+++ b/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/query.rego
@@ -1,0 +1,24 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.k8s as k8sLib
+
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	specInfo := k8sLib.getSpecInfo(resource)
+	types := {"initContainers", "containers"}
+	container := specInfo.spec[types[x]][j]
+	common_lib.inArray(container.command, "kube-apiserver")
+	not k8sLib.hasFlagWithValue(container, "--enable-admission-plugins", "NodeRestriction")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.command", [metadata.name, specInfo.path, types[x], container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "--enable-admission-plugins flag should contain 'NodeRestriction' plugin",
+		"keyActualValue": "--enable-admission-plugins flag does not contain 'NodeRestriction' plugin",
+		"searchLine": common_lib.build_search_line(split(specInfo.path, "."), [types[x], j, "command"]),
+	}
+}
+

--- a/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/test/negative1.yaml
+++ b/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/test/negative1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      command: ["kube-apiserver"]
+      args: ["--enable-admission-plugins=NodeRestriction", "--admission-control-config-file=path/to/plugin/config/file.yaml"]
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/test/negative2.yaml
+++ b/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/test/negative2.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      command: ["kube-apiserver","--enable-admission-plugins=NodeRestriction", "--admission-control-config-file=path/to/plugin/config/file.yaml"]
+      args: []
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/test/positive1.yaml
+++ b/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/test/positive1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      command: ["kube-apiserver"]
+      args: ["--enable-admission-plugins=AlwaysAdmit"]
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/test/positive_expected_result.json
+++ b/assets/queries/k8s/node_restriction_admission_control_plugin_not_set/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+	{
+		"queryName": "Node Restriction Admission Control Plugin Not Set",
+		"severity": "HIGH",
+		"line": 11,
+		"fileName": "positive1.yaml"
+	}
+]


### PR DESCRIPTION
**Proposed Changes**
- Added Node Restriction Admission Control Plugin Not Set for Kubernetes

I submit this contribution under the Apache-2.0 license.
