### PR TITLE
doc(security): add VEX file with vulnerabilities information to SBOM

### DIFF
--- a/kics.spdx.vex.json
+++ b/kics.spdx.vex.json
@@ -1,0 +1,154 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-82e0d97c42d89d13be398c4f0176b64277713a28f9ba5832b22d2389a65e6d9a",
+  "author": "Unknown Author",
+  "timestamp": "2024-10-04T13:29:59.756369+02:00",
+  "last_updated": "2024-10-04T13:30:00.041231+02:00",
+  "version": 12,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2019-25210"
+      },
+      "timestamp": "2024-10-04T13:29:59.75637+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/helm.sh/helm/v3@v3.14.2"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2020-8911"
+      },
+      "timestamp": "2024-10-04T13:29:59.783436+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/aws/aws-sdk-go@v1.44.295"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2020-8912"
+      },
+      "timestamp": "2024-10-04T13:29:59.809217+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/aws/aws-sdk-go@v1.44.295"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-45288"
+      },
+      "timestamp": "2024-10-04T13:29:59.83638+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net/http2@v0.17.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-45288"
+      },
+      "timestamp": "2024-10-04T13:29:59.861663+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/golang.org/x/net@v0.17.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-45288"
+      },
+      "timestamp": "2024-10-04T13:29:59.887893+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/net/http@v0.17.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-45288"
+      },
+      "timestamp": "2024-10-04T13:29:59.913218+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v0.17.0"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-3817"
+      },
+      "timestamp": "2024-10-04T13:29:59.938902+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/hashicorp/go-getter@v1.7.1"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-41110"
+      },
+      "timestamp": "2024-10-04T13:29:59.964348+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v24.0.9+incompatible"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-41110"
+      },
+      "timestamp": "2024-10-04T13:29:59.989591+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/moby/moby@v24.0.9+incompatible"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-6257"
+      },
+      "timestamp": "2024-10-04T13:30:00.015183+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/hashicorp/go-getter@v1.7.1"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-8260"
+      },
+      "timestamp": "2024-10-04T13:30:00.041234+02:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/open-policy-agent/opa@v0.58.0"
+        }
+      ],
+      "status": "under_investigation"
+    }
+  ]
+}


### PR DESCRIPTION
Dear project owners,
We are a group of researchers investigating the usefulness of augmenting Software Bills of Materials (SBOMs) with information about known vulnerabilities of third-party dependencies.

As claimed in previous interview-based studies, a major limitation—according to software practitioners—of existing SBOMs is the lack of information about known vulnerabilities.  For this reason, we would like to investigate how augmented SBOMs are received in open-source projects.

To this aim, we have identified popular open-source repositories on GitHub that provided SBOMs, statically detected vulnerabilities on their dependencies in the OSV database, and, based on its output, we have augmented your repository’s SBOM by leveraging the OpenVEX implementation of the Vulnerability Exploitability eXchange (VEX). 

The JSON file in this pull request consists of statements each indicating i) the software products (i.e., dependencies) that may be affected by a vulnerability. These are linked to the SBOM components through the @id field in their Persistent uniform resource locator (pURL); ii) a CVE affecting the product; iii) an impact status defined by VEX. By default, all statements have status `under_investigation` as it is not yet known whether these product versions are actually affected by the vulnerability. After investigating the vulnerability, further statuses can be `affected`, `not_affected`, `fixed`. It is possible to motivate the new status in a `justification` field (see https://www.cisa.gov/sites/default/files/publications/VEX_Status_Justification_Jun22.pdf for more information). 
 
We open this pull request containing a VEX file related to the SBOM of your project, and hope it will be considered. 
We would also like to hear your opinion on the usefulness (or not) of this information by answering a 3-minute anonymous survey:
https://ww2.unipark.de/uc/sbom/

Thanks in advance, and regards,
Davide Fucci (Blekinge Institute of Technology, Sweden) 
Simone Romano and Giuseppe Scaniello (University of Salerno, Italy),
Massimiliano Di Penta (University of Sannio, Italy)

I submit this contribution under the Apache-2.0 license.