### PR TITLE
Feat(Query): Restart Policy On Failure Not Set To 5 for docker compose

### DIFF
--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/metadata.json
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/metadata.json
@@ -1,0 +1,10 @@
+{
+    "id": "2fc99041-ddad-49d5-853f-e35e70a48391",
+    "queryName": "Restart Policy On Failure Not Set To 5",
+    "severity": "MEDIUM",
+    "category": "Build Process",
+    "descriptionText": "Attribute 'restart:on-failure' should be set to 5. Restart policies in general should be used, and 5 retries is the recommended by CIS.",
+    "descriptionUrl": "https://docs.docker.com/config/containers/start-containers-automatically/#use-a-restart-policy",
+    "platform": "DockerCompose",
+    "descriptionID": "d21fff2e"
+  }

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/query.rego
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/query.rego
@@ -1,0 +1,39 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i]
+	service_parameters := resource.services[name]
+    restart := service_parameters.restart
+    splitted := split(restart, ":")
+    attempts := splitted[1]
+    to_number(attempts) != 5
+   
+	result := {
+		"documentId": sprintf("%s", [resource.id]),
+		"searchKey": sprintf("services.%s.restart",[name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "on-failure restart attempts should be 5",
+		"keyActualValue": "on-failure restart attempts are not 5",
+		"searchLine": common_lib.build_search_line(["services", name, "restart"], []),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i]
+	service_parameters := resource.services[name]
+    deploy := service_parameters.deploy
+    restart_policy := deploy.restart_policy
+    restart_policy.condition == "on-failure"
+    restart_policy.max_attempts != 5
+   
+	result := {
+		"documentId": sprintf("%s", [resource.id]),
+		"searchKey": sprintf("services.%s.deploy.restart_policy.max_attempts",[name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "on-failure restart attempts should be 5",
+		"keyActualValue": "on-failure restart attempts are not 5",
+		"searchLine": common_lib.build_search_line(["services", name, "deploy", "restart_policy", "max_attempts" ], []),
+	}
+}

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/negative1.yaml
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/negative1.yaml
@@ -4,8 +4,6 @@ services:
   customer:
     image: whoa/hello
     restart: on-failure:5
-    depends_on:
-      - hellodb
     networks:
       - netnet
     expose:

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/negative1.yaml
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/negative1.yaml
@@ -1,0 +1,24 @@
+version: "3.9"
+
+services:
+  customer:
+    image: whoa/hello
+    restart: on-failure:5
+    depends_on:
+      - hellodb
+    networks:
+      - netnet
+    expose:
+     - 8080
+    ports:
+     - 8082:8080
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 5
+        window: 120s
+
+networks:
+  netnet:
+

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive1.yaml
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive1.yaml
@@ -4,8 +4,6 @@ services:
   customer:
     image: whoa/hello
     restart: on-failure:10
-    depends_on:
-      - hellodb
     networks:
       - netnet
     expose:

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive1.yaml
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive1.yaml
@@ -1,0 +1,23 @@
+version: "3.9"
+
+services:
+  customer:
+    image: whoa/hello
+    restart: on-failure:10
+    depends_on:
+      - hellodb
+    networks:
+      - netnet
+    expose:
+     - 8080
+    ports:
+     - 8082:8080
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 10
+        window: 120s
+
+networks:
+  netnet:

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive2.yaml
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive2.yaml
@@ -9,7 +9,7 @@ services:
   name_of_service:
     image: not_a_real_one
     container_name: container1
-    build: ./service_bridge
+    build: ./
     ports:
       - '5002:80'
     restart: on-failure:3

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive2.yaml
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive2.yaml
@@ -1,0 +1,17 @@
+version: '3.6'
+
+networks:
+  name_of_network:
+    name: name_of_network
+    driver: overlay
+
+services:
+  name_of_service:
+    image: not_a_real_one
+    container_name: container1
+    build: ./service_bridge
+    ports:
+      - '5002:80'
+    restart: on-failure:3
+    networks:
+      - name_of_network

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive3.yaml
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive3.yaml
@@ -4,8 +4,6 @@ services:
   customer:
     image: whoa/hello
     restart: on-failure:10
-    depends_on:
-      - hellodb
     networks:
       - netnet
     expose:

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive3.yaml
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive3.yaml
@@ -1,0 +1,23 @@
+version: "3.9"
+
+services:
+  customer:
+    image: whoa/hello
+    restart: on-failure:10
+    depends_on:
+      - hellodb
+    networks:
+      - netnet
+    expose:
+     - 8080
+    ports:
+     - 8082:8080
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 5
+        window: 120s
+
+networks:
+  netnet:

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive4.yaml
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive4.yaml
@@ -4,8 +4,6 @@ services:
   customer:
     image: whoa/hello
     restart: on-failure:5
-    depends_on:
-      - hellodb
     networks:
       - netnet
     expose:

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive4.yaml
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive4.yaml
@@ -1,0 +1,23 @@
+version: "3.9"
+
+services:
+  customer:
+    image: whoa/hello
+    restart: on-failure:5
+    depends_on:
+      - hellodb
+    networks:
+      - netnet
+    expose:
+     - 8080
+    ports:
+     - 8082:8080
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 10
+        window: 120s
+
+networks:
+  netnet:

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive_expected_result.json
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive_expected_result.json
@@ -8,7 +8,7 @@
   {
     "queryName": "Restart Policy On Failure Not Set To 5",
     "severity": "MEDIUM",
-    "line": 19,
+    "line": 17,
     "filename": "positive1.yaml"
   },
   {
@@ -26,7 +26,7 @@
   {
     "queryName": "Restart Policy On Failure Not Set To 5",
     "severity": "MEDIUM",
-    "line": 19,
+    "line": 17,
     "filename": "positive4.yaml"
   }
 ]

--- a/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive_expected_result.json
+++ b/assets/queries/dockerCompose/restart_policy_on_failure_not_set_to_5/test/positive_expected_result.json
@@ -1,0 +1,32 @@
+[
+  {
+    "queryName": "Restart Policy On Failure Not Set To 5",
+    "severity": "MEDIUM",
+    "line": 6,
+    "filename": "positive1.yaml"
+  },
+  {
+    "queryName": "Restart Policy On Failure Not Set To 5",
+    "severity": "MEDIUM",
+    "line": 19,
+    "filename": "positive1.yaml"
+  },
+  {
+    "queryName": "Restart Policy On Failure Not Set To 5",
+    "severity": "MEDIUM",
+    "line": 15,
+    "filename": "positive2.yaml"
+  },
+  {
+    "queryName": "Restart Policy On Failure Not Set To 5",
+    "severity": "MEDIUM",
+    "line": 6,
+    "filename": "positive3.yaml"
+  },
+  {
+    "queryName": "Restart Policy On Failure Not Set To 5",
+    "severity": "MEDIUM",
+    "line": 19,
+    "filename": "positive4.yaml"
+  }
+]


### PR DESCRIPTION
**Proposed Changes**
- Query: Restart Policy On Failure Not Set To 5 for docker compose.

I submit this contribution under the Apache-2.0 license.
