### PR TITLE
fix(scan behavior): fixed different behavior based on flag -t

### DIFF
--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -2,7 +2,6 @@ package scan
 
 import (
 	_ "embed" // Embed kics CLI img and scan-flags
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +9,7 @@ import (
 
 	consoleHelpers "github.com/Checkmarx/kics/internal/console/helpers"
 	"github.com/Checkmarx/kics/pkg/descriptions"
+	"github.com/Checkmarx/kics/pkg/engine/provider"
 	"github.com/Checkmarx/kics/pkg/model"
 	consolePrinter "github.com/Checkmarx/kics/pkg/printer"
 	"github.com/Checkmarx/kics/pkg/progress"
@@ -96,8 +96,12 @@ func printOutput(outputPath, filename string, body interface{}, formats []string
 func (c *Client) postScan(scanResults *Results) error {
 	if scanResults == nil {
 		log.Info().Msg("No files were scanned")
-		fmt.Println("No files were scanned")
-		return nil
+		scanResults = &Results{
+			Results:        []model.Vulnerability{},
+			ExtractedPaths: provider.ExtractedPath{},
+			Files:          model.FileMetadatas{},
+			FailedQueries:  map[string]error{},
+		}
 	}
 
 	summary := c.getSummary(scanResults.Results, time.Now(), model.PathParameters{

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -153,11 +153,6 @@ func analyzePaths(paths, types, exclude []string) (model.AnalyzedPaths, error) {
 		return model.AnalyzedPaths{}, err
 	}
 
-	// flag -t was passed but KICS did not find any matching file
-	if types[0] != "" && len(pathsFlag.Types) == 0 {
-		pathsFlag.Types = append(pathsFlag.Types, types...)
-	}
-
 	logLoadingQueriesType(pathsFlag.Types)
 
 	excluded = append(excluded, exclude...)


### PR DESCRIPTION
Issue #4848 will be closed when the branch `release/1.6` is merged into the master.

**Proposed Changes**
- fixed different behavior based on flag -t

With or without the flag -t, when -o flag is used, it will generate a file like the following:

<img width="194" alt="image" src="https://user-images.githubusercontent.com/74001161/174822865-6a07652e-1be0-4eb1-a790-813a6bfbb234.png">


I submit this contribution under the Apache-2.0 license.
