### PR TITLE
update(dockerfile): revert KICS user change from 65532 back to root

### DIFF
--- a/.github/scripts/report/go.mod
+++ b/.github/scripts/report/go.mod
@@ -1,6 +1,6 @@
 module github.com/Checkmarx/e2e-report
 
-go 1.23.1
+go 1.23.5
 
 require (
 	github.com/rs/zerolog v1.31.0

--- a/.github/workflows/kics-gh-action.yaml
+++ b/.github/workflows/kics-gh-action.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run KICS Scan
-        uses: checkmarx/kics-github-action@94469746ec2c43de89a42fb9d2a80070f5d25b16 # v2.1.3
+        uses: checkmarx/kics-github-action@5a6152ef88416063435cebadfec9de28bcfd041d # v2.1.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: "./Dockerfile"

--- a/.github/workflows/kics-gh-action.yaml
+++ b/.github/workflows/kics-gh-action.yaml
@@ -20,6 +20,7 @@ jobs:
           output_path: ./results
           output_formats: json,html
           type: dockerfile
+          exclude_queries: 67fd0c4a-68cf-46d7-8c41-bc9fba7e40ae # Ignore Last User Is 'root'
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: results

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=build_env /app/assets/libraries/* /app/bin/assets/libraries/
 
 WORKDIR /app/bin
 
-USER 65532
+USER root
 
 # Healthcheck the container
 ENV PATH $PATH:/app/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM checkmarx/go:1.23.4-r0@sha256:07aa6232e1255b14e2cbde76323059af733b5017890d64670b57d51b33744220 AS build_env
+FROM checkmarx/go:1.23.5-r1@sha256:c7ad1d8f075e123f4b477bbe364b9c793b2d2c6cdbd299f4900e7e473913a1fa AS build_env
 
 # Copy the source from the current directory to the Working Directory inside the container
 WORKDIR /app
@@ -29,7 +29,7 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM checkmarx/git:2.47.0-r0@sha256:2f3ce1eb50ac04e3a9930a5f71526e3e3e22cd09964a9a2aab9d4c3787f25b21
+FROM checkmarx/git:2.47.0-r0@sha256:b80cefbc536108e0e8e4305f01fd76445533133f3e2d1fedc4cb64754e915a14
 
 ENV TERM xterm-256color
 

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -3,7 +3,7 @@
 # it does not define an ENTRYPOINT as this is a requirement described here:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops#linux-based-containers
 #
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.23.1-bookworm as build_env
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.23.5-bookworm as build_env
 # Create a group and user
 RUN groupadd checkmarx && useradd -g checkmarx -M -s /bin/bash checkmarx
 USER checkmarx

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -4,10 +4,10 @@ WORKDIR /build
 
 ENV PATH=$PATH:/usr/local/go/bin
 
-ADD https://golang.org/dl/go1.23.1.linux-amd64.tar.gz .
+ADD https://golang.org/dl/go1.23.5.linux-amd64.tar.gz .
 RUN yum install git gcc -y \
-  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.1.linux-amd64.tar.gz \
-  && rm -f go1.23.1.linux-amd64.tar.gz
+  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.5.linux-amd64.tar.gz \
+  && rm -f go1.23.5.linux-amd64.tar.gz
 
 ENV GOPRIVATE=github.com/Checkmarx/*
 ARG VERSION="development"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Checkmarx/kics/v2
 
-go 1.23.1
+go 1.23.5
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20240604172014-5a751eb643b0


### PR DESCRIPTION
**Reason for Proposed Changes**
- KICS always used root, but in the latest release, we changed it to 65532 due to FedRAMP policies. This change is causing issues in AST-CLI. Since we only use the binaries inside the image, there is no relevant reason to use 65532 instead of root. A possible fix is to run the KICS image with the same user as the container running it. However, since this would require users to change their setup, I am reverting this change to avoid that and to prevent other potential issues.

**Proposed Changes**
- revert KICS user change from 65532 back to root
- update KICS gh action to v2.1.4
- fix vulnerabilities

I submit this contribution under the Apache-2.0 license.