### PR TITLE
update(queries): Add check for traffic direction in port queries in some providers

### DIFF
--- a/assets/queries/ansible/azure/sensitive_port_is_exposed_to_entire_network/query.rego
+++ b/assets/queries/ansible/azure/sensitive_port_is_exposed_to_entire_network/query.rego
@@ -19,6 +19,7 @@ CxPolicy[result] {
 	protocol := getProtocolList(resource.protocol)[_]
 
 	upper(resource.access) == "ALLOW"
+	inboud_direction(resource)
 	endswith(resource.source_address_prefix, "/0")
 	containsDestinationPort(portNumber, resource)
 	isTCPorUDP(protocol)
@@ -78,4 +79,10 @@ else = containing {
 
 isTCPorUDP(protocol) = is {
 	is := upper(protocol) != "ICMP"
+}
+
+inboud_direction(resource){
+	upper(resource.direction) == "INBOUND"
+}else{
+	not commonLib.valid_key(resource,"direction")
 }

--- a/assets/queries/terraform/alicloud/public_security_group_rule_all_ports_or_protocols/query.rego
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_all_ports_or_protocols/query.rego
@@ -5,6 +5,7 @@ import data.generic.common as common_lib
 CxPolicy[result] {
 	some i
 	resource := input.document[i].resource.alicloud_security_group_rule[name]
+	resource.type == "ingress"
 	resource.cidr_ip == "0.0.0.0/0"
 	isTCPorUDP(resource.ip_protocol)
 	resource.port_range == "1/65535" 
@@ -25,6 +26,7 @@ isTCPorUDP("udp") = true
 CxPolicy[result] {
 	some i
 	resource := input.document[i].resource.alicloud_security_group_rule[name]
+	resource.type == "ingress"
 	resource.cidr_ip == "0.0.0.0/0"
 	isGREorICMP(resource.ip_protocol)
 	resource.port_range == "-1/-1" 
@@ -46,6 +48,7 @@ isGREorICMP("gre") = true
 CxPolicy[result] {
 	some i
 	resource := input.document[i].resource.alicloud_security_group_rule[name]
+	resource.type == "ingress"
 	resource.cidr_ip == "0.0.0.0/0"
 	resource.ip_protocol == "all"
 	result := {

--- a/assets/queries/terraform/alicloud/public_security_group_rule_sensitive_port/query.rego
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_sensitive_port/query.rego
@@ -6,6 +6,7 @@ import data.generic.terraform as terraform_lib
 CxPolicy[result] {
 	some i
 	resource := input.document[i].resource.alicloud_security_group_rule[name]
+	resource.type == "ingress"
 	resource.cidr_ip == "0.0.0.0/0"
 	isTCPorUDP(resource.ip_protocol)
 	portContent := common_lib.tcpPortsMap[port]

--- a/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/query.rego
+++ b/assets/queries/terraform/alicloud/public_security_group_rule_unknown_port/query.rego
@@ -5,6 +5,7 @@ import data.generic.terraform as terraform_lib
 
 CxPolicy[result] {
 	resource := input.document[i].resource.alicloud_security_group_rule[name]
+	resource.type == "ingress"
 	resource.cidr_ip == "0.0.0.0/0"
 	isTCPorUDP(resource.ip_protocol)
     containsUnknownPort(resource)	
@@ -26,6 +27,7 @@ isTCPorUDP("udp") = true
 
 CxPolicy[result] {
 	resource := input.document[i].resource.alicloud_security_group_rule[name]
+	resource.type == "ingress"
 	resource.cidr_ip == "0.0.0.0/0"
 	resource.ip_protocol == "all"
 	resource.port_range == "-1/-1"

--- a/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/query.rego
+++ b/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/query.rego
@@ -3,7 +3,8 @@ package Cx
 CxPolicy[result] {
 	resource := input.document[i].resource.azurerm_network_security_rule[var0]
 	upper(resource.access) == "ALLOW"
-
+	upper(resource.direction) == "INBOUND"
+	
 	isRelevantProtocol(resource.protocol)
 	isRelevantPort(resource.destination_port_range)
 	isRelevantAddressPrefix(resource.source_address_prefix)

--- a/assets/queries/terraform/azure/sensitive_port_is_exposed_to_entire_network/query.rego
+++ b/assets/queries/terraform/azure/sensitive_port_is_exposed_to_entire_network/query.rego
@@ -12,6 +12,8 @@ CxPolicy[result] {
 	protocol := terraLib.getProtocolList(resource.protocol)[_]
 
 	upper(resource.access) == "ALLOW"
+	upper(resource.direction) == "INBOUND"
+	
 	endswith(resource.source_address_prefix, "/0")
 	terraLib.containsPort(resource, portNumber)
 	isTCPorUDP(protocol)

--- a/assets/queries/terraform/azure/sensitive_port_is_exposed_to_small_public_network/query.rego
+++ b/assets/queries/terraform/azure/sensitive_port_is_exposed_to_small_public_network/query.rego
@@ -12,6 +12,8 @@ CxPolicy[result] {
 	protocol := terraLib.getProtocolList(resource.protocol)[_]
 
 	upper(resource.access) == "ALLOW"
+	upper(resource.direction) == "INBOUND"
+	
 	isSmallPublicNetwork(resource)
 	terraLib.containsPort(resource, portNumber)
 	isTCPorUDP(protocol)

--- a/assets/queries/terraform/azure/sensitive_port_is_exposed_to_wide_private_network/query.rego
+++ b/assets/queries/terraform/azure/sensitive_port_is_exposed_to_wide_private_network/query.rego
@@ -12,6 +12,8 @@ CxPolicy[result] {
 	protocol := terraLib.getProtocolList(resource.protocol)[_]
 
 	upper(resource.access) == "ALLOW"
+	upper(resource.direction) == "INBOUND"
+	
 	commonLib.isPrivateIP(resource.source_address_prefix)
 	terraLib.containsPort(resource, portNumber)
 	isTCPorUDP(protocol)

--- a/assets/queries/terraform/azure/ssh_is_exposed_to_the_internet/query.rego
+++ b/assets/queries/terraform/azure/ssh_is_exposed_to_the_internet/query.rego
@@ -3,6 +3,7 @@ package Cx
 CxPolicy[result] {
 	resource := input.document[i].resource.azurerm_network_security_rule[var0]
 	upper(resource.access) == "ALLOW"
+	upper(resource.direction) == "INBOUND"
 
 	isRelevantProtocol(resource.protocol)
 	isRelevantPort(resource.destination_port_range)


### PR DESCRIPTION
Closes #5246

**Proposed Changes**
- Add check in alicloud_security_group_rule for inbound traffic for Terraform Alicloud Queries
- Add check in azurerm_network_security_rule for inbound traffic for Terraform Azure Queries
-

I submit this contribution under the Apache-2.0 license.
