### PR TITLE
Fix child modules parse tfplan file

### DIFF
--- a/pkg/parser/json/tfplan.go
+++ b/pkg/parser/json/tfplan.go
@@ -64,12 +64,13 @@ func readPlan(plan *hcl_plan.Plan) model.Document {
 func (kp *KicsPlan) readModule(module *hcl_plan.StateModule) {
 	// initialize all the types interfaces
 	for _, resource := range module.Resources {
-		convNamedRes := make(map[string]KicsPlanNamedResource)
-		kp.Resource[resource.Type] = convNamedRes
+		if _, ok := kp.Resource[resource.Type]; !ok {
+			kp.Resource[resource.Type] = make(map[string]KicsPlanNamedResource)
+		}
 	}
 	// fill in all the types interfaces
 	for _, resource := range module.Resources {
-		kp.Resource[resource.Type][resource.Name] = resource.AttributeValues
+		kp.Resource[resource.Type][resource.Address] = resource.AttributeValues
 	}
 
 	for _, childModule := range module.ChildModules {


### PR DESCRIPTION
Closes #7265 

**Reason for Proposed Changes**
- When pasrsing tfplan file:
If there are child modules, each child module overrides the resources in the module above it

**Proposed Changes**
- initialize the resource only once
- use address as resource identifier, as the name is only unique in a module.  

I submit this contribution under the Apache-2.0 license.