### PR TITLE
fix: scanner panics when ctx timeout

### DIFF
--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -481,7 +481,7 @@ func (q QueryLoader) LoadQuery(ctx context.Context, query *model.QueryMetadata) 
 
 	select {
 	case <-ctx.Done():
-		return nil, nil
+		return nil, ctx.Err()
 	default:
 		mergedInputData, err := source.MergeInputData(platformGeneralQuery.LibraryInputData, query.InputData)
 		if err != nil {

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Checkmarx/kics/assets"
 	"github.com/Checkmarx/kics/internal/storage"
@@ -29,6 +30,11 @@ var (
 	sourcePath = []string{filepath.FromSlash("../../assets/queries")}
 )
 
+type testContext struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
 func TestScanner_StartScan(t *testing.T) {
 	type args struct {
 		scanID     string
@@ -38,13 +44,16 @@ func TestScanner_StartScan(t *testing.T) {
 		types          []string
 		cloudProviders []string
 	}
+
+	ctx := context.Background()
 	tests := []struct {
 		name   string
 		args   args
 		fields fields
+		ctx    testContext
 	}{
 		{
-			name: "testing_start_scan",
+			name: "testing_start_scan_no_ctx_timeout",
 			args: args{
 				scanID:     "console",
 				noProgress: true,
@@ -53,14 +62,28 @@ func TestScanner_StartScan(t *testing.T) {
 				types:          []string{""},
 				cloudProviders: []string{""},
 			},
+			ctx: createContext(ctx, time.Second*99999),
+		},
+		{
+			name: "testing_start_scan_with_ctx_timeout",
+			args: args{
+				scanID:     "console",
+				noProgress: true,
+			},
+			fields: fields{
+				types:          []string{""},
+				cloudProviders: []string{""},
+			},
+			ctx: createContext(ctx, time.Second*1),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer tt.ctx.cancel()
 			services, store, err := createServices(tt.fields.types, tt.fields.cloudProviders)
 			require.NoError(t, err)
-			err = StartScan(context.Background(), tt.args.scanID, progress.PbBuilder{}, services)
+			err = StartScan(tt.ctx.ctx, tt.args.scanID, progress.PbBuilder{}, services)
 			require.NoError(t, err)
 			require.NotEmpty(t, &store)
 		})
@@ -130,4 +153,12 @@ func createServices(types, cloudProviders []string) (serviceSlice, *storage.Memo
 		})
 	}
 	return services, store, nil
+}
+
+func createContext(ctx context.Context, timeout time.Duration) testContext {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	return testContext{
+		ctx,
+		cancel,
+	}
 }


### PR DESCRIPTION
Closes #5986

**Proposed Changes**
- Return err in `QueryLoader.LoadQuery` when ctx timeout, instead of nil, to prevent nil dereference panic.


I submit this contribution under the Apache-2.0 license.