### PR TITLE
feat(query): Added Etcd Client Certificate Not Defined for Kubernetes

### DIFF
--- a/assets/queries/k8s/etcd_client_certificate_file_not_defined/metadata.json
+++ b/assets/queries/k8s/etcd_client_certificate_file_not_defined/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "3f5ff8a7-5ad6-4d02-86f5-666307da1b20",
+  "queryName": "Etcd Client Certificate Not Defined",
+  "severity": "MEDIUM",
+  "category": "Secret Management",
+  "descriptionText": "When using kube-apiserver commands, the '--etcd-cafile' flags should be difined",
+  "descriptionUrl": "https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/",
+  "platform": "Kubernetes",
+  "descriptionID": "f385527b"
+}

--- a/assets/queries/k8s/etcd_client_certificate_file_not_defined/query.rego
+++ b/assets/queries/k8s/etcd_client_certificate_file_not_defined/query.rego
@@ -1,0 +1,23 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.k8s as k8sLib
+
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	specInfo := k8sLib.getSpecInfo(resource)
+	types := {"initContainers", "containers"}
+	container := specInfo.spec[types[x]][j]
+	common_lib.inArray(container.command, "kube-apiserver")
+	not k8sLib.startWithFlag(container, "--etcd-cafile")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.command", [metadata.name, specInfo.path, types[x], container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "--etcd-cafile flag should be defined",
+		"keyActualValue": "--etcd-cafile flag is not defined",
+		"searchLine": common_lib.build_search_line(split(specInfo.path, "."), [types[x], j, "command"]),
+	}
+}

--- a/assets/queries/k8s/etcd_client_certificate_file_not_defined/test/negative1.yaml
+++ b/assets/queries/k8s/etcd_client_certificate_file_not_defined/test/negative1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      command: ["kube-apiserver"]
+      args: ["--etcd-cafile=/path/to/ca/file.pem"]
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/etcd_client_certificate_file_not_defined/test/negative2.yaml
+++ b/assets/queries/k8s/etcd_client_certificate_file_not_defined/test/negative2.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      command: ["kube-apiserver","--etcd-cafile=/path/to/ca/file.pem"]
+      args: []
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/etcd_client_certificate_file_not_defined/test/positive1.yaml
+++ b/assets/queries/k8s/etcd_client_certificate_file_not_defined/test/positive1.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: command-demo
+  labels:
+    purpose: demonstrate-command
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-apiserver-amd64:v1.6.0
+      command: ["kube-apiserver"]
+      args: []
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/etcd_client_certificate_file_not_defined/test/positive_expected_result.json
+++ b/assets/queries/k8s/etcd_client_certificate_file_not_defined/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+	{
+		"queryName": "Etcd Client Certificate Not Defined",
+		"severity": "MEDIUM",
+		"line": 11,
+        "file": "positive1.yaml"
+	}
+]


### PR DESCRIPTION
**Proposed Changes**
- Added Etcd Client Certificate Not Defined for Kubernetes

I submit this contribution under the Apache-2.0 license.
