### PR TITLE
Add community tag to new issues by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report to help us improve
 title: ''
-labels: bug
+labels: community, bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/new-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-feature.md
@@ -2,7 +2,7 @@
 name: 'New Feature '
 about: Add a new feature to the project
 title: ''
-labels: feature
+labels: community, feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/query.md
+++ b/.github/ISSUE_TEMPLATE/query.md
@@ -2,7 +2,7 @@
 name: Query
 about: Template to help create/update a query
 title: Add/Update \[QUERY_NAME\] query for \[PLATFORM\] (Terraform, Ansible, ..)
-labels: query
+labels: community, query
 assignees: ''
 
 ---


### PR DESCRIPTION
This change is possible as core team members mostly create PRs.

I submit this contribution under the Apache-2.0 license.