### PR TITLE
Feat(Query): Pids Limit Not Set for docker compose

### DIFF
--- a/assets/queries/dockerCompose/pids_limit_not_set/metadata.json
+++ b/assets/queries/dockerCompose/pids_limit_not_set/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "221e0658-cb2a-44e3-b08a-db96a341d6fa",
+  "queryName": "Pids Limit Not Set",
+  "severity": "MEDIUM",
+  "category": "Resource Management",
+  "descriptionText": "Limit a containers PID count.",
+  "descriptionUrl": "https://docs.docker.com/compose/compose-file/compose-file-v3/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir",
+  "platform": "DockerCompose",
+  "descriptionID": "2d241407"
+}

--- a/assets/queries/dockerCompose/pids_limit_not_set/query.rego
+++ b/assets/queries/dockerCompose/pids_limit_not_set/query.rego
@@ -1,0 +1,38 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i]
+	service_parameters := resource.services[name]
+    version := resource.version
+    to_number(version) < 3
+    not common_lib.valid_key(service_parameters, "pids_limit")
+   
+	result := {
+		"documentId": sprintf("%s", [resource.id]),
+		"searchKey": sprintf("services.%s",[name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": "Pids_limit to be defined.",
+		"keyActualValue": "Pids_limit is not defined.",
+		"searchLine": common_lib.build_search_line(["services", name], []),
+	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i]
+	service_parameters := resource.services[name]
+    version := resource.version
+    to_number(version) < 3
+    pids_limit := service_parameters.pids_limit
+    pids_limit == -1
+   
+	result := {
+		"documentId": sprintf("%s", [resource.id]),
+		"searchKey": sprintf("services.%s.pids_limit",[name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Pids_limit to be limited.",
+		"keyActualValue": "Pids_limit is not limited.",
+		"searchLine": common_lib.build_search_line(["services", name, "pids_limit"], []),
+	}
+}

--- a/assets/queries/dockerCompose/pids_limit_not_set/test/negative1.yaml
+++ b/assets/queries/dockerCompose/pids_limit_not_set/test/negative1.yaml
@@ -1,0 +1,14 @@
+version: '2.2'
+
+volumes:
+  front_build:
+
+services:
+  auth:
+    build:
+      context: .
+      dockerfile: docker_config/Dockerfile
+    restart: on-failure
+    pids_limit: 10
+    cpus: 0.25
+    mem_limit: 500M

--- a/assets/queries/dockerCompose/pids_limit_not_set/test/positive1.yaml
+++ b/assets/queries/dockerCompose/pids_limit_not_set/test/positive1.yaml
@@ -1,0 +1,13 @@
+version: '2.2'
+
+volumes:
+  front_build:
+
+services:
+  auth:
+    build:
+      context: .
+      dockerfile: docker_config/Dockerfile
+    restart: on-failure
+    cpus: 0.25
+    mem_limit: 500M

--- a/assets/queries/dockerCompose/pids_limit_not_set/test/positive2.yaml
+++ b/assets/queries/dockerCompose/pids_limit_not_set/test/positive2.yaml
@@ -1,0 +1,14 @@
+version: '2.2'
+
+volumes:
+  front_build:
+
+services:
+  auth:
+    build:
+      context: .
+      dockerfile: docker_config/Dockerfile
+    restart: on-failure
+    pids_limit: -1
+    cpus: 0.25
+    mem_limit: 500M

--- a/assets/queries/dockerCompose/pids_limit_not_set/test/positive_expected_result.json
+++ b/assets/queries/dockerCompose/pids_limit_not_set/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+    {
+      "queryName": "Pids Limit Not Set",
+      "severity": "MEDIUM",
+      "line": 7,
+      "filename": "positive1.yaml"
+    },
+    {
+      "queryName": "Pids Limit Not Set",
+      "severity": "MEDIUM",
+      "line": 12,
+      "filename": "positive2.yaml"
+    }
+]


### PR DESCRIPTION
**Proposed Changes**
- Query: Pids Limit Not Set for docker compose
- 
**Notes**
- Attribute 'pids_limit' is exclusive for version 2 of docker compose (to date).

I submit this contribution under the Apache-2.0 license.
