### PR TITLE
fix(query): update with version regex for unpinned package version in apk add security query

### DIFF
--- a/assets/libraries/dockerfile.rego
+++ b/assets/libraries/dockerfile.rego
@@ -46,15 +46,15 @@ getCommands(commands) = output{
 }
 
 withVersion(pack) {
-	regex.match("[A-Za-z0-9_-]+[-:][$](.+)", pack)
+	regex.match("[A-Za-z0-9_\\+-]+[-:][$](.+)", pack)
 }
 
 withVersion(pack) {
-	regex.match("[A-Za-z0-9_-]+[:-]([0-9]+.)+[0-9]+", pack)
+	regex.match("[A-Za-z0-9_\\+-]+[:-]([0-9]+.)+[0-9]+", pack)
 }
 
 withVersion(pack) {
-	regex.match("[A-Za-z0-9_-]+=(.+)", pack)
+	regex.match("[A-Za-z0-9_\\+-]+=(.+)", pack)
 }
 
 arrayContains(array, list) {

--- a/assets/queries/dockerfile/unpinned_package_version_in_apk_add/test/negative2.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_apk_add/test/negative2.dockerfile
@@ -10,6 +10,7 @@ CMD ["python", "/usr/src/app/app.py"]
 
 FROM alpine:3.1
 RUN apk add --virtual .test py-pip=7.1.2-r0
+RUN apk --quiet --update --no-cache add libstdc++==11.2.1_git20220219-r2
 RUN ["apk", "add", "--virtual .test", "py-pip=7.1.2-r0"]
 RUN sudo pip install --upgrade pip
 COPY requirements.txt /usr/src/app/


### PR DESCRIPTION
Closes #6000 

**Proposed Changes**
- update with version regex in dockerfile.rego to support packages with '+' in name

I submit this contribution under the Apache-2.0 license.
