### PR TITLE
feat(query): add new k8s rule to detect exec permissions (RBAC)

### DIFF
--- a/assets/queries/k8s/rbac_roles_with_exec_permission/metadata.json
+++ b/assets/queries/k8s/rbac_roles_with_exec_permission/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "c589f42c-7924-4871-aee2-1cede9bc7cbc",
+  "queryName": "RBAC Roles with Exec Permission",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Roles or ClusterRoles with RBAC permissions to run commands in containers via 'kubectl exec' could be abused by attackers to execute malicious code in case of compromise. To prevent this, the 'pods/exec' verb should not be used in production environments",
+  "descriptionUrl": "https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
+  "platform": "Kubernetes",
+  "descriptionID": "c589f42c"
+}

--- a/assets/queries/k8s/rbac_roles_with_exec_permission/query.rego
+++ b/assets/queries/k8s/rbac_roles_with_exec_permission/query.rego
@@ -1,0 +1,25 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+
+	kinds := {"Role", "ClusterRole"}
+	document.kind == kinds[_]
+
+	resources := {"pods/exec", "pods/*"}
+	verbs := {"create", "*"}
+	document.rules[j].resources[_] == resources[_]
+	document.rules[j].verbs[_] == verbs[_]
+
+	result := {
+		"documentId": document.id,
+		"searchKey": sprintf("metadata.name={{%s}}.rules", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.rules[%d].resources should not include the 'pods/exec' resource", [metadata.name, j]),
+		"keyActualValue": sprintf("metadata.name={{%s}}.rules[%d].resources includes the 'pods/exec' resource", [metadata.name, j]),
+		"searchLine": common_lib.build_search_line(["rules", j], ["resources"])
+	}
+}

--- a/assets/queries/k8s/rbac_roles_with_exec_permission/test/negative.yaml
+++ b/assets/queries/k8s/rbac_roles_with_exec_permission/test/negative.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: my-namespace
+  name: allow-exec-neg
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-exec-neg
+  namespace: my-namespace
+subjects:
+- kind: User
+  name: bob
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: allow-exec-neg
+  apiGroup: ""

--- a/assets/queries/k8s/rbac_roles_with_exec_permission/test/positive.yaml
+++ b/assets/queries/k8s/rbac_roles_with_exec_permission/test/positive.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: my-namespace
+  name: allow-exec
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/exec"]
+  verbs: ["get", "list", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-exec
+  namespace: my-namespace
+subjects:
+- kind: User
+  name: bob
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: allow-exec
+  apiGroup: ""

--- a/assets/queries/k8s/rbac_roles_with_exec_permission/test/positive_expected_result.json
+++ b/assets/queries/k8s/rbac_roles_with_exec_permission/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "RBAC Roles with Exec Permission",
+    "severity": "MEDIUM",
+    "line": 8
+  }
+]


### PR DESCRIPTION
**Proposed Changes**

- Add new rule to check whether RBAC roles allow to run 'kubectl exec' to execute commands in containers. This is sometimes useful for troubleshooting but dangerous in production. In case of compromise, attackers may abuse this to subject to execute malicious code

I submit this contribution under the Apache-2.0 license.
