### PR TITLE
docs(guides): changed code-ql action to v2 due to v1 depecration

### DIFF
--- a/docs/integrations_ghactions.md
+++ b/docs/integrations_ghactions.md
@@ -50,7 +50,7 @@ steps:
       path: 'terraform'
       output_path: results-dir
   - name: Upload SARIF file
-    uses: github/codeql-action/upload-sarif@v1
+    uses: github/codeql-action/upload-sarif@v2
     with:
       sarif_file: results-dir/results.sarif
 ```

--- a/docs/integrations_ghactions.md
+++ b/docs/integrations_ghactions.md
@@ -202,7 +202,7 @@ jobs:
           cat results-dir/results.sarif
           cat results-dir/results.json
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results-dir/results.sarif
 ```
@@ -253,7 +253,7 @@ jobs:
           path: 'terraform'
           config_path: ./kics.config
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results-dir/results.sarif
 ```


### PR DESCRIPTION
Updated github/codeql-action/upload-sarif to v2 since v1 was deprecated

Closes #

**Proposed Changes**
- Updated documentation for github/codeql-action/upload-sarif from v1 to v2
- v1 was depecrated by github and if used results in a workflow error

![image](https://github.com/Checkmarx/kics/assets/46198926/0a84e42a-dcc7-450d-9000-bf065bdf1349)


I submit this contribution under the Apache-2.0 license.