### PR TITLE
Feat(Query): Oss Bucket Allows Put Action For All Principals for Alicloud Terraform

### DIFF
--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -590,3 +590,13 @@ has_relation(related_resource_id, related_resource_type, current_resource, curre
 	is_string(value)
 	regex.match(sprintf("\\${%v\\.%v\\.", [related_resource_type, related_resource_id]), value)
 }
+
+#Checks if an action is allowed for all principals
+allows_action_from_all_principals(json_policy, action) {
+ 	policy := common_lib.json_unmarshal(json_policy)
+	st := common_lib.get_statement(policy)
+	statement := st[_]
+	statement.Effect == "Allow"
+    anyPrincipal(statement)
+    common_lib.containsOrInArrayContains(statement.Action, action)
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/metadata.json
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/metadata.json
@@ -1,0 +1,11 @@
+{
+    "id": "fe286195-e75c-4359-bd58-00847c4f855a",
+    "queryName": "OSS Bucket Allows Put Action From All Principals",
+    "severity": "HIGH",
+    "category": "Access Control",
+    "descriptionText": "OSS Bucket should not allow put action from all principals, as to prevent leaking private information to the entire internet or allow unauthorized data tampering/deletion. This means the 'Effect' must not be 'Allow' when the 'Action' contains 'Put', for all Principals.",
+    "descriptionUrl": "https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/oss_bucket#policy",
+    "platform": "Terraform",
+    "descriptionID": "14d65676",
+    "cloudProvider": "alicloud"
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/query.rego
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/query.rego
@@ -1,0 +1,20 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.terraform as terra_lib
+
+CxPolicy[result] {
+
+	json_policy := input.document[i].resource.alicloud_oss_bucket[name].policy
+
+    terra_lib.allows_action_from_all_principals(json_policy, "put")
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("alicloud_oss_bucket[%s].policy",[name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("alicloud_oss_bucket[%s].policy to not accept put action from all principals",[name]),
+		"keyActualValue": sprintf("alicloud_oss_bucket[%s].policy accepts put action from all principals",[name]),
+        "searchLine":common_lib.build_search_line(["resource", "alicloud_oss_bucket", name, "policy"], []),
+	}
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/negative1.tf
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/negative1.tf
@@ -1,0 +1,22 @@
+resource "alicloud_oss_bucket" "bucket-policy1" {
+  bucket = "bucket-1-policy"
+  acl    = "private"
+
+  policy = <<POLICY
+  {"Statement": [
+    {
+        "Action": [
+            "oss:AbortMultipartUpload"
+        ],
+        "Effect": "Allow",
+        "Principal": [
+            "*"
+        ],
+        "Resource": [
+            "acs:oss:*:174649585760xxxx:examplebucket"
+        ]
+    }
+  ],
+   "Version":"1"}
+  POLICY
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/negative2.tf
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/negative2.tf
@@ -1,0 +1,22 @@
+resource "alicloud_oss_bucket" "bucket-policy2" {
+  bucket = "bucket-2-policy"
+  acl    = "private"
+
+  policy = <<POLICY
+  {"Statement": [
+    {
+        "Action": [
+            "oss:PutObjectAcl", "oss:PutObject"
+        ],
+        "Effect": "Allow",
+        "Principal": [
+            "20214760404935xxxx"
+        ],
+        "Resource": [
+            "acs:oss:*:174649585760xxxx:examplebucket"
+        ]
+    }
+  ],
+   "Version":"1"}
+  POLICY
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/negative3.tf
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/negative3.tf
@@ -1,0 +1,22 @@
+resource "alicloud_oss_bucket" "bucket-policy3" {
+  bucket = "bucket-3-policy"
+  acl    = "private"
+
+  policy = <<POLICY
+  {"Statement": [
+    {
+        "Action": [
+            "oss:PutObjectAcl", "oss:PutObject"
+        ],
+        "Effect": "Deny",
+        "Principal": [
+            "*"
+        ],
+        "Resource": [
+            "acs:oss:*:174649585760xxxx:examplebucket"
+        ]
+    }
+  ],
+   "Version":"1"}
+  POLICY
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/positive1.tf
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/positive1.tf
@@ -1,0 +1,22 @@
+resource "alicloud_oss_bucket" "bucket-policy4" {
+  bucket = "bucket-4-policy"
+  acl    = "private"
+
+  policy = <<POLICY
+  {"Statement": [
+    {
+        "Action": [
+            "oss:PutObjectAcl", "oss:PutObject"
+        ],
+        "Effect": "Allow",
+        "Principal": [
+            "*"
+        ],
+        "Resource": [
+            "acs:oss:*:174649585760xxxx:examplebucket"
+        ]
+    }
+  ],
+   "Version":"1"}
+  POLICY
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/positive2.tf
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/positive2.tf
@@ -1,0 +1,22 @@
+resource "alicloud_oss_bucket" "bucket-policy5" {
+  bucket = "bucket-5-policy"
+  acl    = "private"
+
+  policy = <<POLICY
+  {"Statement": [
+    {
+        "Action": [
+            "oss:PutObject", "oss:RestoreObject"
+        ],
+        "Effect": "Allow",
+        "Principal": [
+            "*"
+        ],
+        "Resource": [
+            "acs:oss:*:174649585760xxxx:examplebucket"
+        ]
+    }
+  ],
+   "Version":"1"}
+  POLICY
+}

--- a/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/positive_expected_result.json
+++ b/assets/queries/terraform/alicloud/oss_bucket_allows_put_action_from_all_principals/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+    {
+      "queryName": "OSS Bucket Allows Put Action From All Principals",
+      "severity": "HIGH",
+      "line": 5,
+      "fileName": "positive1.tf"
+    },
+    {
+      "queryName": "OSS Bucket Allows Put Action From All Principals",
+      "severity": "HIGH",
+      "line": 5,
+      "fileName": "positive2.tf"
+    }
+]


### PR DESCRIPTION
**Proposed Changes**
- Query: Oss Bucket Allows Put Action For All Principals for Alicloud Terraform

I submit this contribution under the Apache-2.0 license.
