### PR TITLE
fix(query): vulnerability_alert_score_epss_features

### DIFF
--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_entire_network/query.rego
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_entire_network/query.rego
@@ -27,6 +27,31 @@ CxPolicy[result] {
 	}
 }
 
+CxPolicy[result] {
+	resource := input.document[i].resource.aws_security_group[name]
+
+	portContent := commonLib.tcpPortsMap[port]
+	portNumber = port
+	portName = portContent
+    ingress := resource.ingress[j]
+	protocol := tf_lib.getProtocolList(ingress.protocol)[_]
+
+	endswith(ingress.cidr_blocks[_], "/0")
+	tf_lib.containsPort(ingress, portNumber)
+	isTCPorUDP(protocol)
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_security_group",
+		"resourceName": tf_lib.get_resource_name(resource, name),
+		"searchKey": sprintf("aws_security_group[%s].ingress", [name]),
+		"searchValue": sprintf("%s,%d", [protocol, portNumber]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("%s (%s:%d) should not be allowed", [portName, protocol, portNumber]),
+		"keyActualValue": sprintf("%s (%s:%d) is allowed", [portName, protocol, portNumber]),
+	}
+}
+
 isTCPorUDP("TCP") = true
 
 isTCPorUDP("UDP") = true

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_entire_network/test/positive.json
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_entire_network/test/positive.json
@@ -1,0 +1,274 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "1.0.5",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_security_group.invalid",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "invalid",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "values": {
+            "description": "invalid",
+            "egress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "",
+                "from_port": 0,
+                "ipv6_cidr_blocks": [
+                  "::/0"
+                ],
+                "prefix_list_ids": [],
+                "protocol": "-1",
+                "security_groups": [],
+                "self": false,
+                "to_port": 0
+              }
+            ],
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  "0.0.0.0/0"
+                ],
+                "description": "invalid",
+                "from_port": 443,
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "protocol": "tcp",
+                "security_groups": [],
+                "self": false,
+                "to_port": 443
+              }
+            ],
+            "name": "invalid",
+            "revoke_rules_on_delete": false,
+            "tags": {
+              "Name": "invalid"
+            },
+            "tags_all": {
+              "Name": "invalid"
+            },
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "egress": [
+              {
+                "cidr_blocks": [
+                  false
+                ],
+                "ipv6_cidr_blocks": [
+                  false
+                ],
+                "prefix_list_ids": [],
+                "security_groups": []
+              }
+            ],
+            "ingress": [
+              {
+                "cidr_blocks": [
+                  false
+                ],
+                "ipv6_cidr_blocks": [],
+                "prefix_list_ids": [],
+                "security_groups": []
+              }
+            ],
+            "tags": {},
+            "tags_all": {}
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_security_group.invalid",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "invalid",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": "invalid",
+          "egress": [
+            {
+              "cidr_blocks": [
+                "0.0.0.0/0"
+              ],
+              "description": "",
+              "from_port": 0,
+              "ipv6_cidr_blocks": [
+                "::/0"
+              ],
+              "prefix_list_ids": [],
+              "protocol": "-1",
+              "security_groups": [],
+              "self": false,
+              "to_port": 0
+            }
+          ],
+          "ingress": [
+            {
+              "cidr_blocks": [
+                "0.0.0.0/0"
+              ],
+              "description": "invalid",
+              "from_port": 443,
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "protocol": "tcp",
+              "security_groups": [],
+              "self": false,
+              "to_port": 443
+            }
+          ],
+          "name": "invalid",
+          "revoke_rules_on_delete": false,
+          "tags": {
+            "Name": "invalid"
+          },
+          "tags_all": {
+            "Name": "invalid"
+          },
+          "timeouts": null
+        },
+        "after_unknown": {
+          "arn": true,
+          "egress": [
+            {
+              "cidr_blocks": [
+                false
+              ],
+              "ipv6_cidr_blocks": [
+                false
+              ],
+              "prefix_list_ids": [],
+              "security_groups": []
+            }
+          ],
+          "id": true,
+          "ingress": [
+            {
+              "cidr_blocks": [
+                false
+              ],
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "security_groups": []
+            }
+          ],
+          "name_prefix": true,
+          "owner_id": true,
+          "tags": {},
+          "tags_all": {},
+          "vpc_id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "egress": [
+            {
+              "cidr_blocks": [
+                false
+              ],
+              "ipv6_cidr_blocks": [
+                false
+              ],
+              "prefix_list_ids": [],
+              "security_groups": []
+            }
+          ],
+          "ingress": [
+            {
+              "cidr_blocks": [
+                false
+              ],
+              "ipv6_cidr_blocks": [],
+              "prefix_list_ids": [],
+              "security_groups": []
+            }
+          ],
+          "tags": {},
+          "tags_all": {}
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_security_group.invalid",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "invalid",
+          "provider_config_key": "aws",
+          "expressions": {
+            "description": {
+              "constant_value": "invalid"
+            },
+            "egress": {
+              "constant_value": [
+                {
+                  "cidr_blocks": [
+                    "0.0.0.0/0"
+                  ],
+                  "description": null,
+                  "from_port": 0,
+                  "ipv6_cidr_blocks": [
+                    "::/0"
+                  ],
+                  "prefix_list_ids": null,
+                  "protocol": "-1",
+                  "security_groups": null,
+                  "self": null,
+                  "to_port": 0
+                }
+              ]
+            },
+            "ingress": {
+              "constant_value": [
+                {
+                  "cidr_blocks": [
+                    "0.0.0.0/0"
+                  ],
+                  "description": "invalid",
+                  "from_port": 443,
+                  "ipv6_cidr_blocks": null,
+                  "prefix_list_ids": null,
+                  "protocol": "tcp",
+                  "security_groups": null,
+                  "self": null,
+                  "to_port": 443
+                }
+              ]
+            },
+            "name": {
+              "constant_value": "invalid"
+            },
+            "tags": {
+              "constant_value": {
+                "Name": "invalid"
+              }
+            },
+            "vpc_id": {
+              "references": [
+                "aws_vpc.vpc-a.id",
+                "aws_vpc.vpc-a"
+              ]
+            }
+          },
+          "schema_version": 1
+        }
+      ]
+    }
+  }
+}

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_entire_network/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_entire_network/test/positive_expected_result.json
@@ -2,823 +2,991 @@
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 6
+    "line": 6,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 21
+    "line": 21,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 21
+    "line": 21,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 21
+    "line": 21,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 21
+    "line": 21,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 21
+    "line": 21,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 21
+    "line": 21,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 36
+    "line": 36,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 36
+    "line": 36,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 36
+    "line": 36,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 36
+    "line": 36,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 36
+    "line": 36,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 36
+    "line": 36,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 36
+    "line": 36,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 36
+    "line": 36,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 36
+    "line": 36,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 36
+    "line": 36,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 51
+    "line": 51,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 51
+    "line": 51,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 51
+    "line": 51,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 66
+    "line": 66,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 81
+    "line": 81,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 81
+    "line": 81,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 81
+    "line": 81,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 81
+    "line": 81,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 81
+    "line": 81,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 96
+    "line": 96,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
-  }, 
+    "line": 111,
+    "filename": "positive.t"
+  },
+  {
+    "queryName": "Sensitive Port Is Exposed To Entire Network",
+    "severity": "HIGH",
+    "line": 111,
+    "filename": "positive.t"
+  },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
-  
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 111,
+    "filename": "positive.t"
   },
   {
     "queryName": "Sensitive Port Is Exposed To Entire Network",
     "severity": "HIGH",
-    "line": 111
+    "line": 33,
+    "filename": "positive.json"
   }
-  
 ]


### PR DESCRIPTION
**Proposed Changes**

- Fix a false negative in `terraform/aws/vulnerability_alert_score_epss_features` in cases where a terraform plan json is scanned instead of a .tf file


I submit this contribution under the Apache-2.0 license.