### PR TITLE
fix(engine): added condition to check if gitignore is not empty to fix unit tests

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -633,7 +633,7 @@ func shouldConsiderGitIgnoreFile(path, gitIgnore string, excludeGitIgnoreFile bo
 	gitIgnorePath := filepath.ToSlash(filepath.Join(path, gitIgnore))
 	_, err := os.Stat(gitIgnorePath)
 
-	if !excludeGitIgnoreFile && err == nil {
+	if !excludeGitIgnoreFile && err == nil && gitIgnore != "" {
 		gitIgnore, _ := ignore.CompileIgnoreFile(gitIgnorePath)
 		if gitIgnore != nil {
 			log.Info().Msgf(".gitignore file was found in '%s' and it will be used to automatically exclude paths", path)


### PR DESCRIPTION
**Proposed Changes**
- Added condition into analyzer's function _shouldConsiderGitIgnoreFile_ to check if gitignore is not empty.


I submit this contribution under the Apache-2.0 license.