### PR TITLE
feat(query): add password and secrets detection for sendgrid api key

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -303,6 +303,11 @@
         }
       ],
       "specialMask": "(?i)['\"]?encryption[_]?key['\"]?\\s*[:=]\\s*"
+    },
+    {
+      "id": "8a879bc7-6f82-40fd-bb48-74d25d557fe8",
+      "name": "SendGrid API Key",
+      "regex": "(?i)SG\\.[a-zA-Z0-9\\-\\_]{22}\\.[a-zA-Z0-9\\-\\_]{43}\\s*"
     }
   ],
   "allowRules": [

--- a/assets/queries/common/passwords_and_secrets/test/positive25.dockerfile
+++ b/assets/queries/common/passwords_and_secrets/test/positive25.dockerfile
@@ -7,3 +7,5 @@ ARG picaticKey=sk_live_123as6789o1234567890123a123a5678
 ARG amazonToken=amzn.mws.643a5678-8f9f-1a2b-5c3b-e3ea43f3f4b4
 
 ARG mailChimp=f4f56af5a54a3eaeb3c3beb3cc2ccccc-us36
+
+ARG sgApiK=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

--- a/assets/queries/common/passwords_and_secrets/test/positive_expected_result.json
+++ b/assets/queries/common/passwords_and_secrets/test/positive_expected_result.json
@@ -240,7 +240,7 @@
     "fileName": "positive25.dockerfile"
   },
   {
-    "queryName": "Passwords And Secrets - MailChimp API Key",
+    "queryName": "Passwords And Secrets - SendGrid API Key",
     "severity": "HIGH",
     "line": 11,
     "fileName": "positive25.dockerfile"

--- a/assets/queries/common/passwords_and_secrets/test/positive_expected_result.json
+++ b/assets/queries/common/passwords_and_secrets/test/positive_expected_result.json
@@ -240,6 +240,12 @@
     "fileName": "positive25.dockerfile"
   },
   {
+    "queryName": "Passwords And Secrets - MailChimp API Key",
+    "severity": "HIGH",
+    "line": 11,
+    "fileName": "positive25.dockerfile"
+  },
+  {
     "queryName": "Passwords And Secrets - Generic Private Key",
     "severity": "HIGH",
     "line": 9,


### PR DESCRIPTION
Closes #6098 

**Proposed Changes**
- add password and secrets regex rule for sendgrid API key detection

I submit this contribution under the Apache-2.0 license.
