### PR TITLE
update(docs): improve information in  the configuration docs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -66,6 +66,7 @@ Flags:
       --exclude-severities strings    exclude results by providing the severity of a result
                                       can be provided multiple times or as a comma separated string
                                       example: 'info,low'
+                                      possible values: 'high, medium, low, info, trace'
       --fail-on strings               which kind of results should return an exit code different from 0
                                       accepts: high, medium, low and info
                                       example: "high,low" (default [high,medium,low,info])

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -2,7 +2,9 @@
 
 KICS allow you to provide all configurations either as command line arguments or as code.
 
-Here is a Configuration file example:
+  > 📝 &nbsp; flags that can receive multiple values can be either provided as a comma separated string or an array as in the example above
+
+## Examples
 
 ```JSON
 {
@@ -35,7 +37,6 @@ exclude-paths:
 output-path: "results"
 ```
 
-> 📝 &nbsp; flags that can receive multiple values can be either provided as a comma separated string or an array as in the example above
 
 ---
 

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -1,6 +1,6 @@
 ## Configuration File
 
-KICS allow you to provide all configurations either as command line arguments or as code.
+KICS allow you to provide all configurations either as command line arguments or as code. You can see all possible configurations in the [CLI](commands.md#Scan-Command-Options).
 
 KICS supports JSON, TOML, YAML, and HCL formats for the configuration files, and it is able to infer the format without the need of file extension.
 

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -95,26 +95,26 @@ exclude-categories: "exclude categories by providing its name"
 exclude-paths: "exclude paths or files from scan"
 exclude-queries: "exclude queries by providing the query ID"
 exclude-results: "exclude results by providing a list of similarity IDs of a result"
-exclude-severities: "exclude results by providing the severity of a result"
-libraries-path: "path to directory with libraries (default "./assets/libraries")"
+exclude-severities: [] "Exclude results by providing a list of severities you want to exclude. Possible values: high, medium, low, info, trace."
+libraries-path: ./assets/libraries "path to directory with libraries"
 log-file: true
-log-level: INFO
+log-level: INFO "Possible values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL."
 log-path: path to the log file
 minimal-ui: false
 no-color: false
 no-progress: false
-output-name: "name used on report creations (default \"results\")"
+output-name: results "name used on report creations"
 output-path: "directory path to store reports"
 path: "path to file or directory to scan"
 payload-path: "file path to store source internal representation in JSON format"
 preview-lines: 3
 profiling: "enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)"
-queries-path: "path to directory with queries (default ./assets/queries) (default './assets/queries')"
-report-formats: "formats in which the results will be exported (all, asff, codeclimate, csv, cyclonedx, glsast, html, json, junit, pdf, sarif, sonarqube) (default [json])"
+queries-path: "./assets/queries" "path to directory with queries"
+report-formats: [json] "formats in which the results will be exported (all, asff, codeclimate, csv, cyclonedx, glsast, html, json, junit, pdf, sarif, sonarqube)"
 silent: false
-type: "type of queries to use in the scan"
+type: "type of queries to use in the scan" ???
 timeout: "number of seconds the query has to execute before being canceled"
-verbose: true
+verbose: true ???
 disable-full-descriptions: "disable request for full descriptions and use default vulnerability descriptions"
 ```
 

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -1,8 +1,9 @@
 ## Configuration File
 
-KICS allow you to provide all configurations either as command line arguments or as code. You can see all possible configurations in the [CLI](commands.md#Scan-Command-Options).
+KICS allow you to provide all configurations either as command line arguments or as code. You can see all possible configurations in the [CLI](commands.md#scan-command-options).
+You can disable scanning in certain parts of file using inline comments. More can be found in [Running KICS](running-kics.md#using-commands-on-scanned-files-as-comments) section.
 
-KICS supports JSON, TOML, YAML, and HCL formats for the configuration files, and it is able to infer the format without the need of file extension.
+KICS supports JSON, TOML, YAML, and HCL formats for the configuration files, and it is able to infer the formats without the need of file extension.
 
   > 📝 &nbsp; flags that can receive multiple values can be either provided as a comma separated string or an array as in the example above
 

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -49,69 +49,6 @@ output-path: "results"
 
 
 
-## Templates
-
-#### JSON Format
-
-```JSON
-{
-  "exclude-categories": "exclude categories by providing its name",
-  "exclude-paths": "exclude paths or files from scan",
-  "exclude-queries": "exclude queries by providing the query ID",
-  "exclude-results": "exclude results by providing a list of similarity IDs of a result",
-  "exclude-severities": "exclude results by providing the severity of a result",
-  "libraries-path": "path to directory with libraries (default \"./assets/libraries\")",
-  "log-file": true,
-  "log-level": "INFO",
-  "log-path": "path to the log file",
-  "silent": false,
-  "minimal-ui": false,
-  "no-color": false,
-  "no-progress": false,
-  "output-name": "name used on report creations (default \"results\")",
-  "output-path": "directory path to store reports",
-  "path": "path to file or directory to scan",
-  "payload-path": "file path to store source internal representation in JSON format",
-  "preview-lines": 3,
-  "queries-path": "path to directory with queries (default ./assets/queries) (default './assets/queries')",
-  "report-formats": "formats in which the results will be exported (all, asff, codeclimate, csv, cyclonedx, glsast, html, json, junit, pdf, sarif, sonarqube) (default [json])",
-  "type": "type of queries to use in the scan",
-  "timeout": "number of seconds the query has to execute before being canceled",
-  "verbose": true,
-  "profiling": "enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)",
-  "disable-full-descriptions": "disable request for full descriptions and use default vulnerability descriptions"
-}
-```
-
-#### YAML Format
-
-```YAML
-exclude-categories: "exclude categories by providing its name"
-exclude-paths: "exclude paths or files from scan"
-exclude-queries: "exclude queries by providing the query ID"
-exclude-results: "exclude results by providing a list of similarity IDs of a result"
-exclude-severities: [] "Exclude results by providing a list of severities you want to exclude. Possible values: high, medium, low, info, trace."
-libraries-path: ./assets/libraries "path to directory with libraries"
-log-file: true
-log-level: INFO "Possible values: TRACE, DEBUG, INFO, WARN, ERROR, FATAL."
-log-path: path to the log file
-minimal-ui: false
-no-color: false
-no-progress: false
-output-name: results "name used on report creations"
-output-path: "directory path to store reports"
-path: "path to file or directory to scan"
-payload-path: "file path to store source internal representation in JSON format"
-preview-lines: 3
-profiling: "enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)"
-queries-path: "./assets/queries" "path to directory with queries"
-report-formats: [json] "formats in which the results will be exported (all, asff, codeclimate, csv, cyclonedx, glsast, html, json, junit, pdf, sarif, sonarqube)"
-silent: false
-type: "type of queries to use in the scan" ???
-timeout: "number of seconds the query has to execute before being canceled"
-verbose: true ???
-disable-full-descriptions: "disable request for full descriptions and use default vulnerability descriptions"
-```
 
 #### TOML Format
 

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -53,40 +53,16 @@ exclude-paths = [ "foo/", "bar/" ]
 output-path = "results"
 ```
 
----
-
-
-## Examples
-
-
-#### HCL Format
+#### HCL
 
 ```hcl
-"exclude-categories" = "exclude categories by providing its name"
-"exclude-paths" = "exclude paths or files from scan"
-"exclude-queries" = "exclude queries by providing the query ID"
-"exclude-results" = "exclude results by providing a list of similarity IDs of a result"
-"exclude-severities" = "exclude results by providing the severity of a result"
-"libraries-path" = "path to directory with libraries (default \"./assets/libraries\")"
-"log-file" = true
-"log-level" = "INFO"
-"log-path" = "path to the log file"
-"minimal-ui" = false
-"no-color" = false
-"no-progress" = false
-"output-name" = "name used on report creations (default \"results\")"
-"output-path" = "directory path to store reports"
-"path" = "path to file or directory to scan"
-"payload-path" = "file path to store source internal representation in JSON format"
-"preview-lines" = 3
-"profiling" = "enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)"
-"queries-path" = "path to directory with queries (default ./assets/queries) (default './assets/queries')"
-"report-formats" = "formats in which the results will be exported (all, asff, codeclimate, csv, cyclonedx, glsast, html, json, junit, pdf, sarif, sonarqube) (default [json])"
-"silent" = false
-"type" = "type of queries to use in the scan"
-"timeout" = "number of seconds the query has to execute before being canceled"
+"path" = "assets/iac_samples"
 "verbose" = true
-"disable-full-descriptions" = "disable request for full descriptions and use default vulnerability descriptions"
+"log-file" = true
+"type" = "Dockerfile,Kubernetes"
+"queries-path" = "assets/queries"
+"exclude-paths" = ["foo/", "bar/"]
+"output-path" = "results"
 ```
 
 ---

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -7,6 +7,7 @@ KICS supports JSON, TOML, YAML, and HCL formats for the configuration files, and
   > 📝 &nbsp; flags that can receive multiple values can be either provided as a comma separated string or an array as in the example above
 
 ## Examples
+#### JSON
 
 ```JSON
 {
@@ -23,6 +24,7 @@ KICS supports JSON, TOML, YAML, and HCL formats for the configuration files, and
 }
 ```
 
+#### YAML
 The same example now in YAML format passing `type` as an array of strings:
 
 ```YAML
@@ -39,46 +41,23 @@ exclude-paths:
 output-path: "results"
 ```
 
+#### TOML
+
+```TOML
+path = "assets/iac_samples"
+verbose = true
+log-file = true
+type = "Dockerfile,Kubernetes"
+queries-path = "assets/queries"
+exclude-paths = [ "foo/", "bar/" ]
+output-path = "results"
+```
 
 ---
 
 
 ## Examples
 
-
-
-
-
-
-#### TOML Format
-
-```TOML
-exclude-categories = "exclude categories by providing its name"
-exclude-paths = "exclude paths or files from scan"
-exclude-queries = "exclude queries by providing the query ID"
-exclude-results = "exclude results by providing a list of similarity IDs of a result"
-exclude-severities = "exclude results by providing the severity of a result"
-libraries-path = "path to directory with libraries (default \"./assets/libraries\")"
-log-file = true
-log-level = "INFO"
-log-path = "path to the log file"
-minimal-ui = false
-no-color = false
-no-progress = false
-output-name = "name used on report creations (default \"results\")"
-output-path = "directory path to store reports"
-path = "path to file or directory to scan"
-payload-path = "file path to store source internal representation in JSON format"
-preview-lines = 3
-profiling = "enables performance profiler that prints resource consumption metrics in the logs during the execution (CPU, MEM)"
-queries-path = "path to directory with queries (default ./assets/queries) (default './assets/queries')"
-report-formats = "formats in which the results will be exported (all, asff, codeclimate, csv, cyclonedx, glsast, html, json, junit, pdf, sarif, sonarqube) (default [json])"
-silent = false
-type = "type of queries to use in the scan"
-timeout = "number of seconds the query has to execute before being canceled"
-verbose = true
-disable-full-descriptions = "disable request for full descriptions and use default vulnerability descriptions"
-```
 
 #### HCL Format
 

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -2,6 +2,8 @@
 
 KICS allow you to provide all configurations either as command line arguments or as code.
 
+KICS supports JSON, TOML, YAML, and HCL formats for the configuration files, and it is able to infer the format without the need of file extension.
+
   > 📝 &nbsp; flags that can receive multiple values can be either provided as a comma separated string or an array as in the example above
 
 ## Examples
@@ -40,20 +42,12 @@ output-path: "results"
 
 ---
 
-## Supported Formats
 
-KICS supports the following formats for the configuration files.
+## Examples
 
--   JSON
--   TOML
--   YAML
--   HCL
 
-Notice that format is about the content and not the file extension.
 
-KICS is able to infer the format without the need of file extension.
 
----
 
 ## Templates
 


### PR DESCRIPTION
**Proposed Changes**
- Docs suggestions. When I was trying to setup docs, I had to use the online docs, and finding out anything was an awful pain especially because I had to search through the code.


I did not create an issue first because having something concrete to comment about is faster than explaining my suggestions, and then implementing them. The PR is of course not final, I would like to first know you thoughts, improvements, and I have a few questions. When all is done, I would adjust the JSON, TOML etc. parts as well.


Questions:
- Why is the section "Using commands on scanned files as comments" in "Running KICS" rather than configuration section?
- Does `verbse` flag work? When we set it `verbose=false` there was no difference with `verbose=true` that we could see.
- `type: "type of queries to use in the scan"` does that require list of queries?


I submit this contribution under the Apache-2.0 license.
