### PR TITLE
fix(query): added support for aws_iam_policy_document.Principals to policy_without_principal tf rule

### DIFF
--- a/assets/queries/terraform/aws/policy_without_principal/query.rego
+++ b/assets/queries/terraform/aws/policy_without_principal/query.rego
@@ -5,22 +5,19 @@ import data.generic.common as common_lib
 CxPolicy[result] {
 	doc := input.document[i].resource
 	[path, value] := walk(doc)
+	not is_iam_identity_based_policy(path[0])
 
 	policy := common_lib.json_unmarshal(value.policy)
-	st := common_lib.get_statement(policy)
-	statement := st[_]
+	statement := common_lib.get_statement(policy)[_]
 
 	common_lib.is_allow_effect(statement)
-
-	not common_lib.valid_key(statement, "Principal")
-
-	not is_iam_identity_based_policy(path[0])
+	not has_principal(statement)
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("%s[%s].policy", [path[0], path[1]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "'Principal' is set",
+		"keyExpectedValue": "'Principal' is defined",
 		"keyActualValue": "'Principal' is undefined",
 		"searchLine": common_lib.build_search_line(["resource", path[0], path[1], "policy"], []),
 	}
@@ -29,4 +26,10 @@ CxPolicy[result] {
 is_iam_identity_based_policy(resource) {
 	iam_identity_based_policy := {"aws_iam_group_policy", "aws_iam_policy", "aws_iam_role_policy", "aws_iam_user_policy"}
 	resource == iam_identity_based_policy[_]
+}
+
+has_principal(statement) {
+	common_lib.valid_key(statement, "Principals") # iam_policy_document
+} else {
+	common_lib.valid_key(statement, "Principal")
 }

--- a/assets/queries/terraform/aws/policy_without_principal/test/negative3.tf
+++ b/assets/queries/terraform/aws/policy_without_principal/test/negative3.tf
@@ -1,0 +1,16 @@
+data "aws_iam_policy_document" "glue-example-policyX" {
+  statement {
+    actions = [
+      "glue:CreateTable",
+    ]
+    resources = ["arn:data.aws_partition.current.partition:glue:data.aws_region.current.name:data.aws_caller_identity.current.account_id:*"]
+    principals {
+      identifiers = ["arn:aws:iam::var.account_id:saml-provider/var.provider_name"]
+      type        = "AWS"
+    }
+  }
+}
+
+resource "aws_glue_resource_policy" "exampleX" {
+  policy = data.aws_iam_policy_document.glue-example-policyX.json
+}


### PR DESCRIPTION
**Problem**

[iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) is an alternative policy specification. When unmarshalled, `Principals` remains as-is and is thus not understood by the `policy_without_principal` rule, which checks only for `Principal`, as in traditional policies.

**Proposed Changes**
- Add a check for `Statement.Principals`
- Add another negative testcase

I submit this contribution under the Apache-2.0 license.
