### PR TITLE
feat(query): add new k8s rule to detect account impersonation (RBAC)

### DIFF
--- a/assets/queries/k8s/rbac_roles_with_impersonate_permission/metadata.json
+++ b/assets/queries/k8s/rbac_roles_with_impersonate_permission/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "9f85c3f6-26fd-4007-938a-2e0cb0100980",
+  "queryName": "RBAC Roles with Impersonate Permission",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Roles or ClusterRoles with the permission 'impersonate' allow subjects to assume the rights of other users, groups, or service accounts. In case of compromise, attackers may abuse this sudo-like functionality to achieve privilege escalation",
+  "descriptionUrl": "https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation",
+  "platform": "Kubernetes",
+  "descriptionID": "9f85c3f6"
+}

--- a/assets/queries/k8s/rbac_roles_with_impersonate_permission/query.rego
+++ b/assets/queries/k8s/rbac_roles_with_impersonate_permission/query.rego
@@ -1,0 +1,22 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+
+	kinds := {"Role", "ClusterRole"}
+	document.kind == kinds[_]
+
+	document.rules[j].verbs[_] == "impersonate"
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("metadata.name={{%s}}.rules", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.rules[%d].verbs should not include the 'impersonate' verb", [metadata.name, j]),
+		"keyActualValue": sprintf("metadata.name={{%s}}.rules[%d].verbs includes the 'impersonate' verb", [metadata.name, j]),
+		"searchLine": common_lib.build_search_line(["rules", j], ["verbs"])
+	}
+}

--- a/assets/queries/k8s/rbac_roles_with_impersonate_permission/test/negative.yaml
+++ b/assets/queries/k8s/rbac_roles_with_impersonate_permission/test/negative.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonator-role-neg
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["users", "groups", "serviceaccounts"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbac-impersonate-binding
+subjects:
+- kind: ServiceAccount
+  name: impersonator-sa-neg
+  namespace: default
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: impersonator-role-neg
+  apiGroup: ""

--- a/assets/queries/k8s/rbac_roles_with_impersonate_permission/test/positive.yaml
+++ b/assets/queries/k8s/rbac_roles_with_impersonate_permission/test/positive.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: impersonator-role
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["users", "groups", "serviceaccounts"]
+  verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbac-impersonate-binding
+subjects:
+- kind: ServiceAccount
+  name: impersonator-sa
+  namespace: default
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: impersonator-role
+  apiGroup: ""

--- a/assets/queries/k8s/rbac_roles_with_impersonate_permission/test/positive_expected_result.json
+++ b/assets/queries/k8s/rbac_roles_with_impersonate_permission/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "RBAC Roles with Impersonate Permission",
+    "severity": "MEDIUM",
+    "line": 9
+  }
+]


### PR DESCRIPTION
**Proposed Changes**

- Add new rule to check whether RBAC roles make use of the 'impersonate' verb to allow impersonation of others users, groups, serviceaccounts. This sudo-like functionality is sometimes useful for troubleshooting but very dangerous in production. In case of pod compromise, attackers may be able to impersonate system:admin or other highly privileged users and thereby escalate their privileges to the whole cluster
- This rule covers CIS Kubernetes Benchmark 1.23, 5.1.8

I submit this contribution under the Apache-2.0 license.
