### PR TITLE
fix(query): correct GCP KMS crypto key rotation period queries + descriptions

### DIFF
--- a/assets/queries/ansible/gcp/high_google_kms_crypto_key_rotation_period/metadata.json
+++ b/assets/queries/ansible/gcp/high_google_kms_crypto_key_rotation_period/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "High Google KMS Crypto Key Rotation Period",
   "severity": "MEDIUM",
   "category": "Secret Management",
-  "descriptionText": "Encryption keys should be changed after 90 days",
+  "descriptionText": "KMS encryption keys should be rotated every 90 days or less. A short lifetime of encryption keys reduces the potential blast radius in case of compromise.",
   "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_kms_crypto_key_module.html",
   "platform": "Ansible",
   "descriptionID": "9072f426",

--- a/assets/queries/ansible/gcp/high_google_kms_crypto_key_rotation_period/query.rego
+++ b/assets/queries/ansible/gcp/high_google_kms_crypto_key_rotation_period/query.rego
@@ -18,8 +18,8 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "gcp_kms_key_ring.rotation_period should be defined",
-		"keyActualValue": "gcp_kms_key_ring.rotation_period is undefined",
+		"keyExpectedValue": "gcp_kms_crypto_key.rotation_period should be defined with a value less or equal to 7776000",
+		"keyActualValue": "gcp_kms_crypto_key.rotation_period is undefined",
 	}
 }
 
@@ -28,8 +28,8 @@ CxPolicy[result] {
 	gcpTopic := task[modules[m]]
 	ansLib.checkState(gcpTopic)
 
-	rotationP := substring(gcpTopic.rotation_period, 0, count(gcpTopic.rotation_period) - 1)
-	to_number(rotationP) < 7776000
+	rotationPeriod := substring(gcpTopic.rotation_period, 0, count(gcpTopic.rotation_period) - 1)
+	to_number(rotationPeriod) > 7776000
 
 	result := {
 		"documentId": id,
@@ -37,7 +37,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.rotation_period", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "gcp_kms_key_ring.rotation_period should be >= 7776000",
-		"keyActualValue": "gcp_kms_key_ring.rotation_period is < 7776000",
+		"keyExpectedValue": "gcp_kms_crypto_key.rotation_period should be less or equal to 7776000",
+		"keyActualValue": "gcp_kms_crypto_key.rotation_period exceeds 7776000",
 	}
 }

--- a/assets/queries/ansible/gcp/high_google_kms_crypto_key_rotation_period/test/negative.yaml
+++ b/assets/queries/ansible/gcp/high_google_kms_crypto_key_rotation_period/test/negative.yaml
@@ -14,6 +14,6 @@
     key_ring: projects/{{ gcp_project }}/locations/us-central1/keyRings/key-key-ring
     project: test_project
     auth_kind: serviceaccount
-    rotation_period: 10000000s
+    rotation_period: 7776000s
     service_account_file: /tmp/auth.pem
     state: present

--- a/assets/queries/ansible/gcp/high_google_kms_crypto_key_rotation_period/test/positive.yaml
+++ b/assets/queries/ansible/gcp/high_google_kms_crypto_key_rotation_period/test/positive.yaml
@@ -15,7 +15,7 @@
     key_ring: projects/{{ gcp_project }}/locations/us-central1/keyRings/key-key-ring
     project: test_project
     auth_kind: serviceaccount
-    rotation_period: "100000s"
+    rotation_period: "315356000s"
     service_account_file: "/tmp/auth.pem"
     state: present
 

--- a/assets/queries/terraform/gcp/high_google_kms_crypto_key_rotation_period/metadata.json
+++ b/assets/queries/terraform/gcp/high_google_kms_crypto_key_rotation_period/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "High Google KMS Crypto Key Rotation Period",
   "severity": "MEDIUM",
   "category": "Secret Management",
-  "descriptionText": "Encryption keys should be changed after 90 days",
+  "descriptionText": "KMS encryption keys should be rotated every 90 days or less. A short lifetime of encryption keys reduces the potential blast radius in case of compromise.",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key",
   "platform": "Terraform",
   "descriptionID": "d43302d0",

--- a/assets/queries/terraform/gcp/high_google_kms_crypto_key_rotation_period/query.rego
+++ b/assets/queries/terraform/gcp/high_google_kms_crypto_key_rotation_period/query.rego
@@ -5,20 +5,20 @@ import data.generic.terraform as tf_lib
 
 CxPolicy[result] {
 	cryptoKey := input.document[i].resource.google_kms_crypto_key[name]
-	rotationP := substring(cryptoKey.rotation_period, 0, count(cryptoKey.rotation_period) - 1)
-	to_number(rotationP) > 7776000
+	rotationPeriod := substring(cryptoKey.rotation_period, 0, count(cryptoKey.rotation_period) - 1)
+	to_number(rotationPeriod) > 7776000
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "google_kms_crypto_key",
 		"resourceName": tf_lib.get_resource_name(cryptoKey, name),
-		"searchKey": sprintf("resource.google_kms_crypto_key[%s].rotation_period", [name]),
+		"searchKey": sprintf("google_kms_crypto_key[%s].rotation_period", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'google_kms_crypto_key.rotation_period' is less or equal to 7776000",
-		"keyActualValue": "'google_kms_crypto_key.rotation_period' is higher than 7776000",
+		"keyExpectedValue": "'google_kms_crypto_key.rotation_period' should be less or equal to 7776000",
+		"keyActualValue": "'google_kms_crypto_key.rotation_period' exceeds 7776000",
 		"searchLine": common_lib.build_search_line(["resource", "google_kms_crypto_key", name, "rotation_period"], []),
 		"remediation": json.marshal({
-			"before": sprintf("%s", [rotationP]) ,
+			"before": sprintf("%s", [rotationPeriod]) ,
 			"after": "100000"
 		}),
 		"remediationType": "replacement",
@@ -34,9 +34,9 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"resourceType": "google_kms_crypto_key",
 		"resourceName": tf_lib.get_resource_name(cryptoKey, name),
-		"searchKey": sprintf("resource.google_kms_crypto_key[%s]", [name]),
+		"searchKey": sprintf("google_kms_crypto_key[%s]", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": "'google_kms_crypto_key.rotation_period' is set",
+		"keyExpectedValue": "'google_kms_crypto_key.rotation_period' should be defined with a value less or equal to 7776000",
 		"keyActualValue": "'google_kms_crypto_key.rotation_period' is undefined",
 		"searchLine": common_lib.build_search_line(["resource", "google_kms_crypto_key", name], []),
 		"remediation": "rotation_period = \"100000s\"",


### PR DESCRIPTION
**Problem**

- The same query differs for Ansible and TF queries regarding the checked criteria: > 7776000, < 7776000
- The Ansible testcase is wrong as it checks the opposite

**Proposed Changes**

- Streamline both queries
- Extend description to include reasoning

I submit this contribution under the Apache-2.0 license.
