### PR TITLE
update(linting): update contribuition guide and remove deprecated linting methods

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -96,13 +95,11 @@ linters:
     - noctx
     - nolintlint
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
   # don't enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,7 @@ linters-settings:
       - strings.SplitN
 
   govet:
-    check-shadowing: true
+    shadow: true
     settings:
       printf:
         funcs:
@@ -129,7 +129,7 @@ issues:
 run:
   timeout: 5m
   tests: false
-  skip-dirs:
+  exclude-dirs:
     - assets
     - docs
     - vendor

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,13 +125,12 @@ issues:
       linters:
         - gomnd
         - scopelint
-
-run:
-  timeout: 5m
-  tests: false
-  skip-dirs:
+  exclude-dirs:
     - assets
     - docs
     - vendor
     - pkg/parser/jsonfilter/parser
-    - pkg/parser/bicep/antlr
+    - pkg/parser/bicep/antlr  
+run:
+  timeout: 5m
+  tests: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,7 +129,7 @@ issues:
 run:
   timeout: 5m
   tests: false
-  exclude-dirs:
+  skip-dirs:
     - assets
     - docs
     - vendor

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Use succinct but descriptive name (prefix with *feature/issue#-descriptive-name>
 5. Make your changes locally.
 6. Validate your changes to reassure they meet project quality and contribution standards:
    ```sh
-   golint .
+   golangci-lint run
    ```
    ```sh
    go mod vendor


### PR DESCRIPTION
Closes #7144

**Reason for Proposed Changes**
- change contribution guide linting method suggestion;
- remove deprecated linting methods;

**Proposed Changes**
- remove deprecated linting methods from golangci.yaml;
- update contribution guide with current linting method used by KICS Repo;

I submit this contribution under the Apache-2.0 license.