### PR TITLE
update(dockerfile): fix CVE-2022-1586 and CVE-2022-29810

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN wget https://releases.hashicorp.com/terraform/1.1.3/terraform_1.1.3_linux_am
     && unzip terraform-provider-google_4.10.0_linux_amd64.zip && rm terraform-provider-google_4.10.0_linux_amd64.zip \
     && unzip terraform-provider-aws_3.72.0_linux_amd64.zip && rm terraform-provider-aws_3.72.0_linux_amd64.zip \
     && mkdir ~/.terraform.d && mkdir ~/.terraform.d/plugins && mkdir ~/.terraform.d/plugins/linux_amd64 && mv terraform-provider-aws_v3.72.0_x5 terraform-provider-google_v4.10.0_x5 terraform-provider-azurerm_v2.95.0_x5 ~/.terraform.d/plugins/linux_amd64 \
+    && apk upgrade --no-cache pcre2 \
     && apk add --no-cache \
     git=2.36.1-r0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,16 +38,16 @@ FROM alpine:3.16.0
 ENV TERM xterm-256color
 
 # Install Terraform and Terraform plugins
-RUN wget https://releases.hashicorp.com/terraform/1.1.3/terraform_1.1.3_linux_amd64.zip \
-    && unzip terraform_1.1.3_linux_amd64.zip && rm terraform_1.1.3_linux_amd64.zip \
+RUN wget https://releases.hashicorp.com/terraform/1.2.3/terraform_1.2.3_linux_amd64.zip \
+    && unzip terraform_1.2.3_linux_amd64.zip && rm terraform_1.2.3_linux_amd64.zip \
     && mv terraform /usr/bin/terraform \
-    && wget https://releases.hashicorp.com/terraform-provider-azurerm/2.95.0/terraform-provider-azurerm_2.95.0_linux_amd64.zip \
+    && wget https://releases.hashicorp.com/terraform-provider-azurerm/3.5.0/terraform-provider-azurerm_3.5.0_linux_amd64.zip \
     && wget https://releases.hashicorp.com/terraform-provider-aws/3.72.0/terraform-provider-aws_3.72.0_linux_amd64.zip \
     && wget https://releases.hashicorp.com/terraform-provider-google/4.10.0/terraform-provider-google_4.10.0_linux_amd64.zip \
-    && unzip terraform-provider-azurerm_2.95.0_linux_amd64.zip && rm terraform-provider-azurerm_2.95.0_linux_amd64.zip\
+    && unzip terraform-provider-azurerm_3.5.0_linux_amd64.zip && rm terraform-provider-azurerm_3.5.0_linux_amd64.zip\
     && unzip terraform-provider-google_4.10.0_linux_amd64.zip && rm terraform-provider-google_4.10.0_linux_amd64.zip \
     && unzip terraform-provider-aws_3.72.0_linux_amd64.zip && rm terraform-provider-aws_3.72.0_linux_amd64.zip \
-    && mkdir ~/.terraform.d && mkdir ~/.terraform.d/plugins && mkdir ~/.terraform.d/plugins/linux_amd64 && mv terraform-provider-aws_v3.72.0_x5 terraform-provider-google_v4.10.0_x5 terraform-provider-azurerm_v2.95.0_x5 ~/.terraform.d/plugins/linux_amd64 \
+    && mkdir ~/.terraform.d && mkdir ~/.terraform.d/plugins && mkdir ~/.terraform.d/plugins/linux_amd64 && mv terraform-provider-aws_v3.72.0_x5 terraform-provider-google_v4.10.0_x5 terraform-provider-azurerm_v3.5.0_x5 ~/.terraform.d/plugins/linux_amd64 \
     && apk upgrade --no-cache pcre2 \
     && apk add --no-cache \
     git=2.36.1-r0


### PR DESCRIPTION
Closes #5486
Closes #5487

**Proposed Changes**
- fixed CVE-2022-1586: upgrade pcre2
- fixed CVE-2022-29810: upgrade terraform and terraform azurerm provider

I submit this contribution under the Apache-2.0 license.
