### PR TITLE
Draft: ✨ Change 'SLL' to 'SSL' in queryName for Cloud SQL

### DIFF
--- a/assets/queries/ansible/gcp/sql_db_instance_with_ssl_disabled/metadata.json
+++ b/assets/queries/ansible/gcp/sql_db_instance_with_ssl_disabled/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "SQL DB Instance With SSL Disabled",
   "severity": "HIGH",
   "category": "Encryption",
-  "descriptionText": "Cloud SQL Database Instance should have SLL enabled",
+  "descriptionText": "Cloud SQL Database Instance should have SSL enabled",
   "descriptionUrl": "https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_sql_instance_module.html#parameter-settings/ip_configuration/require_ssl",
   "platform": "Ansible",
   "descriptionID": "50bb06d6",

--- a/assets/queries/googleDeploymentManager/gcp/sql_db_instance_with_ssl_disabled/metadata.json
+++ b/assets/queries/googleDeploymentManager/gcp/sql_db_instance_with_ssl_disabled/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "SQL DB Instance With SSL Disabled",
   "severity": "HIGH",
   "category": "Encryption",
-  "descriptionText": "Cloud SQL Database Instance should have SLL enabled",
+  "descriptionText": "Cloud SQL Database Instance should have SSL enabled",
   "descriptionUrl": "https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances",
   "platform": "GoogleDeploymentManager",
   "descriptionID": "b42ee5a9",

--- a/assets/queries/terraform/gcp/sql_db_instance_with_ssl_disabled/metadata.json
+++ b/assets/queries/terraform/gcp/sql_db_instance_with_ssl_disabled/metadata.json
@@ -3,7 +3,7 @@
   "queryName": "SQL DB Instance With SSL Disabled",
   "severity": "HIGH",
   "category": "Encryption",
-  "descriptionText": "Cloud SQL Database Instance should have SLL enabled",
+  "descriptionText": "Cloud SQL Database Instance should have SSL enabled",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#require_ssl",
   "platform": "Terraform",
   "descriptionID": "8983549e",


### PR DESCRIPTION
Closes #

**Proposed Changes**
-
-
-

I submit this contribution under the Apache-2.0 license.

## 📓 Notes

I was testing GitLab's [Infrastructure as Code scanning](https://docs.gitlab.com/ee/user/application_security/iac_scanning/) with [TerraGoat](https://github.com/bridgecrewio/terragoat) and noticed that one of the vulnerabilities that was detected said:

```
Cloud SQL Database Instance should have SLL enabled
```

The identifier links to [require_ssl](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#require_ssl) and the **Description** said:

```
'settings.ip_configuration.require_ssl' is undefined or null
```

It looks like the `queryName` has included 'SLL' instead of 'SSL' since https://github.com/Checkmarx/kics/pull/4693/files. 

This PR adjusts the `queryName` in three queries. 