### PR TITLE
bump(go) go version 1.19

### DIFF
--- a/.github/workflows/go-ci-coverage.yaml
+++ b/.github/workflows/go-ci-coverage.yaml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Run test metrics script
         id: testcov
         run: |

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.3.1
         with:
@@ -23,10 +23,10 @@ jobs:
     name: go-generate
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Check out code
         uses: actions/checkout@v3
         with:
@@ -38,11 +38,11 @@ jobs:
     name: unit-tests
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.19.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.3.1
         with:
-          version: v1.46.1
+          version: v1.50.1
           args: -c .golangci.yml --timeout 20m
   go-generate:
     name: go-generate

--- a/.github/workflows/go-e2e.yaml
+++ b/.github/workflows/go-e2e.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.19.x]
         os: [ubuntu-latest]
         kics-docker: ["Dockerfile", "docker/Dockerfile.ubi8"]
     runs-on: ${{ matrix.os }}
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/go-test-race.yml
+++ b/.github/workflows/go-test-race.yml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-apispec.yml
+++ b/.github/workflows/release-apispec.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.2.0
         with:

--- a/.github/workflows/release-commits.yaml
+++ b/.github/workflows/release-commits.yaml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@
 #       - name: Set up Go
 #         uses: actions/setup-go@v2
 #         with:
-#           go-version: 1.18.x
+#           go-version: 1.19.x
 #       - name: Run GoReleaser
 #         uses: goreleaser/goreleaser-action@v2.8.1
 #         with:

--- a/.github/workflows/statistics.yaml
+++ b/.github/workflows/statistics.yaml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
       - name: Run test metrics script
         id: testcoverage
         run: |

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -4,10 +4,10 @@ WORKDIR /build
 
 ENV PATH=$PATH:/usr/local/go/bin
 
-ADD https://golang.org/dl/go1.18.2.linux-amd64.tar.gz .
+ADD https://golang.org/dl/go1.19.4.linux-amd64.tar.gz .
 RUN yum install git gcc -y \
-  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz \
-  && rm -f go1.18.2.linux-amd64.tar.gz
+  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.4.linux-amd64.tar.gz \
+  && rm -f go1.19.4.linux-amd64.tar.gz
 
 ENV GOPRIVATE=github.com/Checkmarx/*
 ARG VERSION="development"

--- a/e2e/testcases/e2e-cli-057_fix_all.go
+++ b/e2e/testcases/e2e-cli-057_fix_all.go
@@ -6,7 +6,7 @@ import (
 
 // E2E-CLI-057 - Kics remediate command
 // should remediate all remediation found
-func init() { // nolint
+func init() { //nolint
 	generateResults("results-remediate-all")
 
 	testSample := TestCase{

--- a/e2e/testcases/e2e-cli-058_fix_include_ids.go
+++ b/e2e/testcases/e2e-cli-058_fix_include_ids.go
@@ -6,7 +6,7 @@ import (
 
 // E2E-CLI-057 - Kics remediate command
 // should remediate all remediation found
-func init() { // nolint
+func init() { //nolint
 	generateResults("results-remediate-include-ids")
 
 	testSample := TestCase{

--- a/e2e/testcases/utils.go
+++ b/e2e/testcases/utils.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func generateReport(tmpFile, jsonPath, reportName string) { // nolint
+func generateReport(tmpFile, jsonPath, reportName string) { //nolint
 	var queryHigh = model.QueryResult{
 		QueryName:                   "Ram Account Password Policy Not Required Minimum Length",
 		QueryID:                     "a9dfec39-a740-4105-bbd6-721ba163c053",
@@ -46,7 +46,7 @@ func generateReport(tmpFile, jsonPath, reportName string) { // nolint
 		},
 	}
 
-	var queryMedium1 = model.QueryResult{ // nolint
+	var queryMedium1 = model.QueryResult{ //nolint
 		QueryName:                   "RAM Account Password Policy Not Required Symbols",
 		QueryID:                     "41a38329-d81b-4be4-aef4-55b2615d3282",
 		QueryURI:                    "",
@@ -95,7 +95,7 @@ func generateReport(tmpFile, jsonPath, reportName string) { // nolint
 		},
 	}
 
-	var queryMedium2 = model.QueryResult{ // nolint
+	var queryMedium2 = model.QueryResult{ //nolint
 		QueryName:                   "Ram Account Password Policy Max Password Age Unrecommended",
 		QueryID:                     "2bb13841-7575-439e-8e0a-cccd9ede2fa8",
 		Description:                 "Ram Account Password Policy Password 'max_password_age' should be higher than 0 and lower than 91",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Checkmarx/kics
 
-go 1.18
+go 1.19
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5

--- a/internal/console/remediate.go
+++ b/internal/console/remediate.go
@@ -32,7 +32,7 @@ func NewRemediateCmd() *cobra.Command {
 			return preRemediate(cmd)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return remediate(cmd)
+			return remediate()
 		},
 	}
 }
@@ -75,7 +75,7 @@ func preRemediate(cmd *cobra.Command) error {
 	return err
 }
 
-func remediate(cmd *cobra.Command) error {
+func remediate() error {
 	resultsPath := flags.GetStrFlag(flags.Results)
 	include := flags.GetMultiStrFlag(flags.IncludeIds)
 

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -174,7 +174,7 @@ func executeScan(scanParams *scan.Parameters) error {
 func gracefulShutdown() {
 	c := make(chan os.Signal)
 	// This line should not be lint, since golangci-lint has an issue about it (https://github.com/golang/go/issues/45043)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM) // nolint
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM) //nolint
 	showErrors := consoleHelpers.ShowError("errors")
 	interruptCode := constants.SignalInterruptCode
 	go func(showErrors bool, interruptCode int) {

--- a/internal/storage/memory_test.go
+++ b/internal/storage/memory_test.go
@@ -60,7 +60,7 @@ func TestMemoryStorage_SaveFile(t *testing.T) {
 }
 
 // TestMemoryStorage_SaveFile tests the functions [GetFiles(), GetVulnerabilities(), GetScanSummary()]
-func TestMemoryStorage(t *testing.T) { // nolint
+func TestMemoryStorage(t *testing.T) { //nolint
 	type fields struct {
 		vulnerabilities []model.Vulnerability
 		allFiles        model.FileMetadatas

--- a/pkg/builder/parser/tag/tag_parser_test.go
+++ b/pkg/builder/parser/tag/tag_parser_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestParseTags tests the functions [Parse()] and all the methods called by them (check for equal flags)
-func TestParseTags(t *testing.T) { // nolint
+func TestParseTags(t *testing.T) { //nolint
 	t.Run("empty", func(t *testing.T) {
 		tags, err := Parse("", []string{"test2"})
 		require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestParseTags(t *testing.T) { // nolint
 	})
 
 	t.Run("just_many_comments", func(t *testing.T) {
-		tags, err := Parse("// a:\"something,expected=private,test=false,test2=true,iii=123.3,tt=['a','c']\" commentB a:\"test=1,b,c=!=\"", []string{"a", "commentB"}) // nolint:lll
+		tags, err := Parse("// a:\"something,expected=private,test=false,test2=true,iii=123.3,tt=['a','c']\" commentB a:\"test=1,b,c=!=\"", []string{"a", "commentB"}) //nolint:lll
 		require.NoError(t, err)
 		assertEqualTags(t, tags, []Tag{
 			{
@@ -110,7 +110,7 @@ func TestParseTags(t *testing.T) { // nolint
 	})
 
 	t.Run("parse_escape", func(t *testing.T) {
-		tags, err := Parse("// a:tt=['a\\a','b\\b','f\\f','n\\n','r\\r','t\\t','v\\v']", []string{"a"}) // nolint:lll
+		tags, err := Parse("// a:tt=['a\\a','b\\b','f\\f','n\\n','r\\r','t\\t','v\\v']", []string{"a"}) //nolint:lll
 		require.NoError(t, err)
 		assertEqualTags(t, tags, []Tag{
 			{

--- a/pkg/builder/writer/rego.go
+++ b/pkg/builder/writer/rego.go
@@ -48,11 +48,11 @@ func NewRegoWriter() (*RegoWriter, error) {
 				return r.Conditions[len(r.Conditions)-1]
 			},
 			"unescape": func(v string) template.HTML {
-				return template.HTML(v) // nolint:gosec
+				return template.HTML(v) //nolint:gosec
 			},
 			"innerKey": func(r RegoRule) template.HTML {
 				condition := r.Conditions[len(r.Conditions)-1]
-				return template.HTML(conditionKey(r.Block, condition, false, true)) // nolint:gosec
+				return template.HTML(conditionKey(r.Block, condition, false, true)) //nolint:gosec
 			},
 			"searchKey": func(r RegoRule) template.HTML {
 				format := "%%s[%%s].%s"
@@ -71,7 +71,7 @@ func NewRegoWriter() (*RegoWriter, error) {
 				}
 				format = fmt.Sprintf(format, conditionKey(r.Block, condition, false, true))
 
-				return template.HTML(fmt.Sprintf("sprintf(\"%s\", [%s])", format, strings.Join(vars, ", "))) // nolint
+				return template.HTML(fmt.Sprintf("sprintf(\"%s\", [%s])", format, strings.Join(vars, ", "))) //nolint
 			},
 		}).
 		ParseFiles("./pkg/builder/writer/template.gorego")

--- a/pkg/descriptions/client.go
+++ b/pkg/descriptions/client.go
@@ -72,7 +72,7 @@ func (c *Client) CheckConnection() error {
 	}
 
 	endpointURL := fmt.Sprintf("%s/api/", baseURL)
-	req, err := http.NewRequest(http.MethodGet, endpointURL, http.NoBody)
+	req, err := http.NewRequest(http.MethodGet, endpointURL, http.NoBody) //nolint
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (c *Client) CheckLatestVersion(version string) (model.Version, error) {
 		return model.Version{}, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, endpointURL, bytes.NewReader(requestBody))
+	req, err := http.NewRequest(http.MethodPost, endpointURL, bytes.NewReader(requestBody)) //nolint
 	if err != nil {
 		return model.Version{}, err
 	}
@@ -150,7 +150,7 @@ func (c *Client) RequestDescriptions(descriptionIDs []string) (map[string]descMo
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, endpointURL, bytes.NewReader(requestBody))
+	req, err := http.NewRequest(http.MethodPost, endpointURL, bytes.NewReader(requestBody)) //nolint
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/inspector_test.go
+++ b/pkg/engine/inspector_test.go
@@ -252,7 +252,7 @@ func TestInspect(t *testing.T) { //nolint
 					KeyExpectedValue: "'COPY' app.jar",
 					KeyActualValue:   "'ADD' app.jar",
 					Value:            nil,
-					Output:           `{"documentId":"3a3be8f7-896e-4ef8-9db3-d6c19e60510b","issueType":"IncorrectValue","keyActualValue":"'ADD' app.jar","keyExpectedValue":"'COPY' app.jar","searchKey":"{{ADD ${JAR_FILE} app.jar}}"}`, // nolint
+					Output:           `{"documentId":"3a3be8f7-896e-4ef8-9db3-d6c19e60510b","issueType":"IncorrectValue","keyActualValue":"'ADD' app.jar","keyExpectedValue":"'COPY' app.jar","searchKey":"{{ADD ${JAR_FILE} app.jar}}"}`, //nolint
 				},
 			},
 			wantErr: false,
@@ -342,7 +342,7 @@ func TestInspect(t *testing.T) { //nolint
 }
 
 // TestNewInspector tests the functions [NewInspector()] and all the methods called by them
-func TestNewInspector(t *testing.T) { // nolint
+func TestNewInspector(t *testing.T) { //nolint
 	if err := test.ChangeCurrentDir("kics"); err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +371,7 @@ func TestNewInspector(t *testing.T) { // nolint
 			"queryName":       "All Auth Users Get Read Access",
 			"severity":        model.SeverityHigh,
 			"category":        "Access Control",
-			"descriptionText": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion", // nolint
+			"descriptionText": "Misconfigured S3 buckets can leak private information to the entire internet or allow unauthorized data tampering / deletion", //nolint
 			"descriptionUrl":  "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#acl",
 			"platform":        "Terraform",
 		},

--- a/pkg/engine/source/filesystem_test.go
+++ b/pkg/engine/source/filesystem_test.go
@@ -276,7 +276,7 @@ func TestFilesystemSource_GetQueriesWithInclude(t *testing.T) {
 }
 
 // TestFilesystemSource_GetQueryLibrary tests the functions [GetQueryLibrary()] and all the methods called by them
-func TestFilesystemSource_GetQueryLibrary(t *testing.T) { // nolint
+func TestFilesystemSource_GetQueryLibrary(t *testing.T) { //nolint
 	if err := test.ChangeCurrentDir("kics"); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kics/service.go
+++ b/pkg/kics/service.go
@@ -126,8 +126,8 @@ type Content struct {
 }
 
 /*
-   getContent will read the passed file 1MB at a time
-   to prevent resource exhaustion and return its content
+getContent will read the passed file 1MB at a time
+to prevent resource exhaustion and return its content
 */
 func getContent(rc io.Reader, data []byte) (*Content, error) {
 	maxSizeMB := 5 // Max size of file in MBs

--- a/pkg/parser/terraform/converter/default_test.go
+++ b/pkg/parser/terraform/converter/default_test.go
@@ -405,7 +405,7 @@ block "label_one" {
 }
 
 // TestLabelsWithNestedBlock tests the functions [DefaultConverted] and all the methods called by them
-func TestConversion(t *testing.T) { // nolint
+func TestConversion(t *testing.T) { //nolint
 	const input = `
 locals {
 	test3 = 1 + 2
@@ -571,7 +571,7 @@ variable "region" {
 				}
 			},
 			{
-				"heredoc2": "\t\tAnother heredoc, that\n\t\tdoesn't remove indentation\n\t\t${local.other.3}\n\t\t%{if true ? false : true}\"gotcha\"\\n%{else}4%{endif}\n",` + // nolint
+				"heredoc2": "\t\tAnother heredoc, that\n\t\tdoesn't remove indentation\n\t\t${local.other.3}\n\t\t%{if true ? false : true}\"gotcha\"\\n%{else}4%{endif}\n",` + //nolint
 		`"_kics_lines": {
 					"_kics__default": {
 						"_kics_line": 28

--- a/pkg/resolver/helm/resolver_test.go
+++ b/pkg/resolver/helm/resolver_test.go
@@ -20,7 +20,7 @@ func TestHelm_SupportedTypes(t *testing.T) {
 	})
 }
 
-func TestHelm_Resolve(t *testing.T) { // nolint
+func TestHelm_Resolve(t *testing.T) { //nolint
 	res := &Resolver{}
 	type args struct {
 		filePath string


### PR DESCRIPTION
Closes #

**Proposed Changes**
- go major version update (1.19)

I submit this contribution under the Apache-2.0 license.
