### PR TITLE
fix(query): ca certificate identifier is outdated ansible aws

### DIFF
--- a/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/metadata.json
+++ b/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/metadata.json
@@ -3,8 +3,8 @@
   "queryName": "CA Certificate Identifier Is Outdated",
   "severity": "HIGH",
   "category": "Encryption",
-  "descriptionText": "The CA certificate Identifier must be 'rds-ca-2019'.",
-  "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/community/aws/rds_instance_module.html#parameter-ca_certificate_identifier",
+  "descriptionText": "The certificate authority (CA) is the certificate that identifies the root CA at the top of the certificate chain. The CA certificate identifier must be one provided by Amazon RDS.",
+  "descriptionUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html",
   "platform": "Ansible",
   "descriptionID": "d92aa922",
   "cloudProvider": "aws"

--- a/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/query.rego
+++ b/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/query.rego
@@ -28,7 +28,8 @@ CxPolicy[result] {
 	rds_instance := task[modules[m]]
 	ansLib.checkState(rds_instance)
 
-	rds_instance.ca_certificate_identifier != "rds-ca-2019"
+	allowed := ["rds-ca-2019", "rds-ca-rsa2048-g1", "rds-ca-rsa4096-g1", "rds-ca-ecc384-g1"]
+    not common_lib.inArray(allowed, rds_instance.ca_certificate_identifier)
 
 	result := {
 		"documentId": id,
@@ -36,7 +37,7 @@ CxPolicy[result] {
 		"resourceName": task.name,
 		"searchKey": sprintf("name={{%s}}.{{%s}}.ca_certificate_identifier", [task.name, modules[m]]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "rds_instance.ca_certificate_identifier should equal to 'rds-ca-2019'",
-		"keyActualValue": "rds_instance.ca_certificate_identifier is not equal to 'rds-ca-2019'",
+		"keyExpectedValue": "rds_instance.ca_certificate_identifier should equal to one provided by Amazon RDS.",
+		"keyActualValue": sprintf("'aws_db_instance.ca_cert_identifier' is '%s'", [rds_instance.ca_certificate_identifier]),
 	}
 }

--- a/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/test/negative2.yaml
+++ b/assets/queries/ansible/aws/ca_certificate_identifier_is_outdated/test/negative2.yaml
@@ -1,0 +1,20 @@
+- name: create minimal aurora instance in default VPC and default subnet group
+  community.aws.rds_instance:
+    engine: aurora
+    db_instance_identifier: ansible-test-aurora-db-instance
+    instance_type: db.t2.small
+    password: '{{ password }}'
+    username: '{{ username }}'
+    cluster_id: ansible-test-cluster
+    ca_certificate_identifier: rds-ca-ecc384-g1
+- name: Create a DB instance using the default AWS KMS encryption key
+  community.aws.rds_instance:
+    id: test-encrypted-db
+    state: present
+    engine: mariadb
+    storage_encrypted: true
+    db_instance_class: db.t2.medium
+    username: '{{ username }}'
+    password: '{{ password }}'
+    allocated_storage: '{{ allocated_storage }}'
+    ca_certificate_identifier: rds-ca-ecc384-g1


### PR DESCRIPTION
Contribution to Closes #6680 

**Proposed Changes**
- Transferred the changes for the ca certificate identifier check in Terraform from MR #6683 to Ansible as well.

I submit this contribution under the Apache-2.0 license.