### PR TITLE
bumb(deps): bump sast schema from 14.0.1 to 15.0.6

### DIFF
--- a/pkg/report/model/gitlab_sast.go
+++ b/pkg/report/model/gitlab_sast.go
@@ -86,8 +86,8 @@ type GitlabSASTReport interface {
 // NewGitlabSASTReport initializes a new instance of GitlabSASTReport to be uses
 func NewGitlabSASTReport(start, end time.Time) GitlabSASTReport {
 	return &gitlabSASTReport{
-		Schema:          "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v14.1.0/dist/sast-report-format.json",
-		SchemaVersion:   "14.0.1",
+		Schema:          "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v15.0.6/dist/sast-report-format.json",
+		SchemaVersion:   "15.0.6",
 		Scan:            initGitlabSASTScan(start, end),
 		Vulnerabilities: make([]gitlabSASTVulnerability, 0),
 	}

--- a/pkg/report/model/gitlab_sast_test.go
+++ b/pkg/report/model/gitlab_sast_test.go
@@ -19,7 +19,7 @@ func TestNewGitlabSASTReport(t *testing.T) {
 		"https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v14.1.0/dist/sast-report-format.json",
 		glSAST.Schema,
 	)
-	require.Equal(t, "14.0.1", glSAST.SchemaVersion)
+	require.Equal(t, "15.0.6", glSAST.SchemaVersion)
 	require.Equal(t, constants.Fullname, glSAST.Scan.Scanner.Name)
 	require.Equal(t, constants.URL, glSAST.Scan.Scanner.URL)
 	require.Equal(t, end.Format(timeFormat), glSAST.Scan.EndTime)


### PR DESCRIPTION
Closes #6318

**Proposed Changes**
- bump sast schema from 14.0.1 to 15.0.6

I submit this contribution under the Apache-2.0 license.
