### PR TITLE
fix(query): fix responses with wrong http status code security query

### DIFF
--- a/assets/queries/openAPI/general/responses_wrong_http_status_code/query.rego
+++ b/assets/queries/openAPI/general/responses_wrong_http_status_code/query.rego
@@ -36,4 +36,5 @@ check_status_code(code) {
 
 check_status_code(code) {
 	count(code) != 3
+	code != "default"
 }

--- a/assets/queries/openAPI/general/responses_wrong_http_status_code/test/negative2.yaml
+++ b/assets/queries/openAPI/general/responses_wrong_http_status_code/test/negative2.yaml
@@ -36,3 +36,10 @@ paths:
                         links:
                           - href: http://127.0.0.1:8774/v2/
                             rel: self
+         # Definition of all error statuses
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'


### PR DESCRIPTION
Closes #5805 

**Proposed Changes**
- responses with wrong http status code
I submit this contribution under the Apache-2.0 license.
