### PR TITLE
fix(query): add missing check for stack tags in serverlessfw security query

### DIFF
--- a/assets/queries/serverlessFW/serverless_function_without_tags/query.rego
+++ b/assets/queries/serverlessFW/serverless_function_without_tags/query.rego
@@ -9,6 +9,7 @@ CxPolicy[result] {
 	function := functions[fname]
 
 	not common_lib.valid_key(function, "tags")
+	hasNoStackTags(document)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -20,4 +21,9 @@ CxPolicy[result] {
 		"keyActualValue": "'tags' is not defined",
 		"searchLine": common_lib.build_search_line(["functions", fname], []),
 	}
+}
+
+hasNoStackTags(document){
+	provider := document.provider
+	not common_lib.valid_key(provider, "stackTags")
 }

--- a/assets/queries/serverlessFW/serverless_function_without_tags/test/negative2.yml
+++ b/assets/queries/serverlessFW/serverless_function_without_tags/test/negative2.yml
@@ -1,0 +1,13 @@
+service: service
+frameworkVersion: '2' 
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stackTags:
+    foo: bar
+ 
+functions:
+  hello:
+    handler: handler.hello
+    onError: arn:aws:sns:us-east-1:XXXXXX:test
+      


### PR DESCRIPTION
**Proposed Changes**
- add missing check for stack tags in ServerlessFW Serverless Function Without Tags security query

I submit this contribution under the Apache-2.0 license.
