### PR TITLE
fix(query): improve RegEx rule in curl_or_wget_instead_of_add

### DIFF
--- a/assets/queries/dockerfile/curl_or_wget_instead_of_add/metadata.json
+++ b/assets/queries/dockerfile/curl_or_wget_instead_of_add/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Curl or Wget Instead of Add",
   "severity": "LOW",
   "category": "Best Practices",
-  "descriptionText": "Use Curl or Wget instead of Add to fetch packages from remote URLs, because using Add is strongly discouraged",
+  "descriptionText": "Use of Curl or Wget should be done instead of Add to fetch packages from remote URLs due to the use of Add being strongly discouraged",
   "descriptionUrl": "https://docs.docker.com/develop/develop-images/dockerfile_best-practices/",
   "platform": "Dockerfile",
   "descriptionID": "29e8216b"

--- a/assets/queries/dockerfile/curl_or_wget_instead_of_add/query.rego
+++ b/assets/queries/dockerfile/curl_or_wget_instead_of_add/query.rego
@@ -9,11 +9,11 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("Use 'curl' or 'wget' to download %s", [resource.Value[0]]),
+		"keyExpectedValue": sprintf("Should use 'curl' or 'wget' to download %s", [resource.Value[0]]),
 		"keyActualValue": sprintf("'ADD' %s", [resource.Value[0]]),
 	}
 }
 
 httpRequestChecker(cmdValue) {
-	regex.match("https?", cmdValue[_])
+	regex.match("https?://", cmdValue[_])
 }

--- a/assets/queries/dockerfile/curl_or_wget_instead_of_add/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/curl_or_wget_instead_of_add/test/negative2.dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:10-jdk
+ADD ./drop-http-proxy-header.conf /etc/apache2/conf-available
+RUN mkdir -p /usr/src/things \
+    && curl -SL https://example.com/big.tar.xz \
+    | tar -xJC /usr/src/things \
+    && make -C /usr/src/things all


### PR DESCRIPTION
Closes #5699 

**Proposed Changes**
- improve RegEx to check `://` in http/https check inside query

I submit this contribution under the Apache-2.0 license.
