### PR TITLE
Feat(Query): Userns Set To Host for docker compose

### DIFF
--- a/assets/queries/dockerCompose/security_opt_not_set/test/negative1.yaml
+++ b/assets/queries/dockerCompose/security_opt_not_set/test/negative1.yaml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   webapp:
     build:
-      context: ./dir
+      context: ./
       dockerfile: Dockerfile-alternate
       args:
         buildno: 1

--- a/assets/queries/dockerCompose/userns_set_to_host/metadata.json
+++ b/assets/queries/dockerCompose/userns_set_to_host/metadata.json
@@ -1,0 +1,10 @@
+{
+    "id": "8af7162d-6c98-482f-868e-0d33fb675ca8",
+    "queryName": "Userns Set To Host",
+    "severity": "MEDIUM",
+    "category": "Resource Management",
+    "descriptionText": "The host's user namespace should not be shared.",
+    "descriptionUrl": "https://docs.docker.com/compose/compose-file/compose-file-v3/#userns_mode",
+    "platform": "DockerCompose",
+    "descriptionID": "b7859ec8"
+}

--- a/assets/queries/dockerCompose/userns_set_to_host/query.rego
+++ b/assets/queries/dockerCompose/userns_set_to_host/query.rego
@@ -1,0 +1,18 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	resource := input.document[i]
+	service_parameters := resource.services[name]
+    service_parameters.userns_mode == "host"
+
+	result := {
+		"documentId": sprintf("%s", [resource.id]),
+		"searchKey": sprintf("services.%s.userns_mode",[name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Attribute 'userns_mode' is not set or not set to host",
+		"keyActualValue": "Attribute 'userns_mode' is set to host",
+		"searchLine": common_lib.build_search_line(["services", name, "userns_mode"], []),
+	}
+}

--- a/assets/queries/dockerCompose/userns_set_to_host/test/negative1.yaml
+++ b/assets/queries/dockerCompose/userns_set_to_host/test/negative1.yaml
@@ -1,0 +1,14 @@
+version: "3.9"
+
+services:
+  webapp:
+    build:
+      context: ./
+      dockerfile: Dockerfile-alternate
+      args:
+        buildno: 1
+    ports:
+      - "8080:8080"
+      - "3000:3000"
+    security_opt:
+      - apparmor:unconfined

--- a/assets/queries/dockerCompose/userns_set_to_host/test/negative2.yaml
+++ b/assets/queries/dockerCompose/userns_set_to_host/test/negative2.yaml
@@ -10,3 +10,6 @@ services:
     ports:
       - "8080:8080"
       - "3000:3000"
+    security_opt:
+      - apparmor:unconfined
+    userns_mode: anything_but_host

--- a/assets/queries/dockerCompose/userns_set_to_host/test/positive1.yaml
+++ b/assets/queries/dockerCompose/userns_set_to_host/test/positive1.yaml
@@ -1,0 +1,10 @@
+version: "3"
+
+services:
+  service1:
+    image: service1:3.4
+    hostname: servicer
+    network_mode: host
+    pid: host
+    userns_mode: host
+    privileged: true

--- a/assets/queries/dockerCompose/userns_set_to_host/test/positive_expected_result.json
+++ b/assets/queries/dockerCompose/userns_set_to_host/test/positive_expected_result.json
@@ -1,0 +1,9 @@
+[
+  {
+    "queryName": "Userns Set To Host",
+    "severity": "MEDIUM",
+    "line": 9,
+    "filename": "positive1.yaml"
+  }
+]
+  


### PR DESCRIPTION
**Proposed Changes**
- Query: Userns Set To Host for docker compose
- Validated samples

I submit this contribution under the Apache-2.0 license.
