### PR TITLE
bug: Remove viewer from list of improper privileges

### DIFF
--- a/assets/queries/terraform/gcp/service_account_with_improper_privileges/query.rego
+++ b/assets/queries/terraform/gcp/service_account_with_improper_privileges/query.rego
@@ -37,6 +37,6 @@ CxPolicy[result] {
 }
 
 has_improperly_privileges(role) {
-	privileges := {"admin", "owner", "viewer", "editor"}
+	privileges := {"admin", "owner", "editor"}
 	contains(lower(role), privileges[x])
 }

--- a/assets/queries/terraform/gcp/service_account_with_improper_privileges/test/negative3.tf
+++ b/assets/queries/terraform/gcp/service_account_with_improper_privileges/test/negative3.tf
@@ -1,0 +1,17 @@
+resource "google_project_iam_binding" "project5" {
+  role = "roles/viewer"
+
+  members = [
+    "serviceAccount:jane@example.com",
+  ]
+}
+
+data "google_iam_policy" "policy6" {
+  binding {
+    role = "roles/viewer"
+
+    members = [
+      "user:jane@example.com",
+    ]
+  }
+}


### PR DESCRIPTION
Closes #5206

**Proposed Changes**
- Remove `viewer` from list of improper privileges
- Add test to verify that `role/viewer` does not trigger the query

I submit this contribution under the Apache-2.0 license.
