### PR TITLE
feat(queries): implementation of regal for linting rego files

### DIFF
--- a/.github/workflows/validate-rego.yaml
+++ b/.github/workflows/validate-rego.yaml
@@ -1,0 +1,23 @@
+name: validate-rego
+
+on:
+  pull_request:
+    paths:
+      - "assets/**/*.rego"
+
+jobs:
+  lint-rego:
+    name: Run Regal Linter on Rego Files
+    runs-on: ubuntu-latest
+    env:
+      REGO_FILES_PATH: assets
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Setup Regal
+        uses: StyraInc/setup-regal@v1.0.0
+        with:
+          version: v0.11.0
+      - name: Run Regal Linter
+        run: regal lint --config kics/assets/.regal/rego_config.yaml --format=github ${{ env.REGO_FILES_PATH }}

--- a/assets/.regal/rego_config.yaml
+++ b/assets/.regal/rego_config.yaml
@@ -1,0 +1,63 @@
+rules:
+  bugs:
+    not-equals-in-loop:
+      # https://docs.styra.com/regal/rules/bugs/not-equals-in-loop
+      # The way it's used here with multi-value rules aren't
+      # bugs per se, so we'll ignore this for the time being
+      level: ignore
+  idiomatic:
+    no-defined-entrypoint:
+      # https://docs.styra.com/regal/rules/idiomatic/no-defined-entrypoint
+      # No single entrypoint for this project
+      level: ignore
+    # temporary
+    non-raw-regex-pattern:
+      # https://docs.styra.com/regal/rules/idiomatic/non-raw-regex-pattern
+      # 118 violations — fixing these would remove a lot of redundant
+      # escaping from regexes, providing better readability
+      level: ignore
+    use-in-operator:
+      # https://docs.styra.com/regal/rules/idiomatic/use-in-operator
+      # 42 violations — this would be good to fix, but not critical
+      level: ignore
+    use-some-for-output-vars:
+      # https://docs.styra.com/regal/rules/idiomatic/use-some-for-output-vars
+      # These would be good to address, but would require a concentrated effort
+      level: ignore
+    equals-pattern-matching:
+      # Not critical
+      level: ignore
+    no-undefined-references:
+      level: warn
+    consistent-naming: 
+      level: warn
+  style:
+    # All of these are optional, but worth considering
+    avoid-get-and-list-prefix:
+      level: ignore
+    external-reference:
+      level: ignore
+    file-length:
+      level: ignore
+    line-length:
+      level: ignore
+    no-whitespace-comment:
+      level: ignore
+    opa-fmt:
+      level: ignore
+    prefer-some-in-iteration:
+      level: ignore
+    prefer-snake-case:
+      level: ignore
+    rule-length:
+      level: ignore
+    todo-comment:
+      level: ignore
+    no-trailing-whitespace:
+      level: warn
+    alphabetical-order:
+      level: warn
+    use-assignment-operator:
+      # This is very easy to fix, but would need to be done
+      # in so many places
+      level: ignore


### PR DESCRIPTION
This PR integrates the **Regal linter** for Rego files in KICS to support query maintanance, reusability and best practices. As KICS uses Rego extensively to build queries, adding a linter helps ensuring consistency and quality across our codebase. 

**Thanks to the contributors who initiated the discussions and provided input for this addition. :partying_face: :raised_hands:** 

Closes #6774
Closes #505

**Reason for Proposed Changes**
- Improve code quality, maintainability and consistency by applying the Regal linter to Rego files;
- Implement linter rules that follow best practices while leaving flexibility to refine rules over time (through _rego_config.yaml_);

**Proposed Changes**
- Add Regal Linter (v1.0.0) for Rego files; 
- Create a configuration file ( _rego_config.yaml_) to specify which linter rules to enforce or ignore; 
- Update Rego queries to to address linting issues. 

I submit this contribution under the Apache-2.0 license.