### PR TITLE
feat(kics): add usage of parallel flag for analyzer

### DIFF
--- a/e2e/fixtures/assets/analyze_help
+++ b/e2e/fixtures/assets/analyze_help
@@ -1,11 +1,12 @@
 Usage:
-  kics remediate [flags]
+  kics analyze [flags]
 
 Flags:
-  -h, --help                  help for analyze
-      --analyze-path strings          paths or directories to scan
-                                      example: "./somepath,somefile.txt"
-      --analyze-results string        points to the JSON results file of analyzer (default "platforms.json")
+      --analyze-path strings     paths or directories to scan
+                                 example: "./somepath,somefile.txt"
+      --analyze-results string   points to the JSON results file of analyzer (default "platforms.json")
+  -h, --help                     help for analyze
+      --parallel int             number of workers used for parallel analyzing, set 0 to auto-detect parallelism (default 1)
 
 Global Flags:
       --ci                  display only log messages to CLI output (mutually exclusive with silent)

--- a/internal/console/analyze.go
+++ b/internal/console/analyze.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Checkmarx/kics/pkg/analyzer"
 	"github.com/Checkmarx/kics/pkg/engine/source"
 	"github.com/Checkmarx/kics/pkg/model"
+	"github.com/Checkmarx/kics/pkg/utils"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -68,6 +69,7 @@ func getAnalyzeParameters() *analyzer.Parameters {
 		Path:        flags.GetMultiStrFlag(flags.AnalyzePath),
 		Results:     flags.GetStrFlag(flags.AnalyzeResults),
 		MaxFileSize: flags.GetIntFlag(flags.MaxFileSizeFlag),
+		NumWorkers:  flags.GetIntFlag(flags.ParallelScanFile),
 	}
 
 	return &analyzeParams
@@ -92,6 +94,7 @@ func executeAnalyze(analyzeParams *analyzer.Parameters) error {
 		ExcludeGitIgnore:  false,
 		GitIgnoreFileName: "",
 		MaxFileSize:       analyzeParams.MaxFileSize,
+		NumWorkers:        utils.AdjustNumWorkers(analyzeParams.NumWorkers),
 	}
 
 	analyzedPaths, err := analyzer.Analyze(analyzerStruct)

--- a/internal/console/assets/analyze-flags.json
+++ b/internal/console/assets/analyze-flags.json
@@ -10,5 +10,12 @@
         "shorthandFlag": "",
         "defaultValue": "platforms.json",
         "usage": "points to the JSON results file of analyzer"
+    },
+    "parallel": {
+      "flagType": "int",
+      "shorthandFlag": "",
+      "defaultValue": "1",
+      "usage": "number of workers used for parallel analyzing, set 0 to auto-detect parallelism",
+      "validation": "validateWorkersFlag"
     }
 }

--- a/pkg/engine/inspector.go
+++ b/pkg/engine/inspector.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/Checkmarx/kics/pkg/detector/helm"
 	"github.com/Checkmarx/kics/pkg/engine/source"
 	"github.com/Checkmarx/kics/pkg/model"
+	"github.com/Checkmarx/kics/pkg/utils"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/cover"
 	"github.com/open-policy-agent/opa/rego"
@@ -100,15 +100,6 @@ var (
 	}
 )
 
-func adjustNumWorkers(workers int) int {
-	// for the case in which the end user decides to use num workers as "auto-detected"
-	// we will set the number of workers to the number of CPUs available based on GOMAXPROCS value
-	if workers == 0 {
-		return runtime.GOMAXPROCS(-1)
-	}
-	return workers
-}
-
 // NewInspector initializes a inspector, compiling and loading queries for scan and its tracker
 func NewInspector(
 	ctx context.Context,
@@ -170,7 +161,7 @@ func NewInspector(
 		excludeResults:   excludeResults,
 		detector:         lineDetector,
 		queryExecTimeout: queryExecTimeout,
-		numWorkers:       adjustNumWorkers(numWorkers),
+		numWorkers:       utils.AdjustNumWorkers(numWorkers),
 	}, nil
 }
 

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -60,6 +60,7 @@ func (c *Client) prepareAndAnalyzePaths(ctx context.Context) (provider.Extracted
 		GitIgnoreFileName: ".gitignore",
 		ExcludeGitIgnore:  c.ScanParams.ExcludeGitIgnore,
 		MaxFileSize:       c.ScanParams.MaxFileSizeFlag,
+		NumWorkers:        utils.AdjustNumWorkers(c.ScanParams.ParallelScanFlag),
 	}
 
 	pathTypes, errAnalyze := analyzePaths(a)

--- a/pkg/utils/adjust_workers.go
+++ b/pkg/utils/adjust_workers.go
@@ -1,0 +1,12 @@
+package utils
+
+import "runtime"
+
+func AdjustNumWorkers(workers int) int {
+	// for the case in which the end user decides to use num workers as "auto-detected"
+	// we will set the number of workers to the number of CPUs available based on GOMAXPROCS value
+	if workers == 0 {
+		return runtime.GOMAXPROCS(-1)
+	}
+	return workers
+}

--- a/pkg/utils/adjust_workers_test.go
+++ b/pkg/utils/adjust_workers_test.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AdjustWorkers(t *testing.T) {
+	workers0 := AdjustNumWorkers(0)
+	require.Equal(t, workers0, runtime.GOMAXPROCS(-1))
+	workers1 := AdjustNumWorkers(1)
+	require.Equal(t, workers1, 1)
+	workersnegative1 := AdjustNumWorkers(-1)
+	require.Equal(t, workersnegative1, -1)
+	workers100 := AdjustNumWorkers(100)
+	require.Equal(t, workers100, 100)
+}


### PR DESCRIPTION
Closes #6934

**Proposed Changes**
- Use the already added parallel flag to set the number of workers on the analyze portion of the scan command 
- Use the already added parallel flag to set the number of workers on the analyze standalone command
- Add unit test for flag adjust value utils func

I submit this contribution under the Apache-2.0 license.