### PR TITLE
docs(implementations): fix changed directory for kics assets queries in Gitlab CI example

### DIFF
--- a/docs/integrations_gitlabci.md
+++ b/docs/integrations_gitlabci.md
@@ -26,7 +26,7 @@ stages:
 kics-scan:
     stage: kics
     script:
-        - kics scan --no-progress -q /usr/bin/assets/queries -p ${PWD} -o ${PWD} --report-formats json --output-name kics-results
+        - kics scan --no-progress -q /app/bin/assets/queries -p ${PWD} -o ${PWD} --report-formats json --output-name kics-results
     artifacts:
         name: kics-results.json
         paths:


### PR DESCRIPTION
**Proposed Changes**
- Fix code example for Gitlab CI to use the new path for the asset queries
- With the current example, the pipeline fails to properly run kics

![Screenshot 2022-04-19 at 18 16 40](https://user-images.githubusercontent.com/533172/164049398-6b948372-5896-4451-b05b-1f5b61d56eed.png)

I submit this contribution under the Apache-2.0 license.
