### PR TITLE
doc: fix syntax

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -2,7 +2,8 @@
 
 You can find a list of queries, and their associated categories here: [https://docs.kics.io/latest/queries/all-queries/](https://docs.kics.io/latest/queries/all-queries/)
 
-The category list is: 
+The category list is:
+
 - Access Control
 - Availability
 - Backup


### PR DESCRIPTION
broken markdown syntax without line before list
I submit this contribution under the Apache-2.0 license.
