### PR TITLE
update(workflow): kics github action version 2.0 upgrade

### DIFF
--- a/.github/workflows/release-docker-github-actions.yaml
+++ b/.github/workflows/release-docker-github-actions.yaml
@@ -39,7 +39,7 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: checkmarx/kics:gh-action-kics1.7
+          tags: checkmarx/kics:gh-action-kics2.0
           build-args: |
             VERSION=${{ github.event.inputs.version }}
             COMMIT=${{ github.sha }}


### PR DESCRIPTION
**Proposed Changes**
- kics github action version 2.0 upgrade

I submit this contribution under the Apache-2.0 license.