### PR TITLE
fix(query): fix false positive for rds backup_retention_period not set

### DIFF
--- a/assets/queries/ansible/aws/rds_with_backup_disabled/query.rego
+++ b/assets/queries/ansible/aws/rds_with_backup_disabled/query.rego
@@ -10,24 +10,6 @@ CxPolicy[result] {
 	instance := task[modules[m]]
 	ansLib.checkState(instance)
 
-	not common_lib.valid_key(instance, "backup_retention_period")
-
-	result := {
-		"documentId": id,
-		"resourceType": modules[m],
-		"resourceName": task.name,
-		"searchKey": sprintf("name={{%s}}.{{%s}}", [task.name, modules[m]]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": "rds_instance should have the property 'backup_retention_period' greater than 0",
-		"keyActualValue": "rds_instance has the property 'backup_retention_period' unassigned",
-	}
-}
-
-CxPolicy[result] {
-	task := ansLib.tasks[id][t]
-	instance := task[modules[m]]
-	ansLib.checkState(instance)
-
 	instance.backup_retention_period == 0
 
 	result := {

--- a/assets/queries/ansible/aws/rds_with_backup_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/rds_with_backup_disabled/test/negative.yaml
@@ -7,3 +7,11 @@
     username: '{{ username }}'
     cluster_id: ansible-test-cluster  # This cluster must exist - see rds_cluster to manage it
     backup_retention_period: 5
+- name: create minimal aurora instance in default VPC and default subnet group2
+  community.aws.rds_instance:
+    engine: aurora
+    db_instance_identifier: ansible-test-aurora-db-instance
+    instance_type: db.t2.small
+    password: '{{ password }}'
+    username: '{{ username }}'
+    cluster_id: ansible-test-cluster  # This cluster must exist - see rds_cluster to manage it

--- a/assets/queries/ansible/aws/rds_with_backup_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/rds_with_backup_disabled/test/positive.yaml
@@ -8,11 +8,3 @@
     username: "{{ username }}"
     cluster_id: ansible-test-cluster  # This cluster must exist - see rds_cluster to manage it
     backup_retention_period: 0
-- name: create minimal aurora instance in default VPC and default subnet group2
-  community.aws.rds_instance:
-    engine: aurora
-    db_instance_identifier: ansible-test-aurora-db-instance
-    instance_type: db.t2.small
-    password: "{{ password }}"
-    username: "{{ username }}"
-    cluster_id: ansible-test-cluster  # This cluster must exist - see rds_cluster to manage it

--- a/assets/queries/ansible/aws/rds_with_backup_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/rds_with_backup_disabled/test/positive_expected_result.json
@@ -3,10 +3,5 @@
     "queryName": "RDS With Backup Disabled",
     "severity": "MEDIUM",
     "line": 10
-  },
-  {
-    "queryName": "RDS With Backup Disabled",
-    "severity": "MEDIUM",
-    "line": 12
   }
 ]

--- a/assets/queries/terraform/aws/rds_with_backup_disabled/query.rego
+++ b/assets/queries/terraform/aws/rds_with_backup_disabled/query.rego
@@ -5,45 +5,6 @@ import data.generic.terraform as tf_lib
 
 CxPolicy[result] {
 	db := input.document[i].resource.aws_db_instance[name]
-
-	not common_lib.valid_key(db, "backup_retention_period")
-
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "aws_db_instance",
-		"resourceName": tf_lib.get_resource_name(db, name),
-		"searchKey": sprintf("aws_db_instance[%s]", [name]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": "'backup_retention_period' exists",
-		"keyActualValue": "'backup_retention_period' is missing",
-		"searchLine": common_lib.build_search_line(["resource", "aws_db_instance", name], []),
-		"remediation": "backup_retention_period = 12",
-		"remediationType": "addition",
-	}
-}
-
-CxPolicy[result] {
-	module := input.document[i].module[name]
-	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_db_instance", "backup_retention_period")
-
-	not common_lib.valid_key(module, keyToCheck)
-
-	result := {
-		"documentId": input.document[i].id,
-		"resourceType": "n/a",
-		"resourceName": "n/a",
-		"searchKey": sprintf("module[%s]", [name]),
-		"issueType": "MissingAttribute",
-		"keyExpectedValue": "'backup_retention_period' exists",
-		"keyActualValue": "'backup_retention_period' is missing",
-		"searchLine": common_lib.build_search_line(["module", name], []),
-		"remediation": sprintf("%s = 12",[keyToCheck]),
-		"remediationType": "addition",
-	}
-}
-
-CxPolicy[result] {
-	db := input.document[i].resource.aws_db_instance[name]
 	db.backup_retention_period == 0
 
 	result := {

--- a/assets/queries/terraform/aws/rds_with_backup_disabled/test/negative3.tf
+++ b/assets/queries/terraform/aws/rds_with_backup_disabled/test/negative3.tf
@@ -1,6 +1,6 @@
 //some comments (used just for resource offset)
 
-resource "aws_db_instance" "positive1" {
+resource "aws_db_instance" "negative1" {
   allocated_storage    = 20
   storage_type         = "gp2"
   engine               = "mysql"
@@ -9,5 +9,4 @@ resource "aws_db_instance" "positive1" {
   name                 = "mydb"
   username             = "foo"
   password             = "foobarbaz"
-  backup_retention_period =  0
 }

--- a/assets/queries/terraform/aws/rds_with_backup_disabled/test/negative4.tf
+++ b/assets/queries/terraform/aws/rds_with_backup_disabled/test/negative4.tf
@@ -9,8 +9,6 @@ module "db" {
   instance_class    = "db.t2.large"
   allocated_storage = 5
   auto_minor_version_upgrade = true
-  backup_retention_period =  0
-
 
   name     = "demodb"
   username = "user"

--- a/assets/queries/terraform/aws/rds_with_backup_disabled/test/positive2.tf
+++ b/assets/queries/terraform/aws/rds_with_backup_disabled/test/positive2.tf
@@ -9,6 +9,8 @@ module "db" {
   instance_class    = "db.t2.large"
   allocated_storage = 5
   auto_minor_version_upgrade = true
+  backup_retention_period =  0
+
 
   name     = "demodb"
   username = "user"

--- a/assets/queries/terraform/aws/rds_with_backup_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/rds_with_backup_disabled/test/positive_expected_result.json
@@ -2,25 +2,13 @@
   {
     "queryName": "RDS With Backup Disabled",
     "severity": "MEDIUM",
-    "line": 16,
-    "fileName": "positive1.tf"
-  },
-  {
-    "queryName": "RDS With Backup Disabled",
-    "severity": "MEDIUM",
     "line": 12,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "RDS With Backup Disabled",
     "severity": "MEDIUM",
-    "line": 1,
+    "line": 12,
     "fileName": "positive2.tf"
-  },
-  {
-    "queryName": "RDS With Backup Disabled",
-    "severity": "MEDIUM",
-    "line": 12,
-    "fileName": "positive3.tf"
   }
 ]


### PR DESCRIPTION
Since the there is a default value for `backup_retention_period`, the query reported a false positive if the field was not set. This has been fixed.

Closes #5882

**Proposed Changes**
- Ignore missing backup_retention_period value for rds_instances

I submit this contribution under the Apache-2.0 license.
