### PR TITLE
feat(bicep): added support for Ignore by comments for bicep

### DIFF
--- a/pkg/parser/bicep/comment/comment.go
+++ b/pkg/parser/bicep/comment/comment.go
@@ -1,0 +1,134 @@
+package comment
+
+import (
+	"strings"
+
+	"github.com/Checkmarx/kics/v2/pkg/model"
+	"github.com/Checkmarx/kics/v2/pkg/parser/bicep/antlr/parser"
+)
+
+type comment parser.LineInfo
+
+type Pos struct {
+	Line       int
+	Column     int
+	Byte       int
+	BlockStart int
+	BlockEnd   int
+}
+
+// linePosition returns the position of the comment in the file
+func (c *comment) linePosition() Pos {
+	return Pos{
+		Line:       c.Range.End.Line + 1,
+		Column:     c.Range.End.Column,
+		Byte:       c.Range.End.Byte,
+		BlockStart: c.Block.StartLine + 1,
+		BlockEnd:   c.Block.EndLine,
+	}
+}
+
+// commentContent returns the content of a comment as a model.CommentCommand
+func (c *comment) commentContent() (value model.CommentCommand) {
+	comment := strings.ToLower(string(c.Bytes.Bytes))
+
+	// Trim leading and trailing whitespace
+	comment = strings.TrimSpace(comment)
+
+	// check if we are working with kics command
+	if model.KICSCommentRgxp.MatchString(comment) {
+		comment = model.KICSCommentRgxp.ReplaceAllString(comment, "")
+		comment = strings.Trim(comment, "\n")
+		commands := strings.Split(strings.Trim(comment, "\r"), " ")
+		value = model.ProcessCommands(commands)
+		return
+	}
+	return model.CommentCommand(comment)
+}
+
+// IgnoreMap is a map of all lines and and blocks
+type IgnoreMap map[model.CommentCommand][]Pos
+
+// Build builds the Ignore map
+func (i *IgnoreMap) build(ignoreLine, ignoreBlock, ignoreComment []Pos) {
+	ignoreStruct := map[model.CommentCommand][]Pos{
+		model.IgnoreLine:    ignoreLine,
+		model.IgnoreBlock:   ignoreBlock,
+		model.IgnoreComment: ignoreComment,
+	}
+
+	*i = ignoreStruct
+}
+
+// ProcessLines goes over the lines and returns a map of lines and blocks relations
+func ProcessLines(lines []parser.LineInfo) (ig IgnoreMap) {
+	ignoreLines := make([]Pos, 0)
+	ignoreBlocks := make([]Pos, 0)
+	ignoreComments := make([]Pos, 0)
+	for i := range lines {
+		// line is not a comment or is the last line
+		if lines[i].Type != "SINGLE_LINE_COMMENT" || i+1 >= len(lines) {
+			continue
+		}
+		// case: CONFIGURATION = X # comment
+		if i > 0 && lines[i-1].Range.Start.Line == lines[i].Range.Start.Line {
+			continue
+		}
+		ignoreLines, ignoreBlocks, ignoreComments = processComment((*comment)(&lines[i]),
+			(*comment)(&lines[i+1]), ignoreLines, ignoreBlocks, ignoreComments)
+	}
+	ig = make(map[model.CommentCommand][]Pos)
+	ig.build(ignoreLines, ignoreBlocks, ignoreComments)
+	return ig
+}
+
+// processComment analyzes the comment to determine which type of kics command the comment is
+func processComment(comment *comment, tokenToIgnore *comment,
+	ignoreLine, ignoreBlock, ignoreComments []Pos) (ignoreLineR, ignoreBlockR, ignoreCommentsR []Pos) {
+	ignoreLineR = ignoreLine
+	ignoreBlockR = ignoreBlock
+	ignoreCommentsR = ignoreComments
+
+	switch comment.commentContent() {
+	case model.IgnoreLine:
+		// comment is of type kics ignore-line
+		ignoreLineR = append(ignoreLineR, tokenToIgnore.linePosition())
+	case model.IgnoreBlock:
+		// comment is of type kics ignore-block
+		ignoreBlockR = append(ignoreBlockR, tokenToIgnore.linePosition())
+	default:
+		// comment is not of type kics ignore
+		ignoreCommentsR = append(ignoreCommentsR, Pos{Line: comment.linePosition().Line - 1})
+		return
+	}
+
+	return
+}
+
+// ///////////////////////////
+//     LINES TO IGNORE      //
+// ///////////////////////////
+
+// getLinesFromPos will return a list of lines from a list of positions
+func getLinesFromPos(positions []Pos) (lines []int) {
+	lines = make([]int, 0)
+	for _, position := range positions {
+		lines = append(lines, position.Line)
+	}
+	return
+}
+
+// GetIgnoreLines returns the lines to ignore from a comment
+func GetIgnoreLines(ignore IgnoreMap) (lines []int) {
+	lines = make([]int, 0)
+	for _, position := range ignore[model.IgnoreBlock] {
+		var ignoreBlockLines []int
+		for i := position.BlockStart; i <= position.BlockEnd; i++ {
+			ignoreBlockLines = append(ignoreBlockLines, i)
+		}
+		lines = append(lines, ignoreBlockLines...)
+	}
+	lines = append(lines, getLinesFromPos(ignore[model.IgnoreLine])...)
+	lines = append(lines, getLinesFromPos(ignore[model.IgnoreComment])...)
+	return
+}

--- a/pkg/parser/bicep/comment/comment_test.go
+++ b/pkg/parser/bicep/comment/comment_test.go
@@ -1,0 +1,162 @@
+package comment
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Checkmarx/kics/v2/pkg/model"
+	"github.com/Checkmarx/kics/v2/pkg/parser/bicep/antlr/parser"
+	"github.com/antlr4-go/antlr/v4"
+)
+
+var (
+	samples = map[string][]byte{
+		"ignore-block": []byte(`
+			// kics-scan ignore-block
+			resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+				name: 'storageAccountName'
+				location: 'location'
+				kind: storageAccountKind
+				sku: {
+					name: storageAccountType
+				}
+				properties: {
+					accessTier: accessTier
+					// This is a non-kics comment
+					minimumTlsVersion: 'TLS1_2'
+					publicNetworkAccess: 'Enabled'
+					allowBlobPublicAccess: false // Also a non-kics comment
+					allowSharedKeyAccess: false
+					defaultToOAuthAuthentication: true
+					supportsHttpsTrafficOnly: true
+					networkAcls: {
+						bypass: 'AzureServices'
+						defaultAction: 'Allow'
+					}
+				}
+			}
+  		`),
+		"ignore-line": []byte(`
+		resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+				name: 'storageAccountName'
+				location: 'location'
+				kind: storageAccountKind
+				sku: {
+					// kics-scan ignore-line
+					name: storageAccountType
+				}
+				properties: {
+					accessTier: accessTier
+					// This is a non-skipped comment
+					minimumTlsVersion: 'TLS1_2'
+					// kics-scan ignore-line
+					publicNetworkAccess: 'Enabled'
+					allowBlobPublicAccess: false // Also a non-skipped comment
+					allowSharedKeyAccess: false
+					defaultToOAuthAuthentication: true
+					supportsHttpsTrafficOnly: true
+					networkAcls: {
+						bypass: 'AzureServices'
+						defaultAction: 'Allow'
+					}
+				}
+			}
+		`),
+	}
+)
+
+// TestComment_ProcessLines tests the ignore lines from retrieved comments
+func TestComment_ProcessLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  []byte
+		filename string
+		want     IgnoreMap
+	}{
+		{
+			name:     "TestComment_ProcessLines: ignore-block",
+			content:  samples["ignore-block"],
+			filename: "",
+			want: IgnoreMap{
+				model.IgnoreBlock: []Pos{
+					{Line: 3, Column: 77, Byte: 107, BlockStart: 3, BlockEnd: 23},
+				},
+				model.IgnoreLine: []Pos{},
+				model.IgnoreComment: []Pos{
+					{Line: 11, Column: 0, Byte: 0},
+				},
+			},
+		},
+		{
+			name:     "TestComment_ProcessLines: ignore-line",
+			content:  samples["ignore-line"],
+			filename: "",
+			want: IgnoreMap{
+				model.IgnoreBlock: []Pos{},
+				model.IgnoreLine: []Pos{
+					{Line: 8, Column: 29, Byte: 233, BlockStart: 6, BlockEnd: 8},
+					{Line: 15, Column: 35, Byte: 422, BlockStart: 10, BlockEnd: 23},
+				},
+				model.IgnoreComment: []Pos{
+					{Line: 11, Column: 0, Byte: 0, BlockStart: 0, BlockEnd: 0},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := antlr.NewInputStream(string(tt.content))
+
+			lexer := parser.NewbicepLexer(stream)
+			linesInfo := lexer.GetLinesInfo()
+			ignore := ProcessLines(linesInfo)
+
+			// IgnoreMap
+			if !reflect.DeepEqual(ignore, tt.want) {
+				t.Errorf("ProcessLines() = %v, want %v", ignore, tt.want)
+			}
+
+		})
+	}
+}
+
+// TestComment_GetIgnoreLines tests the ignore lines from retrieved comments
+func TestComment_GetIgnoreLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  []byte
+		filename string
+		want     []int
+	}{
+		{
+			name:     "TestComment_GetIgnoreLines: ignore-block",
+			content:  samples["ignore-block"],
+			filename: "",
+			want:     []int{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 11},
+		},
+		{
+			name:     "TestComment_GetIgnoreLines: ignore-line",
+			content:  samples["ignore-line"],
+			filename: "",
+			want:     []int{8, 15, 11},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := antlr.NewInputStream(string(tt.content))
+
+			lexer := parser.NewbicepLexer(stream)
+			linesInfo := lexer.GetLinesInfo()
+			ignore := ProcessLines(linesInfo)
+
+			GetIgnoreLines := GetIgnoreLines(ignore)
+
+			// GetIgnoreLines test
+			if !reflect.DeepEqual(GetIgnoreLines, tt.want) {
+				t.Errorf("ProcessLines() = %v, want %v", GetIgnoreLines, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #4420

**Reason for Proposed Changes**
- This Pr will add the support for bicep files to handle kics-scan comments

**Proposed Changes**
- Users can now ignore lines by comments in the original file
- lines containing comments are now excluded as well for bicep

I submit this contribution under the Apache-2.0 license.