### PR TITLE
feat(query): add new k8s rule to detect attach permission (RBAC)

### DIFF
--- a/assets/queries/k8s/rbac_roles_with_attach_permission/metadata.json
+++ b/assets/queries/k8s/rbac_roles_with_attach_permission/metadata.json
@@ -1,0 +1,10 @@
+{
+  "id": "df4a3b93-53a4-4e8a-8d3b-3e91d0a664af",
+  "queryName": "RBAC Roles with Attach Permission",
+  "severity": "MEDIUM",
+  "category": "Access Control",
+  "descriptionText": "Roles or ClusterRoles with RBAC permissions to attach to containers via 'kubectl attach' could be abused by attackers to read log output (stdout, stderr) and send input data (stdin) to running processes. To prevent this, the 'pods/attach' verb should not be used in production environments",
+  "descriptionUrl": "https://kubernetes.io/docs/reference/access-authn-authz/rbac/",
+  "platform": "Kubernetes",
+  "descriptionID": "df4a3b93"
+}

--- a/assets/queries/k8s/rbac_roles_with_attach_permission/query.rego
+++ b/assets/queries/k8s/rbac_roles_with_attach_permission/query.rego
@@ -1,0 +1,27 @@
+package Cx
+
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+	document := input.document[i]
+	metadata := document.metadata
+
+	kinds := {"Role", "ClusterRole"}
+	document.kind == kinds[_]
+
+	resources := {"pods/attach", "pods/*"}
+	verbs := {"create", "*"}
+	document.rules[j].resources[_] == resources[_]
+	document.rules[j].verbs[_] == verbs[_]
+
+	result := {
+		"documentId": document.id,
+		"resourceType": document.kind,
+		"resourceName": metadata.name,
+		"searchKey": sprintf("metadata.name={{%s}}.rules", [metadata.name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.rules[%d].resources should not include the 'pods/attach' resource", [metadata.name, j]),
+		"keyActualValue": sprintf("metadata.name={{%s}}.rules[%d].resources includes the 'pods/attach' resource", [metadata.name, j]),
+		"searchLine": common_lib.build_search_line(["rules", j], ["resources"])
+	}
+}

--- a/assets/queries/k8s/rbac_roles_with_attach_permission/test/negative.yaml
+++ b/assets/queries/k8s/rbac_roles_with_attach_permission/test/negative.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: my-namespace
+  name: allow-attach-neg
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-attach-neg
+  namespace: my-namespace
+subjects:
+- kind: User
+  name: bob
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: allow-attach-neg
+  apiGroup: ""

--- a/assets/queries/k8s/rbac_roles_with_attach_permission/test/positive.yaml
+++ b/assets/queries/k8s/rbac_roles_with_attach_permission/test/positive.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: my-namespace
+  name: allow-attach
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/attach"]
+  verbs: ["get", "list", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-attach
+  namespace: my-namespace
+subjects:
+- kind: User
+  name: bob
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: allow-attach
+  apiGroup: ""

--- a/assets/queries/k8s/rbac_roles_with_attach_permission/test/positive_expected_result.json
+++ b/assets/queries/k8s/rbac_roles_with_attach_permission/test/positive_expected_result.json
@@ -1,0 +1,7 @@
+[
+  {
+    "queryName": "RBAC Roles with Attach Permission",
+    "severity": "MEDIUM",
+    "line": 8
+  }
+]


### PR DESCRIPTION
**Proposed Changes**

- Add new rule to check whether RBAC roles allow to attach to contains via 'kubectl attach'. This is useful for debugging but in case of compromise, an attacker could misuse the permission to read stdout, stderr and write stdin. In a worst-case scenario, log output may include sensitive information and the control flow of a running process could be tainted.

More information [here](https://stackoverflow.com/a/50031131/5685796). Thanks to @Dentrax for drawing my attention to this.

I submit this contribution under the Apache-2.0 license.
