### PR TITLE
fix(docker): test fails on legit npm version pinning

### DIFF
--- a/assets/queries/dockerfile/npm_install_without_pinned_version/test/negative.dockerfile
+++ b/assets/queries/dockerfile/npm_install_without_pinned_version/test/negative.dockerfile
@@ -6,3 +6,6 @@ RUN npm install sax@0.1.1 | grep fail && npm install sax@latest
 RUN npm install git://github.com/npm/cli.git
 RUN npm install git+ssh://git@github.com:npm/cli#semver:^5.0
 RUN npm install --production --no-cache
+RUN npm install -g @commitlint/cli@17.4.4 @commitlint/config-conventional@17.4.4 @ionic/cli@6.18.0 @semantic-release/changelog@5.0.1 @semantic-release/git@9.0.0 @semantic-release/gitlab@6.2.1
+RUN npm install -g @commitlint/cli@17.4.4 @commitlint/config-conventional@17.4.4 \
+    @ionic/cli@6.18.0 @semantic-release/changelog@5.0.1 @semantic-release/git@9.0.0 @semantic-release/gitlab@6.2.1


### PR DESCRIPTION
WIP: verifying this test case is broken on HEAD.

**Proposed Changes**
- NPM install without pinned version fails when using legitimate pinned versions
-
-

I submit this contribution under the Apache-2.0 license.