### PR TITLE
chore(databricks): add new spark LTS runtime

### DIFF
--- a/assets/queries/terraform/databricks/use_lts_spark_version/query.rego
+++ b/assets/queries/terraform/databricks/use_lts_spark_version/query.rego
@@ -36,6 +36,6 @@ CxPolicy[result] {
 }
 
 isLtsVersion(version) {
-	versions = {"3.0.1", "3.1.2", "3.2.1", "3.3.0", "3.3.2", "3.4.1"}
+	versions = {"3.0.1", "3.1.2", "3.2.1", "3.3.0", "3.3.2", "3.4.1", "3.5.0"}
 	version = versions[j]
 }


### PR DESCRIPTION
Add new LTS databricks's runtime

https://docs.databricks.com/en/release-notes/runtime/index.html

I submit this contribution under the Apache-2.0 license.