### PR TITLE
fix(keyExpectedValue): convert to a recommendation rather than a current status

### DIFF
--- a/assets/queries/ansible/aws/ec2_instance_has_public_ip/query.rego
+++ b/assets/queries/ansible/aws/ec2_instance_has_public_ip/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.assign_public_ip", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "ec2.assign_public_ip is false, 'no' or undefined",
+		"keyExpectedValue": "ec2.assign_public_ip should be set to false, 'no' or undefined",
 		"keyActualValue": sprintf("ec2.assign_public_ip is '%s'", [ec2.assign_public_ip]),
 	}
 }
@@ -40,7 +40,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network_interfaces.associate_public_ip_address", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "ec2_launch_template.network_interfaces.associate_public_ip_address is false, 'no' or undefined",
+		"keyExpectedValue": "ec2_launch_template.network_interfaces.associate_public_ip_address should be set to false, 'no' or undefined",
 		"keyActualValue": sprintf("ec2_launch_template.network_interfaces.associate_public_ip_address is '%s'", [ipValue]),
 	}
 }
@@ -62,7 +62,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.network.assign_public_ip", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "ec2_instance.network.assign_public_ip is false, 'no' or undefined",
+		"keyExpectedValue": "ec2_instance.network.assign_public_ip should be set to false, 'no' or undefined",
 		"keyActualValue": sprintf("ec2_instance.network.assign_public_ip is '%s'", [ipValue]),
 	}
 }

--- a/assets/queries/ansible/aws/redshift_publicly_accessible/query.rego
+++ b/assets/queries/ansible/aws/redshift_publicly_accessible/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.publicly_accessible", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "redshift.publicly_accessible is false",
+		"keyExpectedValue": "redshift.publicly_accessible should be set to false",
 		"keyActualValue": "redshift.publicly_accessible is true",
 	}
 }

--- a/assets/queries/ansible/aws/stack_retention_disabled/query.rego
+++ b/assets/queries/ansible/aws/stack_retention_disabled/query.rego
@@ -38,7 +38,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.purge_stacks", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "cloudformation_stack_set.purge_stacks is false",
+		"keyExpectedValue": "cloudformation_stack_set.purge_stacks should be set to false",
 		"keyActualValue": "cloudformation_stack_set.purge_stacks is true",
 	}
 }

--- a/assets/queries/ansible/azure/redis_cache_allows_non_ssl_connections/query.rego
+++ b/assets/queries/ansible/azure/redis_cache_allows_non_ssl_connections/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.enable_non_ssl_port", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "azure_rm_rediscache.enable_non_ssl_port is false or undefined",
+		"keyExpectedValue": "azure_rm_rediscache.enable_non_ssl_port should be set to false or undefined",
 		"keyActualValue": "azure_rm_rediscache.enable_non_ssl_port is true",
 	}
 }

--- a/assets/queries/ansible/gcp/gke_legacy_authorization_enabled/query.rego
+++ b/assets/queries/ansible/gcp/gke_legacy_authorization_enabled/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.legacy_abac.enabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "gcp_container_cluster.legacy_abac.enabled is false",
+		"keyExpectedValue": "gcp_container_cluster.legacy_abac.enabled should be set to false",
 		"keyActualValue": "gcp_container_cluster.legacy_abac.enabled is true",
 	}
 }

--- a/assets/queries/ansible/gcp/ip_forwarding_enabled/query.rego
+++ b/assets/queries/ansible/gcp/ip_forwarding_enabled/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.can_ip_forward", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "gcp_compute_instance.can_ip_forward is false",
+		"keyExpectedValue": "gcp_compute_instance.can_ip_forward should be set to false",
 		"keyActualValue": "gcp_compute_instance.can_ip_forward is true",
 	}
 }

--- a/assets/queries/ansible/gcp/network_policy_disabled/query.rego
+++ b/assets/queries/ansible/gcp/network_policy_disabled/query.rego
@@ -75,7 +75,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.addons_config.network_policy_config.disabled", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "gcp_container_cluster.addons_config.network_policy_config.disabled is false",
+		"keyExpectedValue": "gcp_container_cluster.addons_config.network_policy_config.disabled should be set to false",
 		"keyActualValue": "gcp_container_cluster.addons_config.network_policy_config.disabled is true",
 	}
 }

--- a/assets/queries/cloudFormation/aws/batch_job_definition_with_privileged_container_properties/query.rego
+++ b/assets/queries/cloudFormation/aws/batch_job_definition_with_privileged_container_properties/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"resourceName": cf_lib.get_resource_name(resource, name),
 		"searchKey": sprintf("Resources.%s.Properties.ContainerProperties.Privileged", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.ContainerProperties.Privileged is false", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.ContainerProperties.Privileged should be set to false", [name]),
 		"keyActualValue": sprintf("Resources.%s.Properties.ContainerProperties.Privileged is true", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/aws/mq_broker_is_publicly_accessible/query.rego
+++ b/assets/queries/cloudFormation/aws/mq_broker_is_publicly_accessible/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 		"resourceName": cf_lib.get_resource_name(resource, name),
 		"searchKey": sprintf("Resources.%s.Properties.PubliclyAccessible", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Resources.%s.Properties.PubliclyAccessible is false or undefined", [name]),
+		"keyExpectedValue": sprintf("Resources.%s.Properties.PubliclyAccessible should be set to false or undefined", [name]),
 		"keyActualValue": sprintf("Resources.%s.Properties.PubliclyAccessible is true", [name]),
 	}
 }

--- a/assets/queries/cloudFormation/aws/redshift_publicly_accessible/query.rego
+++ b/assets/queries/cloudFormation/aws/redshift_publicly_accessible/query.rego
@@ -30,7 +30,7 @@ CxPolicy[result] {
 		"resourceName": cf_lib.get_resource_name(resource, name),
 		"searchKey": sprintf("Resources.%s.Properties.PubliclyAccessible", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.PubliclyAccessible' is false", [name]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.PubliclyAccessible' should be set to false", [name]),
 		"keyActualValue": sprintf("'Resources.%s.Properties.PubliclyAccessible' is true", [name]),
 	}
 }

--- a/assets/queries/k8s/privilege_escalation_allowed/query.rego
+++ b/assets/queries/k8s/privilege_escalation_allowed/query.rego
@@ -20,7 +20,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.allowPrivilegeEscalation", [metadata.name, specInfo.path, types[x], container.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.allowPrivilegeEscalation is false", [metadata.name, specInfo.path, types[x], container.name]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.allowPrivilegeEscalation should be set to false", [metadata.name, specInfo.path, types[x], container.name]),
 		"keyActualValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.allowPrivilegeEscalation is true", [metadata.name, specInfo.path, types[x], container.name]),
 	}
 }
@@ -41,7 +41,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}", [metadata.name, specInfo.path, types[x], container.name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.allowPrivilegeEscalation is set and is false", [metadata.name, specInfo.path, types[x], container.name]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.allowPrivilegeEscalation is set and should be set to false", [metadata.name, specInfo.path, types[x], container.name]),
 		"keyActualValue": sprintf("metadata.name={{%s}}.%s.%s.name={{%s}}.securityContext.allowPrivilegeEscalation is undefined", [metadata.name, specInfo.path, types[x], container.name]),
 		"searchLine": common_lib.build_search_line(split(specInfo.path, "."), [types[x], c, "securityContext"])
 	}

--- a/assets/queries/k8s/psp_allows_privilege_escalation/query.rego
+++ b/assets/queries/k8s/psp_allows_privilege_escalation/query.rego
@@ -38,7 +38,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"issueType": "IncorrectValue",
 		"searchKey": sprintf("metadata.name={{%s}}.%s.allowPrivilegeEscalation", [metadata.name, specInfo.path]),
-		"keyExpectedValue": "Attribute 'allowPrivilegeEscalation' is false",
+		"keyExpectedValue": "Attribute 'allowPrivilegeEscalation' should be set to false",
 		"keyActualValue": "Attribute 'allowPrivilegeEscalation' is true",
 	}
 }

--- a/assets/queries/k8s/psp_allows_sharing_host_ipc/query.rego
+++ b/assets/queries/k8s/psp_allows_sharing_host_ipc/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.hostIPC", [metadata.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'spec.hostIPC' is false or undefined",
+		"keyExpectedValue": "'spec.hostIPC' should be set to false or undefined",
 		"keyActualValue": "'spec.hostIPC' is true",
 	}
 }

--- a/assets/queries/k8s/psp_allows_sharing_host_pid/query.rego
+++ b/assets/queries/k8s/psp_allows_sharing_host_pid/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.hostPID", [metadata.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'spec.hostPID' is false or undefined",
+		"keyExpectedValue": "'spec.hostPID' should be set to false or undefined",
 		"keyActualValue": "'spec.hostPID' is true",
 	}
 }

--- a/assets/queries/k8s/psp_containers_share_host_network_namespace/query.rego
+++ b/assets/queries/k8s/psp_containers_share_host_network_namespace/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.hostNetwork", [metadata.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'spec.hostNetwork' is false or undefined",
+		"keyExpectedValue": "'spec.hostNetwork' should be set to false or undefined",
 		"keyActualValue": "'spec.hostNetwork' is true",
 	}
 }

--- a/assets/queries/k8s/psp_set_to_privileged/query.rego
+++ b/assets/queries/k8s/psp_set_to_privileged/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.spec.privileged", [metadata.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.spec.privileged is false", [metadata.name]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.spec.privileged should be set to false", [metadata.name]),
 		"keyActualValue": sprintf("metadata.name={{%s}}.spec.privileged is true", [metadata.name]),
 	}
 }

--- a/assets/queries/k8s/service_account_token_automount_not_disabled/query.rego
+++ b/assets/queries/k8s/service_account_token_automount_not_disabled/query.rego
@@ -53,7 +53,7 @@ checkAutomount(specInfo, document, metadata) = result {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.%s.automountServiceAccountToken", [metadata.name, specInfo.path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s.automountServiceAccountToken is false", [metadata.name, specInfo.path]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.%s.automountServiceAccountToken should be set to false", [metadata.name, specInfo.path]),
 		"keyActualValue": sprintf("metadata.name={{%s}}.%s.automountServiceAccountToken is true", [metadata.name, specInfo.path]),
 	}
 }
@@ -76,7 +76,7 @@ checkAutomount(specInfo, document, metadata) = result {
 		"resourceName": SAWithAutoMount[k].metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.automountServiceAccountToken", [SAWithAutoMount[k].metadata.name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("metadata.name={{%s}}.automountServiceAccountToken is false", [SAWithAutoMount[k].metadata.name]),
+		"keyExpectedValue": sprintf("metadata.name={{%s}}.automountServiceAccountToken should be set to false", [SAWithAutoMount[k].metadata.name]),
 		"keyActualValue": sprintf("metadata.name={{%s}}.automountServiceAccountToken is true", [SAWithAutoMount[k].metadata.name]),
 	}
 }

--- a/assets/queries/k8s/shared_host_ipc_namespace/query.rego
+++ b/assets/queries/k8s/shared_host_ipc_namespace/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.%s.hostIPC", [metadata.name, specInfo.path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'%s.hostIPC' is false or undefined", [specInfo.path]),
+		"keyExpectedValue": sprintf("'%s.hostIPC' should be set to false or undefined", [specInfo.path]),
 		"keyActualValue": sprintf("'%s.hostIPC' is true", [specInfo.path]),
 	}
 }

--- a/assets/queries/k8s/shared_host_network_namespace/query.rego
+++ b/assets/queries/k8s/shared_host_network_namespace/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.%s.hostNetwork", [metadata.name, specInfo.path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'%s.hostNetwork' is false or undefined", [specInfo.path]),
+		"keyExpectedValue": sprintf("'%s.hostNetwork' should be set to false or undefined", [specInfo.path]),
 		"keyActualValue": sprintf("'%s.hostNetwork' is true", [specInfo.path]),
 	}
 }

--- a/assets/queries/k8s/shared_host_pid_namespace/query.rego
+++ b/assets/queries/k8s/shared_host_pid_namespace/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"resourceName": metadata.name,
 		"searchKey": sprintf("metadata.name={{%s}}.%s.hostPID", [metadata.name, specInfo.path]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'%s.hostPID' is false or undefined", [specInfo.path]),
+		"keyExpectedValue": sprintf("'%s.hostPID' should be set to false or undefined", [specInfo.path]),
 		"keyActualValue": sprintf("'%s.hostPID' is true", [specInfo.path]),
 	}
 }

--- a/assets/queries/terraform/aws/ec2_instance_has_public_ip/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_has_public_ip/query.rego
@@ -49,7 +49,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(resource, name),
 		"searchKey": sprintf("aws_instance.%s.associate_public_ip_address", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'associate_public_ip_address' is false",
+		"keyExpectedValue": "'associate_public_ip_address' should be set to false",
 		"keyActualValue": "'associate_public_ip_address' is true",
 		"searchLine": common_lib.build_search_line(["resource", "aws_instance", name, "associate_public_ip_address"], []),
 	}
@@ -67,7 +67,7 @@ CxPolicy[result] {
 		"resourceName": "n/a",
 		"searchKey": sprintf("module[%s].associate_public_ip_address", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'associate_public_ip_address' is false",
+		"keyExpectedValue": "'associate_public_ip_address' should be set to false",
 		"keyActualValue": "'associate_public_ip_address' is true",
 		"searchLine": common_lib.build_search_line(["module", name, "associate_public_ip_address"], []),
 	}

--- a/assets/queries/terraform/aws/redshift_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/redshift_not_encrypted/query.rego
@@ -28,7 +28,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(cluster, name),
 		"searchKey": sprintf("aws_redshift_cluster[%s].encrypted", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "aws_redshift_cluster.encrypted is false",
+		"keyExpectedValue": "aws_redshift_cluster.encrypted should be set to false",
 		"keyActualValue": "aws_redshift_cluster.encrypted is true",
 	}
 }

--- a/assets/queries/terraform/aws/redshift_publicly_accessible/query.rego
+++ b/assets/queries/terraform/aws/redshift_publicly_accessible/query.rego
@@ -28,7 +28,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(public, name),
 		"searchKey": sprintf("aws_redshift_cluster[%s].publicly_accessible", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "aws_redshift_cluster.publicly_accessible is false",
+		"keyExpectedValue": "aws_redshift_cluster.publicly_accessible should be set to false",
 		"keyActualValue": "aws_redshift_cluster.publicly_accessible is true",
 	}
 }

--- a/assets/queries/terraform/azure/dashboard_is_enabled/query.rego
+++ b/assets/queries/terraform/azure/dashboard_is_enabled/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(cluster, name),
 		"searchKey": sprintf("azurerm_kubernetes_cluster[%s].addon_profile.kube_dashboard.enabled", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'azurerm_kubernetes_cluster[%s].addon_profile.kube_dashboard.enabled' is false or undefined", [name]),
+		"keyExpectedValue": sprintf("'azurerm_kubernetes_cluster[%s].addon_profile.kube_dashboard.enabled' should be set to false or undefined", [name]),
 		"keyActualValue": sprintf("'azurerm_kubernetes_cluster[%s].addon_profile.kube_dashboard.enabled' is true", [name]),
 	}
 }

--- a/assets/queries/terraform/azure/redis_cache_allows_non_ssl_connections/query.rego
+++ b/assets/queries/terraform/azure/redis_cache_allows_non_ssl_connections/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(cache, name),
 		"searchKey": sprintf("azurerm_redis_cache[%s].enable_non_ssl_port", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'azurerm_redis_cache[%s].enable_non_ssl_port' is false or undefined (false as default)", [name]),
+		"keyExpectedValue": sprintf("'azurerm_redis_cache[%s].enable_non_ssl_port' should be set to false or undefined (false as default)", [name]),
 		"keyActualValue": sprintf("'azurerm_redis_cache[%s].enable_non_ssl_port' is true", [name]),
 	}
 }

--- a/assets/queries/terraform/gcp/gke_legacy_authorization_enabled/query.rego
+++ b/assets/queries/terraform/gcp/gke_legacy_authorization_enabled/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(resource, primary),
 		"searchKey": sprintf("google_container_cluster[%s].enable_legacy_abac", [primary]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Attribute 'enable_legacy_abac' is false",
+		"keyExpectedValue": "Attribute 'enable_legacy_abac' should be set to false",
 		"keyActualValue": "Attribute 'enable_legacy_abac' is true",
 	}
 }

--- a/assets/queries/terraform/gcp/google_project_auto_create_network_disabled/query.rego
+++ b/assets/queries/terraform/gcp/google_project_auto_create_network_disabled/query.rego
@@ -13,7 +13,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(project, name),
 		"searchKey": sprintf("google_project[%s].auto_create_network", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("google_project[%s].auto_create_network is false", [name]),
+		"keyExpectedValue": sprintf("google_project[%s].auto_create_network should be set to false", [name]),
 		"keyActualValue": sprintf("google_project[%s].auto_create_network is true", [name]),
 	}
 }
@@ -28,7 +28,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(project, name),
 		"searchKey": sprintf("google_project[%s]", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("google_project[%s].auto_create_network is false", [name]),
+		"keyExpectedValue": sprintf("google_project[%s].auto_create_network should be set to false", [name]),
 		"keyActualValue": sprintf("google_project[%s].auto_create_network is undefined", [name]),
 	}
 }

--- a/assets/queries/terraform/gcp/ip_forwarding_enabled/query.rego
+++ b/assets/queries/terraform/gcp/ip_forwarding_enabled/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(dt, appserver),
 		"searchKey": sprintf("google_compute_instance[%s]", [appserver]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Attribute 'can_ip_forward' is false or Attribute 'can_ip_forward' is undefined",
+		"keyExpectedValue": "Attribute 'can_ip_forward' should be set to false or Attribute 'can_ip_forward' is undefined",
 		"keyActualValue": "Attribute 'can_ip_forward' is true",
 	}
 }

--- a/assets/queries/terraform/gcp/network_policy_disabled/query.rego
+++ b/assets/queries/terraform/gcp/network_policy_disabled/query.rego
@@ -61,7 +61,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(resource, primary),
 		"searchKey": sprintf("google_container_cluster[%s].addons_config.network_policy_config", [primary]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Attribute 'addons_config.network_policy_config.disabled' is false",
+		"keyExpectedValue": "Attribute 'addons_config.network_policy_config.disabled' should be set to false",
 		"keyActualValue": "Attribute 'addons_config.network_policy_config.disabled' is true",
 	}
 }

--- a/assets/queries/terraform/gcp/vm_serial_ports_are_enabled_for_vm_instances/query.rego
+++ b/assets/queries/terraform/gcp/vm_serial_ports_are_enabled_for_vm_instances/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(compute, name),
 		"searchKey": sprintf("google_compute_instance[%s].metadata.serial-port-enable", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("google_compute_instance[%s].metadata.serial-port-enable is false or undefined", [name]),
+		"keyExpectedValue": sprintf("google_compute_instance[%s].metadata.serial-port-enable should be set to false or undefined", [name]),
 		"keyActualValue": sprintf("google_compute_instance[%s].metadata.serial-port-enable is true", [name]),
 	}
 }
@@ -31,7 +31,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(project, name),
 		"searchKey": sprintf("google_compute_project_metadata[%s].metadata.serial-port-enable", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("google_compute_project_metadata[%s].metadata.serial-port-enable is false or undefined", [name]),
+		"keyExpectedValue": sprintf("google_compute_project_metadata[%s].metadata.serial-port-enable should be set to false or undefined", [name]),
 		"keyActualValue": sprintf("google_compute_project_metadata[%s].metadata.serial-port-enable is true", [name]),
 	}
 }
@@ -48,7 +48,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(metadata, name),
 		"searchKey": sprintf("google_compute_project_metadata_item[%s].value", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("google_compute_project_metadata[%s].value is false", [name]),
+		"keyExpectedValue": sprintf("google_compute_project_metadata[%s].value should be set to false", [name]),
 		"keyActualValue": sprintf("google_compute_project_metadata[%s].value is true", [name]),
 	}
 }

--- a/assets/queries/terraform/github/github_organization_webhook_with_ssl_disabled/query.rego
+++ b/assets/queries/terraform/github/github_organization_webhook_with_ssl_disabled/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(webhook, name),
 		"searchKey": sprintf("github_organization_webhook[%s].configuration.insecure_ssl", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("github_organization_webhook[%s].configuration.insecure_ssl is false", [name]),
+		"keyExpectedValue": sprintf("github_organization_webhook[%s].configuration.insecure_ssl should be set to false", [name]),
 		"keyActualValue": sprintf("github_organization_webhook[%s].configuration.insecure_ssl is true", [name]),
 	}
 }

--- a/assets/queries/terraform/kubernetes/psp_allows_containers_to_share_the_host_network_namespace/query.rego
+++ b/assets/queries/terraform/kubernetes/psp_allows_containers_to_share_the_host_network_namespace/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(resource, name),
 		"searchKey": sprintf("kubernetes_pod_security_policy[%s].spec.host_network", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'spec.hostNetwork' is false or undefined",
+		"keyExpectedValue": "'spec.hostNetwork' should be set to false or undefined",
 		"keyActualValue": "'spec.hostNetwork' is true",
 	}
 }

--- a/test/fixtures/tc-sim01/query.rego
+++ b/test/fixtures/tc-sim01/query.rego
@@ -27,7 +27,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("aws_redshift_cluster[%s].publicly_accessible", [name]),
 		"issueType": "IncorrectValue",
 		# change
-		"keyExpectedValue": "aws_redshift_cluster.publicly_accessible is false",
+		"keyExpectedValue": "aws_redshift_cluster.publicly_accessible should be set to false",
 		"keyActualValue": "aws_redshift_cluster.publicly_accessible is true",
 	}
 }

--- a/test/fixtures/tc-sim03/query.rego
+++ b/test/fixtures/tc-sim03/query.rego
@@ -31,7 +31,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("aws_redshift_cluster[%s].publicly_accessible", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "aws_redshift_cluster.publicly_accessible is false",
+		"keyExpectedValue": "aws_redshift_cluster.publicly_accessible should be set to false",
 		"keyActualValue": "aws_redshift_cluster.publicly_accessible is true",
 	}
 }


### PR DESCRIPTION
I propose changing the "keyExpectedValue" field to be more of a recommendation than what it sounds like today as the current status.

I will open some more PRs like this, covering most of the queries.
Closes #

**Proposed Changes**
-
-
-

I submit this contribution under the Apache-2.0 license.
