### PR TITLE
fix(query): add search line to array without maximum number items open api query

### DIFF
--- a/assets/queries/openAPI/general/array_without_maximum_number_items/query.rego
+++ b/assets/queries/openAPI/general/array_without_maximum_number_items/query.rego
@@ -19,6 +19,7 @@ CxPolicy[result] {
 		"issueType": "MissingAttribute",
 		"keyActualValue": "Array schema has 'maxItems' set",
 		"keyExpectedValue": "Array schema has 'maxItems' undefined",
+		"searchLine": common_lib.build_search_line(path, []) ,
 		"overrideKey": version,
 	}
 }
@@ -38,6 +39,7 @@ CxPolicy[result] {
 		"issueType": "MissingAttribute",
 		"keyActualValue": "Array schema has 'maxItems' set",
 		"keyExpectedValue": "Array schema has 'maxItems' undefined",
+		"searchLine": common_lib.build_search_line(path, []) ,
 		"overrideKey": version,
 	}
 }

--- a/assets/queries/openAPI/general/array_without_maximum_number_items/test/positive_expected_result.json
+++ b/assets/queries/openAPI/general/array_without_maximum_number_items/test/positive_expected_result.json
@@ -2,37 +2,37 @@
   {
     "queryName": "Array Without Maximum Number of Items (v3)",
     "severity": "HIGH",
-    "line": 57,
+    "line": 56,
     "filename": "positive1.json"
   },
   {
     "queryName": "Array Without Maximum Number of Items (v3)",
     "severity": "HIGH",
-    "line": 29,
+    "line": 28,
     "filename": "positive2.json"
   },
   {
     "queryName": "Array Without Maximum Number of Items (v3)",
     "severity": "HIGH",
-    "line": 33,
+    "line": 32,
     "filename": "positive3.yaml"
   },
   {
     "queryName": "Array Without Maximum Number of Items (v3)",
     "severity": "HIGH",
-    "line": 21,
+    "line": 20,
     "filename": "positive4.yaml"
   },
   {
     "queryName": "Array Without Maximum Number of Items (v2)",
     "severity": "HIGH",
-    "line": 32,
+    "line": 31,
     "filename": "positive5.json"
   },
   {
     "queryName": "Array Without Maximum Number of Items (v2)",
     "severity": "HIGH",
-    "line": 24,
+    "line": 23,
     "filename": "positive6.yaml"
   }
 ]


### PR DESCRIPTION
**Proposed Changes**
- add search line to array without maximum number items open api query

I submit this contribution under the Apache-2.0 license.
