### PR TITLE
fix(query): exclude configMap and secret from "Volume Mount With OS Directory Write Permissions"

### DIFF
--- a/assets/queries/k8s/volume_mount_with_os_directory_write_permissions/query.rego
+++ b/assets/queries/k8s/volume_mount_with_os_directory_write_permissions/query.rego
@@ -16,6 +16,10 @@ CxPolicy[result] {
 	is_os_dir(volumeMounts[v].mountPath)
 	volumeMounts[v].readOnly == false
 
+    volumes := specInfo.spec["volumes"]
+	not is_configMap(volumeMounts[v].name, volumes)
+	not is_secret(volumeMounts[v].name, volumes)
+
 	result := {
 		"documentId": document.id,
 		"resourceType": document.kind,
@@ -38,6 +42,10 @@ CxPolicy[result] {
 	is_os_dir(volumeMounts[v].mountPath)
 	not common_lib.valid_key(volumeMounts[v], "readOnly")
 
+	volumes := specInfo.spec["volumes"]
+	not is_configMap(volumeMounts[v].name, volumes)
+	not is_secret(volumeMounts[v].name, volumes)
+
 	result := {
 		"documentId": document.id,
 		"resourceType": document.kind,
@@ -54,4 +62,14 @@ is_os_dir(mountPath) {
 	startswith(mountPath, hostSensitiveDir[_])
 } else {
 	mountPath == "/"
+}
+
+is_configMap(mount_name, volumes) {
+    volumes[m].name == mount_name
+    common_lib.valid_key(volumes[m], "configMap")
+}
+
+is_secret(mount_name, volumes) {
+    volumes[m].name == mount_name
+    common_lib.valid_key(volumes[m], "secret")
 }

--- a/assets/queries/k8s/volume_mount_with_os_directory_write_permissions/test/negative2.yaml
+++ b/assets/queries/k8s/volume_mount_with_os_directory_write_permissions/test/negative2.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secret-dotfiles-pod
+spec:
+  volumes:
+    - name: secret-volume
+      secret:
+        secretName: dotfile-secret
+  containers:
+    - name: dotfile-test-container
+      image: registry.k8s.io/busybox
+      command:
+        - ls
+        - "-l"
+        - "/etc/secret-volume"
+      volumeMounts:
+        - name: secret-volume
+          mountPath: "/etc/secret-volume"
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: configmap-pod
+spec:
+  containers:
+    - name: test
+      image: busybox:1.28
+      command: ['sh', '-c', 'echo "The app is running!" && tail -f /dev/null']
+      volumeMounts:
+        - name: config-vol
+          mountPath: /etc/config
+  volumes:
+    - name: config-vol
+      configMap:
+        name: log-config
+        items:
+          - key: log_level
+            path: log_level.conf


### PR DESCRIPTION
Exclude configMap and secret from "Volume Mount With OS Directory Write Permissions"

Closes #

**Reason for Proposed Changes**
- `configMap` and `secret` are read-only volumes by design

**Proposed Changes**
- check for `configMap` and `secret` volumes

I submit this contribution under the Apache-2.0 license.