### PR TITLE
fix(terraform/aws): sse query failing on bucket with count

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_sse_disabled/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_sse_disabled/query.rego
@@ -107,12 +107,11 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
-	
 	bucket := input.document[i].resource.aws_s3_bucket[bucketName]
-	
+
+	not is_associated(bucketName, input.document[i])
 	not tf_lib.has_target_resource(bucketName, "aws_s3_bucket_server_side_encryption_configuration") # version after TF AWS 4.0
 	not common_lib.valid_key(bucket, "server_side_encryption_configuration") # version before TF AWS 4.0
-	
 
 	result := {
 		"documentId": input.document[i].id,
@@ -128,9 +127,8 @@ CxPolicy[result] {
 
 # version after TF AWS 4.0
 CxPolicy[result] {
-	
 	input.document[_].resource.aws_s3_bucket[bucketName]
-	
+
 	sse := input.document[i].resource.aws_s3_bucket_server_side_encryption_configuration[name]
 	split(sse.bucket, ".")[1] == bucketName
 	not common_lib.valid_key(sse.rule, "apply_server_side_encryption_by_default")
@@ -149,9 +147,8 @@ CxPolicy[result] {
 
 # version after TF AWS 4.0
 CxPolicy[result] {
-	
 	input.document[_].resource.aws_s3_bucket[bucketName]
-	
+
 	sse := input.document[i].resource.aws_s3_bucket_server_side_encryption_configuration[name]
 	split(sse.bucket, ".")[1] == bucketName
 	algorithm := sse.rule.apply_server_side_encryption_by_default
@@ -172,7 +169,6 @@ CxPolicy[result] {
 
 # version after TF AWS 4.0
 CxPolicy[result] {
-
 	input.document[_].resource.aws_s3_bucket[bucketName]
 
 	sse := input.document[i].resource.aws_s3_bucket_server_side_encryption_configuration[name]
@@ -198,4 +194,10 @@ check_master_key(assed) {
 	not common_lib.valid_key(assed, "kms_master_key_id")
 } else {
 	common_lib.emptyOrNull(assed.kms_master_key_id)
+}
+
+is_associated(aws_s3_bucket_name, doc) {
+	[_, value] := walk(doc)
+	sse_configurations := value.aws_s3_bucket_server_side_encryption_configuration[_]
+	contains(sse_configurations.bucket, sprintf("aws_s3_bucket.%s", [aws_s3_bucket_name]))
 }

--- a/assets/queries/terraform/aws/s3_bucket_sse_disabled/test/negative4.tf
+++ b/assets/queries/terraform/aws/s3_bucket_sse_disabled/test/negative4.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.2.0"
+    }
+  }
+}
+
+provider "aws" {
+  # Configuration options
+}
+
+resource "aws_s3_bucket" "mybucket22" {
+  count  = 1
+  bucket = "my-tf-example-bucket"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "example33" {
+  count  = 1
+  bucket = aws_s3_bucket.mybucket22[count.index].bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}


### PR DESCRIPTION
**Context**
When a bucket and its SSE configuration use `count`, the query evaluates to true (false positive). (AWS provider v4)

**Proposed Changes**
- Add function is_associated to lookup all bucket associated with a sse configuration.

**How to test**
- See new test `negative4.tf`
- Comment out line 112 and `kics scan -p test/negative4.tf -q .` -> query is positive
- Put line 112 back and `kics scan -p test/negative4.tf -q .` -> query is negative

I submit this contribution under the Apache-2.0 license.
