### PR TITLE
update(query): add CWE infos to gRPC, Knative and Buildah queries

### DIFF
--- a/assets/queries/buildah/run_using_apt/metadata.json
+++ b/assets/queries/buildah/run_using_apt/metadata.json
@@ -7,6 +7,7 @@
   "descriptionUrl": "https://github.com/containers/buildah/blob/main/docs/buildah-run.1.md",
   "platform": "Buildah",
   "descriptionID": "eb58fa0b",
-  "cwe": "",
+  "cloudProvider": "common",
+  "cwe": "1188",
   "oldSeverity": "MEDIUM"
 }

--- a/assets/queries/grpc/enum_name_not_camel_case/metadata.json
+++ b/assets/queries/grpc/enum_name_not_camel_case/metadata.json
@@ -7,6 +7,6 @@
   "descriptionUrl": "https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#enum_definition",
   "platform": "GRPC",
   "descriptionID": "a780a54d",
-  "cwe": "",
+  "cwe": "1099",
   "oldSeverity": "LOW"
 }

--- a/assets/queries/knative/serving_revision_spec_without_timeout_settings/metadata.json
+++ b/assets/queries/knative/serving_revision_spec_without_timeout_settings/metadata.json
@@ -7,5 +7,5 @@
   "descriptionUrl": "https://knative.dev/docs/reference/api/serving-api/#serving.knative.dev/v1.RevisionSpec",
   "platform": "Knative",
   "descriptionID": "0b6ca133",
-  "cwe": ""
+  "cwe": "799"
 }


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- gRPC, Knative and Buildah queries don't provide cwe infos;

**Proposed Changes**
- add CWE infos to all gRPC, Knative and Buildah queries;
- add cwe info to the queries metadata;
-

I submit this contribution under the Apache-2.0 license.