### PR TITLE
feat(query): Added Use Service Account Credentials Not Set To True for Kubernetes

### DIFF
--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/metadata.json
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "1acd93f1-5a37-45c0-aaac-82ece818be7d",
+  "queryName": "Use Service Account Credentials Not Set To True",
+  "severity": "HIGH",
+  "category": "Access Control",
+  "descriptionText": "When using kube-controller-manager commands, the '--use-service-account-credentials' should be set to true",
+  "descriptionUrl": "https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/",
+  "platform": "Kubernetes",
+  "descriptionID": "f6b4d617"
+}

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/query.rego
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/query.rego
@@ -1,0 +1,43 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.k8s as k8sLib
+
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	specInfo := k8sLib.getSpecInfo(resource)
+	types := {"initContainers", "containers"}
+	container := specInfo.spec[types[x]][j]
+	common_lib.inArray(container.command, "kube-controller-manager")
+	k8sLib.startWithFlag(container, "--use-service-account-credentials")
+	k8sLib.hasFlag(container, "--use-service-account-credentials=false")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.command", [metadata.name, specInfo.path, types[x], container.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "--use-service-account-credentials flag should be set to true",
+		"keyActualValue": "--use-service-account-credentials flag is set to false",
+		"searchLine": common_lib.build_search_line(split(specInfo.path, "."), [types[x], j, "command"]),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i]
+	metadata := resource.metadata
+	specInfo := k8sLib.getSpecInfo(resource)
+	types := {"initContainers", "containers"}
+	container := specInfo.spec[types[x]][j]
+	common_lib.inArray(container.command, "kube-controller-manager")
+	not k8sLib.startWithFlag(container, "--use-service-account-credentials")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.command", [metadata.name, specInfo.path, types[x], container.name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "--use-service-account-credentials flag should be defined and set to true",
+		"keyActualValue": "--use-service-account-credentials flag is not defined",
+		"searchLine": common_lib.build_search_line(split(specInfo.path, "."), [types[x], j, "command"]),
+	}
+}

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/negative1.yaml
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/negative1.yaml
@@ -7,6 +7,13 @@ metadata:
     tier: control-plane
     k8s-app: kube-controller-manager
 spec:
+  selector:
+    matchLabels:
+      app: kube-controller-manager
+  template:
+    metadata:
+      labels:
+        app: kube-controller-manager
   containers:
     - name: command-demo-container
       image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/negative1.yaml
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/negative1.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    k8s-app: kube-controller-manager
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0
+      command: ["kube-controller-manager"]
+      args: ["--use-service-account-credentials=true"]
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/negative2.yaml
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/negative2.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    k8s-app: kube-controller-manager
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0
+      command: ["kube-controller-manager","--use-service-account-credentials=true"]
+      args: []
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/negative2.yaml
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/negative2.yaml
@@ -7,6 +7,13 @@ metadata:
     tier: control-plane
     k8s-app: kube-controller-manager
 spec:
+  selector:
+    matchLabels:
+      app: kube-controller-manager
+  template:
+    metadata:
+      labels:
+        app: kube-controller-manager
   containers:
     - name: command-demo-container
       image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive1.yaml
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive1.yaml
@@ -7,6 +7,13 @@ metadata:
     tier: control-plane
     k8s-app: kube-controller-manager
 spec:
+  selector:
+    matchLabels:
+      app: kube-controller-manager
+  template:
+    metadata:
+      labels:
+        app: kube-controller-manager
   containers:
     - name: command-demo-container
       image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive1.yaml
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive1.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    k8s-app: kube-controller-manager
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0
+      command: ["kube-controller-manager","--use-service-account-credentials=false"]
+      args: []
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive2.yaml
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive2.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    tier: control-plane
+    k8s-app: kube-controller-manager
+spec:
+  containers:
+    - name: command-demo-container
+      image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0
+      command: ["kube-controller-manager"]
+      args: []
+  restartPolicy: OnFailure

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive2.yaml
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive2.yaml
@@ -7,6 +7,13 @@ metadata:
     tier: control-plane
     k8s-app: kube-controller-manager
 spec:
+  selector:
+    matchLabels:
+      app: kube-controller-manager
+  template:
+    metadata:
+      labels:
+        app: kube-controller-manager
   containers:
     - name: command-demo-container
       image: gcr.io/google_containers/kube-controller-manager-amd64:v1.6.0

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive_expected_result.json
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+	{
+		"queryName": "Use Service Account Credentials Not Set To True",
+		"severity": "HIGH",
+		"line": 13,
+        "file": "positive1.yaml"
+	},
+	{
+		"queryName": "Use Service Account Credentials Not Set To True",
+		"severity": "HIGH",
+		"line": 13,
+        "file": "positive2.yaml"
+	}
+]

--- a/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive_expected_result.json
+++ b/assets/queries/k8s/use_service_account_credentials_not_set_to_true/test/positive_expected_result.json
@@ -2,13 +2,13 @@
 	{
 		"queryName": "Use Service Account Credentials Not Set To True",
 		"severity": "HIGH",
-		"line": 13,
+		"line": 20,
         "file": "positive1.yaml"
 	},
 	{
 		"queryName": "Use Service Account Credentials Not Set To True",
 		"severity": "HIGH",
-		"line": 13,
+		"line": 20,
         "file": "positive2.yaml"
 	}
 ]


### PR DESCRIPTION
**Proposed Changes**
- Added Use Service Account Credentials Not Set To True for Kubernetes

I submit this contribution under the Apache-2.0 license.
