### PR TITLE
fix(query): cover additional deprecated API versions in k8s rule

### DIFF
--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/metadata.json
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/metadata.json
@@ -2,9 +2,9 @@
   "id": "94b76ea5-e074-4ca2-8a03-c5a606e30645",
   "queryName": "Object Is Using A Deprecated API Version",
   "severity": "HIGH",
-  "category": "Insecure Configurations",
-  "descriptionText": "Check if any objects are using a deprecated version of API.",
-  "descriptionUrl": "https://kubernetes.io/docs/reference/using-api/deprecation-policy/",
+  "category": "Best Practices",
+  "descriptionText": "Kubernetes APIs evolve over time and are sometimes removed with newer releases. To prevent incompatibilities when upgrading Kubernetes, deprecated APIs should be replaced with newer and more stable API versions.",
+  "descriptionUrl": "https://kubernetes.io/docs/reference/using-api/deprecation-guide/",
   "platform": "Kubernetes",
   "descriptionID": "d5c30c5b"
 }

--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/metadata.json
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "94b76ea5-e074-4ca2-8a03-c5a606e30645",
   "queryName": "Object Is Using A Deprecated API Version",
-  "severity": "HIGH",
+  "severity": "LOW",
   "category": "Best Practices",
   "descriptionText": "Kubernetes APIs evolve over time and are sometimes removed with newer releases. To prevent incompatibilities when upgrading Kubernetes, deprecated APIs should be replaced with newer and more stable API versions.",
   "descriptionUrl": "https://kubernetes.io/docs/reference/using-api/deprecation-guide/",

--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/query.rego
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/query.rego
@@ -35,6 +35,12 @@ CxPolicy[result] {
 			"Role": "rbac.authorization.k8s.io/v1",
 			"RoleBinding": "rbac.authorization.k8s.io/v1",
 		},
+		"batch/v1beta1": {
+			"CronJob": "batch/v1",
+		},
+		"policy/v1beta1": {
+			"PodDisruptionBudget": "policy/v1",
+		}
 	}
 
 	common_lib.valid_key(recommendedVersions[document.apiVersion], document.kind)

--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/positive.yaml
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/positive.yaml
@@ -90,3 +90,23 @@ spec:
             name: test
             port:
               number: 80
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - date; echo Hello from kics
+          restartPolicy: OnFailure

--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/positive_expected_result.json
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/positive_expected_result.json
@@ -1,27 +1,27 @@
 [
 	{
 		"queryName": "Object Is Using A Deprecated API Version",
-		"severity": "HIGH",
+		"severity": "LOW",
 		"line": 1
 	},
 	{
 		"queryName": "Object Is Using A Deprecated API Version",
-		"severity": "HIGH",
+		"severity": "LOW",
 		"line": 23
 	},
 	{
 		"queryName": "Object Is Using A Deprecated API Version",
-		"severity": "HIGH",
+		"severity": "LOW",
 		"line": 58
 	},
 	{
 		"queryName": "Object Is Using A Deprecated API Version",
-		"severity": "HIGH",
+		"severity": "LOW",
 		"line": 76
 	},
 	{
 		"queryName": "Object Is Using A Deprecated API Version",
-		"severity": "HIGH",
+		"severity": "LOW",
 		"line": 94
 	}
 ]

--- a/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/positive_expected_result.json
+++ b/assets/queries/k8s/object_is_using_a_deprecated_api_version/test/positive_expected_result.json
@@ -18,5 +18,10 @@
 		"queryName": "Object Is Using A Deprecated API Version",
 		"severity": "HIGH",
 		"line": 76
+	},
+	{
+		"queryName": "Object Is Using A Deprecated API Version",
+		"severity": "HIGH",
+		"line": 94
 	}
 ]


### PR DESCRIPTION
**Proposed Changes**

- Add more CRD deprecations to the rule (previously mentioned here: https://github.com/Checkmarx/kics/pull/4830#pullrequestreview-881390156)
- Extend description
- Change category to "Best Practices": Using a Kubernetes resource with a deprecated API version is not a security risk, comparable to others in that category (e.g. seccomp profile missing). Newer versions are not "more secure", only less likely to cause problems during K8s upgrades.

I submit this contribution under the Apache-2.0 license.
