### PR TITLE
update(query):  StatefulSet Without Service Name for Kubernetes

### DIFF
--- a/assets/queries/k8s/statefulset_without_service_name/metadata.json
+++ b/assets/queries/k8s/statefulset_without_service_name/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "StatefulSet Without Service Name",
   "severity": "LOW",
   "category": "Availability",
-  "descriptionText": "Check if the StatefulSets have a headless 'serviceName'",
+  "descriptionText": "StatefulSets should have a headless 'serviceName'. The headless service labels should also be implemented on StatefulSets labels.",
   "descriptionUrl": "https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/",
   "platform": "Kubernetes",
   "descriptionID": "2ce554f2"

--- a/assets/queries/k8s/statefulset_without_service_name/metadata.json
+++ b/assets/queries/k8s/statefulset_without_service_name/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "StatefulSet Without Service Name",
   "severity": "LOW",
   "category": "Availability",
-  "descriptionText": "StatefulSets should have a headless 'serviceName'. The headless service labels should also be implemented on StatefulSets labels.",
+  "descriptionText": "StatefulSets should have an existing headless 'serviceName'. The headless service labels should also be implemented on StatefulSets labels.",
   "descriptionUrl": "https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/",
   "platform": "Kubernetes",
   "descriptionID": "2ce554f2"

--- a/assets/queries/k8s/statefulset_without_service_name/query.rego
+++ b/assets/queries/k8s/statefulset_without_service_name/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("metadata.name=%s.spec.serviceName", [metadata]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name=%s.spec.serviceName refers to a Headless Service", [metadata]),
+		"keyExpectedValue": sprintf("metadata.name=%s.spec.serviceName should refer to a Headless Service", [metadata]),
 		"keyActualValue": sprintf("metadata.name=%s.spec.serviceName doesn't refers to a Headless Service", [metadata]),
 		"searchLine": common_lib.build_search_line(["spec", "serviceName"], [])
 	}

--- a/assets/queries/k8s/statefulset_without_service_name/query.rego
+++ b/assets/queries/k8s/statefulset_without_service_name/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
             	resource.spec.clusterIP == "None"; 
             	statefulset.metadata.namespace == resource.metadata.namespace; 
             	statefulset.spec.serviceName == resource.metadata.name; 
-            	not unmatchedLabels( resource.spec.selector, statefulset.spec.template.metadata.labels)
+            	match_labels( resource.spec.selector, statefulset.spec.template.metadata.labels)
             	}) == 0
 
 	metadata := statefulset.metadata.name
@@ -26,13 +26,6 @@ CxPolicy[result] {
 	}
 }
 
-unmatchedLabels(serviceLabels, statefulsetLabels){
-    value := serviceLabels[name]
-    notContain(value, name , statefulsetLabels)
-}
-
-notContain( value, name, list){
-	list[name] != value
-}else{
-	not common_lib.valid_key(list, name)
+match_labels(serviceLabels, statefulsetLabels) {
+    count({x | label := serviceLabels[x]; label == statefulsetLabels[x]}) == count(serviceLabels)
 }

--- a/assets/queries/k8s/statefulset_without_service_name/query.rego
+++ b/assets/queries/k8s/statefulset_without_service_name/query.rego
@@ -1,10 +1,18 @@
-package Cx
+package Cx  
+
+import data.generic.common as common_lib
 
 CxPolicy[result] {
 	statefulset := input.document[i]
 	statefulset.kind == "StatefulSet"
 
-	count({x | resource := input.document[x]; resource.kind == "Service"; resource.spec.clusterIP == "None"; statefulset.metadata.namespace == resource.metadata.namespace; statefulset.spec.serviceName == resource.metadata.name; labelsMatch(statefulset, resource) == true}) == 0
+	count({x | 	resource := input.document[x];
+    			resource.kind == "Service"; 
+            	resource.spec.clusterIP == "None"; 
+            	statefulset.metadata.namespace == resource.metadata.namespace; 
+            	statefulset.spec.serviceName == resource.metadata.name; 
+            	not unmatchedLabels( resource.spec.selector, statefulset.spec.template.metadata.labels)
+            	}) == 0
 
 	metadata := statefulset.metadata.name
 
@@ -14,9 +22,17 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("metadata.name=%s.spec.serviceName refers to a Headless Service", [metadata]),
 		"keyActualValue": sprintf("metadata.name=%s.spec.serviceName doesn't refers to a Headless Service", [metadata]),
+		"searchLine": common_lib.build_search_line(["spec", "serviceName"], [])
 	}
 }
 
-labelsMatch(stateful, service) {
-	service.spec.selector == stateful.spec.template.metadata.labels
+unmatchedLabels(serviceLabels, statefulsetLabels){
+    value := serviceLabels[name]
+    notContain(value, name , statefulsetLabels)
+}
+
+notContain( value, name, list){
+	list[name] != value
+}else{
+	not common_lib.valid_key(list, name)
 }

--- a/assets/queries/k8s/statefulset_without_service_name/test/negative.yaml
+++ b/assets/queries/k8s/statefulset_without_service_name/test/negative.yaml
@@ -29,6 +29,7 @@ spec:
     metadata:
       labels:
         app: nginx2
+        foo: bar
     spec:
       terminationGracePeriodSeconds: 10
       containers:

--- a/assets/queries/terraform/kubernetes/statefulset_without_service_name/metadata.json
+++ b/assets/queries/terraform/kubernetes/statefulset_without_service_name/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "StatefulSet Without Service Name",
   "severity": "LOW",
   "category": "Availability",
-  "descriptionText": "StatefulSets should have a headless 'serviceName'. The headless service labels should also be implemented on StatefulSets labels.",
+  "descriptionText": "StatefulSets should have an existing headless 'serviceName'. The headless service labels should also be implemented on StatefulSets labels.",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/stateful_set#selector",
   "platform": "Terraform",
   "descriptionID": "a0d17b18"

--- a/assets/queries/terraform/kubernetes/statefulset_without_service_name/metadata.json
+++ b/assets/queries/terraform/kubernetes/statefulset_without_service_name/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "StatefulSet Without Service Name",
   "severity": "LOW",
   "category": "Availability",
-  "descriptionText": "Check if the StatefulSet have a headless 'serviceName'",
+  "descriptionText": "StatefulSets should have a headless 'serviceName'. The headless service labels should also be implemented on StatefulSets labels.",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/stateful_set#selector",
   "platform": "Terraform",
   "descriptionID": "a0d17b18"

--- a/assets/queries/terraform/kubernetes/statefulset_without_service_name/query.rego
+++ b/assets/queries/terraform/kubernetes/statefulset_without_service_name/query.rego
@@ -3,7 +3,11 @@ package Cx
 CxPolicy[result] {
 	stateful := input.document[i].resource.kubernetes_stateful_set[name]
 
-	count({x | resource := input.document[_].resource.kubernetes_service[x]; resource.spec.cluster_ip == "None"; stateful.metadata.namespace == resource.metadata.namespace; stateful.spec.service_name == resource.metadata.name; labelsMatch(stateful, resource) == true}) == 0
+	count({x | 	resource := input.document[_].resource.kubernetes_service[x];
+				resource.spec.cluster_ip == "None"; 
+				stateful.metadata.namespace == resource.metadata.namespace;
+				stateful.spec.service_name == resource.metadata.name;
+				match_labels(stateful.spec.template.metadata.labels, resource.spec.selector) == true}) == 0
 
 	result := {
 		"documentId": input.document[i].id,
@@ -14,6 +18,6 @@ CxPolicy[result] {
 	}
 }
 
-labelsMatch(stateful, service) {
-	service.spec.selector == stateful.spec.template.metadata.labels
+match_labels(serviceLabels, statefulsetLabels) {
+    count({x | label := serviceLabels[x]; label == statefulsetLabels[x]}) == count(serviceLabels)
 }

--- a/assets/queries/terraform/kubernetes/statefulset_without_service_name/query.rego
+++ b/assets/queries/terraform/kubernetes/statefulset_without_service_name/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("kubernetes_stateful_set[%s].spec.service_name", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("kubernetes_stateful_set[%s].spec.service_name refers to a Headless Service", [name]),
+		"keyExpectedValue": sprintf("kubernetes_stateful_set[%s].spec.service_name should refer to a Headless Service", [name]),
 		"keyActualValue": sprintf("kubernetes_stateful_set[%s].spec.service_name does not refer to a Headless Service", [name]),
 	}
 }


### PR DESCRIPTION
**Proposed Changes**
- Modify check for matched labels between Headless service and StatefulSet

I submit this contribution under the Apache-2.0 license.
