### PR TITLE
fix(query): update CloudWatch Log Group Without KMS Security Query MetaData

### DIFF
--- a/assets/queries/terraform/aws/cloudwatch_log_group_not_encrypted/metadata.json
+++ b/assets/queries/terraform/aws/cloudwatch_log_group_not_encrypted/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "0afbcfe9-d341-4b92-a64c-7e6de0543879",
-  "queryName": "CloudWatch Log Group Not Encrypted",
-  "severity": "HIGH",
+  "queryName": "CloudWatch Log Group Without KMS",
+  "severity": "MEDIUM",
   "category": "Encryption",
   "descriptionText": "AWS CloudWatch Log groups should be encrypted using KMS",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group",

--- a/assets/queries/terraform/aws/cloudwatch_log_group_not_encrypted/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_log_group_not_encrypted/test/positive_expected_result.json
@@ -1,7 +1,7 @@
 [
   {
-    "queryName": "CloudWatch Log Group Not Encrypted",
-    "severity": "HIGH",
+    "queryName": "CloudWatch Log Group Without KMS",
+    "severity": "MEDIUM",
     "line": 1
   }
 ]


### PR DESCRIPTION
Closes #5862

**Proposed Changes**
- update query name
- update query severity

I submit this contribution under the Apache-2.0 license.
