### PR TITLE
fix(tf parser): added parentheses expr to convertStringPart

### DIFF
--- a/pkg/parser/terraform/converter/default.go
+++ b/pkg/parser/terraform/converter/default.go
@@ -365,6 +365,8 @@ func (c *converter) convertStringPart(expr hclsyntax.Expression) (string, error)
 		return c.convertTemplateConditional(v)
 	case *hclsyntax.TemplateJoinExpr:
 		return c.convertTemplateFor(v.Tuple.(*hclsyntax.ForExpr))
+	case *hclsyntax.ParenthesesExpr:
+		return c.convertStringPart(v.Expression)
 	default:
 		// try to evaluate with variables
 		valueConverted, _ := expr.Value(&hcl.EvalContext{

--- a/pkg/parser/terraform/terraform_test.go
+++ b/pkg/parser/terraform/terraform_test.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -121,7 +120,6 @@ func Test_Parentheses_Expr(t *testing.T) {
 	parser := NewDefault()
 	getInputVariables(filepath.FromSlash("../../../test/fixtures/test-tf-parentheses"))
 	document, _, err := parser.Parse("parentheses.tf", []byte(parentheses))
-	fmt.Println(document)
 	require.NoError(t, err)
 	require.Len(t, document, 1)
 	require.Contains(t, document[0], "data")

--- a/test/fixtures/test-tf-parentheses/parenteses.tf
+++ b/test/fixtures/test-tf-parentheses/parenteses.tf
@@ -1,0 +1,15 @@
+variable "default" {
+    type    = "string"
+    default = "default_var_file"
+}
+
+data "aws_ami" "example" {
+	most_recent = true
+  
+	owners = ["self"]
+	tags = {
+	  Name   = "app-server"
+	  Tested = "true"
+	  ("Tag/${var.default}") = "test"
+	}
+}


### PR DESCRIPTION
Closes #5605

**Proposed Changes**
- added parentheses expr to convertStringPart

I submit this contribution under the Apache-2.0 license.
