### PR TITLE
fix(bug): add version to gcompat in kics dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN wget https://releases.hashicorp.com/terraform/1.2.3/terraform_1.2.3_linux_am
 RUN wget https://github.com/GoogleCloudPlatform/terraformer/releases/download/0.8.21/terraformer-all-linux-amd64 \
     && chmod +x terraformer-all-linux-amd64 \
     && mv terraformer-all-linux-amd64 /usr/bin/terraformer \
-    && apk add gcompat --no-cache
+    && apk add gcompat=1.0.0-r4 --no-cache
 
 
 # Copy built binary to the runtime container


### PR DESCRIPTION
**Proposed Changes**
- Add version pining to KICS DockerFIle gcompat package

I submit this contribution under the Apache-2.0 license.
