### PR TITLE
fix(query): adjusted severity rating and added searchLine in rbac_wildcard_in_rule k8s rule

### DIFF
--- a/assets/queries/k8s/rbac_wildcard_in_rule/metadata.json
+++ b/assets/queries/k8s/rbac_wildcard_in_rule/metadata.json
@@ -1,9 +1,9 @@
 {
   "id": "6b896afb-ca07-467a-b256-1a0077a1c08e",
   "queryName": "RBAC Wildcard In Rule",
-  "severity": "LOW",
+  "severity": "MEDIUM",
   "category": "Access Control",
-  "descriptionText": "Kubernetes Roles and ClusterRoles should not use wildcards in rules (objects or actions)",
+  "descriptionText": "Roles and ClusterRoles with wildcard RBAC permissions provide excessive rights to the Kubernetes API and should be avoided. The principle of least privilege recommends to specify only the set of needed objects and actions",
   "descriptionUrl": "https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
   "platform": "Kubernetes",
   "descriptionID": "ccf4e279"

--- a/assets/queries/k8s/rbac_wildcard_in_rule/metadata.json
+++ b/assets/queries/k8s/rbac_wildcard_in_rule/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "6b896afb-ca07-467a-b256-1a0077a1c08e",
   "queryName": "RBAC Wildcard In Rule",
-  "severity": "MEDIUM",
+  "severity": "HIGH",
   "category": "Access Control",
   "descriptionText": "Roles and ClusterRoles with wildcard RBAC permissions provide excessive rights to the Kubernetes API and should be avoided. The principle of least privilege recommends to specify only the set of needed objects and actions",
   "descriptionUrl": "https://kubernetes.io/docs/reference/access-authn-authz/rbac/",

--- a/assets/queries/k8s/rbac_wildcard_in_rule/query.rego
+++ b/assets/queries/k8s/rbac_wildcard_in_rule/query.rego
@@ -1,60 +1,25 @@
 package Cx
 
-import data.generic.k8s as k8s
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	document := input.document[i]
 	metadata := document.metadata
-    kind := document.kind
-    listKinds := ["Role", "ClusterRole"]
-	k8s.checkKind(kind, listKinds)
-	metadata.name
-	notExpectedKey := "*"
-	document.rules[r].apiGroups[j] == notExpectedKey
+
+	kinds := {"Role", "ClusterRole"}
+	document.kind == kinds[_]
+
+	attr := {"apiGroups", "resources", "verbs"}
+	common_lib.valid_key(document.rules[j], attr[k])
+
+	document.rules[j][k][_] == "*"
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": document.id,
 		"searchKey": sprintf("metadata.name={{%s}}.rules", [metadata.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.rules[%d].apiGroups shouldn't contain value: '%s'", [metadata.name, r, notExpectedKey]),
-		"keyActualValue": sprintf("metadata.name={{%s}}.rules[%d].apiGroups contains value: '%s'", [metadata.name, r, notExpectedKey]),
-	}
-}
-
-CxPolicy[result] {
-	document := input.document[i]
-	metadata := document.metadata
-	kind := document.kind
-    listKinds := ["Role", "ClusterRole"]
-	k8s.checkKind(kind, listKinds)
-	metadata.name
-	notExpectedKey := "*"
-	document.rules[r].resources[j] == notExpectedKey
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name={{%s}}.rules", [metadata.name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.rules[%d].resources shouldn't contain value: '%s'", [metadata.name, r, notExpectedKey]),
-		"keyActualValue": sprintf("metadata.name={{%s}}.rules[%d].resources contains value: '%s'", [metadata.name, r, notExpectedKey]),
-	}
-}
-
-CxPolicy[result] {
-	document := input.document[i]
-	metadata := document.metadata
-	kind := document.kind
-    listKinds := ["Role", "ClusterRole"]
-	k8s.checkKind(kind, listKinds)
-	metadata.name
-	notExpectedKey := "*"
-	document.rules[r].verbs[j] == notExpectedKey
-
-	result := {
-		"documentId": input.document[i].id,
-		"searchKey": sprintf("metadata.name={{%s}}.rules", [metadata.name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.rules[%d].verbs shouldn't contain value: '%s'", [metadata.name, r, notExpectedKey]),
-		"keyActualValue": sprintf("metadata.name={{%s}}.rules[%d].verbs contains value: '%s'", [metadata.name, r, notExpectedKey]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.rules[%d].%s should list the minimal set of needed objects or actions", [metadata.name, j, k]),
+		"keyActualValue": sprintf("metadata.name={{%s}}.rules[%d].%s uses wildcards to specify objects or actions", [metadata.name, j, k]),
+		"searchLine": common_lib.build_search_line(["rules", j], [k])
 	}
 }

--- a/assets/queries/k8s/rbac_wildcard_in_rule/test/positive_expected_result.json
+++ b/assets/queries/k8s/rbac_wildcard_in_rule/test/positive_expected_result.json
@@ -1,37 +1,37 @@
 [
-	{
-		"queryName": "RBAC Wildcard In Rule",
-		"severity": "LOW",
-		"line": 6
-	},
-	{
-		"queryName": "RBAC Wildcard In Rule",
-		"severity": "LOW",
-		"line": 6
-	},
   {
     "queryName": "RBAC Wildcard In Rule",
-    "severity": "LOW",
-    "line": 17
+    "severity": "MEDIUM",
+    "line": 7
   },
   {
     "queryName": "RBAC Wildcard In Rule",
-    "severity": "LOW",
-    "line": 17
+    "severity": "MEDIUM",
+    "line": 9
   },
-	{
-		"queryName": "RBAC Wildcard In Rule",
-		"severity": "LOW",
-		"line": 17
-	},
   {
     "queryName": "RBAC Wildcard In Rule",
-    "severity": "LOW",
-    "line": 27
+    "severity": "MEDIUM",
+    "line": 18
   },
-	{
-		"queryName": "RBAC Wildcard In Rule",
-		"severity": "LOW",
-		"line": 27
-	}
+  {
+    "queryName": "RBAC Wildcard In Rule",
+    "severity": "MEDIUM",
+    "line": 19
+  },
+  {
+    "queryName": "RBAC Wildcard In Rule",
+    "severity": "MEDIUM",
+    "line": 20
+  },
+  {
+    "queryName": "RBAC Wildcard In Rule",
+    "severity": "MEDIUM",
+    "line": 29
+  },
+  {
+    "queryName": "RBAC Wildcard In Rule",
+    "severity": "MEDIUM",
+    "line": 31
+  }
 ]

--- a/assets/queries/k8s/rbac_wildcard_in_rule/test/positive_expected_result.json
+++ b/assets/queries/k8s/rbac_wildcard_in_rule/test/positive_expected_result.json
@@ -1,37 +1,37 @@
 [
   {
     "queryName": "RBAC Wildcard In Rule",
-    "severity": "MEDIUM",
+    "severity": "HIGH",
     "line": 7
   },
   {
     "queryName": "RBAC Wildcard In Rule",
-    "severity": "MEDIUM",
+    "severity": "HIGH",
     "line": 9
   },
   {
     "queryName": "RBAC Wildcard In Rule",
-    "severity": "MEDIUM",
+    "severity": "HIGH",
     "line": 18
   },
   {
     "queryName": "RBAC Wildcard In Rule",
-    "severity": "MEDIUM",
+    "severity": "HIGH",
     "line": 19
   },
   {
     "queryName": "RBAC Wildcard In Rule",
-    "severity": "MEDIUM",
+    "severity": "HIGH",
     "line": 20
   },
   {
     "queryName": "RBAC Wildcard In Rule",
-    "severity": "MEDIUM",
+    "severity": "HIGH",
     "line": 29
   },
   {
     "queryName": "RBAC Wildcard In Rule",
-    "severity": "MEDIUM",
+    "severity": "HIGH",
     "line": 31
   }
 ]


### PR DESCRIPTION
**Proposed Changes**

- Add `searchLine` to point to specific rule attributes
- Combine the CxPolicy rules into one
- Extend description
- Adjust rating from LOW to MEDIUM (or HIGH?) for the following reasons:
  - The rule [rbac_roles_with_read_secrets_permissions](https://github.com/Checkmarx/kics/blob/master/assets/queries/k8s/rbac_roles_with_read_secrets_permissions/query.rego) checks for a specific "permission subset" of this rule and  is rated MEDIUM. This rule here implicitly also covers the same case as the other rule by checking for wildcards, which allow even wider access rights
  - Wildcard permissions on resources (pods, depoyments, secrets, ...) also include create, update, patch, delete, bind, escalate, impersonate verbs. Attackers may abuse this to perform mutating changes, e.g., create malicious pods, delete secrets, change role bindings, impersonate users/groups/service accounts. Overall, this can put the availability of deployments at risk, in addition to violating confidentiality and integrity
  - The worst-case setting would be * on all `apiGroups`, `resources`, and `verbs`, essentially meaning cluster admin rights and this would even justify a HIGH severity rating. Depending on what is set to *, the potential blast radius varies. If you think it would be reasonable to assume the worst-case scenario here, HIGH would be appropriate - otherwise at least MEDIUM, I'd say 😊

I submit this contribution under the Apache-2.0 license.
