### PR TITLE
fix: ignore kubernetes_cronjob_v1 when checking for readiness probe

### DIFF
--- a/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/query.rego
+++ b/assets/queries/terraform/kubernetes/readiness_probe_is_not_configured/query.rego
@@ -53,7 +53,7 @@ CxPolicy[result] {
 }
 
 resource_equal(type) {
-	resources := {"kubernetes_cron_job", "kubernetes_job"}
+	resources := {"kubernetes_cron_job", "kubernetes_cron_job_v1", "kubernetes_job"}
 
 	type == resources[_]
 }


### PR DESCRIPTION
**Proposed Changes**
- Ignores the new kubernetes_cronjob_v1 resource when checking for resources that don't define their readiness probe


I submit this contribution under the Apache-2.0 license.