### PR TITLE
fix(query): fixed searchKey rbac_roles_with_read_secrets_permissions …

### DIFF
--- a/assets/queries/k8s/rbac_roles_with_read_secrets_permissions/metadata.json
+++ b/assets/queries/k8s/rbac_roles_with_read_secrets_permissions/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "RBAC Roles with Read Secrets Permissions",
   "severity": "MEDIUM",
   "category": "Access Control",
-  "descriptionText": "Minimize access to secrets (RBAC)",
+  "descriptionText": "Roles and ClusterRoles with get/watch/list RBAC permissions on Kubernetes secrets are dangerous and should be avoided. In case of compromise, attackers could abuse these roles to access sensitive data, such as passwords, tokens and keys",
   "descriptionUrl": "https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
   "platform": "Kubernetes",
   "descriptionID": "ca97f029"

--- a/assets/queries/k8s/rbac_roles_with_read_secrets_permissions/test/positive_expected_result.json
+++ b/assets/queries/k8s/rbac_roles_with_read_secrets_permissions/test/positive_expected_result.json
@@ -2,11 +2,11 @@
 	{
 		"queryName": "RBAC Roles with Read Secrets Permissions",
 		"severity": "MEDIUM",
-		"line": 6
+		"line": 9
 	},
 	{
 		"queryName": "RBAC Roles with Read Secrets Permissions",
 		"severity": "MEDIUM",
-		"line": 15
+		"line": 18
 	}
 ]


### PR DESCRIPTION
**Proposed Changes**

- Add `searchLine` to point to problematic `verbs` instead of `rules`
- Combine the two CxPolicy rules into one
- Extend the description

I submit this contribution under the Apache-2.0 license.
