### PR TITLE
feat(workflows): added branching process for major versions

### DIFF
--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -2,7 +2,7 @@ name: go-ci-integration
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, release/1.6]
 
 jobs:
   integration-tests:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -2,7 +2,7 @@ name: go-ci
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, release/1.6]
 
 jobs:
   lint:

--- a/.github/workflows/go-e2e.yaml
+++ b/.github/workflows/go-e2e.yaml
@@ -2,7 +2,7 @@ name: go-e2e
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, release/1.6]
 
 jobs:
   e2e-tests:

--- a/.github/workflows/kics-gh-action.yaml
+++ b/.github/workflows/kics-gh-action.yaml
@@ -2,7 +2,7 @@ name: kics-github-action
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, release/1.6]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,8 +2,7 @@ name: static-analysis
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, release/1.6]
 
 jobs:
   sonarcloud:

--- a/.github/workflows/sync_major_release.yaml
+++ b/.github/workflows/sync_major_release.yaml
@@ -1,0 +1,23 @@
+name: sync-branches-action
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  sync-major-release-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Sync Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "master"
+          destination_branch: "release/1.6"                
+          pr_title: "update(branch): sync master to release/1.6"
+          pr_body: |
+            **Automated Changes**
+            - :magic_wand: Syncing master to release/1.6
+            
+            Triggered by SHA: _${{ github.sha }}_
+          github_token: ${{ secrets.KICS_BOT_PAT }}


### PR DESCRIPTION
**Proposed Changes**
- added a workflow that creates a PR that merges the `master` to `release/1.6` (name of the branch for KICS v1.6 development process) every time a push is done in the master (sync `master` to `release/1.6`). Furthermore, it was added the KICS tests to branch `release/1.6`.
- As an example how the Sync PR will look like, see:

<img width="555" alt="image" src="https://user-images.githubusercontent.com/74001161/173788793-039db654-451d-4737-ae61-17278d7bb279.png">

I submit this contribution under the Apache-2.0 license.
