### PR TITLE
fix(query): fix false positive in aws_instance

### DIFF
--- a/assets/queries/terraform/aws/ec2_instance_using_api_keys/query.rego
+++ b/assets/queries/terraform/aws/ec2_instance_using_api_keys/query.rego
@@ -6,7 +6,7 @@ import data.generic.terraform as tf_lib
 aws_cli_config_files = {"/etc/awscli.conf", "/etc/aws/config", "/etc/aws/credentials", "~/.aws/credentials", "~/.aws/config", "$HOME/.aws/credentials", "$HOME/.aws/config"}
 
 check_aws_api_keys(mdata) {
-	regex.find_n(`aws_access_key_id\s*=|AWS_ACCESS_KEY_ID\s*=|aws_secret_access_key\s*=|AWS_SECRET_ACCESS_KEY\s*=`, mdata, -1) > 0
+	count(regex.find_n(`aws_access_key_id\s*=|AWS_ACCESS_KEY_ID\s*=|aws_secret_access_key\s*=|AWS_SECRET_ACCESS_KEY\s*=`, mdata, -1)) > 0
 }
 
 check_aws_api_keys_or_config_files(remote) {

--- a/assets/queries/terraform/aws/ec2_instance_using_api_keys/test/negative3.tf
+++ b/assets/queries/terraform/aws/ec2_instance_using_api_keys/test/negative3.tf
@@ -1,0 +1,75 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_iam_role_policy_attachment" "test_attach" {
+  roles      = [aws_iam_role.test_role.name]
+  policy_arn = aws_iam_policy.test_policy.arn
+}
+
+resource "aws_iam_policy" "test_policy" {
+  name = "test_policy"
+  description = "test policy"
+  path = "/"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Action": [
+              "s3:Get*",
+              "s3:List*"
+          ],
+          "Effect": "Allow",
+          "Resource": "*"
+      }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "test_role"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "test_profile" {
+  name = "test_profile"
+  role = aws_iam_role.role.name
+}
+
+resource "aws_instance" "negative3" {
+  ami           = "ami-005e54dee72cc1d00" # us-west-2
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = "test"
+  }
+
+  iam_instance_profile = aws_iam_instance_profile.test_profile.name
+
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+
+  user_data = <<-EOF
+    #!/bin/bash
+    apt-get update
+  EOF
+}

--- a/assets/queries/terraform/aws/ec2_instance_using_api_keys/test/negative4.tf
+++ b/assets/queries/terraform/aws/ec2_instance_using_api_keys/test/negative4.tf
@@ -1,0 +1,23 @@
+module "ec2_instance" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 3.0"
+
+  name = "single-instance"
+
+  ami                    = "ami-ebd02392"
+  instance_type          = "t2.micro"
+  key_name               = "user1"
+  monitoring             = true
+  vpc_security_group_ids = ["sg-12345678"]
+  subnet_id              = "subnet-eddcdzz4"
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
+
+  user_data = <<-EOF
+    #!/bin/bash
+    apt-get update
+  EOF
+}


### PR DESCRIPTION
Fix user_data in aws_instance reporting false positive, even when API keys are not present in string.

Closes #5890

**Proposed Changes**
- Compare the size of the resulting array instead of the array directly 

I submit this contribution under the Apache-2.0 license.
