### PR TITLE
Fix bug 6384 by changing the implementation of locating the assets di...

### DIFF
--- a/internal/console/helpers/helpers_test.go
+++ b/internal/console/helpers/helpers_test.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -184,11 +185,9 @@ func TestHelpers_GenerateReport(t *testing.T) {
 }
 
 func TestHelpers_GetDefaultQueryPath(t *testing.T) {
-	if err := test.ChangeCurrentDir("kics"); err != nil {
-		t.Fatal(err)
-	}
-
 	cd, err := os.Getwd()
+	kicsPath := filepath.Dir(filepath.Dir(filepath.Dir(cd)))
+	fmt.Printf("kicsPath='%s', cd='%s'", kicsPath, cd)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -200,7 +199,7 @@ func TestHelpers_GetDefaultQueryPath(t *testing.T) {
 		{
 			name:        "test_get_default_query_path",
 			queriesPath: filepath.FromSlash("assets/queries"),
-			want:        filepath.Join(cd, filepath.FromSlash("assets/queries")),
+			want:        filepath.Join(kicsPath, filepath.FromSlash("assets/queries")),
 			wantErr:     false,
 		},
 		{
@@ -213,7 +212,7 @@ func TestHelpers_GetDefaultQueryPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetDefaultQueryPath(tt.queriesPath)
+			got, err := GetDefaultQueryPath(cd, tt.queriesPath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetDefaultQueryPath() = %v, wantErr = %v", err, tt.wantErr)
 			}

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -135,7 +135,7 @@ func (c *Client) GetQueryPath() (provider.ExtractedPath, error) {
 		}
 	} else {
 		log.Debug().Msgf("Looking for queries in executable path and in current work directory")
-		defaultQueryPath, errDefaultQueryPath := consoleHelpers.GetDefaultQueryPath(c.ScanParams.QueriesPath[0])
+		defaultQueryPath, errDefaultQueryPath := consoleHelpers.GetDefaultQueryPath("", c.ScanParams.QueriesPath[0])
 		if errDefaultQueryPath != nil {
 			return extPath, errors.Wrap(errDefaultQueryPath, "unable to find queries")
 		}


### PR DESCRIPTION
…rectory

Closes #6384 

**Proposed Changes**
Instead of looking for the hardwired value "kics" directory in the executable path, the proposed implementation starts from the executable location upwards until it finds the queries directory (which is by default "assets/queries" and can be configured with a command line flag). 

I submit this contribution under the Apache-2.0 license.
