### PR TITLE
update(queries): prefix "(beta)" added to queries that are still under review

### DIFF
--- a/assets/queries/terraform/databricks/autoscale_badly_setup/metadata.json
+++ b/assets/queries/terraform/databricks/autoscale_badly_setup/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "953c0cc6-5f30-44cb-a803-bf4ef2571be8",
-  "queryName": "Databricks Autoscale Badly Setup",
+  "queryName": "(Beta) Databricks Autoscale Badly Setup",
   "severity": "MEDIUM",
   "category": "Resource Management",
   "descriptionText": "Databricks should have min and max worker setup for autoscale",

--- a/assets/queries/terraform/databricks/autoscale_badly_setup/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/autoscale_badly_setup/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Databricks Autoscale Badly Setup",
+		"queryName": "(Beta) Databricks Autoscale Badly Setup",
 		"severity": "MEDIUM",
 		"line": 6,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Databricks Autoscale Badly Setup",
+		"queryName": "(Beta) Databricks Autoscale Badly Setup",
 		"severity": "MEDIUM",
 		"line": 6,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/databricks/cluster_aws_attributes/metadata.json
+++ b/assets/queries/terraform/databricks/cluster_aws_attributes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "b0749c53-e3ff-4d09-bbe4-dca94e2e7a38",
-  "queryName": "Check Databricks Cluster AWS Attribute Best Practices",
+  "queryName": "(Beta) Check Databricks Cluster AWS Attribute Best Practices",
   "severity": "LOW",
   "category": "Best Practices",
   "descriptionText": "One or some Databricks Cluster AWS Attribute Best Practices are not respected",

--- a/assets/queries/terraform/databricks/cluster_aws_attributes/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/cluster_aws_attributes/test/positive_expected_result.json
@@ -1,24 +1,24 @@
 [
   {
-    "queryName": "Check Databricks Cluster AWS Attribute Best Practices",
+    "queryName": "(Beta) Check Databricks Cluster AWS Attribute Best Practices",
     "severity": "LOW",
     "line": 11,
     "fileName": "positive1.tf"
   },
   {
-    "queryName": "Check Databricks Cluster AWS Attribute Best Practices",
+    "queryName": "(Beta) Check Databricks Cluster AWS Attribute Best Practices",
     "severity": "LOW",
     "line": 13,
     "fileName": "positive2.tf"
   },
   {
-    "queryName": "Check Databricks Cluster AWS Attribute Best Practices",
+    "queryName": "(Beta) Check Databricks Cluster AWS Attribute Best Practices",
     "severity": "LOW",
     "line": 10,
     "fileName": "positive3.tf"
   },
   {
-    "queryName": "Check Databricks Cluster AWS Attribute Best Practices",
+    "queryName": "(Beta) Check Databricks Cluster AWS Attribute Best Practices",
     "severity": "LOW",
     "line": 12,
     "fileName": "positive4.tf"

--- a/assets/queries/terraform/databricks/cluster_azure_attributes/metadata.json
+++ b/assets/queries/terraform/databricks/cluster_azure_attributes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "38028698-e663-4ef7-aa92-773fef0ca86f",
-  "queryName": "Check Databricks Cluster Azure Attribute Best Practices",
+  "queryName": "(Beta) Check Databricks Cluster Azure Attribute Best Practices",
   "severity": "LOW",
   "category": "Best Practices",
   "descriptionText": "One or some Databricks Cluster Azure Attribute Best Practices are not respected",

--- a/assets/queries/terraform/databricks/cluster_azure_attributes/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/cluster_azure_attributes/test/positive_expected_result.json
@@ -1,18 +1,18 @@
 [
   {
-    "queryName": "Check Databricks Cluster Azure Attribute Best Practices",
+    "queryName": "(Beta) Check Databricks Cluster Azure Attribute Best Practices",
     "severity": "LOW",
     "line": 11,
     "fileName": "positive1.tf"
   },
   {
-    "queryName": "Check Databricks Cluster Azure Attribute Best Practices",
+    "queryName": "(Beta) Check Databricks Cluster Azure Attribute Best Practices",
     "severity": "LOW",
     "line": 12,
     "fileName": "positive2.tf"
   },
   {
-    "queryName": "Check Databricks Cluster Azure Attribute Best Practices",
+    "queryName": "(Beta) Check Databricks Cluster Azure Attribute Best Practices",
     "severity": "LOW",
     "line": 10,
     "fileName": "positive3.tf"

--- a/assets/queries/terraform/databricks/cluster_gcp_attributes/metadata.json
+++ b/assets/queries/terraform/databricks/cluster_gcp_attributes/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "539e4557-d2b5-4d57-a001-cb01140a4e2d",
-  "queryName": "Check Databricks Cluster GCP Attribute Best Practices",
+  "queryName": "(Beta) Check Databricks Cluster GCP Attribute Best Practices",
   "severity": "LOW",
   "category": "Best Practices",
   "descriptionText": "One or some Databricks Cluster GCP Attribute Best Practices are not respected",

--- a/assets/queries/terraform/databricks/cluster_gcp_attributes/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/cluster_gcp_attributes/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
   {
-    "queryName": "Check Databricks Cluster GCP Attribute Best Practices",
+    "queryName": "(Beta) Check Databricks Cluster GCP Attribute Best Practices",
     "severity": "LOW",
     "line": 11,
     "fileName": "positive1.tf"

--- a/assets/queries/terraform/databricks/databricks_permissions/metadata.json
+++ b/assets/queries/terraform/databricks/databricks_permissions/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "a4edb7e1-c0e0-4f7f-9d7c-d1b603e81ad5",
-  "queryName": "Databricks Cluster or Job With None Or Insecure Permission(s)",
+  "queryName": "(Beta) Databricks Cluster or Job With None Or Insecure Permission(s)",
   "severity": "HIGH",
   "category": "Insecure Configurations",
   "descriptionText": "Databricks Cluster and Job must have restricted permissions",

--- a/assets/queries/terraform/databricks/databricks_permissions/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/databricks_permissions/test/positive_expected_result.json
@@ -1,24 +1,24 @@
 [
   {
-    "queryName": "Databricks Cluster or Job With None Or Insecure Permission(s)",
+    "queryName": "(Beta) Databricks Cluster or Job With None Or Insecure Permission(s)",
     "severity": "HIGH",
     "line": 16,
     "fileName": "positive1.tf"
   },
   {
-    "queryName": "Databricks Cluster or Job With None Or Insecure Permission(s)",
+    "queryName": "(Beta) Databricks Cluster or Job With None Or Insecure Permission(s)",
     "severity": "HIGH",
     "line": 12,
     "fileName": "positive2.tf"
   },
   {
-    "queryName": "Databricks Cluster or Job With None Or Insecure Permission(s)",
+    "queryName": "(Beta) Databricks Cluster or Job With None Or Insecure Permission(s)",
     "severity": "HIGH",
     "line": 16,
     "fileName": "positive3.tf"
   },
   {
-    "queryName": "Databricks Cluster or Job With None Or Insecure Permission(s)",
+    "queryName": "(Beta) Databricks Cluster or Job With None Or Insecure Permission(s)",
     "severity": "HIGH",
     "line": 16,
     "fileName": "positive4.tf"

--- a/assets/queries/terraform/databricks/group_without_user_or_instance_profile/metadata.json
+++ b/assets/queries/terraform/databricks/group_without_user_or_instance_profile/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "23c3067a-8cc9-480c-b645-7c1e0ad4bf60",
-  "queryName": "Databricks Group Without User Or Instance Profile",
+  "queryName": "(Beta) Databricks Group Without User Or Instance Profile",
   "severity": "LOW",
   "category": "Access Control",
   "descriptionText": "Databricks Group should have at least one user or one instance profile associated",

--- a/assets/queries/terraform/databricks/group_without_user_or_instance_profile/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/group_without_user_or_instance_profile/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Databricks Group Without User Or Instance Profile",
+		"queryName": "(Beta) Databricks Group Without User Or Instance Profile",
 		"severity": "LOW",
 		"line": 16,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Databricks Group Without User Or Instance Profile",
+		"queryName": "(Beta) Databricks Group Without User Or Instance Profile",
 		"severity": "LOW",
 		"line": 14,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/databricks/indefinitely_obo_token/metadata.json
+++ b/assets/queries/terraform/databricks/indefinitely_obo_token/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "23e1f5f0-12b7-4d7e-9087-f60f42ccd514",
-  "queryName": "Indefinitely Databricks OBO Token Lifetime",
+  "queryName": "(Beta) Indefinitely Databricks OBO Token Lifetime",
   "severity": "MEDIUM",
   "category": "Insecure Defaults",
   "descriptionText": "OBO Token has an indefinitely lifetime",

--- a/assets/queries/terraform/databricks/indefinitely_obo_token/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/indefinitely_obo_token/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Indefinitely Databricks OBO Token Lifetime",
+		"queryName": "(Beta) Indefinitely Databricks OBO Token Lifetime",
 		"severity": "MEDIUM",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/databricks/indefinitely_token/metadata.json
+++ b/assets/queries/terraform/databricks/indefinitely_token/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "7d05ca25-91b4-42ee-b6f6-b06611a87ce8",
-  "queryName": "Indefinitely Databricks Token Lifetime",
+  "queryName": "(Beta) Indefinitely Databricks Token Lifetime",
   "severity": "MEDIUM",
   "category": "Insecure Defaults",
   "descriptionText": "Token has an indefinitely lifetime",

--- a/assets/queries/terraform/databricks/indefinitely_token/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/indefinitely_token/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Indefinitely Databricks Token Lifetime",
+		"queryName": "(Beta) Indefinitely Databricks Token Lifetime",
 		"severity": "MEDIUM",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/databricks/unrestricted_acl/metadata.json
+++ b/assets/queries/terraform/databricks/unrestricted_acl/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "2c4fe4a9-f44b-4c70-b09b-5b75cd251805",
-  "queryName": "Unrestricted Databricks ACL",
+  "queryName": "(Beta) Unrestricted Databricks ACL",
   "severity": "HIGH",
   "category": "Networking and Firewall",
   "descriptionText": "ACL allow ingress from 0.0.0.0/0 and/or ::/0",

--- a/assets/queries/terraform/databricks/unrestricted_acl/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/unrestricted_acl/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Unrestricted Databricks ACL",
+		"queryName": "(Beta) Unrestricted Databricks ACL",
 		"severity": "HIGH",
 		"line": 10,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Unrestricted Databricks ACL",
+		"queryName": "(Beta) Unrestricted Databricks ACL",
 		"severity": "HIGH",
 		"line": 10,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/databricks/use_lts_spark_version/metadata.json
+++ b/assets/queries/terraform/databricks/use_lts_spark_version/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "5a627dfa-a4dd-4020-a4c6-5f3caf4abcd6",
-  "queryName": "Check use no LTS Spark Version",
+  "queryName": "(Beta) Check use no LTS Spark Version",
   "severity": "LOW",
   "category": "Best Practices",
   "descriptionText": "Spark Version is not a Long-term Support",

--- a/assets/queries/terraform/databricks/use_lts_spark_version/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/use_lts_spark_version/test/positive_expected_result.json
@@ -1,18 +1,18 @@
 [
   {
-    "queryName": "Check use no LTS Spark Version",
+    "queryName": "(Beta) Check use no LTS Spark Version",
     "severity": "LOW",
     "line": 8,
     "fileName": "positive1.tf"
   },
   {
-    "queryName": "Check use no LTS Spark Version",
+    "queryName": "(Beta) Check use no LTS Spark Version",
     "severity": "LOW",
     "line": 11,
     "fileName": "positive2.tf"
   },
   {
-    "queryName": "Check use no LTS Spark Version",
+    "queryName": "(Beta) Check use no LTS Spark Version",
     "severity": "LOW",
     "line": 10,
     "fileName": "positive3.tf"

--- a/assets/queries/terraform/databricks/use_spark_submit_task/metadata.json
+++ b/assets/queries/terraform/databricks/use_spark_submit_task/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "375cdab9-3f94-4ae0-b1e3-8fbdf9cdf4d7",
-  "queryName": "Job's Task is Legacy (spark_submit_task)",
+  "queryName": "(Beta) Job's Task is Legacy (spark_submit_task)",
   "severity": "MEDIUM",
   "category": "Best Practices",
   "descriptionText": "Job's Task Is spark_submit_task",

--- a/assets/queries/terraform/databricks/use_spark_submit_task/test/positive_expected_result.json
+++ b/assets/queries/terraform/databricks/use_spark_submit_task/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Job's Task is Legacy (spark_submit_task)",
+		"queryName": "(Beta) Job's Task is Legacy (spark_submit_task)",
 		"severity": "MEDIUM",
 		"line": 36,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Job's Task is Legacy (spark_submit_task)",
+		"queryName": "(Beta) Job's Task is Legacy (spark_submit_task)",
 		"severity": "MEDIUM",
 		"line": 18,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/nifcloud/computing_instance_has_common_private/metadata.json
+++ b/assets/queries/terraform/nifcloud/computing_instance_has_common_private/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "df58dd45-8009-43c2-90f7-c90eb9d53ed9",
-  "queryName": "Nifcloud Computing Has Common Private Network",
+  "queryName": "(Beta) Nifcloud Computing Has Common Private Network",
   "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "The instance has common private network",

--- a/assets/queries/terraform/nifcloud/computing_instance_has_common_private/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/computing_instance_has_common_private/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Nifcloud Computing Has Common Private Network",
+		"queryName": "(Beta) Nifcloud Computing Has Common Private Network",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Nifcloud Computing Has Common Private Network",
+		"queryName": "(Beta) Nifcloud Computing Has Common Private Network",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/nifcloud/computing_instance_has_public_ingress_sgr/metadata.json
+++ b/assets/queries/terraform/nifcloud/computing_instance_has_public_ingress_sgr/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "b2ea2367-8dc9-4231-a035-d0b28bfa3dde",
-  "queryName": "Nifcloud Computing Has Public Ingress Security Group Rule",
+  "queryName": "(Beta) Nifcloud Computing Has Public Ingress Security Group Rule",
   "severity": "HIGH",
   "category": "Networking and Firewall",
   "descriptionText": "An ingress security group rule allows traffic from /0",

--- a/assets/queries/terraform/nifcloud/computing_instance_has_public_ingress_sgr/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/computing_instance_has_public_ingress_sgr/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud Computing Has Public Ingress Security Group Rule",
+		"queryName": "(Beta) Nifcloud Computing Has Public Ingress Security Group Rule",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/computing_instance_security_group_undefined/metadata.json
+++ b/assets/queries/terraform/nifcloud/computing_instance_security_group_undefined/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "89218b48-75c9-4cb3-aaba-5299e852e8bc",
-  "queryName": "Nifcloud Computing Undefined Security Group To Instance",
+  "queryName": "(Beta) Nifcloud Computing Undefined Security Group To Instance",
   "severity": "HIGH",
   "category": "Networking and Firewall",
   "descriptionText": "Missing security group for instance",

--- a/assets/queries/terraform/nifcloud/computing_instance_security_group_undefined/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/computing_instance_security_group_undefined/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud Computing Undefined Security Group To Instance",
+		"queryName": "(Beta) Nifcloud Computing Undefined Security Group To Instance",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/computing_security_group_description_undefined/metadata.json
+++ b/assets/queries/terraform/nifcloud/computing_security_group_description_undefined/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "41c127a9-3a85-4bc3-a333-ed374eb9c3e4",
-  "queryName": "Nifcloud Computing Undefined Description To Security Group",
+  "queryName": "(Beta) Nifcloud Computing Undefined Description To Security Group",
   "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "Missing description for security group",

--- a/assets/queries/terraform/nifcloud/computing_security_group_description_undefined/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/computing_security_group_description_undefined/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud Computing Undefined Description To Security Group",
+		"queryName": "(Beta) Nifcloud Computing Undefined Description To Security Group",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/computing_security_group_rule_description_undefined/metadata.json
+++ b/assets/queries/terraform/nifcloud/computing_security_group_rule_description_undefined/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "e4610872-0b1c-4fb7-ab57-d81c0afdb291",
-  "queryName": "Nifcloud Computing Undefined Description To Security Group Rule",
+  "queryName": "(Beta) Nifcloud Computing Undefined Description To Security Group Rule",
   "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "Missing description for security group rule",

--- a/assets/queries/terraform/nifcloud/computing_security_group_rule_description_undefined/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/computing_security_group_rule_description_undefined/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud Computing Undefined Description To Security Group Rule",
+		"queryName": "(Beta) Nifcloud Computing Undefined Description To Security Group Rule",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/db_does_not_have_long_backup_retention/metadata.json
+++ b/assets/queries/terraform/nifcloud/db_does_not_have_long_backup_retention/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "e5071f76-cbe7-468d-bb2b-d10f02d2b713",
-  "queryName": "Nifcloud RDB Has Backup Retention Less Than 2 Day",
+  "queryName": "(Beta) Nifcloud RDB Has Backup Retention Less Than 2 Day",
   "severity": "MEDIUM",
   "category": "Backup",
   "descriptionText": "The rdb has backup retention less than 2 day",

--- a/assets/queries/terraform/nifcloud/db_does_not_have_long_backup_retention/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/db_does_not_have_long_backup_retention/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Nifcloud RDB Has Backup Retention Less Than 2 Day",
+		"queryName": "(Beta) Nifcloud RDB Has Backup Retention Less Than 2 Day",
 		"severity": "MEDIUM",
 		"line": 1,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Nifcloud RDB Has Backup Retention Less Than 2 Day",
+		"queryName": "(Beta) Nifcloud RDB Has Backup Retention Less Than 2 Day",
 		"severity": "MEDIUM",
 		"line": 1,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/nifcloud/db_has_public_access/metadata.json
+++ b/assets/queries/terraform/nifcloud/db_has_public_access/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "fb387023-e4bb-42a8-9a70-6708aa7ff21b",
-  "queryName": "Nifcloud RDB Has Public DB Access",
+  "queryName": "(Beta) Nifcloud RDB Has Public DB Access",
   "severity": "HIGH",
   "category": "Networking and Firewall",
   "descriptionText": "The rdb has public db access",

--- a/assets/queries/terraform/nifcloud/db_has_public_access/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/db_has_public_access/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud RDB Has Public DB Access",
+		"queryName": "(Beta) Nifcloud RDB Has Public DB Access",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/db_instance_has_common_private/metadata.json
+++ b/assets/queries/terraform/nifcloud/db_instance_has_common_private/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "9bf57c23-fbab-4222-85f3-3f207a53c6a8",
-  "queryName": "Nifcloud RDB Has Common Private Network",
+  "queryName": "(Beta) Nifcloud RDB Has Common Private Network",
   "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "The rdb has common private network",

--- a/assets/queries/terraform/nifcloud/db_instance_has_common_private/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/db_instance_has_common_private/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud RDB Has Common Private Network",
+		"queryName": "(Beta) Nifcloud RDB Has Common Private Network",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/db_security_group_description_undefined/metadata.json
+++ b/assets/queries/terraform/nifcloud/db_security_group_description_undefined/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "940ddce2-26bd-4e31-a9b4-382714f73231",
-  "queryName": "Nifcloud RDB Undefined Description To DB Security Group",
+  "queryName": "(Beta) Nifcloud RDB Undefined Description To DB Security Group",
   "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "Missing description for db security group",

--- a/assets/queries/terraform/nifcloud/db_security_group_description_undefined/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/db_security_group_description_undefined/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud RDB Undefined Description To DB Security Group",
+		"queryName": "(Beta) Nifcloud RDB Undefined Description To DB Security Group",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/db_security_group_has_public_ingress_sgr/metadata.json
+++ b/assets/queries/terraform/nifcloud/db_security_group_has_public_ingress_sgr/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "a0b846e8-815f-4f15-b660-bc4ab9fa1e1a",
-  "queryName": "Nifcloud RDB Has Public DB Ingress Security Group Rule",
+  "queryName": "(Beta) Nifcloud RDB Has Public DB Ingress Security Group Rule",
   "severity": "HIGH",
   "category": "Networking and Firewall",
   "descriptionText": "An db ingress security group rule allows traffic from /0",

--- a/assets/queries/terraform/nifcloud/db_security_group_has_public_ingress_sgr/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/db_security_group_has_public_ingress_sgr/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud RDB Has Public DB Ingress Security Group Rule",
+		"queryName": "(Beta) Nifcloud RDB Has Public DB Ingress Security Group Rule",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/dns_has_verified_record/metadata.json
+++ b/assets/queries/terraform/nifcloud/dns_has_verified_record/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "a1defcb6-55e8-4511-8c2a-30b615b0e057",
-  "queryName": "Nifcloud DNS Has Verified Record",
+  "queryName": "(Beta) Nifcloud DNS Has Verified Record",
   "severity": "HIGH",
   "category": "Insecure Configurations",
   "descriptionText": "Removing verified record of TXT auth the risk that If the authentication record remains, anyone can register the zone",

--- a/assets/queries/terraform/nifcloud/dns_has_verified_record/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/dns_has_verified_record/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud DNS Has Verified Record",
+		"queryName": "(Beta) Nifcloud DNS Has Verified Record",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/elb_has_common_private/metadata.json
+++ b/assets/queries/terraform/nifcloud/elb_has_common_private/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "5061f84c-ab66-4660-90b9-680c9df346c0",
-  "queryName": "Nifcloud ELB Has Common Private Network",
+  "queryName": "(Beta) Nifcloud ELB Has Common Private Network",
   "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "The elb has common private network",

--- a/assets/queries/terraform/nifcloud/elb_has_common_private/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/elb_has_common_private/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Nifcloud ELB Has Common Private Network",
+		"queryName": "(Beta) Nifcloud ELB Has Common Private Network",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Nifcloud ELB Has Common Private Network",
+		"queryName": "(Beta) Nifcloud ELB Has Common Private Network",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/nifcloud/elb_listener_use_http/metadata.json
+++ b/assets/queries/terraform/nifcloud/elb_listener_use_http/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "afcb0771-4f94-44ed-ad4a-9f73f11ce6e0",
-  "queryName": "Nifcloud ELB Listener Use HTTP Protocol",
+  "queryName": "(Beta) Nifcloud ELB Listener Use HTTP Protocol",
   "severity": "HIGH",
   "category": "Insecure Configurations",
   "descriptionText": "The elb listener use http protocol",

--- a/assets/queries/terraform/nifcloud/elb_listener_use_http/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/elb_listener_use_http/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Nifcloud ELB Listener Use HTTP Protocol",
+		"queryName": "(Beta) Nifcloud ELB Listener Use HTTP Protocol",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Nifcloud ELB Listener Use HTTP Protocol",
+		"queryName": "(Beta) Nifcloud ELB Listener Use HTTP Protocol",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/nifcloud/elb_use_http/metadata.json
+++ b/assets/queries/terraform/nifcloud/elb_use_http/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "e2de2b80-2fc2-4502-a764-40930dfcc70a",
-  "queryName": "Nifcloud ELB Use HTTP Protocol",
+  "queryName": "(Beta) Nifcloud ELB Use HTTP Protocol",
   "severity": "HIGH",
   "category": "Insecure Configurations",
   "descriptionText": "The elb use http protocol",

--- a/assets/queries/terraform/nifcloud/elb_use_http/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/elb_use_http/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Nifcloud ELB Use HTTP Protocol",
+		"queryName": "(Beta) Nifcloud ELB Use HTTP Protocol",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Nifcloud ELB Use HTTP Protocol",
+		"queryName": "(Beta) Nifcloud ELB Use HTTP Protocol",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/nifcloud/load_balancer_listener_use_http/metadata.json
+++ b/assets/queries/terraform/nifcloud/load_balancer_listener_use_http/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "9f751a80-31f0-43a3-926c-20772791a038",
-  "queryName": "Nifcloud LB Listener Use HTTP Port",
+  "queryName": "(Beta) Nifcloud LB Listener Use HTTP Port",
   "severity": "HIGH",
   "category": "Insecure Configurations",
   "descriptionText": "The lb listener use http port",

--- a/assets/queries/terraform/nifcloud/load_balancer_listener_use_http/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/load_balancer_listener_use_http/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud LB Listener Use HTTP Port",
+		"queryName": "(Beta) Nifcloud LB Listener Use HTTP Port",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/load_balancer_use_http/metadata.json
+++ b/assets/queries/terraform/nifcloud/load_balancer_use_http/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "94e47f3f-b90b-43a1-a36d-521580bae863",
-  "queryName": "Nifcloud LB Use HTTP Port",
+  "queryName": "(Beta) Nifcloud LB Use HTTP Port",
   "severity": "HIGH",
   "category": "Insecure Configurations",
   "descriptionText": "The lb use http port",

--- a/assets/queries/terraform/nifcloud/load_balancer_use_http/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/load_balancer_use_http/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud LB Use HTTP Port",
+		"queryName": "(Beta) Nifcloud LB Use HTTP Port",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/load_balancer_use_insecure_tls_policy_id/metadata.json
+++ b/assets/queries/terraform/nifcloud/load_balancer_use_insecure_tls_policy_id/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "944439c7-b4b8-476a-8f83-14641ea876ba",
-  "queryName": "Nifcloud LB Use Insecure TLS Policy ID",
+  "queryName": "(Beta) Nifcloud LB Use Insecure TLS Policy ID",
   "severity": "HIGH",
   "category": "Insecure Configurations",
   "descriptionText": "The lb use insecure tls policy",

--- a/assets/queries/terraform/nifcloud/load_balancer_use_insecure_tls_policy_id/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/load_balancer_use_insecure_tls_policy_id/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Nifcloud LB Use Insecure TLS Policy ID",
+		"queryName": "(Beta) Nifcloud LB Use Insecure TLS Policy ID",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Nifcloud LB Use Insecure TLS Policy ID",
+		"queryName": "(Beta) Nifcloud LB Use Insecure TLS Policy ID",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/nifcloud/load_balancer_use_insecure_tls_policy_name/metadata.json
+++ b/assets/queries/terraform/nifcloud/load_balancer_use_insecure_tls_policy_name/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "675e8eaa-2754-42b7-bf33-bfa295d1601d",
-  "queryName": "Nifcloud LB Use Insecure TLS Policy Name",
+  "queryName": "(Beta) Nifcloud LB Use Insecure TLS Policy Name",
   "severity": "HIGH",
   "category": "Insecure Configurations",
   "descriptionText": "The lb use insecure tls policy",

--- a/assets/queries/terraform/nifcloud/load_balancer_use_insecure_tls_policy_name/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/load_balancer_use_insecure_tls_policy_name/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Nifcloud LB Use Insecure TLS Policy Name",
+		"queryName": "(Beta) Nifcloud LB Use Insecure TLS Policy Name",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Nifcloud LB Use Insecure TLS Policy Name",
+		"queryName": "(Beta) Nifcloud LB Use Insecure TLS Policy Name",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/nifcloud/nas_instance_has_common_private/metadata.json
+++ b/assets/queries/terraform/nifcloud/nas_instance_has_common_private/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "4b801c38-ebb4-4c81-984b-1ba525d43adf",
-  "queryName": "Nifcloud NAS Has Common Private Network",
+  "queryName": "(Beta) Nifcloud NAS Has Common Private Network",
   "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "The nas has common private network",

--- a/assets/queries/terraform/nifcloud/nas_instance_has_common_private/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/nas_instance_has_common_private/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud NAS Has Common Private Network",
+		"queryName": "(Beta) Nifcloud NAS Has Common Private Network",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/nas_security_group_description_undefined/metadata.json
+++ b/assets/queries/terraform/nifcloud/nas_security_group_description_undefined/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "e840c54a-7a4c-405f-b8c1-c49a54b87d11",
-  "queryName": "Nifcloud NAS Undefined Description To NAS Security Group",
+  "queryName": "(Beta) Nifcloud NAS Undefined Description To NAS Security Group",
   "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "Missing description for nas security group",

--- a/assets/queries/terraform/nifcloud/nas_security_group_description_undefined/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/nas_security_group_description_undefined/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud NAS Undefined Description To NAS Security Group",
+		"queryName": "(Beta) Nifcloud NAS Undefined Description To NAS Security Group",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/nas_security_group_has_public_ingress_sgr/metadata.json
+++ b/assets/queries/terraform/nifcloud/nas_security_group_has_public_ingress_sgr/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "8d7758a7-d9cd-499a-a83e-c9bdcbff728d",
-  "queryName": "Nifcloud NAS Has Public Ingress NAS Security Group Rule",
+  "queryName": "(Beta) Nifcloud NAS Has Public Ingress NAS Security Group Rule",
   "severity": "HIGH",
   "category": "Networking and Firewall",
   "descriptionText": "An ingress nas security group rule allows traffic from /0",

--- a/assets/queries/terraform/nifcloud/nas_security_group_has_public_ingress_sgr/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/nas_security_group_has_public_ingress_sgr/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud NAS Has Public Ingress NAS Security Group Rule",
+		"queryName": "(Beta) Nifcloud NAS Has Public Ingress NAS Security Group Rule",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/router_has_common_private/metadata.json
+++ b/assets/queries/terraform/nifcloud/router_has_common_private/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "30c2760c-740e-4672-9d7f-2c29e0cb385d",
-  "queryName": "Nifcloud Router Has Common Private Network",
+  "queryName": "(Beta) Nifcloud Router Has Common Private Network",
   "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "The router has common private network",

--- a/assets/queries/terraform/nifcloud/router_has_common_private/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/router_has_common_private/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
 	{
-		"queryName": "Nifcloud Router Has Common Private Network",
+		"queryName": "(Beta) Nifcloud Router Has Common Private Network",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive1.tf"
 	},
 	{
-		"queryName": "Nifcloud Router Has Common Private Network",
+		"queryName": "(Beta) Nifcloud Router Has Common Private Network",
 		"severity": "LOW",
 		"line": 1,
 		"fileName": "positive2.tf"

--- a/assets/queries/terraform/nifcloud/router_security_group_undefined/metadata.json
+++ b/assets/queries/terraform/nifcloud/router_security_group_undefined/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "e7dada38-af20-4899-8955-dabea84ab1f0",
-  "queryName": "Nifcloud Router Undefined Security Group To Router",
+  "queryName": "(Beta) Nifcloud Router Undefined Security Group To Router",
   "severity": "HIGH",
   "category": "Networking and Firewall",
   "descriptionText": "Missing security group for router",

--- a/assets/queries/terraform/nifcloud/router_security_group_undefined/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/router_security_group_undefined/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud Router Undefined Security Group To Router",
+		"queryName": "(Beta) Nifcloud Router Undefined Security Group To Router",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/nifcloud/vpn_gateway_security_group_undefined/metadata.json
+++ b/assets/queries/terraform/nifcloud/vpn_gateway_security_group_undefined/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "b3535a48-910c-47f8-8b3b-14222f29ef80",
-  "queryName": "Nifcloud Vpn Gateway Undefined Security Group To Vpn Gateway",
+  "queryName": "(Beta) Nifcloud Vpn Gateway Undefined Security Group To Vpn Gateway",
   "severity": "HIGH",
   "category": "Networking and Firewall",
   "descriptionText": "Missing security group for vpn gateway",

--- a/assets/queries/terraform/nifcloud/vpn_gateway_security_group_undefined/test/positive_expected_result.json
+++ b/assets/queries/terraform/nifcloud/vpn_gateway_security_group_undefined/test/positive_expected_result.json
@@ -1,6 +1,6 @@
 [
 	{
-		"queryName": "Nifcloud Vpn Gateway Undefined Security Group To Vpn Gateway",
+		"queryName": "(Beta) Nifcloud Vpn Gateway Undefined Security Group To Vpn Gateway",
 		"severity": "HIGH",
 		"line": 1,
 		"fileName": "positive.tf"

--- a/assets/queries/terraform/tencentcloud/disk_encryption_disabled/metadata.json
+++ b/assets/queries/terraform/tencentcloud/disk_encryption_disabled/metadata.json
@@ -1,6 +1,6 @@
 {
   "id": "1ee0f202-31da-49ba-bbce-04a989912e4b",
-  "queryName": "Disk Encryption Disabled",
+  "queryName": "(Beta) Disk Encryption Disabled",
   "severity": "MEDIUM",
   "category": "Encryption",
   "descriptionText": "Disks should have encryption enabled",

--- a/assets/queries/terraform/tencentcloud/disk_encryption_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/tencentcloud/disk_encryption_disabled/test/positive_expected_result.json
@@ -1,12 +1,12 @@
 [
   {
-    "queryName": "Disk Encryption Disabled",
+    "queryName": "(Beta) Disk Encryption Disabled",
     "severity": "MEDIUM",
     "line": 6,
     "fileName": "positive2.tf"
   },
   {
-    "queryName": "Disk Encryption Disabled",
+    "queryName": "(Beta) Disk Encryption Disabled",
     "severity": "MEDIUM",
     "line": 1,
     "fileName": "positive1.tf"


### PR DESCRIPTION
**Reason**
For queries that are still under review (`severity` and `description`), we added the prefix "_(beta)_", so the users have a clear perspective if the triggered queries are still under review or not.

**Proposed Changes**
- prefix "(beta)" added to queries that are still under review

I submit this contribution under the Apache-2.0 license.