### PR TITLE
fix(query): extended scope of MissingAttribute rule in seccomp k8s rule

### DIFF
--- a/assets/queries/k8s/seccomp_profile_is_not_configured/metadata.json
+++ b/assets/queries/k8s/seccomp_profile_is_not_configured/metadata.json
@@ -3,8 +3,8 @@
   "queryName": "Seccomp Profile Is Not Configured",
   "severity": "MEDIUM",
   "category": "Insecure Configurations",
-  "descriptionText": "Check if any resource does not configure Seccomp default profile properly",
-  "descriptionUrl": "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp",
+  "descriptionText": "Containers should be configured with a secure Seccomp profile to restrict potentially dangerous syscalls",
+  "descriptionUrl": "https://kubernetes.io/docs/tutorials/security/seccomp/#create-pod-that-uses-the-container-runtime-default-seccomp-profile",
   "platform": "Kubernetes",
   "descriptionID": "d943c7e7"
 }

--- a/assets/queries/k8s/seccomp_profile_is_not_configured/test/positive_expected_result.json
+++ b/assets/queries/k8s/seccomp_profile_is_not_configured/test/positive_expected_result.json
@@ -2,6 +2,18 @@
 	{
 		"queryName": "Seccomp Profile Is Not Configured",
 		"severity": "MEDIUM",
+		"line": 7,
+		"fileName": "positive1.yaml"
+	},
+	{
+		"queryName": "Seccomp Profile Is Not Configured",
+		"severity": "MEDIUM",
+		"line": 18,
+		"fileName": "positive1.yaml"
+	},
+	{
+		"queryName": "Seccomp Profile Is Not Configured",
+		"severity": "MEDIUM",
 		"line": 26,
 		"fileName": "positive1.yaml"
 	},


### PR DESCRIPTION
**Problem**

#4789 updated the seccomp k8s rule to support `seccompProfile`. For backward compatibility with deprecated annotations, the `MissingAttribute` check only proceeded when a `securityContext` already existed. This introduced an unwanted side effect: if containers didn't specify a `securityContext`, no alert was shown.

There is another rule to check the existence of a `securityContext` but it's only rated LOW, meaning that only after fixing this LOW severity issue, the seccomp issue with MEDIUM severity show up.

**Proposed Changes**
- Add a check to the `MissingAttribute` query to also work without `securityContext`. A new check ensures that `MissingAttribute` is not shown, if annotations are used
- Extended the description text and updated the URL to point to the modern way of using seccomp with K8s
- `MissingAttribute` findings in `positive1.yaml` test: they fell out in #4789 but should actually be reported

I submit this contribution under the Apache-2.0 license.
