### PR TITLE
fix(query): updated lambda_function_with_privileged_role

### DIFF
--- a/assets/libraries/terraform.rego
+++ b/assets/libraries/terraform.rego
@@ -441,13 +441,14 @@ uses_aws_managed_key(key, awsManagedKey) {
 
 getStatement(policy) = st {
 	is_array(policy.Statement)
-	st = policy.Statement[_]
+	st = policy.Statement
 } else = st {
-	st := policy.Statement
+	st := [policy.Statement]
 }
 
 is_publicly_accessible(policy) {
-	statement := getStatement(policy)
+	statements := getStatement(policy)
+	statement:= statements[_]
 	statement.Effect == "Allow"
 	anyPrincipal(statement)
 }

--- a/assets/queries/terraform/aws/lambda_function_with_privileged_role/metadata.json
+++ b/assets/queries/terraform/aws/lambda_function_with_privileged_role/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "1b3af2f9-af8c-4dfc-a0f1-a03adb70deb2",
-  "queryName": "Lambda Function With Privileged role",
+  "queryName": "Lambda Function With Privileged Role",
   "severity": "HIGH",
   "category": "Insecure Configurations",
   "descriptionText": "It is not advisable for AWS Lambda Functions to have privileged permissions.",

--- a/assets/queries/terraform/aws/lambda_function_with_privileged_role/test/positive.tf
+++ b/assets/queries/terraform/aws/lambda_function_with_privileged_role/test/positive.tf
@@ -120,6 +120,13 @@ resource "aws_iam_policy" "positivecustomermanagedpolicy1" {
       ],
       "Effect": "Allow",
       "Resource": "*"
+    },
+    {
+      "Action": [
+        "iam:CreateLoginProfile"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
     }
   ]
 }

--- a/assets/queries/terraform/aws/lambda_function_with_privileged_role/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/lambda_function_with_privileged_role/test/positive_expected_result.json
@@ -1,22 +1,32 @@
 [
   {
-    "queryName": "Lambda Function With Privileged role",
+    "queryName": "Lambda Function With Privileged Role",
     "severity": "HIGH",
-    "line": 4
+    "line": 4,
+    "fileName": "positive.tf"
   },
   {
-    "queryName": "Lambda Function With Privileged role",
+    "queryName": "Lambda Function With Privileged Role",
     "severity": "HIGH",
-    "line": 4
+    "line": 4,
+    "fileName": "positive.tf"
   },
   {
-    "queryName": "Lambda Function With Privileged role",
+    "queryName": "Lambda Function With Privileged Role",
     "severity": "HIGH",
-    "line": 4
+    "line": 4,
+    "fileName": "positive.tf"
   },
   {
-    "queryName": "Lambda Function With Privileged role",
+    "queryName": "Lambda Function With Privileged Role",
     "severity": "HIGH",
-    "line": 23
+    "line": 4,
+    "fileName": "positive.tf"
+  },
+  {
+    "queryName": "Lambda Function With Privileged Role",
+    "severity": "HIGH",
+    "line": 23,
+    "fileName": "positive.tf"
   }
 ]


### PR DESCRIPTION
**Proposed Changes**
- lambda_function_with_privileged_role was failing with 'multiple outputs for same input' when the policy had multiple statements

I submit this contribution under the Apache-2.0 license.
