### PR TITLE
fix(secrets inspector): added mutex to lock addVulnerability

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.2.0
         with:
           version: v1.46.1
-          args: -c .golangci.yml --timeout 15m
+          args: -c .golangci.yml --timeout 20m
   go-generate:
     name: go-generate
     runs-on: ubuntu-latest

--- a/.github/workflows/go-test-race.yml
+++ b/.github/workflows/go-test-race.yml
@@ -41,7 +41,7 @@ jobs:
           go mod vendor
       - name: Test and Generate Report
         run: |
-          go test -race -timeout 3600s -mod=vendor -v $(go list ./... | grep -v e2e) -count=1 -coverprofile=cover.out | tee unit-test.log
+          go test -race -timeout 9999s -mod=vendor -v $(go list ./... | grep -v e2e) -count=1 -coverprofile=cover.out | tee unit-test.log
           result_code=${PIPESTATUS[0]}
           exit $result_code
       - name: Archive test logs

--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/query.rego
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/query.rego
@@ -44,7 +44,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("apiVersion={{%s}}", [document.apiVersion]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.apiVersion should be {{%s}}", [metadata.name, recommendedVersions[document.apiVersion][document.kind]]),
-		"keyActualValue": sprintf("metadata.name={{%s}}.apiVersion is deprecated and is {{%s}}", [metadata.name, document.apiVersion]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.apiVersion of %s should be {{%s}}", [metadata.name,  document.kind, recommendedVersions[document.apiVersion][document.kind]]),
+		"keyActualValue": sprintf("metadata.name={{%s}}.apiVersion of %s  is deprecated and is {{%s}}", [metadata.name, document.kind, document.apiVersion]),
 	}
 }

--- a/assets/queries/k8s/tiller_is_deployed/query.rego
+++ b/assets/queries/k8s/tiller_is_deployed/query.rego
@@ -12,8 +12,8 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}", [metadata.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'metadata' does not refer any to a Tiller resource",
-		"keyActualValue": "'metadata' refers to a Tiller resource",
+		"keyExpectedValue": sprintf("'metadata' of %s does not refer to any Tiller resource", [document.kind]),
+		"keyActualValue": sprintf("'metadata' of %s refers to a Tiller resource", [document.kind]),
 	}
 }
 
@@ -33,8 +33,8 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.%s", [metadata.name, types[x]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'spec.containers' doesn't have any Tiller containers", [types[x]]),
-		"keyActualValue": sprintf("'spec.containers' contains a Tiller container", [types[x]]),
+		"keyExpectedValue": sprintf("'spec.%s' of %s doesn't have any Tiller containers", [types[x], document.kind]),
+		"keyActualValue": sprintf("'spec.%s' of %s contains a Tiller container", [types[x], document.kind]),
 	}
 }
 
@@ -51,8 +51,8 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.template.metadata", [metadata.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'spec.template.metadata' does not refer to any Tiller resource",
-		"keyActualValue": "'spec.template.metadata' refers to a Tiller resource",
+		"keyExpectedValue": sprintf("'spec.template.metadata' does not refer to any Tiller resource", [document.kind]),
+		"keyActualValue": sprintf("'spec.template.metadata' refers to a Tiller resource", [document.kind]),
 	}
 }
 
@@ -70,8 +70,8 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.template.spec.%s", [metadata.name, types[x]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'spec.template.spec.%s' doesn't have any Tiller containers", [types[x]]),
-		"keyActualValue": sprintf("'spec.template.spec.%s' contains a Tiller container", [types[x]]),
+		"keyExpectedValue": sprintf("'spec.template.spec.%s' of %s doesn't have any Tiller containers", [types[x], document.kind]),
+		"keyActualValue": sprintf("'spec.template.spec.%s' of %s contains a Tiller container", [types[x], document.kind]),
 	}
 }
 

--- a/assets/queries/k8s/tiller_service_is_not_deleted/query.rego
+++ b/assets/queries/k8s/tiller_service_is_not_deleted/query.rego
@@ -13,8 +13,8 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}", [metadata.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "metadata.name does not contain 'tiller'",
-		"keyActualValue": "metadata.name contains 'tiller'",
+		"keyExpectedValue": sprintf("metadata.name of %s does not contain 'tiller'", [document.kind]),
+		"keyActualValue": sprintf("metadata.name of %s contains 'tiller'", [document.kind]),
 	}
 }
 
@@ -33,8 +33,8 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}", [metadata.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "metadata.labels does not have values that contain 'tiller'",
-		"keyActualValue": sprintf("metadata.labels.%s contains 'tiller'", [j]),
+		"keyExpectedValue": sprintf("metadata.labels of %s does not have values that contain 'tiller'", [document.kind]),
+		"keyActualValue": sprintf("metadata.labels.%s of %s contains 'tiller'", [document.kind, j]),
 	}
 }
 
@@ -54,7 +54,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.selector.%s", [metadata.name, j]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "spec.selector does not have values that contain 'tiller'",
-		"keyActualValue": sprintf("spec.selector.%s contains 'tiller'", [j]),
+		"keyExpectedValue": sprintf("spec.selector of %s does not have values that contain 'tiller'", [document.kind]),
+		"keyActualValue": sprintf("spec.selector.%s of %s contains 'tiller'", [document.kind, j]),
 	}
 }

--- a/pkg/engine/secrets/inspector.go
+++ b/pkg/engine/secrets/inspector.go
@@ -41,6 +41,7 @@ type Inspector struct {
 	vulnerabilities       []model.Vulnerability
 	queryExecutionTimeout time.Duration
 	foundLines            []int
+	mu                    sync.RWMutex
 }
 
 type Entropy struct {
@@ -480,6 +481,7 @@ func (c *Inspector) addVulnerability(basePaths []string, file *model.FileMetadat
 		log.Error().Msg("unable to compute similarity ID")
 	}
 
+	c.mu.Lock()
 	if _, ok := c.excludeResults[engine.PtrStringToString(simID)]; !ok {
 		linesVuln := c.detector.GetAdjecent(file, lineNumber+1)
 		if !ignoreLine(linesVuln.Line, file.LinesIgnore) {
@@ -505,6 +507,7 @@ func (c *Inspector) addVulnerability(basePaths []string, file *model.FileMetadat
 			c.vulnerabilities = append(c.vulnerabilities, vuln)
 		}
 	}
+	c.mu.Unlock()
 }
 
 // CheckEntropyInterval - verifies if a given token's entropy is within expected bounds


### PR DESCRIPTION
**Proposed Changes**
- added mutex to lock `addVulnerability` function. This way, the GitHub action `go-test-race` will no longer fail due to data race in `addVulnerability` function
- increased timeout for go-test-race action (to 3600 s)
- increased timeout for go lint action (to 20 min)
- fixed tiller queries

I submit this contribution under the Apache-2.0 license.
