### PR TITLE
fix(query): meaningful "Value" and "Expected Value" in multiple queries

### DIFF
--- a/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
+++ b/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
@@ -37,7 +37,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [name, resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
+++ b/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
@@ -18,8 +18,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} avoids manual input", [name, resource.Original]),
-		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} doesn't avoid manual input", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
+		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [resource.Original]),
 	}
 }
 
@@ -37,8 +37,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} avoids manual input", [name, resource.Original]),
-		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} doesn't avoid manual input", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [name, resource.Original]),
+		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [name, resource.Original]),
 	}
 }
 

--- a/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
+++ b/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
@@ -38,7 +38,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
-		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [name, resource.Original]),
+		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [resource.Original]),
 	}
 }
 

--- a/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
+++ b/assets/queries/dockerfile/apt_get_missing_yes_flag_to_avoid_manual_input/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} sould avoid manual input", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [resource.Original]),
 	}
 }
@@ -37,7 +37,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should avoid manual input", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/changing_default_shell_using_run_command/query.rego
+++ b/assets/queries/dockerfile/changing_default_shell_using_run_command/query.rego
@@ -34,7 +34,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("{{%s}} should use the SHELL command to change the default shell", [resource.Original]),
-		"keyActualValue": sprintf("{{%s}} uses the RUN command to change the default shell", [name, resource.Original]),
+		"keyActualValue": sprintf("{{%s}} uses the RUN command to change the default shell", [resource.Original]),
 	}
 }
 

--- a/assets/queries/dockerfile/changing_default_shell_using_run_command/query.rego
+++ b/assets/queries/dockerfile/changing_default_shell_using_run_command/query.rego
@@ -33,7 +33,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} should use the SHELL command to change the default shell", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should use the SHELL command to change the default shell", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} uses the RUN command to change the default shell", [name, resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/changing_default_shell_using_run_command/query.rego
+++ b/assets/queries/dockerfile/changing_default_shell_using_run_command/query.rego
@@ -51,6 +51,6 @@ CxPolicy[result] {
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("{{%s}} should use the SHELL command to change the default shell", [name, resource.Original]),
-		"keyActualValue": sprintf("{{%s}} uses the RUN command to change the default shell", [name, resource.Original]),
+		"keyActualValue": sprintf("{{%s}} uses the RUN command to change the default shell", [resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/changing_default_shell_using_run_command/query.rego
+++ b/assets/queries/dockerfile/changing_default_shell_using_run_command/query.rego
@@ -21,20 +21,20 @@ CxPolicy[result] {
 	resource := input.document[i].command[name][_]
 	resource.Cmd == "run"
     value := resource.Value
-	
+
 	contains(value[v], shell_possibilities[p])
 	run_values := split(value[v], " ")
 	command := run_values[0]
 	command_possibilities := {"mv", "chsh", "usermod", "ln"}
-	command == command_possibilities[cp] 
+	command == command_possibilities[cp]
 
 	result := {
     	"debug": sprintf("%s", [value[v]]),
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} should use the SHELL command to change the default shell", [name, resource.Original]),
-		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} uses the RUN command to change the default shell", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should use the SHELL command to change the default shell", [name, resource.Original]),
+		"keyActualValue": sprintf("{{%s}} uses the RUN command to change the default shell", [name, resource.Original]),
 	}
 }
 
@@ -50,7 +50,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} should use the SHELL command to change the default shell", [name, resource.Original]),
-		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} uses the RUN command to change the default shell", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should use the SHELL command to change the default shell", [name, resource.Original]),
+		"keyActualValue": sprintf("{{%s}} uses the RUN command to change the default shell", [name, resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/changing_default_shell_using_run_command/query.rego
+++ b/assets/queries/dockerfile/changing_default_shell_using_run_command/query.rego
@@ -50,7 +50,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} should use the SHELL command to change the default shell", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should use the SHELL command to change the default shell", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} uses the RUN command to change the default shell", [resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/missing_flag_from_dnf_install/query.rego
+++ b/assets/queries/dockerfile/missing_flag_from_dnf_install/query.rego
@@ -18,7 +18,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "When running `dnf install`, `-y` or `--assumeyes` switch should be set to avoid build failure ",
-		"keyActualValue": sprintf("Command `FROM={{%s}}.RUN={{%s}}` doesn't have the `-y` or `--assumeyes` switch set", [name, trim_space(commands[k])]),
+		"keyActualValue": sprintf("Command `RUN={{%s}}` doesn't have the `-y` or `--assumeyes` switch set", [trim_space(commands[k])]),
 	}
 }
 

--- a/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/query.rego
+++ b/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/query.rego
@@ -5,7 +5,7 @@ import data.generic.dockerfile as dockerLib
 CxPolicy[result] {
 	resource := input.document[i].command[name][_]
 	dockerLib.check_multi_stage(name, input.document[i].command)
-	
+
 	resource.Cmd == "cmd"
 	resource.JSON == false
 
@@ -13,15 +13,15 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} is in the JSON Notation", [name, resource.Original]),
-		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} isn't in the JSON Notation", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} is in the JSON Notation", [resource.Original]),
+		"keyActualValue": sprintf("{{%s}} isn't in the JSON Notation", [resource.Original]),
 	}
 }
 
 CxPolicy[result] {
 	resource := input.document[i].command[name][_]
 	dockerLib.check_multi_stage(name, input.document[i].command)
-	
+
 	resource.Cmd == "entrypoint"
 	resource.JSON == false
 
@@ -29,7 +29,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} is in the JSON Notation", [name, resource.Original]),
-		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} isn't in the JSON Notation", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} is in the JSON Notation", [resource.Original]),
+		"keyActualValue": sprintf("{{%s}} isn't in the JSON Notation", [resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/query.rego
+++ b/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/query.rego
@@ -14,7 +14,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("{{%s}} is in the JSON Notation", [resource.Original]),
-		"keyActualValue": sprintf("{{%s}} isn't in the JSON Notation", [resource.Original]),
+		"keyActualValue": sprintf("{{%s}} should be in JSON Notation", [resource.Original]),
 	}
 }
 

--- a/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/query.rego
+++ b/assets/queries/dockerfile/not_using_json_in_cmd_and_entrypoint_arguments/query.rego
@@ -13,8 +13,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} is in the JSON Notation", [resource.Original]),
-		"keyActualValue": sprintf("{{%s}} should be in JSON Notation", [resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should be in the JSON Notation", [resource.Original]),
+		"keyActualValue": sprintf("{{%s}} isn't in JSON Notation", [resource.Original]),
 	}
 }
 
@@ -29,7 +29,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} is in the JSON Notation", [resource.Original]),
-		"keyActualValue": sprintf("{{%s}} isn't in the JSON Notation", [resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should be in the JSON Notation", [resource.Original]),
+        "keyActualValue": sprintf("{{%s}} isn't in JSON Notation", [resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/yum_clean_all_missing/query.rego
+++ b/assets/queries/dockerfile/yum_clean_all_missing/query.rego
@@ -19,8 +19,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} should have 'yum clean all' after 'yum install' command", [name, resource.Original]),
-		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} doesn't have 'yum clean all' after 'yum install' command", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should have 'yum clean all' after 'yum install' command", [resource.Original]),
+		"keyActualValue": sprintf("{{%s}} doesn't have 'yum clean all' after 'yum install' command", [resource.Original]),
 	}
 }
 

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
-		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [name, resource.Original]),
+		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [resource.Original]),
 	}
 }
 

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} should avoids manual input", [resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should avoid manual input", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [resource.Original]),
 	}
 }
@@ -34,7 +34,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} should avoids manual input", [resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should avoid manual input", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should avoids manual input", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [resource.Original]),
 	}
 }
@@ -34,7 +34,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} should avoids manual input", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
@@ -34,7 +34,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [name, resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
@@ -35,7 +35,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
-		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [name, resource.Original]),
+		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [resource.Original]),
 	}
 }
 

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
@@ -16,7 +16,7 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [resource.Original]),
 		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [name, resource.Original]),
 	}
 }

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
@@ -16,8 +16,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} avoids manual input", [name, resource.Original]),
-		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} doesn't avoid manual input", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [name, resource.Original]),
+		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [name, resource.Original]),
 	}
 }
 
@@ -34,8 +34,8 @@ CxPolicy[result] {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("FROM={{%s}}.{{%s}} avoids manual input", [name, resource.Original]),
-		"keyActualValue": sprintf("FROM={{%s}}.{{%s}} doesn't avoid manual input", [name, resource.Original]),
+		"keyExpectedValue": sprintf("{{%s}} avoids manual input", [name, resource.Original]),
+		"keyActualValue": sprintf("{{%s}} doesn't avoid manual input", [name, resource.Original]),
 	}
 }
 


### PR DESCRIPTION
Closes #

**Proposed Changes**
-Update the fields informative from the queries (keyExpectedValue & keyActualValue) to not contain the "FROM {%s}" when is not necessary

I submit this contribution under the Apache-2.0 license.