### PR TITLE
fix(script): queries validator files filtering

### DIFF
--- a/.github/scripts/queries-validator/queries-validator.py
+++ b/.github/scripts/queries-validator/queries-validator.py
@@ -18,7 +18,7 @@ def exit_success():
     exit(0)
 
 def fetch(page=1, max_items=100):
-    print('Fetching PR files... #page{}'.format(page))
+    print('Fetching PR #{} files... #page{}'.format(KICS_PR_NUMBER, page))
     headers = {'Authorization': 'token {}'.format(KICS_GITHUB_TOKEN)}
     url = 'https://api.github.com/repos/checkmarx/kics/pulls/{}/files?per_page={}page={}'.format(KICS_PR_NUMBER, max_items, page)
     response = requests.get(url, headers=headers)
@@ -35,7 +35,8 @@ def fetch_pr_files():
             return exit_with_error('Failed to fetch PR files\n- status code: {}'.format(response['status']))
 
         for obj in response['data']:
-            files.append(obj['filename'])
+            if obj['status'] != 'removed':
+                files.append(obj['filename'])
 
         if len(response['data']) < max_items:
             return files


### PR DESCRIPTION
Closes #

**Proposed Changes**
- This PR fixes a bug related to the queries validator script which was failing when trying to read files that were removed in the PR.

I submit this contribution under the Apache-2.0 license.
