### PR TITLE
fix(query): improved regex to find AWS Access Key in assets/queries/terraform/aws/hardcoded_aws_access_key_in_lambda

### DIFF
--- a/assets/queries/terraform/aws/hardcoded_aws_access_key_in_lambda/query.rego
+++ b/assets/queries/terraform/aws/hardcoded_aws_access_key_in_lambda/query.rego
@@ -1,12 +1,13 @@
 package Cx
 
+import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
 
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_lambda_function[name]
 	vars := resource.environment.variables
 
-	containsAccessKey(vars[_])
+	re_match("(A3T[A-Z0-9]|AKIA|ASIA)[A-Z0-9]{16}", vars[idx])
 
 	result := {
 		"documentId": input.document[i].id,
@@ -14,15 +15,8 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(resource, name),
 		"searchKey": sprintf("aws_lambda_function[%s].environment.variables", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'environment.variables' doesn't contain access key",
-		"keyActualValue": "'environment.variables' contains access key",
+		"keyExpectedValue": "'environment.variables' doesn't contain AWS Access Key",
+		"keyActualValue": "'environment.variables' contains AWS Access Key",
+		"searchLine": common_lib.build_search_line(["resource", "aws_lambda_function", name, "environment", "variables", idx], []),
 	}
-}
-
-containsAccessKey(var) {
-	re_match("[A-Za-z0-9/+=]{40}", var)
-}
-
-containsAccessKey(var) {
-	re_match("[A-Z0-9]{20}", var)
 }

--- a/assets/queries/terraform/aws/hardcoded_aws_access_key_in_lambda/test/positive.tf
+++ b/assets/queries/terraform/aws/hardcoded_aws_access_key_in_lambda/test/positive.tf
@@ -33,7 +33,7 @@ resource "aws_lambda_function" "positive2" {
 
   environment {
     variables = {
-      foo = "1234567890123456789012345678901234567890$"
+      foo = "AKIAIOSFODNN7EXAMAAA"
     }
   }
 }
@@ -54,7 +54,7 @@ resource "aws_lambda_function" "positive3" {
 
   environment {
     variables = {
-      foo = "12345678901234567890123456789012345678901234567890123456789012345678901234567890$"
+      foo = "AKIASXANV9XVIJ1YCIJ5"
     }
   }
 }

--- a/assets/queries/terraform/aws/hardcoded_aws_access_key_in_lambda/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/hardcoded_aws_access_key_in_lambda/test/positive_expected_result.json
@@ -2,13 +2,13 @@
   {
     "queryName": "Hardcoded AWS Access Key In Lambda",
     "severity": "MEDIUM",
-    "line": 57,
+    "line": 56,
     "fileName": "positive.tf"
   },
   {
     "queryName": "Hardcoded AWS Access Key In Lambda",
     "severity": "MEDIUM",
-    "line": 36,
+    "line": 35,
     "fileName": "positive.tf"
   }
 ]

--- a/assets/queries/terraform/aws/hardcoded_aws_access_key_in_lambda/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/hardcoded_aws_access_key_in_lambda/test/positive_expected_result.json
@@ -2,11 +2,13 @@
   {
     "queryName": "Hardcoded AWS Access Key In Lambda",
     "severity": "MEDIUM",
-    "line": 56
+    "line": 57,
+    "fileName": "positive.tf"
   },
   {
     "queryName": "Hardcoded AWS Access Key In Lambda",
     "severity": "MEDIUM",
-    "line": 35
+    "line": 36,
+    "fileName": "positive.tf"
   }
 ]


### PR DESCRIPTION
Closes #5859

**Proposed Changes**
- improved regex to find AWS Access Key in `assets/queries/terraform/aws/hardcoded_aws_access_key_in_lambda`

I submit this contribution under the Apache-2.0 license.
