### PR TITLE
fix(cpu): fixed number of cpus available info

### DIFF
--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -172,7 +172,11 @@ func GetNumCPU() (float32, error) {
 			return -1, err
 		}
 
-		defer f.Close()
+		defer func() {
+			if err := f.Close(); err != nil {
+				log.Err(err)
+			}
+		}()
 
 		scanner := bufio.NewScanner(f)
 		if scanner.Scan() {

--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -163,8 +163,8 @@ func ListReportFormats() []string {
 	return supportedFormats
 }
 
-// GetNumCpu return the number of cpus available
-func GetNumCpu() (float32, error) {
+// GetNumCPU return the number of cpus available
+func GetNumCPU() (float32, error) {
 	// Check if application is running inside docker
 	if _, err := os.Stat("/.dockerenv"); err == nil {
 		f, err := os.Open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")

--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -174,15 +174,15 @@ func GetNumCpu() (float32, error) {
 
 		scanner := bufio.NewScanner(f)
 		if scanner.Scan() {
-			divisionValue := float32(100000)
+			divisor := float32(100000)
 			text := scanner.Text()
 			cpus, err := strconv.Atoi(text)
 			if err != nil {
-				return float32(cpus) / divisionValue, err
+				return float32(cpus) / divisor, err
 			}
 
 			if cpus != -1 {
-				return float32(cpus) / divisionValue, nil
+				return float32(cpus) / divisor, nil
 			}
 
 			return float32(runtime.NumCPU()), nil

--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -174,7 +174,7 @@ func GetNumCPU() (float32, error) {
 
 		defer func() {
 			if err := f.Close(); err != nil {
-				log.Err(err)
+				log.Err(err).Msg("failed to close '/sys/fs/cgroup/cpu/cpu.cfs_quota_us'")
 			}
 		}()
 

--- a/internal/console/helpers/helpers.go
+++ b/internal/console/helpers/helpers.go
@@ -23,6 +23,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const divisor = float32(100000)
+
 var reportGenerators = map[string]func(path, filename string, body interface{}) error{
 	"json":        report.PrintJSONReport,
 	"sarif":       report.PrintSarifReport,
@@ -174,7 +176,6 @@ func GetNumCpu() (float32, error) {
 
 		scanner := bufio.NewScanner(f)
 		if scanner.Scan() {
-			divisor := float32(100000)
 			text := scanner.Text()
 			cpus, err := strconv.Atoi(text)
 			if err != nil {

--- a/internal/console/pre_scan.go
+++ b/internal/console/pre_scan.go
@@ -150,7 +150,7 @@ func (console *console) preScan() {
 
 	cpu, err := consoleHelpers.GetNumCPU()
 	if err != nil {
-		log.Err(err)
+		log.Err(err).Msg("failed to get CPU")
 	} else {
 		log.Info().Msgf("CPU: %.1f", cpu)
 	}

--- a/internal/console/pre_scan.go
+++ b/internal/console/pre_scan.go
@@ -148,7 +148,7 @@ func (console *console) preScan() {
 		log.Info().Msgf("Total memory: %s", bytefmt.ByteSize(mem.Total))
 	}
 
-	cpu, err := consoleHelpers.GetNumCpu()
+	cpu, err := consoleHelpers.GetNumCPU()
 	if err != nil {
 		log.Err(err)
 	} else {

--- a/internal/console/pre_scan.go
+++ b/internal/console/pre_scan.go
@@ -148,8 +148,12 @@ func (console *console) preScan() {
 		log.Info().Msgf("Total memory: %s", bytefmt.ByteSize(mem.Total))
 	}
 
-	cpu := runtime.NumCPU()
-	log.Info().Msgf("CPU: %d", cpu)
+	cpu, err := consoleHelpers.GetNumCpu()
+	if err != nil {
+		log.Err(err)
+	} else {
+		log.Info().Msgf("CPU: %.1f", cpu)
+	}
 
 	noProgress := flags.GetBoolFlag(flags.NoProgressFlag)
 	if strings.EqualFold(flags.GetStrFlag(flags.LogLevelFlag), "debug") {


### PR DESCRIPTION
Signed-off-by: joaorufi <joao.rufino@checkmarx.com>

**Proposed Changes**
- If application is running inside docker container, we should look at `/sys/fs/cgroup/cpu/cpu.cfs_quota_us` to get the actual number of cpus available

I submit this contribution under the Apache-2.0 license.
