### PR TITLE
Terraform/line with comment

### DIFF
--- a/pkg/parser/terraform/comment/comment.go
+++ b/pkg/parser/terraform/comment/comment.go
@@ -135,6 +135,10 @@ func processTokens(tokens hclsyntax.Tokens) (ig Ignore) {
 		if tokens[i].Type != hclsyntax.TokenComment || i+1 > len(tokens) {
 			continue
 		}
+		// case: CONFIGURATION = X # comment
+		if i > 0 && tokens[i-1].Range.End.Line == tokens[i].Range.Start.Line {
+			continue
+		}
 		ignoreLines, ignoreBlocks, ignoreComments = processComment((*comment)(&tokens[i]),
 			(*comment)(&tokens[i+1]), ignoreLines, ignoreBlocks, ignoreComments)
 	}

--- a/pkg/parser/terraform/comment/comment.go
+++ b/pkg/parser/terraform/comment/comment.go
@@ -136,7 +136,7 @@ func processTokens(tokens hclsyntax.Tokens) (ig Ignore) {
 			continue
 		}
 		// case: CONFIGURATION = X # comment
-		if i > 0 && tokens[i-1].Range.End.Line == tokens[i].Range.Start.Line {
+		if i > 0 && tokens[i-1].Range.Start.Line == tokens[i].Range.Start.Line {
 			continue
 		}
 		ignoreLines, ignoreBlocks, ignoreComments = processComment((*comment)(&tokens[i]),

--- a/pkg/parser/terraform/comment/comment_test.go
+++ b/pkg/parser/terraform/comment/comment_test.go
@@ -44,6 +44,13 @@ var (
 		  }
 		  stage_name    = "development"
 		}`),
+		"dnot-ignore-lines-with-comment-in-the-end": []byte(`
+		resource "aws_api_gateway_stage" "positive2" {
+			deployment_id = "some deployment id"
+			rest_api_id   = "some rest api id" # comment
+			stage_name    = "development"     // comment
+			description   = "DEV"             /* comment */
+		}`),
 	}
 )
 
@@ -159,6 +166,12 @@ func TestComment_GetIgnoreLines(t *testing.T) {
 			content:  samples["ignore-inner-block"],
 			filename: "",
 			want:     []int{5, 6, 7, 8},
+		},
+		{
+			name:     "TestComment_GetIgnoreLines: dnot-ignore-lines-with-comment-in-the-end",
+			content:  samples["dnot-ignore-line-with-comment-in-the-end"],
+			filename: "",
+			want:     []int{},
 		},
 	}
 


### PR DESCRIPTION
Closes #

**Proposed Changes**
- Fixed bug - Terraform ParseComments, in case of comment at the end line do not ignore this line for example:
-			rest_api_id   = "some rest api id" # comment
			stage_name    = "development"     // comment
			description   = "DEV"             /* comment */
- Added test case 

I submit this contribution under the Apache-2.0 license.
