### PR TITLE
chore(gitlab-ci): add --ci flag to gitlab examples

### DIFF
--- a/examples/gitlab/KICS.gitlabci.yaml
+++ b/examples/gitlab/KICS.gitlabci.yaml
@@ -8,7 +8,7 @@ stages:
 kics-scan:
   stage: kics
   script:
-    - kics scan -q /app/bin/assets/queries -p ${PWD} --ignore-on-exit all --report-formats glsast -o ${PWD} --output-name kics-results
+    - kics scan -q /app/bin/assets/queries -p ${PWD} --ignore-on-exit all --report-formats glsast -o ${PWD} --output-name kics-results --ci
   artifacts:
     reports:
       sast: gl-sast-kics-results.json

--- a/examples/gitlab/KICS.v3.gitlabci.yaml
+++ b/examples/gitlab/KICS.v3.gitlabci.yaml
@@ -14,7 +14,7 @@ stages:
 kics-scan:
   stage: kics
   script:
-    - kics scan -q /app/bin/assets/queries -p ${PWD} --ignore-on-exit all --report-formats glsast -o ${PWD} --output-name kics-results
+    - kics scan -q /app/bin/assets/queries -p ${PWD} --ignore-on-exit all --report-formats glsast -o ${PWD} --output-name kics-results --ci
   artifacts:
     reports:
       sast: gl-sast-kics-results.json


### PR DESCRIPTION
**Proposed Changes**
- add --ci flag to gitlab examples

using the example unnecessarily spams the gitlab output and makes it uncomfortable to work with it. especially results of long lasting scans are hard to read.

I submit this contribution under the Apache-2.0 license.
