### PR TITLE
update(tfplan parser): support child modules

### DIFF
--- a/assets/queries/terraform/azure/default_azure_storage_account_network_access_is_too_permissive/query.rego
+++ b/assets/queries/terraform/azure/default_azure_storage_account_network_access_is_too_permissive/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Expected 'default_action' to be set to 'Deny'",
 		"keyActualValue": "'default_action' is set to 'Allow'",
-		"searchLine": common_lib.build_search_line(["resources", "azurerm_storage_account", name, "network_rules", "default_action"], []),
+		"searchLine": common_lib.build_search_line(["resource", "azurerm_storage_account", name, "network_rules", "default_action"], []),
 	}
 }
 
@@ -24,6 +24,6 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "Expected 'default_action' to be set to 'Deny'",
 		"keyActualValue": "'default_action' is set to 'Allow'",
-		"searchLine": common_lib.build_search_line(["resources", "azurerm_storage_account_network_rules", name, "default_action"], []),
+		"searchLine": common_lib.build_search_line(["resource", "azurerm_storage_account_network_rules", name, "default_action"], []),
 	}
 }

--- a/assets/queries/terraform/general/name_is_not_snake_case/query.rego
+++ b/assets/queries/terraform/general/name_is_not_snake_case/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "All names should be on snake case pattern",
 		"keyActualValue": sprintf("'%s' is not in snake case", [name]),
-		"searchLine": common_lib.build_search_line(["resources", type, name], []),
+		"searchLine": common_lib.build_search_line(["resource", type, name], []),
 	}
 }
 


### PR DESCRIPTION
Closes #5327

**Proposed Changes**
- support child modules
- corrected `searchLine` in queries `assets/queries/terraform/general/name_is_not_snake_case` and `assets/queries/terraform/azure/default_azure_storage_account_network_access_is_too_permissive`

I submit this contribution under the Apache-2.0 license.
