### PR TITLE
update(go): update go version to 1.23.1

### DIFF
--- a/.github/scripts/report/go.mod
+++ b/.github/scripts/report/go.mod
@@ -1,6 +1,6 @@
 module github.com/Checkmarx/e2e-report
 
-go 1.21
+go 1.23.1
 
 require (
 	github.com/rs/zerolog v1.31.0

--- a/.github/scripts/server-mock/package-lock.json
+++ b/.github/scripts/server-mock/package-lock.json
@@ -630,7 +630,7 @@
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -642,34 +642,6 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/serve-static/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/serve-static/node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/set-function-length": {

--- a/.github/scripts/server-mock/package-lock.json
+++ b/.github/scripts/server-mock/package-lock.json
@@ -30,9 +30,9 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -42,7 +42,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -50,6 +50,20 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/bytes": {
@@ -157,9 +171,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -197,36 +211,36 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.20.0.tgz",
+      "integrity": "sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "finalhandler": "1.2.0",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
         "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.0",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -250,6 +264,14 @@
         "statuses": "2.0.1",
         "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -399,9 +421,12 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -455,9 +480,12 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -482,9 +510,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -559,9 +587,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -581,20 +609,64 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.0.tgz",
+      "integrity": "sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==",
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
         "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-static/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serve-static/node_modules/send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
       },
       "engines": {
         "node": ">= 0.8.0"

--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -47,7 +47,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Set Permissions
         run: |
-          sudo chmod -R 770 ${PWD}/assets/queries
+          sudo chmod -R 777 ${PWD}/assets/queries
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Run docker image and generate results.json

--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -45,9 +45,6 @@ jobs:
             COMMIT=${GITHUB_SHA}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Set Permissions
-        run: |
-          sudo chmod -R 777 ${PWD}/assets/queries
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Run docker image and generate results.json

--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -47,7 +47,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Set Permissions
         run: |
-          sudo chmod -R 777 ${PWD}/assets/queries
+          sudo chmod -R 770 ${PWD}/assets/queries
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Run docker image and generate results.json

--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -45,6 +45,9 @@ jobs:
             COMMIT=${GITHUB_SHA}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: Set Output Permissions
+        run: |
+          sudo chmod -R 777 ${PWD}/assets/queries
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Run docker image and generate results.json

--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -45,7 +45,7 @@ jobs:
             COMMIT=${GITHUB_SHA}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      - name: Set Output Permissions
+      - name: Set Permissions
         run: |
           sudo chmod -R 777 ${PWD}/assets/queries
       - name: Image digest

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -16,7 +16,7 @@ jobs:
           go-version-file: go.mod
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
           version: v1.57.2
           args: -c .golangci.yml --timeout 20m

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -104,8 +104,7 @@ jobs:
           args: "-no-fail -fmt sarif -out results.sarif ./..."
       - name: Show results
         run: |
-          cat results-dir/results.sarif
-          cat results-dir/results.json
+          cat results.sarif
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@0ce4453ddd8cca1291d2056cf903b545baad95a0
+        uses: securego/gosec@6fbd381238e97e1d1f3358f0d6d65de78dcf9245
         with:
           args: "-no-fail -fmt sarif -out results.sarif ./..."
       - name: Show results

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -102,6 +102,10 @@ jobs:
         uses: securego/gosec@master
         with:
           args: "-no-fail -fmt sarif -out results.sarif ./..."
+      - name: Show results
+        run: |
+          cat results-dir/results.sarif
+          cat results-dir/results.json
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@abfe8cfd6d5687c96abf31f8e7f57982df2a6e4f
         with:
           args: "-no-fail -fmt sarif -out results.sarif ./..."
       - name: Show results

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@abfe8cfd6d5687c96abf31f8e7f57982df2a6e4f
+        uses: securego/gosec@master
         with:
           args: "-no-fail -fmt sarif -out results.sarif ./..."
       - name: Upload SARIF file

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@abfe8cfd6d5687c96abf31f8e7f57982df2a6e4f
         with:
           args: "-no-fail -fmt sarif -out results.sarif ./..."
       - name: Upload SARIF file

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: v1.57.2
+          version: v1.61.0
           args: -c .golangci.yml --timeout 20m
   go-generate:
     name: go-generate
@@ -39,7 +39,7 @@ jobs:
     name: unit-tests
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -99,13 +99,13 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@6fbd381238e97e1d1f3358f0d6d65de78dcf9245
+        uses: securego/gosec@6fbd381238e97e1d1f3358f0d6d65de78dcf9245 # v2.20.0
         with:
           args: "-no-fail -fmt sarif -out results.sarif ./..."
       - name: Show results
         run: |
           cat results.sarif
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@2bbafcdd7fbf96243689e764c2f15d9735164f33
         with:
           sarif_file: results.sarif

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@abfe8cfd6d5687c96abf31f8e7f57982df2a6e4f
+        uses: securego/gosec@0ce4453ddd8cca1291d2056cf903b545baad95a0
         with:
           args: "-no-fail -fmt sarif -out results.sarif ./..."
       - name: Show results

--- a/.github/workflows/go-e2e-debian.yaml
+++ b/.github/workflows/go-e2e-debian.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/go-e2e.yaml
+++ b/.github/workflows/go-e2e.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         os: [ubuntu-latest]
         kics-docker: ["Dockerfile", "docker/Dockerfile.ubi8"]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release-apispec.yml
+++ b/.github/workflows/release-apispec.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 #v5.1.0
         with:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go@sha256:4f11a0dfbd73832405bc3f611e53b4dbd61a1d1d23d205f2665cabfbd295a109 as build_env
+FROM cgr.dev/chainguard/go@sha256:27d8b84203a3acb1bdeb128874d2b89749a6fb3582535e7703680a9f46e08422 as build_env
 
 # Copy the source from the current directory to the Working Directory inside the container
 WORKDIR /app
@@ -31,7 +31,7 @@ USER nonroot
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM cgr.dev/chainguard/git@sha256:51620806588a4738b536e1f328206b17ae2a988b2a424a6a37c419041eb2b9a9
+FROM cgr.dev/chainguard/busybox@sha256:464c46b551bb3187f893f48d29556a944720d4680d35dfd9ece956493b15c33b
 
 ENV TERM xterm-256color
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM cgr.dev/chainguard/go@sha256:1b27d8f2f9bb49434e38fbb7456cb8b72b6652235bb07e
 WORKDIR /app
 
 ENV GOPRIVATE=github.com/Checkmarx/*
+ENV GIT_VERSION=2.46.0
 ARG VERSION="development"
 ARG COMMIT="NOCOMMIT"
 ARG SENTRY_DSN=""
@@ -25,13 +26,13 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
     -a -installsuffix cgo \
     -o bin/kics cmd/console/main.go
-
+    
 USER nonroot
 
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM cgr.dev/chainguard/busybox@sha256:02e248d0c2ad1cb8c110f550a0a9d881699e09879de2b8fed91ef03b3abef05c
+FROM cgr.dev/chainguard/git:latest-glibc@sha256:6234bec5d1a6a3d46ae11117b5d803846366b728297503e00396d4203b8a0cc5
 
 ENV TERM xterm-256color
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go@sha256:4f11a0dfbd73832405bc3f611e53b4dbd61a1d1d23d205f2665cabfbd295a109 as build_env
+FROM cgr.dev/chainguard/go@sha256:1b27d8f2f9bb49434e38fbb7456cb8b72b6652235bb07e2ee002d06f44821c29 as build_env
 
 # Copy the source from the current directory to the Working Directory inside the container
 WORKDIR /app
@@ -31,7 +31,7 @@ USER nonroot
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM cgr.dev/chainguard/busybox@sha256:464c46b551bb3187f893f48d29556a944720d4680d35dfd9ece956493b15c33b
+FROM cgr.dev/chainguard/busybox@sha256:02e248d0c2ad1cb8c110f550a0a9d881699e09879de2b8fed91ef03b3abef05c
 
 ENV TERM xterm-256color
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ USER nonroot
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM cgr.dev/chainguard/git:latest-glibc@sha256:6234bec5d1a6a3d46ae11117b5d803846366b728297503e00396d4203b8a0cc5
+FROM cgr.dev/chainguard/git:latest@sha256:6234bec5d1a6a3d46ae11117b5d803846366b728297503e00396d4203b8a0cc5
 
 ENV TERM xterm-256color
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ USER nonroot
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM docker.io/ruigomes99/git-sed:golden-amd64@sha256:66f75ea8d23050cc261f7d72add62cdbb40869c8bc3c8fbbeede4fe18db12c30
+FROM cgr.dev/chainguard/git@sha256:02660563e96b553d6aeb4093e3fcc3e91b2ad3a86e05c65b233f37f035e5044e
 
 ENV TERM xterm-256color
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go@sha256:1b27d8f2f9bb49434e38fbb7456cb8b72b6652235bb07e2ee002d06f44821c29 as build_env
+FROM cgr.dev/chainguard/go@sha256:1e17e06119fc26b78a9a2208aeab6209f9ef90b6a19f3fc69d4cc581e70d09bf as build_env
 
 # Copy the source from the current directory to the Working Directory inside the container
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM cgr.dev/chainguard/go@sha256:1b27d8f2f9bb49434e38fbb7456cb8b72b6652235bb07e
 WORKDIR /app
 
 ENV GOPRIVATE=github.com/Checkmarx/*
-ENV GIT_VERSION=2.46.0
 ARG VERSION="development"
 ARG COMMIT="NOCOMMIT"
 ARG SENTRY_DSN=""
@@ -26,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
     -a -installsuffix cgo \
     -o bin/kics cmd/console/main.go
-    
+
 USER nonroot
 
 # Runtime image

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ USER nonroot
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM cgr.dev/chainguard/git@sha256:02660563e96b553d6aeb4093e3fcc3e91b2ad3a86e05c65b233f37f035e5044e
+FROM docker.io/ruigomes99/git-sed:golden-amd64@sha256:66f75ea8d23050cc261f7d72add62cdbb40869c8bc3c8fbbeede4fe18db12c30
 
 ENV TERM xterm-256color
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM cgr.dev/chainguard/go@sha256:1b27d8f2f9bb49434e38fbb7456cb8b72b6652235bb07e
 WORKDIR /app
 
 ENV GOPRIVATE=github.com/Checkmarx/*
-ENV GIT_VERSION=2.46.0
 ARG VERSION="development"
 ARG COMMIT="NOCOMMIT"
 ARG SENTRY_DSN=""
@@ -32,13 +31,7 @@ USER nonroot
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM cgr.dev/chainguard/bash@sha256:2faccc3e8ab049d82dec0e4d2dd8b45718c71ce640608584d95a39092b5006b5
-
-RUN curl -LO https://github.com/git/git/archive/refs/tags/v${GIT_VERSION}.tar.gz && \
-    tar -zxf v${GIT_VERSION}.tar.gz && \
-    mv git-${GIT_VERSION}/bin/git /usr/local/bin/git && \
-    chmod +x /usr/local/bin/git && \
-    rm -rf git-${GIT_VERSION} v${GIT_VERSION}.tar.gz
+FROM cgr.dev/chainguard/busybox@sha256:02e248d0c2ad1cb8c110f550a0a9d881699e09879de2b8fed91ef03b3abef05c
 
 ENV TERM xterm-256color
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go@sha256:27d8b84203a3acb1bdeb128874d2b89749a6fb3582535e7703680a9f46e08422 as build_env
+FROM cgr.dev/chainguard/go@sha256:4f11a0dfbd73832405bc3f611e53b4dbd61a1d1d23d205f2665cabfbd295a109 as build_env
 
 # Copy the source from the current directory to the Working Directory inside the container
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM cgr.dev/chainguard/go@sha256:1b27d8f2f9bb49434e38fbb7456cb8b72b6652235bb07e
 WORKDIR /app
 
 ENV GOPRIVATE=github.com/Checkmarx/*
+ENV GIT_VERSION=2.46.0
 ARG VERSION="development"
 ARG COMMIT="NOCOMMIT"
 ARG SENTRY_DSN=""
@@ -31,7 +32,13 @@ USER nonroot
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM cgr.dev/chainguard/busybox@sha256:02e248d0c2ad1cb8c110f550a0a9d881699e09879de2b8fed91ef03b3abef05c
+FROM cgr.dev/chainguard/bash@sha256:2faccc3e8ab049d82dec0e4d2dd8b45718c71ce640608584d95a39092b5006b5
+
+RUN curl -LO https://github.com/git/git/archive/refs/tags/v${GIT_VERSION}.tar.gz && \
+    tar -zxf v${GIT_VERSION}.tar.gz && \
+    mv git-${GIT_VERSION}/bin/git /usr/local/bin/git && \
+    chmod +x /usr/local/bin/git && \
+    rm -rf git-${GIT_VERSION} v${GIT_VERSION}.tar.gz
 
 ENV TERM xterm-256color
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ USER nonroot
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM cgr.dev/chainguard/git:latest@sha256:6234bec5d1a6a3d46ae11117b5d803846366b728297503e00396d4203b8a0cc5
+FROM cgr.dev/chainguard/git@sha256:02660563e96b553d6aeb4093e3fcc3e91b2ad3a86e05c65b233f37f035e5044e
 
 ENV TERM xterm-256color
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ KICS is used by various companies and organizations, some are listed below. If y
 -   [Keptn](https://github.com/keptn) / [Keptn Lifecycle Toolkit](https://keptn.sh)
 
 **Keeping Infrastructure as Code Secure!**
-
+ 
 ---
 
 &copy; 2024 Checkmarx Ltd. All Rights Reserved.

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -3,7 +3,7 @@
 # it does not define an ENTRYPOINT as this is a requirement described here:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops#linux-based-containers
 #
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22.5-bookworm as build_env
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22.7-bookworm as build_env
 # Create a group and user
 RUN groupadd checkmarx && useradd -g checkmarx -M -s /bin/bash checkmarx
 USER checkmarx

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -3,7 +3,7 @@
 # it does not define an ENTRYPOINT as this is a requirement described here:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops#linux-based-containers
 #
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22.7-bookworm as build_env
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.23.1-bookworm as build_env
 # Create a group and user
 RUN groupadd checkmarx && useradd -g checkmarx -M -s /bin/bash checkmarx
 USER checkmarx

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -6,8 +6,8 @@ ENV PATH=$PATH:/usr/local/go/bin
 
 ADD https://golang.org/dl/go1.22.4.linux-amd64.tar.gz .
 RUN yum install git gcc -y \
-  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz \
-  && rm -f go1.22.4.linux-amd64.tar.gz
+  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.7.linux-amd64.tar.gz \
+  && rm -f go1.22.7.linux-amd64.tar.gz
 
 ENV GOPRIVATE=github.com/Checkmarx/*
 ARG VERSION="development"

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -4,10 +4,10 @@ WORKDIR /build
 
 ENV PATH=$PATH:/usr/local/go/bin
 
-ADD https://golang.org/dl/go1.22.7.linux-amd64.tar.gz .
+ADD https://golang.org/dl/go1.23.1.linux-amd64.tar.gz .
 RUN yum install git gcc -y \
-  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.7.linux-amd64.tar.gz \
-  && rm -f go1.22.7.linux-amd64.tar.gz
+  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.1.linux-amd64.tar.gz \
+  && rm -f go1.23.1.linux-amd64.tar.gz
 
 ENV GOPRIVATE=github.com/Checkmarx/*
 ARG VERSION="development"

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -4,7 +4,7 @@ WORKDIR /build
 
 ENV PATH=$PATH:/usr/local/go/bin
 
-ADD https://golang.org/dl/go1.22.4.linux-amd64.tar.gz .
+ADD https://golang.org/dl/go1.22.7.linux-amd64.tar.gz .
 RUN yum install git gcc -y \
   && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.7.linux-amd64.tar.gz \
   && rm -f go1.22.7.linux-amd64.tar.gz

--- a/docs/queries/cicd-queries/20f14e1a-a899-4e79-9f09-b6a84cd4649b.md
+++ b/docs/queries/cicd-queries/20f14e1a-a899-4e79-9f09-b6a84cd4649b.md
@@ -205,10 +205,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Go 1.22.x
+      - name: Set up Go 1.23.x
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Run test metrics script
         id: testcov
         run: |

--- a/examples/github/kics-docker-runner-sarif.yaml
+++ b/examples/github/kics-docker-runner-sarif.yaml
@@ -37,6 +37,6 @@ jobs:
           cat results-dir/results.sarif
           cat results-dir/results.json
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@4dd16135b69a43b6c8efb853346f8437d92d3c93
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results-dir/results.sarif

--- a/examples/github/kics-docker-runner-sarif.yaml
+++ b/examples/github/kics-docker-runner-sarif.yaml
@@ -32,7 +32,6 @@ jobs:
           exclude_paths: "terraform/gcp/big_data.tf,terraform/azure"
           # look for the queries' ID in its metadata.json
           exclude_queries: 0437633b-daa6-4bbc-8526-c0d2443b946e
-      - name: Show results
         run: |
           cat results-dir/results.sarif
           cat results-dir/results.json

--- a/examples/github/kics-docker-runner-sarif.yaml
+++ b/examples/github/kics-docker-runner-sarif.yaml
@@ -37,6 +37,6 @@ jobs:
           cat results-dir/results.sarif
           cat results-dir/results.json
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@2bbafcdd7fbf96243689e764c2f15d9735164f33
         with:
           sarif_file: results-dir/results.sarif

--- a/examples/github/kics-docker-runner-sarif.yaml
+++ b/examples/github/kics-docker-runner-sarif.yaml
@@ -37,6 +37,6 @@ jobs:
           cat results-dir/results.sarif
           cat results-dir/results.json
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@4dd16135b69a43b6c8efb853346f8437d92d3c93
         with:
           sarif_file: results-dir/results.sarif

--- a/examples/github/kics-docker-runner-sarif.yaml
+++ b/examples/github/kics-docker-runner-sarif.yaml
@@ -32,6 +32,7 @@ jobs:
           exclude_paths: "terraform/gcp/big_data.tf,terraform/azure"
           # look for the queries' ID in its metadata.json
           exclude_queries: 0437633b-daa6-4bbc-8526-c0d2443b946e
+      - name: Show results
         run: |
           cat results-dir/results.sarif
           cat results-dir/results.json

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Checkmarx/kics/v2
 
-go 1.22.5
+go 1.22.7
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.26

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Checkmarx/kics/v2
 
-go 1.22.7
+go 1.23.1
 
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.26

--- a/internal/console/analyze.go
+++ b/internal/console/analyze.go
@@ -77,7 +77,7 @@ func executeAnalyze(analyzeParams *analyzer.Parameters) error {
 	log.Debug().Msg("console.scan()")
 
 	for _, warn := range warnings {
-		log.Warn().Msgf(warn)
+		log.Warn().Msgf("%s", warn)
 	}
 
 	console := newConsole()

--- a/internal/console/pre_scan.go
+++ b/internal/console/pre_scan.go
@@ -135,7 +135,7 @@ func newConsole() *console {
 func (console *console) preScan() {
 	log.Debug().Msg("console.scan()")
 	for _, warn := range warnings {
-		log.Warn().Msgf(warn)
+		log.Warn().Msgf("%s", warn)
 	}
 
 	printer := internalPrinter.NewPrinter(flags.GetBoolFlag(flags.MinimalUIFlag))

--- a/internal/console/pre_scan.go
+++ b/internal/console/pre_scan.go
@@ -143,7 +143,7 @@ func (console *console) preScan() {
 
 	versionMsg := fmt.Sprintf("\nScanning with %s\n\n", constants.GetVersion())
 	fmt.Println(versionMsg)
-	log.Info().Msgf(strings.ReplaceAll(versionMsg, "\n", ""))
+	log.Info().Msgf("%s", strings.ReplaceAll(versionMsg, "\n", ""))
 
 	log.Info().Msgf("Operating system: %s", runtime.GOOS)
 

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -35,7 +35,7 @@ func ReportSentry(report *Report, shouldLog bool) {
 	})
 
 	if shouldLog {
-		log.Err(report.Err).Msgf(report.Message)
+		log.Err(report.Err).Msgf("%s", report.Message)
 		log.Debug().Msgf("Error Report: \n%+v\n", report.string())
 	}
 }

--- a/pkg/engine/secrets/inspector.go
+++ b/pkg/engine/secrets/inspector.go
@@ -316,18 +316,18 @@ func (c *Inspector) isSecret(s string, query *RegexQuery) (isSecretRet bool, gro
 
 	for _, group := range groups {
 		splitedText := strings.Split(s, "\n")
-		max := -1
+		maxSplit := -1
 		for i, splited := range splitedText {
 			if len(groups) < query.Multiline.DetectLineGroup {
-				if strings.Contains(splited, group[query.Multiline.DetectLineGroup]) && i > max {
-					max = i
+				if strings.Contains(splited, group[query.Multiline.DetectLineGroup]) && i > maxSplit {
+					maxSplit = i
 				}
 			}
 		}
-		if max == -1 {
+		if maxSplit == -1 {
 			continue
 		}
-		secret, newGroups := c.isSecret(strings.Join(append(splitedText[:max], splitedText[max+1:]...), "\n"), query)
+		secret, newGroups := c.isSecret(strings.Join(append(splitedText[:maxSplit], splitedText[maxSplit+1:]...), "\n"), query)
 		if !secret {
 			continue
 		}

--- a/pkg/parser/buildah/comments.go
+++ b/pkg/parser/buildah/comments.go
@@ -17,7 +17,7 @@ func getKicsIgnore(comment string) string {
 
 func (i *Info) getIgnoreLines(comment *syntax.Comment) {
 	// get normal comments
-	i.IgnoreLines = append(i.IgnoreLines, int(comment.Hash.Line()))
+	i.IgnoreLines = append(i.IgnoreLines, int(comment.Hash.Line())) //nolint:gosec
 
 	if model.KICSCommentRgxp.MatchString(comment.Text) {
 		kicsIgnore := getKicsIgnore(comment.Text)
@@ -25,10 +25,10 @@ func (i *Info) getIgnoreLines(comment *syntax.Comment) {
 		switch model.CommentCommand(kicsIgnore) {
 		case model.IgnoreLine:
 			// get kics-scan ignore-line
-			i.IgnoreLines = append(i.IgnoreLines, int(comment.Hash.Line())+1)
+			i.IgnoreLines = append(i.IgnoreLines, int(comment.Hash.Line())+1) //nolint:gosec
 		case model.IgnoreBlock:
 			// get kics-scan ignore-block for ignoreFromBlock
-			i.IgnoreBlockLines = append(i.IgnoreBlockLines, int(comment.Pos().Line()))
+			i.IgnoreBlockLines = append(i.IgnoreBlockLines, int(comment.Pos().Line())) //nolint:gosec
 		}
 	}
 }

--- a/pkg/parser/buildah/comments.go
+++ b/pkg/parser/buildah/comments.go
@@ -42,7 +42,7 @@ func (i *Info) getIgnoreBlockLines(comments []syntax.Comment, start, end int) {
 			kicsIgnore := getKicsIgnore(comment.Text)
 
 			if model.CommentCommand(kicsIgnore) == model.IgnoreBlock {
-				if int(comment.Hash.Line()) == start-1 {
+				if int(comment.Hash.Line()) == start-1 { //nolint:gosec
 					i.IgnoreLines = append(i.IgnoreLines, model.Range(start, end)...)
 					i.IgnoreBlockLines = append(i.IgnoreBlockLines, model.Range(start, end)...)
 				}

--- a/pkg/parser/buildah/parser.go
+++ b/pkg/parser/buildah/parser.go
@@ -134,8 +134,8 @@ func (i *Info) getStmtInfo(stmt *syntax.Stmt, args []*syntax.Word) Command {
 			cmd := "buildah " + strings.TrimSpace(getWordValue(args[1]))
 			fullCmd := strings.TrimSpace(getFullCommand(args))
 			value := strings.TrimPrefix(fullCmd, cmd)
-			start := int(args[0].Pos().Line())
-			end := int(args[len(args)-1].End().Line())
+			start := int(args[0].Pos().Line())         //nolint:gosec
+			end := int(args[len(args)-1].End().Line()) //nolint:gosec
 
 			command = Command{
 				Cmd:       cmd,

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -280,15 +280,15 @@ func NewPrinter(minimal bool) *Printer {
 func (p *Printer) PrintBySev(content, sev string) string {
 	switch strings.ToUpper(sev) {
 	case model.SeverityCritical:
-		return p.Critical.Sprintf(content)
+		return p.Critical.Sprintf("%s", content)
 	case model.SeverityHigh:
-		return p.High.Sprintf(content)
+		return p.High.Sprintf("%s", content)
 	case model.SeverityMedium:
-		return p.Medium.Sprintf(content)
+		return p.Medium.Sprintf("%s", content)
 	case model.SeverityLow:
-		return p.Low.Sprintf(content)
+		return p.Low.Sprintf("%s", content)
 	case model.SeverityInfo:
-		return p.Info.Sprintf(content)
+		return p.Info.Sprintf("%s", content)
 	}
 	return content
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -295,7 +295,7 @@ func (p *Printer) PrintBySev(content, sev string) string {
 
 // Bold returns the output in a bold format
 func (p *Printer) Bold(content string) string {
-	return color.Bold.Sprintf(content)
+	return color.Bold.Sprintf("%s", content)
 }
 
 func validQueryID(queryID string) bool {

--- a/pkg/remediation/remediation.go
+++ b/pkg/remediation/remediation.go
@@ -153,10 +153,14 @@ func addition(r *Remediation, lines *[]string) []string {
 	return remediation
 }
 
+const (
+	FilePermMode = 0600 // File permissions mode with read and write only
+)
+
 func (s *Summary) writeRemediation(remediatedLines, lines []string, filePath, similarityID string) []string {
 	remediated := []byte(strings.Join(remediatedLines, "\n"))
 
-	mode := os.FileMode(0600)
+	mode := os.FileMode(FilePermMode)
 
 	if err := os.WriteFile(filePath, remediated, mode); err != nil {
 		log.Error().Msgf("failed to write file: %s", err)

--- a/pkg/remediation/remediation.go
+++ b/pkg/remediation/remediation.go
@@ -156,7 +156,9 @@ func addition(r *Remediation, lines *[]string) []string {
 func (s *Summary) writeRemediation(remediatedLines, lines []string, filePath, similarityID string) []string {
 	remediated := []byte(strings.Join(remediatedLines, "\n"))
 
-	if err := os.WriteFile(filePath, remediated, 0600); err != nil {
+	mode := os.FileMode(0600)
+
+	if err := os.WriteFile(filePath, remediated, mode); err != nil {
 		log.Error().Msgf("failed to write file: %s", err)
 		return lines
 	}

--- a/pkg/remediation/remediation.go
+++ b/pkg/remediation/remediation.go
@@ -156,7 +156,7 @@ func addition(r *Remediation, lines *[]string) []string {
 func (s *Summary) writeRemediation(remediatedLines, lines []string, filePath, similarityID string) []string {
 	remediated := []byte(strings.Join(remediatedLines, "\n"))
 
-	if err := os.WriteFile(filePath, remediated, os.ModePerm); err != nil {
+	if err := os.WriteFile(filePath, remediated, 0600); err != nil {
 		log.Error().Msgf("failed to write file: %s", err)
 		return lines
 	}

--- a/pkg/scan/preview_secrets_mask.go
+++ b/pkg/scan/preview_secrets_mask.go
@@ -126,18 +126,18 @@ func isSecret(line string, rule *secrets.RegexQuery, allowRules *[]secrets.Allow
 
 	for _, group := range groups {
 		splitedText := strings.Split(line, "\n")
-		max := -1
+		maxSplit := -1
 		for i, splited := range splitedText {
 			if len(groups) < rule.Multiline.DetectLineGroup {
-				if strings.Contains(splited, group[rule.Multiline.DetectLineGroup]) && i > max {
-					max = i
+				if strings.Contains(splited, group[rule.Multiline.DetectLineGroup]) && i > maxSplit {
+					maxSplit = i
 				}
 			}
 		}
-		if max == -1 {
+		if maxSplit == -1 {
 			continue
 		}
-		secret, newGroups := isSecret(strings.Join(append(splitedText[:max], splitedText[max+1:]...), "\n"), rule, allowRules)
+		secret, newGroups := isSecret(strings.Join(append(splitedText[:maxSplit], splitedText[maxSplit+1:]...), "\n"), rule, allowRules)
 		if !secret {
 			continue
 		}

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -240,7 +240,7 @@ func printVersionCheck(customPrint *consolePrinter.Printer, s *model.Summary) {
 	if !s.LatestVersion.Latest {
 		message := fmt.Sprintf("A new version 'v%s' of KICS is available, please consider updating", s.LatestVersion.LatestVersionTag)
 
-		fmt.Println(customPrint.VersionMessage.Sprintf(message))
+		fmt.Println(customPrint.VersionMessage.Sprintf("%s", message))
 		log.Warn().Msgf("%s", message)
 	}
 }

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -241,7 +241,7 @@ func printVersionCheck(customPrint *consolePrinter.Printer, s *model.Summary) {
 		message := fmt.Sprintf("A new version 'v%s' of KICS is available, please consider updating", s.LatestVersion.LatestVersionTag)
 
 		fmt.Println(customPrint.VersionMessage.Sprintf(message))
-		log.Warn().Msgf(message)
+		log.Warn().Msgf("%s", message)
 	}
 }
 

--- a/pkg/scan/utils.go
+++ b/pkg/scan/utils.go
@@ -226,7 +226,7 @@ func contributionAppeal(customPrint *consolePrinter.Printer, queriesPath []strin
 		msg := "\nAre you using a custom query? If so, feel free to contribute to KICS!\n"
 		contributionPage := "Check out how to do it: https://github.com/Checkmarx/kics/blob/master/docs/CONTRIBUTING.md\n"
 
-		output := customPrint.ContributionMessage.Sprintf(msg + contributionPage)
+		output := customPrint.ContributionMessage.Sprintf("%s", msg+contributionPage)
 		fmt.Println(output)
 	}
 }

--- a/pkg/utils/random.go
+++ b/pkg/utils/random.go
@@ -14,7 +14,7 @@ var randmu sync.Mutex
 const tempDirFormat = 1e9
 
 func reseed() uint32 {
-	return uint32(int32(time.Now().UnixNano()) + int32(os.Getpid()))
+	return uint32(int32(time.Now().UnixNano()) + int32(os.Getpid())) //nolint:gosec
 }
 
 // NextRandom returns a random number

--- a/pkg/utils/random.go
+++ b/pkg/utils/random.go
@@ -14,7 +14,7 @@ var randmu sync.Mutex
 const tempDirFormat = 1e9
 
 func reseed() uint32 {
-	return uint32(time.Now().UnixNano() + int64(os.Getpid()))
+	return uint32(int32(time.Now().UnixNano()) + int32(os.Getpid()))
 }
 
 // NextRandom returns a random number


### PR DESCRIPTION
**Reason for Proposed Changes**
- go version 1.22.5 has 3 known vulnerabilities;

**Proposed Changes**
- update go version from 1.22.5 to version 1.23.1;
- revert gosec version to [v2.20.0](https://github.com/securego/gosec/releases/tag/v2.20.0); 
- update dockerfile images and add git to dockerfile;
- tackle new golang-lint issues;
- for the linting job, ubuntu-20.04 is the most stable version used for runner;

I submit this contribution under the Apache-2.0 license.