### PR TITLE
fix(gitGuardian): add gitGuardian ignore file to fix FP on secret detection

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,0 +1,3 @@
+paths:
+  exclude:
+    - "assets/queries/common/passwords_and_secrets/test/**"


### PR DESCRIPTION
**Reason for Proposed Changes**
- GitGuardian is creating noise due to passwords and secrets test files;

**Proposed Changes**
- Add gitguardian ignore file to reduce development noise and fix FP results on secret detection;

I submit this contribution under the Apache-2.0 license.