### PR TITLE
added exit code for scans when no files are scanned

### DIFF
--- a/internal/console/helpers/exit_handler.go
+++ b/internal/console/helpers/exit_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Checkmarx/kics/internal/constants"
 	"github.com/Checkmarx/kics/pkg/model"
 )
 
@@ -14,7 +15,13 @@ var shouldFail map[string]struct{}
 func ResultsExitCode(summary *model.Summary) int {
 	// severityArr is needed to make sure 'for' cycle is made in an ordered fashion
 	severityArr := []model.Severity{"HIGH", "MEDIUM", "LOW", "INFO", "TRACE"}
-	codeMap := map[model.Severity]int{"HIGH": 50, "MEDIUM": 40, "LOW": 30, "INFO": 20, "TRACE": 0}
+	codeMap := map[model.Severity]int{
+		"HIGH":   constants.HighResultsExitCode,
+		"MEDIUM": constants.MediumResultsExitCode,
+		"LOW":    constants.LowResultsExitCode,
+		"INFO":   constants.InfoResultsExitCode,
+		"TRACE":  constants.TraceResultsExitCode,
+	}
 	exitMap := summary.SeveritySummary.SeverityCounters
 	for _, severity := range severityArr {
 		if _, reportSeverity := shouldFail[strings.ToLower(string(severity))]; !reportSeverity {
@@ -24,7 +31,15 @@ func ResultsExitCode(summary *model.Summary) int {
 			return codeMap[severity]
 		}
 	}
-	return 0
+	return constants.NoErrors
+}
+
+func FilesExitCode(summary *model.Summary) int {
+	if summary.ScannedFiles == 0 {
+		return constants.NoFilesScannedExitCode
+	}
+
+	return constants.NoErrors
 }
 
 // InitShouldIgnoreArg initializes what kind of errors should be used on exit codes
@@ -72,11 +87,10 @@ func ShowError(kind string) bool {
 
 // RemediateExitCode calculate exit code base on the difference between remediation selected and done
 func RemediateExitCode(selectedRemediationNumber, actualRemediationDoneNumber int) int {
-	statusCode := 70
 	if selectedRemediationNumber != actualRemediationDoneNumber {
 		// KICS AR was not able to remediate all the selected remediation
-		return statusCode
+		return constants.RemediationFailedExitCode
 	}
 
-	return 0
+	return constants.NoErrors
 }

--- a/internal/console/helpers/exit_handler_test.go
+++ b/internal/console/helpers/exit_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/Checkmarx/kics/internal/constants"
 	"github.com/Checkmarx/kics/pkg/model"
 	"github.com/Checkmarx/kics/test"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,7 @@ var resultsExitCodeTests = []struct {
 				"info":   {},
 			},
 		},
-		expectedResult: 50,
+		expectedResult: constants.HighResultsExitCode,
 	},
 	{
 		caseTest: resultExitCode{
@@ -37,7 +38,7 @@ var resultsExitCodeTests = []struct {
 				"medium": {},
 			},
 		},
-		expectedResult: 0,
+		expectedResult: constants.NoErrors,
 	},
 	{
 		caseTest: resultExitCode{
@@ -46,7 +47,7 @@ var resultsExitCodeTests = []struct {
 				"medium": {},
 			},
 		},
-		expectedResult: 40,
+		expectedResult: constants.MediumResultsExitCode,
 	},
 	{
 		caseTest: resultExitCode{
@@ -58,7 +59,7 @@ var resultsExitCodeTests = []struct {
 				"info":   {},
 			},
 		},
-		expectedResult: 50,
+		expectedResult: constants.HighResultsExitCode,
 	},
 }
 
@@ -70,6 +71,20 @@ func TestExitHandler_ResultsExitCode(t *testing.T) {
 			require.Equal(t, testCase.expectedResult, result)
 		})
 	}
+}
+
+func TestExitHandler_NoFilesScanned_NoFilesExitCode(t *testing.T) {
+	t.Run("Test case No Files Scanned", func(t *testing.T) {
+		result := FilesExitCode(&test.NoFilesSummaryMock)
+		require.Equal(t, constants.NoFilesScannedExitCode, result)
+	})
+}
+
+func TestExitHandler2_FilesScanned_NoErrorsExitCode(t *testing.T) {
+	t.Run("Test case Files Scanned", func(t *testing.T) {
+		result := FilesExitCode(&test.SimpleSummaryMock)
+		require.Equal(t, constants.NoErrors, result)
+	})
 }
 
 type initIgnoreResult struct {
@@ -248,13 +263,13 @@ func TestExitHandler_ShowError(t *testing.T) {
 func Test_RemediateAll(t *testing.T) {
 	t.Run("RemediateAllExitCode", func(t *testing.T) {
 		statusCode := RemediateExitCode(11, 11)
-		require.Equal(t, statusCode, 0)
+		require.Equal(t, constants.NoErrors, statusCode)
 	})
 }
 
 func Test_RemediateNotAll(t *testing.T) {
 	t.Run("RemediateNotAllExitCode", func(t *testing.T) {
 		statusCode := RemediateExitCode(11, 6)
-		require.Equal(t, statusCode, 70)
+		require.Equal(t, constants.RemediationFailedExitCode, statusCode)
 	})
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -104,12 +104,6 @@ const (
 	// MaximumPreviewLines - default maximum preview lines number
 	MaximumPreviewLines = 30
 
-	// EngineErrorCode - Exit Status code for error in engine
-	EngineErrorCode = 126
-
-	// SignalInterruptCode - Exit Status code for a signal interrupt
-	SignalInterruptCode = 130
-
 	// MaxInteger - max possible integer in golang
 	MaxInteger = math.MaxInt64
 

--- a/internal/constants/exit_codes.go
+++ b/internal/constants/exit_codes.go
@@ -1,0 +1,33 @@
+package constants
+
+const (
+	//NoErrors - Exit Status code for no errors found
+	NoErrors = 0
+
+	// EngineErrorCode - Exit Status code for error in engine
+	EngineErrorCode = 126
+
+	// SignalInterruptCode - Exit Status code for a signal interrupt
+	SignalInterruptCode = 130
+
+	//NoFilesScannedExitCode - Exit Status code for a scan without files
+	NoFilesScannedExitCode = 60
+
+	//HighResultsExitCode - Exit Status code for a scan with High results
+	HighResultsExitCode = 50
+
+	//MediumResultsExitCode - Exit Status code for a scan with High results
+	MediumResultsExitCode = 40
+
+	//LowResultsExitCode - Exit Status code for a scan with High results
+	LowResultsExitCode = 30
+
+	//HighResuInfoResultsExitCodeltsExitCode - Exit Status code for a scan with High results
+	InfoResultsExitCode = 20
+
+	//TraceResultsExitCode - Exit Status code for a scan with High results
+	TraceResultsExitCode = 0
+
+	//RemediationFailedExitCode - Exit Status code for calculate exit code base on the difference between remediation selected and done
+	RemediationFailedExitCode = 70
+)

--- a/pkg/scan/post_scan.go
+++ b/pkg/scan/post_scan.go
@@ -142,5 +142,10 @@ func (c *Client) postScan(scanResults *Results) error {
 		os.Exit(exitCode)
 	}
 
+	exitCode = consoleHelpers.FilesExitCode(&summary)
+	if consoleHelpers.ShowError("errors") && exitCode != 0 {
+		os.Exit(exitCode)
+	}
+
 	return nil
 }

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -321,3 +321,30 @@ var SimpleSummaryMock = model.Summary{
 		"./",
 	},
 }
+
+// SimpleSummaryMock a summary with specific results to ASFF report tests
+var NoFilesSummaryMock = model.Summary{
+	Counters: model.Counters{
+		ScannedFiles:           0,
+		ParsedFiles:            0,
+		FailedToScanFiles:      0,
+		TotalQueries:           0,
+		FailedToExecuteQueries: 0,
+	},
+	Queries: []model.QueryResult{
+		queryMedium,
+	},
+	SeveritySummary: model.SeveritySummary{
+		ScanID: "console",
+		SeverityCounters: map[model.Severity]int{
+			model.SeverityInfo:   0,
+			model.SeverityLow:    0,
+			model.SeverityMedium: 0,
+			model.SeverityHigh:   0,
+		},
+		TotalCounter: 0,
+	},
+	ScannedPaths: []string{
+		"./",
+	},
+}


### PR DESCRIPTION
**Proposed Changes**

Adds exit code `60` for scans when there are no files to scan (either empty or no recognizable files)

I submit this contribution under the Apache-2.0 license.
