### PR TITLE
fix(query): updated ecr_repositories_not_encrypted TF rule to match KMS encryption

### DIFF
--- a/assets/queries/terraform/aws/ecr_repository_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/ecr_repository_not_encrypted/metadata.json
@@ -1,9 +1,9 @@
 {
   "id": "0e32d561-4b5a-4664-a6e3-a3fa85649157",
-  "queryName": "ECR Repository Not Encrypted",
-  "severity": "MEDIUM",
+  "queryName": "ECR Repository Not Encrypted With CMK",
+  "severity": "LOW",
   "category": "Encryption",
-  "descriptionText": "ECR (Elastic Container Registry) Repository encryption should be set",
+  "descriptionText": "ECR repositories should be encrypted with customer-managed keys to meet stricter security and compliance requirements on access control, monitoring, and key rotation",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository#encryption_configuration",
   "platform": "Terraform",
   "descriptionID": "e96d149c",

--- a/assets/queries/terraform/aws/ecr_repository_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/ecr_repository_not_encrypted/query.rego
@@ -11,7 +11,27 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_ecr_repository[%s]", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "The attribute 'encryption_configuration' is defined and not null",
-		"keyActualValue": "The attribute 'encryption_configuration' is undefined or null",
+		"keyExpectedValue": "'encryption_configuration' is defined with 'KMS' as encryption type and a KMS key ARN",
+		"keyActualValue": "'encryption_configuration' is undefined or null",
 	}
+}
+
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_ecr_repository[name]
+
+	common_lib.valid_key(resource, "encryption_configuration")
+	not valid_encryption_configuration(resource)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("aws_ecr_repository[%s].encryption_configuration", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "'encryption_configuration.encryption_type' is set to 'KMS' and 'encryption_configuration.kms_key' specifies a KMS key ARN",
+		"keyActualValue": "'encryption_configuration.encryption_type' is not set to 'KMS' and/or 'encryption_configuration.kms_key' does not specify a KMS key ARN",
+	}
+}
+
+valid_encryption_configuration(resource) {
+	resource.encryption_configuration.encryption_type == "KMS"
+	common_lib.valid_key(resource.encryption_configuration, "kms_key")
 }

--- a/assets/queries/terraform/aws/ecr_repository_not_encrypted/test/positive.tf
+++ b/assets/queries/terraform/aws/ecr_repository_not_encrypted/test/positive.tf
@@ -6,3 +6,16 @@ resource "aws_ecr_repository" "foo" {
     scan_on_push = true
   }
 }
+
+resource "aws_ecr_repository" "fooX" {
+  name                 = "barX"
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+}

--- a/assets/queries/terraform/aws/ecr_repository_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/ecr_repository_not_encrypted/test/positive_expected_result.json
@@ -1,7 +1,12 @@
 [
   {
-    "queryName": "ECR Repository Not Encrypted",
-    "severity": "MEDIUM",
+    "queryName": "ECR Repository Not Encrypted With CMK",
+    "severity": "LOW",
     "line": 1
+  },
+  {
+    "queryName": "ECR Repository Not Encrypted With CMK",
+    "severity": "LOW",
+    "line": 18
   }
 ]


### PR DESCRIPTION
**Problem**

The TF rule _ECR Repository Not Encrypted_ issues an alert in case `encryption_configuration` is not specified, assuming there is no encryption at all. This is not correct since encryption-at-rest is enabled out-of-the-box for ECR repositories using AWS managed keys. In the AWS TF provider, this is denoted as `AES256` (see [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository#encryption_configuration) and [here](https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html)).

Practically, this means that the check this rule performs does not match the rule's purpose and it should actually check whether customer-managed keys are used (see [here](https://aws.amazon.com/about-aws/whats-new/2020/07/ecr-supports-encryption-images-aws-kms-keys/?nc1=h_ls)) instead of the default encryption. 

**Proposed Changes**
- Rename the rule to _ECR Repository Not Encrypted With CMK_
- Extend the description
- Check whether `encryption_type = 'KMS'` and a KMS key ARN is specified in `kms_key`
  -  `kms_key` is optional but, if unspecified, an AWS-managed key is used, effectively resulting in the same situation as if no `KMS` but `AES256` was used
- Change severity from MEDIUM to LOW
  - Using a CMK is "best practice" and the security implications of not doing it are not comparable to "not encrypted at all" but mostly needed for compliance (PCI-DSS and friends)

I submit this contribution under the Apache-2.0 license.
