### PR TITLE
feat(terraform/aws): ingress ipv6 security group

### DIFF
--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/metadata.json
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "Unrestricted Security Group Ingress",
   "severity": "HIGH",
   "category": "Networking and Firewall",
-  "descriptionText": "Security groups allow ingress from 0.0.0.0:0",
+  "descriptionText": "Security groups allow ingress from 0.0.0.0:0 and/or ::/0",
   "descriptionUrl": "https://www.terraform.io/docs/providers/aws/r/security_group.html",
   "platform": "Terraform",
   "descriptionID": "ce3ee5e0",

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/query.rego
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/query.rego
@@ -75,3 +75,76 @@ CxPolicy[result] {
 		"searchLine": common_lib.build_search_line(["module", name, "ingress_cidr_blocks", idxCidr], []),
 	}
 }
+
+CxPolicy[result] {
+	rule := input.document[i].resource.aws_security_group_rule[name]
+
+	lower(rule.type) == "ingress"
+	some j
+	contains(rule.ipv6_cidr_blocks[j], "::/0")
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_security_group_rule",
+		"resourceName": tf_lib.get_resource_name(rule, name),
+		"searchKey": sprintf("aws_security_group_rule[%s].ipv6_cidr_blocks", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "One of 'rule.ipv6_cidr_blocks' not equal '::/0'",
+		"keyActualValue": "One of 'rule.ipv6_cidr_blocks' is equal '::/0'",
+		"searchLine": common_lib.build_search_line(["resource", "aws_security_group_rule", name, "ipv6_cidr_blocks"], []),
+	}
+}
+
+CxPolicy[result] {
+	ingrs := input.document[i].resource.aws_security_group[name].ingress
+
+	some j
+	contains(ingrs.ipv6_cidr_blocks[j], "::/0")
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_security_group",
+		"resourceName": tf_lib.get_resource_name(input.document[i].resource.aws_security_group[name], name),
+		"searchKey": sprintf("aws_security_group[%s].ingress.ipv6_cidr_blocks", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "One of 'ingress.ipv6_cidr_blocks' not equal '::/0'",
+		"keyActualValue": "One of 'ingress.ipv6_cidr_blocks' equal '::/0'",
+		"searchLine": common_lib.build_search_line(["resource", "aws_security_group_rule", name, "ingress", "ipv6_cidr_blocks"], []),
+	}
+}
+
+CxPolicy[result] {
+	ingrs := input.document[i].resource.aws_security_group[name].ingress[j]
+	contains(ingrs.ipv6_cidr_blocks[idx], "::/0")
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_security_group",
+		"resourceName": tf_lib.get_resource_name(input.document[i].resource.aws_security_group[name], name),
+		"searchKey": sprintf("aws_security_group[%s]", [name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "One of 'ingress.ipv6_cidr_blocks' not equal '::/0'",
+		"keyActualValue": "One of 'ingress.ipv6_cidr_blocks' equal '::/0'",
+		"searchLine": common_lib.build_search_line(["resource", "aws_security_group", name, "ingress", j, "ipv6_cidr_blocks", idx], []),
+	}
+}
+
+# rule for modules
+CxPolicy[result] {
+	module := input.document[i].module[name]
+	keyToCheck := common_lib.get_module_equivalent_key("aws", module.source, "aws_security_group_rule", "ingress_ipv6_cidr_blocks") # based on module terraform-aws-modules/security-group/aws
+
+	cidr := module[keyToCheck][idxCidr]
+	contains(cidr, "::/0")
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "n/a",
+		"resourceName": "n/a",
+		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "One of 'ingress.ipv6_cidr_blocks' not equal '::/0'",
+		"keyActualValue": "One of 'ingress.ipv6_cidr_blocks' equal '::/0'",
+		"searchLine": common_lib.build_search_line(["module", name, "ingress_ipv6_cidr_blocks", idxCidr], []),
+	}
+}

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/query.rego
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/query.rego
@@ -89,7 +89,7 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(rule, name),
 		"searchKey": sprintf("aws_security_group_rule[%s].ipv6_cidr_blocks", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "One of 'rule.ipv6_cidr_blocks' not equal '::/0'",
+		"keyExpectedValue": "One of 'rule.ipv6_cidr_blocks' should not be equal to '::/0'",
 		"keyActualValue": "One of 'rule.ipv6_cidr_blocks' is equal '::/0'",
 		"searchLine": common_lib.build_search_line(["resource", "aws_security_group_rule", name, "ipv6_cidr_blocks"], []),
 	}
@@ -107,8 +107,8 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(input.document[i].resource.aws_security_group[name], name),
 		"searchKey": sprintf("aws_security_group[%s].ingress.ipv6_cidr_blocks", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "One of 'ingress.ipv6_cidr_blocks' not equal '::/0'",
-		"keyActualValue": "One of 'ingress.ipv6_cidr_blocks' equal '::/0'",
+		"keyExpectedValue": "One of 'ingress.ipv6_cidr_blocks' should not be equal to '::/0'",
+		"keyActualValue": "One of 'ingress.ipv6_cidr_blocks' is equal '::/0'",
 		"searchLine": common_lib.build_search_line(["resource", "aws_security_group_rule", name, "ingress", "ipv6_cidr_blocks"], []),
 	}
 }
@@ -123,8 +123,8 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(input.document[i].resource.aws_security_group[name], name),
 		"searchKey": sprintf("aws_security_group[%s]", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "One of 'ingress.ipv6_cidr_blocks' not equal '::/0'",
-		"keyActualValue": "One of 'ingress.ipv6_cidr_blocks' equal '::/0'",
+		"keyExpectedValue": "One of 'ingress.ipv6_cidr_blocks' should not be equal to '::/0'",
+		"keyActualValue": "One of 'ingress.ipv6_cidr_blocks' is equal '::/0'",
 		"searchLine": common_lib.build_search_line(["resource", "aws_security_group", name, "ingress", j, "ipv6_cidr_blocks", idx], []),
 	}
 }
@@ -143,8 +143,8 @@ CxPolicy[result] {
 		"resourceName": "n/a",
 		"searchKey": sprintf("module[%s].%s", [name, keyToCheck]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "One of 'ingress.ipv6_cidr_blocks' not equal '::/0'",
-		"keyActualValue": "One of 'ingress.ipv6_cidr_blocks' equal '::/0'",
+		"keyExpectedValue": "One of 'ingress.ipv6_cidr_blocks' should not be equal to '::/0'",
+		"keyActualValue": "One of 'ingress.ipv6_cidr_blocks' is equal '::/0'",
 		"searchLine": common_lib.build_search_line(["module", name, "ingress_ipv6_cidr_blocks", idxCidr], []),
 	}
 }

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative5.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative5.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group_rule" "negative1" {
+resource "aws_security_group_rule" "negative5" {
   type              = "ingress"
   from_port         = 3306
   to_port           = 3306

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative5.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative5.tf
@@ -1,0 +1,9 @@
+resource "aws_security_group_rule" "negative1" {
+  type              = "ingress"
+  from_port         = 3306
+  to_port           = 3306
+  protocol          = "tcp"
+  ipv6_cidr_blocks  = ["fc00::/8"]
+  security_group_id = aws_security_group.default.id
+}
+

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative6.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative6.tf
@@ -1,0 +1,9 @@
+resource "aws_security_group" "negative2" {
+  ingress {
+    from_port         = 3306
+    to_port           = 3306
+    protocol          = "tcp"
+    ipv6_cidr_blocks  = ["fc00::/8"]
+    security_group_id = aws_security_group.default.id
+  }
+}

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative6.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative6.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "negative2" {
+resource "aws_security_group" "negative6" {
   ingress {
     from_port         = 3306
     to_port           = 3306

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative7.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative7.tf
@@ -1,0 +1,15 @@
+resource "aws_security_group" "negative3" {
+  ingress {
+    from_port         = 3306
+    to_port           = 3306
+    protocol          = "tcp"
+    ipv6_cidr_blocks  = ["fc00::/9"]
+  }
+
+  ingress {
+    from_port         = 3306
+    to_port           = 3306
+    protocol          = "tcp"
+    ipv6_cidr_blocks  = ["fc00::/8"]
+  }
+}

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative7.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative7.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "negative3" {
+resource "aws_security_group" "negative7" {
   ingress {
     from_port         = 3306
     to_port           = 3306

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative8.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/negative8.tf
@@ -1,0 +1,10 @@
+module "web_server_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "4.3.0"
+
+  name        = "web-server"
+  description = "Security group for web-server with HTTP ports open within VPC"
+  vpc_id      = "vpc-12345678"
+
+  ingress_ipv6_cidr_blocks  = ["fc00::/8"]
+}

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive10.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive10.tf
@@ -1,0 +1,10 @@
+module "web_server_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "4.3.0"
+
+  name        = "web-server"
+  description = "Security group for web-server with HTTP ports open within VPC"
+  vpc_id      = "vpc-12345678"
+
+  ingress_ipv6_cidr_blocks  = ["fc00::/8", "::/0"]
+}

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive6.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive6.tf
@@ -1,0 +1,8 @@
+resource "aws_security_group_rule" "positive1" {
+  type              = "ingress"
+  from_port         = 3306
+  to_port           = 3306
+  protocol          = "tcp"
+  ipv6_cidr_blocks  = ["::/0"]
+  security_group_id = aws_security_group.default.id
+}

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive6.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive6.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group_rule" "positive1" {
+resource "aws_security_group_rule" "positive6" {
   type              = "ingress"
   from_port         = 3306
   to_port           = 3306

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive7.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive7.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "positive2" {
+resource "aws_security_group" "positive7" {
   ingress {
     from_port         = 3306
     to_port           = 3306

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive7.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive7.tf
@@ -1,0 +1,9 @@
+resource "aws_security_group" "positive2" {
+  ingress {
+    from_port         = 3306
+    to_port           = 3306
+    protocol          = "tcp"
+    ipv6_cidr_blocks  = ["::/0"]
+    security_group_id = aws_security_group.default.id
+  }
+}

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive8.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive8.tf
@@ -1,0 +1,15 @@
+resource "aws_security_group" "positive3" {
+  ingress {
+    from_port         = 3306
+    to_port           = 3306
+    protocol          = "tcp"
+    ipv6_cidr_blocks  = ["fc00::/8"]
+  }
+
+  ingress {
+    from_port         = 3306
+    to_port           = 3306
+    protocol          = "tcp"
+    ipv6_cidr_blocks  = ["::/0"]
+  }
+}

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive8.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive8.tf
@@ -1,4 +1,4 @@
-resource "aws_security_group" "positive3" {
+resource "aws_security_group" "positive8" {
   ingress {
     from_port         = 3306
     to_port           = 3306

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive9.tf
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive9.tf
@@ -1,0 +1,10 @@
+module "web_server_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "4.3.0"
+
+  name        = "web-server"
+  description = "Security group for web-server with HTTP ports open within VPC"
+  vpc_id      = "vpc-12345678"
+
+  ingress_ipv6_cidr_blocks  = ["::/0"]
+}

--- a/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/unrestricted_security_group_ingress/test/positive_expected_result.json
@@ -28,5 +28,35 @@
     "severity": "HIGH",
     "line": 9,
     "filename": "positive5.tf"
+  },
+  {
+    "queryName": "Unrestricted Security Group Ingress",
+    "severity": "HIGH",
+    "line": 6,
+    "filename": "positive6.tf"
+  },
+  {
+    "queryName": "Unrestricted Security Group Ingress",
+    "severity": "HIGH",
+    "line": 6,
+    "filename": "positive7.tf"
+  },
+  {
+    "queryName": "Unrestricted Security Group Ingress",
+    "severity": "HIGH",
+    "line": 13,
+    "filename": "positive8.tf"
+  },
+  {
+    "queryName": "Unrestricted Security Group Ingress",
+    "severity": "HIGH",
+    "line": 9,
+    "filename": "positive9.tf"
+  },
+  {
+    "queryName": "Unrestricted Security Group Ingress",
+    "severity": "HIGH",
+    "line": 9,
+    "filename": "positive10.tf"
   }
 ]


### PR DESCRIPTION
### Context
There is currently no limitation on IPV6 security groups in ingress. So I propose rules to avoid opening to everything.

### Proposed Changes
Add the same IPV4 rules with ipv6 settings

### How to test
I created :
- 4 negative tests : `negative5.tf`, `negative6.tf`, `negative7.tf`, `negative8.tf`
- 5 positive tests : `postive6.tf`, `positive7.tf`, `positive8.tf`, `positive9.tf`, `positive10.tf`

I submit this contribution under the Apache-2.0 license.
