### PR TITLE
chore(databricks): remove deprecated spark lts version

### DIFF
--- a/assets/queries/terraform/databricks/use_lts_spark_version/query.rego
+++ b/assets/queries/terraform/databricks/use_lts_spark_version/query.rego
@@ -36,6 +36,6 @@ CxPolicy[result] {
 }
 
 isLtsVersion(version) {
-	versions = {"3.0.1", "3.1.2", "3.2.1", "3.3.0", "3.3.2", "3.4.1"}
+	versions = {"3.1.2", "3.2.1", "3.3.0", "3.3.2", "3.4.1"}
 	version = versions[j]
 }


### PR DESCRIPTION
Remove deprecated LTS version

https://docs.databricks.com/en/release-notes/runtime/index.html

I submit this contribution under the Apache-2.0 license.