### PR TITLE
fix(deps): update go version version in debian image

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -3,7 +3,7 @@
 # it does not define an ENTRYPOINT as this is a requirement described here:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops#linux-based-containers
 #
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.18.2-buster as build_env
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.20.5-buster as build_env
 # Create a group and user
 RUN groupadd checkmarx && useradd -g checkmarx -M -s /bin/bash checkmarx
 USER checkmarx


### PR DESCRIPTION
**Proposed Changes**
- bump go version in debian dockerfile

I submit this contribution under the Apache-2.0 license.