### PR TITLE
fix(yaml parser): added model.NewIgnore.Reset() at the beginning of the YAML parser

### DIFF
--- a/pkg/parser/yaml/parser.go
+++ b/pkg/parser/yaml/parser.go
@@ -21,6 +21,7 @@ func (p *Parser) Resolve(fileContent []byte, filename string) (*[]byte, error) {
 
 // Parse parses yaml/yml file and returns it as a Document
 func (p *Parser) Parse(filePath string, fileContent []byte) ([]model.Document, []int, error) {
+	model.NewIgnore.Reset()
 	var documents []model.Document
 	dec := yaml.NewDecoder(bytes.NewReader(fileContent))
 
@@ -37,7 +38,6 @@ func (p *Parser) Parse(filePath string, fileContent []byte) ([]model.Document, [
 	}
 
 	linesToIgnore := model.NewIgnore.GetLines()
-	model.NewIgnore.Reset()
 
 	return convertKeysToString(addExtraInfo(documents, filePath)), linesToIgnore, nil
 }


### PR DESCRIPTION
PR #5222 lost some results because "it found" a bug related to the ignoreLines (that was caught miraculously).

For example, with the flag -`t openapi`, the analyzer will call `checkReturnType` which calls `checkYamlPlatform`. 
In the `checkYamlPlatform` function, the YAML file is unmarshalled and it saves the ignoresLines in `model.NewIgnore`.

Since the `model.NewIgnore` is not reset at the beginning of the parser, it keeps the ignoreLines of the previous files that were discarded.

**Proposed Changes**
- This PR resets the model.NewIgnore in at the beginning of the parser.

I submit this contribution under the Apache-2.0 license.
