### PR TITLE
fix(databricks): correct databricks permissions checks

### DIFF
--- a/assets/queries/terraform/databricks/databricks_permissions/query.rego
+++ b/assets/queries/terraform/databricks/databricks_permissions/query.rego
@@ -6,7 +6,7 @@ import data.generic.terraform as tf_lib
 CxPolicy[result] {
 	databricks_job := input.document[i].resource.databricks_job[name]
 
-	is_associated_to_job(name, input.document[i])
+	not is_associated_to_job(name, input.document[i])
 
 	result := {
 		"documentId": input.document[i].id,
@@ -22,14 +22,14 @@ CxPolicy[result] {
 is_associated_to_job(databricks_job_name, doc) {
 	[path, value] := walk(doc)
 	databricks_permissions_used := value.databricks_permissions[_]
-	not contains(databricks_permissions_used.job_id, sprintf("databricks_job.%s", [databricks_job_name]))
+	contains(databricks_permissions_used.job_id, sprintf("databricks_job.%s", [databricks_job_name]))
 }
 
 
 CxPolicy[result] {
 	databricks_cluster := input.document[i].resource.databricks_cluster[name]
 
-	is_associated_to_cluster(name, input.document[i])
+	not is_associated_to_cluster(name, input.document[i])
 
 	result := {
 		"documentId": input.document[i].id,
@@ -45,7 +45,7 @@ CxPolicy[result] {
 is_associated_to_cluster(databricks_cluster_name, doc) {
 	[path, value] := walk(doc)
 	databricks_permissions_used := value.databricks_permissions[_]
-	not contains(databricks_permissions_used.cluster_id, sprintf("databricks_cluster.%s", [databricks_cluster_name]))
+	contains(databricks_permissions_used.cluster_id, sprintf("databricks_cluster.%s", [databricks_cluster_name]))
 }
 
 CxPolicy[result] {

--- a/assets/queries/terraform/databricks/databricks_permissions/test/negative4.tf
+++ b/assets/queries/terraform/databricks/databricks_permissions/test/negative4.tf
@@ -1,0 +1,47 @@
+resource "databricks_job" "negative4_1" {
+  name                = "Featurization"
+  max_concurrent_runs = 1
+
+  new_cluster {
+    num_workers   = 300
+    spark_version = data.databricks_spark_version.latest.id
+    node_type_id  = data.databricks_node_type.smallest.id
+  }
+
+  notebook_task {
+    notebook_path = "/Production/MakeFeatures"
+  }
+}
+
+resource "databricks_permissions" "negative4_1" {
+  job_id = databricks_job.negative4_1.id
+
+  access_control {
+    service_principal_name = databricks_service_principal.aws_principal.application_id
+    permission_level       = "IS_OWNER"
+  }
+}
+
+resource "databricks_job" "negative4_2" {
+  name                = "Featurization"
+  max_concurrent_runs = 1
+
+  new_cluster {
+    num_workers   = 300
+    spark_version = data.databricks_spark_version.latest.id
+    node_type_id  = data.databricks_node_type.smallest.id
+  }
+
+  notebook_task {
+    notebook_path = "/Production/MakeFeatures"
+  }
+}
+
+resource "databricks_permissions" "negative4_2" {
+  job_id = databricks_job.negative4_2.id
+
+  access_control {
+    service_principal_name = databricks_service_principal.aws_principal.application_id
+    permission_level       = "IS_OWNER"
+  }
+}

--- a/assets/queries/terraform/databricks/databricks_permissions/test/negative5.tf
+++ b/assets/queries/terraform/databricks/databricks_permissions/test/negative5.tf
@@ -1,0 +1,59 @@
+resource "databricks_cluster" "negative5_1" {
+  cluster_name            = "Shared Autoscaling"
+  spark_version           = data.databricks_spark_version.latest.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 60
+  autoscale {
+    min_workers = 1
+    max_workers = 10
+  }
+}
+
+resource "databricks_permissions" "negative5_1" {
+  cluster_id = databricks_cluster.negative5_1.id
+
+  access_control {
+    group_name       = databricks_group.auto.display_name
+    permission_level = "CAN_ATTACH_TO"
+  }
+
+  access_control {
+    group_name       = databricks_group.eng.display_name
+    permission_level = "CAN_RESTART"
+  }
+
+  access_control {
+    group_name       = databricks_group.ds.display_name
+    permission_level = "CAN_MANAGE"
+  }
+}
+
+resource "databricks_cluster" "negative5_2" {
+  cluster_name            = "Shared Autoscaling"
+  spark_version           = data.databricks_spark_version.latest.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 60
+  autoscale {
+    min_workers = 1
+    max_workers = 10
+  }
+}
+
+resource "databricks_permissions" "negative5_2" {
+  cluster_id = databricks_cluster.negative5_2.id
+
+  access_control {
+    group_name       = databricks_group.auto.display_name
+    permission_level = "CAN_ATTACH_TO"
+  }
+
+  access_control {
+    group_name       = databricks_group.eng.display_name
+    permission_level = "CAN_RESTART"
+  }
+
+  access_control {
+    group_name       = databricks_group.ds.display_name
+    permission_level = "CAN_MANAGE"
+  }
+}

--- a/assets/queries/terraform/databricks/databricks_permissions/test/positive5.tf
+++ b/assets/queries/terraform/databricks/databricks_permissions/test/positive5.tf
@@ -1,0 +1,46 @@
+resource "databricks_job" "positive5_1" {
+  name                = "Featurization"
+  max_concurrent_runs = 1
+
+  new_cluster {
+    num_workers   = 300
+    spark_version = data.databricks_spark_version.latest.id
+    node_type_id  = data.databricks_node_type.smallest.id
+  }
+
+  notebook_task {
+    notebook_path = "/Production/MakeFeatures"
+  }
+}
+
+resource "databricks_permissions" "positive5_1" {
+  job_id = databricks_job.positive5_1.id
+
+  access_control {
+    service_principal_name = databricks_service_principal.aws_principal.application_id
+    permission_level       = "IS_OWNER"
+  }
+}
+
+resource "databricks_job" "positive5_2" {
+  name                = "Featurization"
+  max_concurrent_runs = 1
+
+  new_cluster {
+    num_workers   = 300
+    spark_version = data.databricks_spark_version.latest.id
+    node_type_id  = data.databricks_node_type.smallest.id
+  }
+
+  notebook_task {
+    notebook_path = "/Production/MakeFeatures"
+  }
+}
+
+resource "databricks_permissions" "positive5_2" {
+
+  access_control {
+    service_principal_name = databricks_service_principal.aws_principal.application_id
+    permission_level       = "IS_OWNER"
+  }
+}

--- a/assets/queries/terraform/databricks/databricks_permissions/test/positive6.tf
+++ b/assets/queries/terraform/databricks/databricks_permissions/test/positive6.tf
@@ -1,0 +1,22 @@
+resource "databricks_job" "positive6" {
+  name                = "Featurization"
+  max_concurrent_runs = 1
+
+  new_cluster {
+    num_workers   = 300
+    spark_version = data.databricks_spark_version.latest.id
+    node_type_id  = data.databricks_node_type.smallest.id
+  }
+
+  notebook_task {
+    notebook_path = "/Production/MakeFeatures"
+  }
+}
+
+resource "databricks_permissions" "positive6" {
+
+  access_control {
+    service_principal_name = databricks_service_principal.aws_principal.application_id
+    permission_level       = "IS_OWNER"
+  }
+}

--- a/assets/queries/terraform/databricks/databricks_permissions/test/positive7.tf
+++ b/assets/queries/terraform/databricks/databricks_permissions/test/positive7.tf
@@ -1,0 +1,58 @@
+resource "databricks_cluster" "positive7_1" {
+  cluster_name            = "Shared Autoscaling"
+  spark_version           = data.databricks_spark_version.latest.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 60
+  autoscale {
+    min_workers = 1
+    max_workers = 10
+  }
+}
+
+resource "databricks_permissions" "positive7_1" {
+  cluster_id = databricks_cluster.positive7_1.id
+
+  access_control {
+    group_name       = databricks_group.auto.display_name
+    permission_level = "CAN_ATTACH_TO"
+  }
+
+  access_control {
+    group_name       = databricks_group.eng.display_name
+    permission_level = "CAN_RESTART"
+  }
+
+  access_control {
+    group_name       = databricks_group.ds.display_name
+    permission_level = "CAN_MANAGE"
+  }
+}
+
+resource "databricks_cluster" "positive7_2" {
+  cluster_name            = "Shared Autoscaling"
+  spark_version           = data.databricks_spark_version.latest.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 60
+  autoscale {
+    min_workers = 1
+    max_workers = 10
+  }
+}
+
+resource "databricks_permissions" "positive7_2" {
+
+  access_control {
+    group_name       = databricks_group.auto.display_name
+    permission_level = "CAN_ATTACH_TO"
+  }
+
+  access_control {
+    group_name       = databricks_group.eng.display_name
+    permission_level = "CAN_RESTART"
+  }
+
+  access_control {
+    group_name       = databricks_group.ds.display_name
+    permission_level = "CAN_MANAGE"
+  }
+}

--- a/assets/queries/terraform/databricks/databricks_permissions/test/positive8.tf
+++ b/assets/queries/terraform/databricks/databricks_permissions/test/positive8.tf
@@ -1,0 +1,28 @@
+resource "databricks_cluster" "positive8" {
+  cluster_name            = "Shared Autoscaling"
+  spark_version           = data.databricks_spark_version.latest.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 60
+  autoscale {
+    min_workers = 1
+    max_workers = 10
+  }
+}
+
+resource "databricks_permissions" "positive8" {
+
+  access_control {
+    group_name       = databricks_group.auto.display_name
+    permission_level = "CAN_ATTACH_TO"
+  }
+
+  access_control {
+    group_name       = databricks_group.eng.display_name
+    permission_level = "CAN_RESTART"
+  }
+
+  access_control {
+    group_name       = databricks_group.ds.display_name
+    permission_level = "CAN_MANAGE"
+  }
+}


### PR DESCRIPTION
fix(databricks): correct databricks permissions checks

**Reason for Proposed Changes**
- `databricks_permissions` checks were not working properly

**Proposed Changes**
- Move `not` operator
- Add test files (containing tests where multiple permissions are present in a single file)

I submit this contribution under the Apache-2.0 license.