### PR TITLE
Policy effect should be case insensitive

### DIFF
--- a/assets/libraries/common.rego
+++ b/assets/libraries/common.rego
@@ -412,7 +412,7 @@ is_allow_effect(statement) {
 } else {
 	statement.Effect == "Allow"
 } else {
-    satement.effect == "Allow"
+    statement.effect == "Allow"
 }
 
 get_policy(p) = policy {

--- a/assets/libraries/common.rego
+++ b/assets/libraries/common.rego
@@ -408,8 +408,11 @@ get_statement(policy) = st {
 
 is_allow_effect(statement) {
 	not valid_key(statement, "Effect")
+	not valid_key(statement, "effect")
 } else {
 	statement.Effect == "Allow"
+} else {
+    satement.effect == "Allow"
 }
 
 get_policy(p) = policy {


### PR DESCRIPTION
**Proposed Changes**
- Per [Terraform's documentation](https://developer.hashicorp.com/terraform/tutorials/aws/aws-iam-policy#:~:text=Copy%20the-,aws_iam_policy_document,-configuration%20below%20into), iam policy statements' `Effect` can be declared as either `Effect` or `effect`
- The proposed change ensures both cases are validated when checking whether the statements is an `Allow` statement
- This solves false-positive cases where statements with `effect: Deny` are evaluated as being `Allow`

I submit this contribution under the Apache-2.0 license.
