### PR TITLE
fix(query): fix unexpected behaviour in parameter-checking function for ARM queries

### DIFF
--- a/assets/libraries/azureresourcemanager.rego
+++ b/assets/libraries/azureresourcemanager.rego
@@ -81,7 +81,7 @@ getDefaultValueFromParametersIfPresent(doc, valueToCheck) = [value, propertyType
 isParameterReference(valueToCheck) = parameterName {
 	startswith(valueToCheck, "[parameters('")
 	endswith(valueToCheck, "')]")
-	parameterName := trim_right(trim_left(valueToCheck, "[parameters('"),"')]")
+	parameterName := trim_right(trim_left(trim_left(valueToCheck, "[parameters"), "('"), "')]")
 }
 
 


### PR DESCRIPTION
**Reason for Proposed Changes**
- ARM queries could give incorrect results in some cases because of a bug in an ARM-specific parameter-checking function.

**Proposed Changes**
- Fix parameter-checking function for ARM queries

I submit this contribution under the Apache-2.0 license.