### PR TITLE
remove unused allowRule

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -6,10 +6,6 @@
       "regex": "(?i)['\"]?password['\"]?\\s*[:=]\\s*['\"]?([A-Za-z0-9/~^_!@&%()=?*+-.]{4,})['\"]?",
       "allowRules": [
         {
-          "description": "Avoiding TF resource access",
-          "regex": "(?i)['\"]?password['\"]?\\s*=\\s*([a-zA-z_]+(.))?[a-zA-z_]+(.)[a-zA-z_]+(.)[a-zA-z_]+"
-        },
-        {
           "description": "Avoiding CF AllowUsersToChangePassword",
           "regex": "['\"]?AllowUsersToChangePassword['\"]?\\s*[:=]\\s*['\"]?([A-Za-z0-9/~^_!@&%()=?*+-.]{4,})['\"]?"
         }


### PR DESCRIPTION
**Proposed Changes**
- Remove allowRule for query Generic Password (this allow rule is not relevant in any test and the tests pass without it, it is however excluding some good results)

I submit this contribution under the Apache-2.0 license.
