### PR TITLE
Feat(Query):  OSS Bucket Allows Delete From All Principals for Alicloud Terraform

### DIFF
--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -590,3 +590,13 @@ has_relation(related_resource_id, related_resource_type, current_resource, curre
 	is_string(value)
 	regex.match(sprintf("\\${%v\\.%v\\.", [related_resource_type, related_resource_id]), value)
 }
+
+#Checks if an action is allowed for all principals
+allows_action_from_all_principals(json_policy, action) {
+ 	policy := common_lib.json_unmarshal(json_policy)
+	st := common_lib.get_statement(policy)
+	statement := st[_]
+	statement.Effect == "Allow"
+    anyPrincipal(statement)
+    common_lib.containsOrInArrayContains(statement.Action, action)
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/metadata.json
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/metadata.json
@@ -1,0 +1,11 @@
+{
+    "id": "8c0695d8-2378-4cd6-8243-7fd5894fa574",
+    "queryName": "OSS Bucket Allows Delete Action From All Principals",
+    "severity": "HIGH",
+    "category": "Access Control",
+    "descriptionText": "OSS Bucket should not allow delete action from all principals.",
+    "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/oss_bucket#policy",
+    "platform": "Terraform",
+    "descriptionID": "ee07e6f5",
+    "cloudProvider": "alicloud"
+  }

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/metadata.json
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/metadata.json
@@ -3,7 +3,7 @@
     "queryName": "OSS Bucket Allows Delete Action From All Principals",
     "severity": "HIGH",
     "category": "Access Control",
-    "descriptionText": "OSS Bucket should not allow delete action from all principals.",
+    "descriptionText": "OSS Bucket should not allow delete action from all principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering/deletion. This means the 'Effect' must not be 'Allow' when the 'Action' is DeleteBucket, for all Principals.",
     "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/oss_bucket#policy",
     "platform": "Terraform",
     "descriptionID": "ee07e6f5",

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/query.rego
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 	statement := st[_]
 	statement.Effect == "Allow"
     terra_lib.anyPrincipal(statement)
-    common_lib.containsOrInArrayContains(statement.Action, "deletebucket")
+    common_lib.containsOrInArrayContains(statement.Action, "delete")
 	
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/query.rego
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/query.rego
@@ -12,15 +12,14 @@ CxPolicy[result] {
 	statement := st[_]
 	statement.Effect == "Allow"
     terra_lib.anyPrincipal(statement)
-    action := statement.Action
-    contains(action[a],"DeleteBucket")
+    common_lib.containsOrInArrayContains(statement.Action, "deletebucket")
 	
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("alicloud_oss_bucket[%s].policy",[name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s.policy to not accept delete action from all principals",[name]),
-		"keyActualValue": sprintf("%s.policy accepts delete action from all principals",[name]),
+		"keyExpectedValue": sprintf("alicloud_oss_bucket[%s].policy to not accept delete action from all principals",[name]),
+		"keyActualValue": sprintf("alicloud_oss_bucket[%s].policy accepts delete action from all principals",[name]),
         "searchLine":common_lib.build_search_line(["resource", "alicloud_oss_bucket", name, "policy"], []),
 	}
 }

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/query.rego
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/query.rego
@@ -7,12 +7,7 @@ CxPolicy[result] {
 
 	json_policy := input.document[i].resource.alicloud_oss_bucket[name].policy
     
-    policy := common_lib.json_unmarshal(json_policy)
-	st := common_lib.get_statement(policy)
-	statement := st[_]
-	statement.Effect == "Allow"
-    terra_lib.anyPrincipal(statement)
-    common_lib.containsOrInArrayContains(statement.Action, "delete")
+    terra_lib.allows_action_from_all_principals(json_policy, "delete")
 	
 	result := {
 		"documentId": input.document[i].id,

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/query.rego
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/query.rego
@@ -1,0 +1,26 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.terraform as terra_lib
+
+CxPolicy[result] {
+
+	json_policy := input.document[i].resource.alicloud_oss_bucket[name].policy
+    
+    policy := common_lib.json_unmarshal(json_policy)
+	st := common_lib.get_statement(policy)
+	statement := st[_]
+	statement.Effect == "Allow"
+    terra_lib.anyPrincipal(statement)
+    action := statement.Action
+    contains(action[a],"DeleteBucket")
+	
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("alicloud_oss_bucket[%s].policy",[name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s.policy to not accept delete action from all principals",[name]),
+		"keyActualValue": sprintf("%s.policy accepts delete action from all principals",[name]),
+        "searchLine":common_lib.build_search_line(["resource", "alicloud_oss_bucket", name, "policy"], []),
+	}
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/test/negative1.tf
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/test/negative1.tf
@@ -1,0 +1,22 @@
+resource "alicloud_oss_bucket" "bucket-policy2" {
+  bucket = "bucket-2-policy"
+  acl    = "private"
+
+  policy = <<POLICY
+  {"Statement": [
+    {
+        "Action": [
+            "oss:ListObjects"
+        ],
+        "Effect": "Allow",
+        "Principal": [
+            "*"
+        ],
+        "Resource": [
+            "acs:oss:*:174649585760xxxx:examplebucket"
+        ]
+    }
+  ],
+   "Version":"1"}
+  POLICY
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/test/negative2.tf
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/test/negative2.tf
@@ -1,0 +1,22 @@
+resource "alicloud_oss_bucket" "bucket-policy3" {
+  bucket = "bucket-3-policy"
+  acl    = "private"
+
+  policy = <<POLICY
+  {"Statement": [
+    {
+        "Action": [
+            "oss:PutObject", "oss:DeleteBucket"
+        ],
+        "Effect": "Allow",
+        "Principal": [
+            "20214760404935xxxx"
+        ],
+        "Resource": [
+            "acs:oss:*:174649585760xxxx:examplebucket"
+        ]
+    }
+  ],
+   "Version":"1"}
+  POLICY
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/test/negative3.tf
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/test/negative3.tf
@@ -1,0 +1,22 @@
+resource "alicloud_oss_bucket" "bucket-policy4" {
+  bucket = "bucket-4-policy"
+  acl    = "private"
+
+  policy = <<POLICY
+  {"Statement": [
+    {
+        "Action": [
+            "oss:PutObject", "oss:DeleteBucket"
+        ],
+        "Effect": "Deny",
+        "Principal": [
+            "*"
+        ],
+        "Resource": [
+            "acs:oss:*:174649585760xxxx:examplebucket"
+        ]
+    }
+  ],
+   "Version":"1"}
+  POLICY
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/test/positive1.tf
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/test/positive1.tf
@@ -1,0 +1,22 @@
+resource "alicloud_oss_bucket" "bucket-policy1" {
+  bucket = "bucket-1-policy"
+  acl    = "private"
+
+  policy = <<POLICY
+  {"Statement": [
+    {
+        "Action": [
+            "oss:PutObject", "oss:DeleteBucket"
+        ],
+        "Effect": "Allow",
+        "Principal": [
+            "*"
+        ],
+        "Resource": [
+            "acs:oss:*:174649585760xxxx:examplebucket"
+        ]
+    }
+  ],
+   "Version":"1"}
+  POLICY
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_delete_from_all_principals/test/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+    {
+      "queryName": "OSS Bucket Allows Delete Action From All Principals",
+      "severity": "HIGH",
+      "line": 5,
+      "fileName": "positive1.tf"
+    }
+]


### PR DESCRIPTION
**Proposed Changes**
- Query: OSS Bucket Allows Delete From All Principals for Alicloud Terraform


I submit this contribution under the Apache-2.0 license.
