### PR TITLE
fix(query): fix CWE field not appearing in KICS CLI and sarif reports

### DIFF
--- a/pkg/engine/secrets/inspector.go
+++ b/pkg/engine/secrets/inspector.go
@@ -527,6 +527,7 @@ func (c *Inspector) addVulnerability(basePaths []string, file *model.FileMetadat
 				VulnLines:        hideSecret(&linesVuln, issueLine, query, &c.SecretTracker),
 				IssueType:        "RedundantAttribute",
 				Platform:         SecretsQueryMetadata["platform"],
+				CWE:              SecretsQueryMetadata["cwe"],
 				Severity:         model.SeverityHigh,
 				QueryURI:         SecretsQueryMetadata["descriptionUrl"],
 				Category:         SecretsQueryMetadata["category"],


### PR DESCRIPTION
**Reason for Proposed Changes**
- CWE field was not appearing on KICS CLI and sarif reports;

**Proposed Changes**
- Add CWE field to secrets inspector in order to appear on KICS CLI and Sarif reports;

I submit this contribution under the Apache-2.0 license.