### PR TITLE
fix(regex_rules): align aws secretmanager arn pattern with vendor spec

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -38,7 +38,7 @@
         },
         {
           "description": "Avoiding Secrets Manager arn",
-          "regex": ":secretsmanager:[a-z0-9-]+:[0-9]+:(?i)['\"]?secret[_]?(key)?['\"]?\\s*(:|=)\\s*['\"]?([A-Za-z0-9/~^_!@&%()=?*+-]{10,})['\"]?"
+          "regex": ":secretsmanager:[a-z0-9-*?]+:[0-9*?]+:(?i)['\"]?secret[_]?(key)?['\"]?\\s*(:|=)\\s*['\"]?([A-Za-z0-9/~^_!@&%()=?*+-]+)['\"]?"
         },
         {
           "description": "Avoiding CloudFormation Parameters Descriptions",


### PR DESCRIPTION
**Proposed Changes**
+add wildcard character support to regex (? and *) for region and account fields
+reduce Secret name min. length constraint (from 10+ chars to 1+)

Closes #6256

I submit this contribution under the Apache-2.0 license.
