### PR TITLE
fix(kics): support v1.5 of cyclone dx report format

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -682,7 +682,7 @@ PDF reports are sorted by severity (from high to info), the results will have qu
 
 ## CycloneDX
 
-Now, the CycloneDX report is only available in XML format since the vulnerability schema extension is not currently available in JSON. The guidelines used to build the CycloneDX report were the [bom schema 1.3](http://cyclonedx.org/schema/bom/1.5) and [vulnerability schema 1.0](https://github.com/CycloneDX/specification/blob/master/schema/ext/vulnerability-1.0.xsd).                                                                                               
+Now, the CycloneDX report is only available in XML format since the vulnerability schema extension is not currently available in JSON. The guidelines used to build the CycloneDX report were the [bom schema 1.5](http://cyclonedx.org/schema/bom/1.5) and [vulnerability schema 1.0](https://github.com/CycloneDX/specification/blob/master/schema/ext/vulnerability-1.0.xsd).                                                                                               
 **Note:** As of the latest update, the CycloneDX version utilized in the report is 1.5. However, it's important to clarify that no additional features or fields introduced in version 1.5 are currently utilized. The functionality remains consistent with the version 1.3 for KICS. Future updates will leverage the new features introduced in CycloneDX version 1.5.
 
 

--- a/docs/results.md
+++ b/docs/results.md
@@ -682,7 +682,7 @@ PDF reports are sorted by severity (from high to info), the results will have qu
 
 ## CycloneDX
 
-Now, the CycloneDX report is only available in XML format since the vulnerability schema extension is not currently available in JSON. The guidelines used to build the CycloneDX report were the [bom schema 1.3](http://cyclonedx.org/schema/bom/1.3) and [vulnerability schema 1.0](https://github.com/CycloneDX/specification/blob/master/schema/ext/vulnerability-1.0.xsd).                                                                                               
+Now, the CycloneDX report is only available in XML format since the vulnerability schema extension is not currently available in JSON. The guidelines used to build the CycloneDX report were the [bom schema 1.3](http://cyclonedx.org/schema/bom/1.5) and [vulnerability schema 1.0](https://github.com/CycloneDX/specification/blob/master/schema/ext/vulnerability-1.0.xsd).                                                                                               
 **Note:** As of the latest update, the CycloneDX version utilized in the report is 1.5. However, it's important to clarify that no additional features or fields introduced in version 1.5 are currently utilized. The functionality remains consistent with the version 1.3 for KICS. Future updates will leverage the new features introduced in CycloneDX version 1.5.
 
 
@@ -690,7 +690,7 @@ You can export CycloneDX report by using `--report-formats "cyclonedx"`. The gen
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:031053e5-97fa-4776-bd4b-d8705b37748c" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" serialNumber="urn:uuid:031053e5-97fa-4776-bd4b-d8705b37748c" xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0" version="1">
 	<metadata>
 		<timestamp>2024-02-14T12:21:17Z</timestamp>
 		<tools>

--- a/pkg/report/model/cyclonedx.go
+++ b/pkg/report/model/cyclonedx.go
@@ -222,7 +222,7 @@ func InitCycloneDxReport() *CycloneDxReport {
 	}
 
 	return &CycloneDxReport{
-		XMLNS:        "http://cyclonedx.org/schema/bom/1.3",
+		XMLNS:        "http://cyclonedx.org/schema/bom/1.5",
 		XMLNSV:       "http://cyclonedx.org/schema/ext/vulnerability/1.0",
 		SerialNumber: "urn:uuid:" + uuid.New().String(),
 		Version:      1,

--- a/pkg/report/model/cyclonedx_test.go
+++ b/pkg/report/model/cyclonedx_test.go
@@ -26,7 +26,7 @@ var metadata Metadata = Metadata{
 }
 
 var initCycloneDxReport CycloneDxReport = CycloneDxReport{
-	XMLNS:        "http://cyclonedx.org/schema/bom/1.3",
+	XMLNS:        "http://cyclonedx.org/schema/bom/1.5",
 	XMLNSV:       "http://cyclonedx.org/schema/ext/vulnerability/1.0",
 	SerialNumber: "urn:uuid:", // set to "urn:uuid:" because it will be different for every report
 	Version:      1,


### PR DESCRIPTION
Closes #6926

**Proposed Changes**
- use version 1.5 in cycloneDX reports
- modify correspondent tests

I submit this contribution under the Apache-2.0 license.