### PR TITLE
Drop patch version from alpine docker tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ HEALTHCHECK CMD wget -q --method=HEAD localhost/system-status.txt
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM alpine:3.18.0
+FROM alpine:3.18
 
 ENV TERM xterm-256color
 


### PR DESCRIPTION
Closes #6459

Drop patch version from alpine docker tag

I submit this contribution under the Apache-2.0 license.