### PR TITLE
gh action tag update for 1.6 kics version

### DIFF
--- a/.github/workflows/release-docker-github-actions.yaml
+++ b/.github/workflows/release-docker-github-actions.yaml
@@ -39,7 +39,7 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: checkmarx/kics:gh-action
+          tags: checkmarx/kics:gh-action-kics1.6
           build-args: |
             VERSION=${{ github.event.inputs.version }}
             COMMIT=${{ github.sha }}


### PR DESCRIPTION
**Proposed Changes**
- Tag update for the 1.6 KICS version

I submit this contribution under the Apache-2.0 license.
