### PR TITLE
fix(workflow): update release-kics-queries-repo-branch.yaml

### DIFF
--- a/.github/workflows/release-kics-queries-repo-branch.yaml
+++ b/.github/workflows/release-kics-queries-repo-branch.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Copy queries to new branch
       run: |
           mkdir -p ../$REPO_NAME/kics-queries
-          rsync -av --exclude='*/test/*' --exclude='*/common/*' ./assets/queries/ ../$REPO_NAME/kics-queries/
+          rsync -av --exclude='*/test/*' --exclude='common/*' ./assets/queries/ ../$REPO_NAME/kics-queries/
 
     - name: Copy circle ci configuration to new branch
       run: |


### PR DESCRIPTION
**Proposed Changes**
- Remove the "/", when trying to exclude the copying of the common queries

I submit this contribution under the Apache-2.0 license.