### PR TITLE
feat(query): add new k8s rule to detect bind or escalate permissions (RBAC)

### DIFF
--- a/assets/queries/k8s/rbac_roles_allow_privilege_escalation/metadata.json
+++ b/assets/queries/k8s/rbac_roles_allow_privilege_escalation/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "8320826e-7a9c-4b0b-9535-578333193432",
+  "queryName": "RBAC Roles Allow Privilege Escalation",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Roles or ClusterRoles with RBAC permissions 'bind' or 'escalate' allow subjects to create new bindings with other roles. This is dangerous, as users with these privileges can bind to roles that may exceed their own privileges",
+  "descriptionUrl": "https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update",
+  "platform": "Kubernetes",
+  "descriptionID": "8320826e"
+}

--- a/assets/queries/k8s/rbac_roles_allow_privilege_escalation/query.rego
+++ b/assets/queries/k8s/rbac_roles_allow_privilege_escalation/query.rego
@@ -1,0 +1,25 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+
+	kinds := {"Role", "ClusterRole"}
+	document.kind == kinds[_]
+
+	verbs := {"bind", "escalate", "*"}
+	resources := {"roles", "clusterroles"}
+	document.rules[j].resources[_] == resources[_]
+	document.rules[j].verbs[_] == verbs[_]
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("metadata.name={{%s}}.rules", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.rules[%d].verbs should not include the 'bind' and/or 'escalate' permission", [metadata.name, j]),
+		"keyActualValue": sprintf("metadata.name={{%s}}.rules[%d].verbs includes the 'bind' and/or 'escalate' permission", [metadata.name, j]),
+		"searchLine": common_lib.build_search_line(["rules", j], ["verbs"])
+	}
+}

--- a/assets/queries/k8s/rbac_roles_allow_privilege_escalation/test/negative.yaml
+++ b/assets/queries/k8s/rbac_roles_allow_privilege_escalation/test/negative.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: not-rbac-binder
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterrolebindings"]
+  verbs: ["create"]

--- a/assets/queries/k8s/rbac_roles_allow_privilege_escalation/test/positive.yaml
+++ b/assets/queries/k8s/rbac_roles_allow_privilege_escalation/test/positive.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbac-binder
+rules:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  verbs: ["bind"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterrolebindings"]
+  verbs: ["create"]

--- a/assets/queries/k8s/rbac_roles_allow_privilege_escalation/test/positive_expected_result.json
+++ b/assets/queries/k8s/rbac_roles_allow_privilege_escalation/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "RBAC Roles Allow Privilege Escalation",
+    "severity": "MEDIUM",
+    "line": 8
+  }
+]


### PR DESCRIPTION
**Proposed Changes**

- Add new rule to check whether RBAC roles are allowed to create new Roles or RoleBindings. This is dangerous, as the created roles may include resources and permissions that exceed the privileges of the role that is used to create them.
- This rule covers CIS Kubernetes Benchmark 1.23, 5.1.8

A longer explanation of why this is a problem, can also be found [here](https://raesene.github.io/blog/2021/01/16/Getting-Into-A-Bind-with-Kubernetes/).

I submit this contribution under the Apache-2.0 license.
