### PR TITLE
fix(query): fixed searchKey and resource kind in pod_or_container_without_limit_range k8s rule

### DIFF
--- a/assets/queries/k8s/pod_or_container_without_limit_range/metadata.json
+++ b/assets/queries/k8s/pod_or_container_without_limit_range/metadata.json
@@ -3,8 +3,8 @@
   "queryName": "Pod or Container Without LimitRange",
   "severity": "LOW",
   "category": "Insecure Configurations",
-  "descriptionText": "Pod or Container should have a LimitRange associated",
-  "descriptionUrl": "https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-constraint-namespace/#create-a-limitrange-and-a-pod",
+  "descriptionText": "Each namespace should have a LimitRange policy associated to ensure that resource allocations of Pods, Containers and PersistentVolumeClaims do not exceed the defined boundaries",
+  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/limit-range/",
   "platform": "Kubernetes",
   "descriptionID": "142ed21f"
 }

--- a/assets/queries/k8s/pod_or_container_without_limit_range/query.rego
+++ b/assets/queries/k8s/pod_or_container_without_limit_range/query.rego
@@ -1,62 +1,33 @@
 package Cx
 
-import data.generic.k8s as k8s_lib
 import data.generic.common as common_lib
+import data.generic.k8s as k8sLib
 
-types := {"initContainers", "containers"}
-
-CxPolicy[result] {
-	document := input.document[i]
-	specInfo := k8s_lib.getSpecInfo(document)
-	metadata := document.metadata
-
-	pod_or_container(specInfo, document)
-
-	namespace := document.metadata.namespace
-
-	count({ x | doc := input.document[x]; doc.kind == "LimitRange"; doc.metadata.namespace == namespace}) == 0
-
-	result := {
-		"documentId": document.id,
-		"issueType": "MissingAttribute",
-		"searchKey": sprintf("metadata.name={{%s}}.namespace", [metadata.name]),
-		"keyExpectedValue": sprintf("metadata.name={{%s}} has a 'LimitRange' associated", [metadata.name]),
-		"keyActualValue": sprintf("metadata.name={{%s}} does not have a 'LimitRange' associated", [metadata.name]),
-		"searchLine": common_lib.build_search_line(["metadata", "namespace"], [])
-	}
-}
+listKinds := ["Pod", "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "ReplicationController", "Job", "CronJob", "PersistentVolumeClaim"]
 
 CxPolicy[result] {
 	document := input.document[i]
-	specInfo := k8s_lib.getSpecInfo(document)
+	k8sLib.checkKind(document.kind, listKinds)
 	metadata := document.metadata
 
-	pod_or_container(specInfo, document)
+	namespace := object.get(metadata, "namespace", "default")
 
-	is_default(document)
-
-	count({ x | doc := input.document[x]; doc.kind == "LimitRange"; is_default(doc)}) == 0
+	limitRange := [doc | doc := input.document[_]; doc.kind == "LimitRange"; matchNamespace(doc, namespace)]
+	count(limitRange) == 0
 
 	result := {
 		"documentId": document.id,
 		"issueType": "MissingAttribute",
 		"searchKey": sprintf("metadata.name={{%s}}", [metadata.name]),
-		"keyExpectedValue": sprintf("metadata.name={{%s}} has a 'LimitRange' associated", [metadata.name]),
-		"keyActualValue": sprintf("metadata.name={{%s}} does not have a 'LimitRange' associated", [metadata.name]),
-		"searchLine": common_lib.build_search_line(["metadata"], [])
+		"keyExpectedValue": sprintf("metadata.name={{%s}} has a 'LimitRange' policy associated", [metadata.name]),
+		"keyActualValue": sprintf("metadata.name={{%s}} does not have a 'LimitRange' policy associated", [metadata.name]),
+		"searchLine": common_lib.build_search_line(["metadata", "namespace"], [])
 	}
 }
 
-is_default(document) {
-	document.metadata.namespace == "default"
+matchNamespace(document, namespace) {
+	document.metadata.namespace == namespace
 } else {
+	namespace == "default"
 	not common_lib.valid_key(document.metadata, "namespace")
-}
-
-
-pod_or_container(specInfo, document) {
-	specInfo.spec[types[x]]
-	document.kind != "Pod"
-} else {
-	document.kind == "Pod"
 }

--- a/assets/queries/k8s/pod_or_container_without_limit_range/test/positive4.yaml
+++ b/assets/queries/k8s/pod_or_container_without_limit_range/test/positive4.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: webcontent
+  namespace: k8s-test9
+  annotations:
+    volume.alpha.kubernetes.io/storage-class: default
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 5Gi

--- a/assets/queries/k8s/pod_or_container_without_limit_range/test/positive_expected_result.json
+++ b/assets/queries/k8s/pod_or_container_without_limit_range/test/positive_expected_result.json
@@ -16,5 +16,11 @@
 		"severity": "LOW",
 		"line": 5,
 		"fileName": "positive3.yaml"
+	},
+	{
+		"queryName": "Pod or Container Without LimitRange",
+		"severity": "LOW",
+		"line": 5,
+		"fileName": "positive4.yaml"
 	}
 ]


### PR DESCRIPTION
**Proposed Changes**

- Change `searchKey` to point to the namespace, where possible, otherwise the document name
- Use `checkKind` and also include `PersistentVolumeClaim`
- Merge the two `MissingAttribute` rules. They still deliver the same matches
- Extend the description text

I submit this contribution under the Apache-2.0 license.
