### PR TITLE
fix(query): remove string check in open api security query

### DIFF
--- a/assets/queries/openAPI/general/invalid_format/metadata.json
+++ b/assets/queries/openAPI/general/invalid_format/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Invalid Format (v3)",
   "severity": "LOW",
   "category": "Insecure Configurations",
-  "descriptionText": "The format should be valid for the type defined. For integer type must be int32 or int64, number type must be float or double, and for string type must be date, date-time, password, byte, binary, email, uuid, uri, hostname, ipv4 or ipv6",
+  "descriptionText": "The format should be valid for the type defined. For integer type must be int32 or int64 and number type must be float or double",
   "descriptionUrl": "https://swagger.io/docs/specification/data-models/data-types/",
   "platform": "OpenAPI",
   "override": {

--- a/assets/queries/openAPI/general/invalid_format/query.rego
+++ b/assets/queries/openAPI/general/invalid_format/query.rego
@@ -13,7 +13,6 @@ CxPolicy[result] {
 	correctTypes := {
 		"number": "float or double",
 		"integer": "int32 or int64",
-		"string": "'date', 'date-time', 'password', 'byte', 'binary', 'email', 'uuid', 'uri', 'hostname', 'ipv4' or 'ipv6'",
 	}
 
 	result := {
@@ -33,9 +32,5 @@ is_format_valid(type, format) {
 } else {
 	type == "integer"
 	validFormats := {"int32", "int64"}
-	count({format} - validFormats) > 0
-} else {
-	type == "string"
-	validFormats := {"date", "date-time", "password", "byte", "binary", "email", "uuid", "uri", "hostname", "ipv4", "ipv6"}
 	count({format} - validFormats) > 0
 }

--- a/assets/queries/openAPI/general/invalid_format/test/positive_expected_result.json
+++ b/assets/queries/openAPI/general/invalid_format/test/positive_expected_result.json
@@ -38,32 +38,8 @@
   {
     "queryName": "Invalid Format (v2)",
     "severity": "LOW",
-    "line": 34,
-    "filename": "positive3.json"
-  },
-  {
-    "queryName": "Invalid Format (v2)",
-    "severity": "LOW",
-    "line": 56,
-    "filename": "positive3.json"
-  },
-  {
-    "queryName": "Invalid Format (v2)",
-    "severity": "LOW",
     "line": 42,
     "filename": "positive3.json"
-  },
-  {
-    "queryName": "Invalid Format (v2)",
-    "severity": "LOW",
-    "line": 27,
-    "filename": "positive4.yaml"
-  },
-  {
-    "queryName": "Invalid Format (v2)",
-    "severity": "LOW",
-    "line": 40,
-    "filename": "positive4.yaml"
   },
   {
     "queryName": "Invalid Format (v2)",


### PR DESCRIPTION
Closes #5747 

**Proposed Changes**
- remove string format check for security query "Invalid Format"

I submit this contribution under the Apache-2.0 license.
