### PR TITLE
chore(-): update gitlab sast schema to 15.0.6

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -318,9 +318,17 @@ Gitlab SAST reports are sorted by severity (from high to info), following [Gitla
 
 ```json
 {
-    "schema": "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v14.1.0/dist/sast-report-format.json",
-    "version": "14.1.0",
+    "schema": "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v15.0.6/dist/sast-report-format.json",
+    "version": "15.0.6",
     "scan": {
+        "analyzer": {
+              "id": "keeping-infrastructure-as-code-secure",
+              "name": "Keeping Infrastructure as Code Secure",
+              "version": "1.2.0",
+              "vendor":{
+                "name": "Checkmarx"
+            }
+        },
         "start_time": "2021-05-26T17:22:13",
         "end_time": "2021-05-26T17:22:13",
         "status": "success",
@@ -338,15 +346,8 @@ Gitlab SAST reports are sorted by severity (from high to info), following [Gitla
     "vulnerabilities": [
         {
             "id": "32e763ac363dfee1ea972d951fb3de00f5f7a8d3f9f57b93e55e2d51957794a6",
-            "category": "sast",
             "severity": "High",
-            "cve": "32e763ac363dfee1ea972d951fb3de00f5f7a8d3f9f57b93e55e2d51957794a6",
-            "scanner": {
-                "id": "keeping_infrastructure_as_code_secure",
-                "name": "Keeping Infrastructure as Code Secure"
-            },
             "name": "Container Is Privileged",
-            "message": "Do not allow container to be privileged.",
             "links": [
                 {
                     "url": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#privileged"
@@ -368,15 +369,8 @@ Gitlab SAST reports are sorted by severity (from high to info), following [Gitla
         },
         {
             "id": "32e763ac363dfee1ea972d951fb3de00f5f7a8d3f9f57b93e55e2d51957794a6",
-            "category": "sast",
             "severity": "High",
-            "cve": "32e763ac363dfee1ea972d951fb3de00f5f7a8d3f9f57b93e55e2d51957794a6",
-            "scanner": {
-                "id": "keeping_infrastructure_as_code_secure",
-                "name": "Keeping Infrastructure as Code Secure"
-            },
             "name": "Container Is Privileged",
-            "message": "Do not allow container to be privileged.",
             "links": [
                 {
                     "url": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#privileged"
@@ -398,15 +392,8 @@ Gitlab SAST reports are sorted by severity (from high to info), following [Gitla
         },
         {
             "id": "3d4f14f3ac2ebc0d2cb1710eec4f61fae359fe78ab244cb716485cb6c90846f6",
-            "category": "sast",
             "severity": "High",
-            "cve": "3d4f14f3ac2ebc0d2cb1710eec4f61fae359fe78ab244cb716485cb6c90846f6",
-            "scanner": {
-                "id": "keeping_infrastructure_as_code_secure",
-                "name": "Keeping Infrastructure as Code Secure"
-            },
             "name": "Container Is Privileged",
-            "message": "Do not allow container to be privileged.",
             "links": [
                 {
                     "url": "https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/pod#privileged"

--- a/e2e/fixtures/schemas/result-gl-sast.json
+++ b/e2e/fixtures/schemas/result-gl-sast.json
@@ -18,6 +18,7 @@
         "scan": {
             "type": "object",
             "required": [
+                "analyzer",
                 "start_time",
                 "end_time",
                 "status",
@@ -25,13 +26,50 @@
                 "scanner"
             ],
             "properties": {
+                "analyzer": {
+                    "type": "object",
+                    "required": [
+                        "id",
+                        "name",
+                        "version",
+                        "vendor"
+                      ],
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "name": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "url": {
+                          "type": "string",
+                          "format": "uri",
+                          "pattern": "^https?://.+"
+                        },
+                        "vendor": {
+                          "type": "object",
+                          "required": [
+                            "name"
+                          ],
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                        }
+                    }
+                }
+            },   
                 "start_time": {
                     "type": "string",
                     "minLength": 1
                 },
                 "end_time": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"
                 },
                 "status": {
                     "type": "string",
@@ -89,12 +127,8 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "category",
                     "severity",
-                    "cve",
-                    "scanner",
                     "name",
-                    "message",
                     "links",
                     "location",
                     "identifiers"
@@ -103,10 +137,6 @@
                     "id": {
                         "type": "string",
                         "pattern": "^[A-Fa-f0-9]{64}$"
-                    },
-                    "category": {
-                        "type": "string",
-                        "minLength": 1
                     },
                     "severity": {
                         "type": "string",
@@ -117,34 +147,10 @@
                             "Info"
                         ]
                     },
-                    "cve": {
-                        "type": "string",
-                        "pattern": "^[A-Fa-f0-9]{64}$"
-                    },
-                    "scanner": {
-                        "type": "object",
-                        "required": [
-                            "id",
-                            "name"
-                        ],
-                        "properties": {
-                            "id": {
-                                "type": "string",
-                                "minLength": 1
-                            },
-                            "name": {
-                                "type": "string",
-                                "minLength": 1
-                            }
-                        }
-                    },
                     "name": {
                         "type": "string",
-                        "minLength": 1
-                    },
-                    "message": {
-                        "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 255
                     },
                     "links": {
                         "type": "array",

--- a/pkg/report/model/gitlab_sast.go
+++ b/pkg/report/model/gitlab_sast.go
@@ -57,11 +57,6 @@ type gitlabSASTVulnerabilityLink struct {
 	URL string `json:"url"`
 }
 
-type gitlabSASTVulnerabilityScanner struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
 type gitlabSASTVulnerabilityLocation struct {
 	File  string `json:"file"`
 	Start int    `json:"start_line"`

--- a/pkg/report/model/gitlab_sast.go
+++ b/pkg/report/model/gitlab_sast.go
@@ -21,11 +21,12 @@ type gitlabSASTReport struct {
 }
 
 type gitlabSASTScan struct {
-	StartTime string            `json:"start_time"`
-	EndTime   string            `json:"end_time"`
-	Status    string            `json:"status"`
-	Scantype  string            `json:"type"`
-	Scanner   gitlabSASTScanner `json:"scanner"`
+	Analyzer  gitlabSASTAnalyzer `json:"analyzer"`
+	StartTime string             `json:"start_time"`
+	EndTime   string             `json:"end_time"`
+	Status    string             `json:"status"`
+	Scantype  string             `json:"type"`
+	Scanner   gitlabSASTScanner  `json:"scanner"`
 }
 
 type gitlabSASTScanner struct {
@@ -44,25 +45,21 @@ type gitlabSASTVulnerabilityDetails map[string]interface{}
 
 type gitlabSASTVulnerability struct {
 	ID          string                              `json:"id"`
-	Category    string                              `json:"category"`
 	Severity    string                              `json:"severity"`
-	CVE         string                              `json:"cve"`
-	Scanner     gitlabSASTVulnerabilityScanner      `json:"scanner"`
 	Name        string                              `json:"name"`
-	Message     string                              `json:"message"`
 	Links       []gitlabSASTVulnerabilityLink       `json:"links"`
 	Location    gitlabSASTVulnerabilityLocation     `json:"location"`
 	Identifiers []gitlabSASTVulnerabilityIdentifier `json:"identifiers"`
 	Details     gitlabSASTVulnerabilityDetails      `json:"details,omitempty"`
 }
 
+type gitlabSASTVulnerabilityLink struct {
+	URL string `json:"url"`
+}
+
 type gitlabSASTVulnerabilityScanner struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
-}
-
-type gitlabSASTVulnerabilityLink struct {
-	URL string `json:"url"`
 }
 
 type gitlabSASTVulnerabilityLocation struct {
@@ -78,16 +75,23 @@ type gitlabSASTVulnerabilityIdentifier struct {
 	Value          string `json:"value"`
 }
 
+type gitlabSASTAnalyzer struct {
+	ID      string                  `json:"id"`
+	Name    string                  `json:"name"`
+	Version string                  `json:"version"`
+	Vendor  gitlabSASTScannerVendor `json:"vendor"`
+}
+
 // GitlabSASTReport represents a usable gitlab sast report reference
 type GitlabSASTReport interface {
 	BuildGitlabSASTVulnerability(issue *model.QueryResult, file *model.VulnerableFile)
 }
 
-// NewGitlabSASTReport initializes a new instance of GitlabSASTReport to be uses
+// NewGitlabSASTReport initializes a new instance of GitlabSASTReport to be used
 func NewGitlabSASTReport(start, end time.Time) GitlabSASTReport {
 	return &gitlabSASTReport{
-		Schema:          "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v14.1.0/dist/sast-report-format.json",
-		SchemaVersion:   "14.0.1",
+		Schema:          "https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v15.0.6/dist/sast-report-format.json",
+		SchemaVersion:   "15.0.6",
 		Scan:            initGitlabSASTScan(start, end),
 		Vulnerabilities: make([]gitlabSASTVulnerability, 0),
 	}
@@ -95,6 +99,14 @@ func NewGitlabSASTReport(start, end time.Time) GitlabSASTReport {
 
 func initGitlabSASTScan(start, end time.Time) gitlabSASTScan {
 	return gitlabSASTScan{
+		Analyzer: gitlabSASTAnalyzer{
+			ID:      "keeping-infrastructure-as-code-secure",
+			Name:    constants.Fullname,
+			Version: constants.Version,
+			Vendor: gitlabSASTScannerVendor{
+				Name: "Checkmarx",
+			},
+		},
 		Status:    "success",
 		Scantype:  "sast",
 		StartTime: start.Format(timeFormat),
@@ -116,15 +128,8 @@ func (glsr *gitlabSASTReport) BuildGitlabSASTVulnerability(issue *model.QueryRes
 	if len(issue.Files) > 0 {
 		vulnerability := gitlabSASTVulnerability{
 			ID:       file.SimilarityID,
-			Category: "sast",
 			Severity: cases.Title(language.Und).String(strings.ToLower(string(issue.Severity))),
-			CVE:      file.SimilarityID,
-			Scanner: gitlabSASTVulnerabilityScanner{
-				ID:   "keeping_infrastructure_as_code_secure",
-				Name: constants.Fullname,
-			},
-			Name:    issue.QueryName,
-			Message: issue.Description,
+			Name:     issue.QueryName,
 			Links: []gitlabSASTVulnerabilityLink{
 				{
 					URL: issue.QueryURI,
@@ -145,7 +150,6 @@ func (glsr *gitlabSASTReport) BuildGitlabSASTVulnerability(issue *model.QueryRes
 			},
 		}
 		if issue.CISDescriptionID != "" {
-			vulnerability.Message = issue.CISDescriptionTextFormatted
 			vulnerability.Details = gitlabSASTVulnerabilityDetails{
 				"cisTitle": issue.CISDescriptionTitle,
 				"cisId":    issue.CISDescriptionIDFormatted,

--- a/pkg/report/model/gitlab_sast_test.go
+++ b/pkg/report/model/gitlab_sast_test.go
@@ -16,10 +16,10 @@ func TestNewGitlabSASTReport(t *testing.T) {
 	glSAST := NewGitlabSASTReport(start, end).(*gitlabSASTReport)
 	require.Equal(
 		t,
-		"https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v14.1.0/dist/sast-report-format.json",
+		"https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/raw/v15.0.6/dist/sast-report-format.json",
 		glSAST.Schema,
 	)
-	require.Equal(t, "14.0.1", glSAST.SchemaVersion)
+	require.Equal(t, "15.0.6", glSAST.SchemaVersion)
 	require.Equal(t, constants.Fullname, glSAST.Scan.Scanner.Name)
 	require.Equal(t, constants.URL, glSAST.Scan.Scanner.URL)
 	require.Equal(t, end.Format(timeFormat), glSAST.Scan.EndTime)
@@ -57,7 +57,6 @@ var tests = []gitlabSASTTest{
 			Description: "test description",
 			QueryURI:    "https://www.test.com",
 			Severity:    model.SeverityHigh,
-			Category:    "sast",
 			Files: []model.VulnerableFile{
 				{KeyActualValue: "test", FileName: "test.json", Line: 1, SimilarityID: "similarity"},
 			},
@@ -72,15 +71,8 @@ var tests = []gitlabSASTTest{
 			Vulnerabilities: []gitlabSASTVulnerability{
 				{
 					ID:       "similarity",
-					Category: "sast",
 					Severity: "High",
-					CVE:      "similarity",
-					Scanner: gitlabSASTVulnerabilityScanner{
-						ID:   "keeping_infrastructure_as_code_secure",
-						Name: constants.Fullname,
-					},
-					Name:    "test",
-					Message: "test description",
+					Name:     "test",
 					Links: []gitlabSASTVulnerabilityLink{
 						{
 							URL: "https://www.test.com",


### PR DESCRIPTION
Closes #6318

**Proposed Changes**
- update SAST report schema to version 15.0.6
- remove deprecated fields from the `vulnerabilities[]` object and add required `analyzer` object

I submit this contribution under the Apache-2.0 license.
