### PR TITLE
docs(guides): remove ZWSPs & align column separators

### DIFF
--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -79,7 +79,7 @@ You can enclose all your configurations in a file and use it in two different wa
 3. Pass the configuration file as argument:
 
 ```
-docker run -t -v {​​​​path_to_kics_config}​​​​:/kics -v {path_to_host_folder_to_scan}:/path checkmarx/kics scan -p /path --config /kics/kics-config.json
+docker run -t -v {path_to_kics_config}:/kics -v {path_to_host_folder_to_scan}:/path checkmarx/kics scan -p /path --config /kics/kics-config.json
 ```
 
 #### Configuration as Code

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -4,13 +4,13 @@ The values below were obtained after scanning 150 open source projects with KICS
 the supported IaC technologies (c.f., Terraform, Ansible, Kubernetes, Docker, AWS Cloudformation).
 
 
-| IaC Technology    | Query Accuracy<sup>1</sup>    | Query Coverage<sup>2</sup> | Scanned IaC files​ | Number of Results​ | Average Scan Time​ (s) | Average Project Size (MB) |
-| :---              | :---     | :---    | :--- | :---     | :---| :---|
-| Terraform​         | 99.7%​    | 46%     | 1176​ | 709      | 6.6  | 33.4​ |
-| Docker​            | 98.8%​​    | 68%​     | 1017​ | 5109     | 11   | 0.7 |​
-| Kubernetes​        | 99.3%​​    | 88.7%​   | 6089​ | 21753    | 7    | 90 |​
-| CloudFormation​    | 95%​      | 73%​     | 1769​ | 5343     | 10.2 | 4.8 |​
-| Ansible ​          | 100%     |​ 54%​     | 3367​ | 1320     | 23.3 | 4.1 |​
+| IaC Technology    | Query Accuracy<sup>1</sup>    | Query Coverage<sup>2</sup> | Scanned IaC files | Number of Results | Average Scan Time (s) | Average Project Size (MB) |
+| :---              | :---     | :---    | :--- | :---     | :---| :---  |
+| Terraform         | 99.7%    | 46%     | 1176 | 709      | 6.6  | 33.4 |
+| Docker            | 98.8%    | 68%     | 1017 | 5109     | 11   | 0.7  |
+| Kubernetes        | 99.3%    | 88.7%   | 6089 | 21753    | 7    | 90   |
+| CloudFormation    | 95%      | 73%     | 1769 | 5343     | 10.2 | 4.8  |
+| Ansible           | 100%     | 54%     | 3367 | 1320     | 23.3 | 4.1  |
 
 ---
 

--- a/docs/running-kics.md
+++ b/docs/running-kics.md
@@ -17,7 +17,7 @@ Files and directories that are not local will be placed in a temporarily folder 
 ### Local Files
 
 ```
-docker run -t -v {​​​​path_to_scan}​​​​:/path checkmarx/kics scan -p /path
+docker run -t -v {path_to_scan}:/path checkmarx/kics scan -p /path
 ```
 
 ### Archived Files
@@ -33,7 +33,7 @@ Available archive formats:
 -   `xz`
 
 ```
-docker run -t -v {​​​​path_to_scan_zip}​​​​:/path checkmarx/kics scan -p /path
+docker run -t -v {path_to_scan_zip}:/path checkmarx/kics scan -p /path
 ```
 
 More information can be seen [here](https://github.com/hashicorp/go-getter#unarchiving)


### PR DESCRIPTION
**Proposed Changes**
- Remove all zero-width spaces from `docs/**/*.md`.
- Where the `IaC Technology` table is touched anyway, also align the `|` cell borders.
 
Unless those were added intentionally?

I submit this contribution under the Apache-2.0 license.