### PR TITLE
fix(goversion): update go version from 1.22.2 to 1.22.3

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -3,7 +3,7 @@
 # it does not define an ENTRYPOINT as this is a requirement described here:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops#linux-based-containers
 #
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22.2-bookworm as build_env
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22.3-bookworm as build_env
 # Create a group and user
 RUN groupadd checkmarx && useradd -g checkmarx -M -s /bin/bash checkmarx
 USER checkmarx

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -4,10 +4,10 @@ WORKDIR /build
 
 ENV PATH=$PATH:/usr/local/go/bin
 
-ADD https://golang.org/dl/go1.22.2.linux-amd64.tar.gz .
+ADD https://golang.org/dl/go1.22.3.linux-amd64.tar.gz .
 RUN yum install git gcc -y \
-  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz \
-  && rm -f go1.22.2.linux-amd64.tar.gz
+  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.3.linux-amd64.tar.gz \
+  && rm -f go1.22.3.linux-amd64.tar.gz
 
 ENV GOPRIVATE=github.com/Checkmarx/*
 ARG VERSION="development"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Checkmarx/kics
 
-go 1.22.2
+go 1.22.3
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.26


### PR DESCRIPTION
**Proposed Changes**
- update go version from 1.22.2 to 1.22.3.

I submit this contribution under the Apache-2.0 license.