### PR TITLE
fix(query): openapi maximum_length_undefined query enum and format sanitizers

### DIFF
--- a/assets/queries/openAPI/general/maximum_length_undefined/query.rego
+++ b/assets/queries/openAPI/general/maximum_length_undefined/query.rego
@@ -12,6 +12,7 @@ CxPolicy[result] {
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
 	openapi_lib.undefined_field_in_string_type(value, "maxLength")
+    checkForSanitizers(value)
 	not limited_regex(value)
 
 	result := {
@@ -33,6 +34,7 @@ CxPolicy[result] {
 	[path, value] := walk(doc)
 	openapi_lib.is_operation(path) == {}
 	openapi_lib.undefined_field_in_string_type(value, "maxLength")
+	checkForSanitizers(value)
 	not limited_regex(value)
 
 	result := {
@@ -50,4 +52,16 @@ limited_regex(value){
 	not contains(value.pattern, "+")
 	not contains(value.pattern, "*")
 	not regex.match("[^\\\\]{\\d+,}", value.pattern)
+}
+
+checkForSanitizers(value) {
+	openapi_lib.undefined_field_in_string_type(value, "enum")   # enums have the maxLength implicit
+	checkStringFormat(value)
+}
+
+checkStringFormat(value) {
+    openapi_lib.undefined_field_in_string_type(value, "format")
+} else {
+    value["format"] != "date"       # date and date-time formats
+    value["format"] != "date-time"  # have the maxLength implicit
 }

--- a/assets/queries/openAPI/general/maximum_length_undefined/query.rego
+++ b/assets/queries/openAPI/general/maximum_length_undefined/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 	info := openapi_lib.is_operation(path)
 	openapi_lib.content_allowed(info.operation, info.code)
 	openapi_lib.undefined_field_in_string_type(value, "maxLength")
-    checkForSanitizers(value)
+    checkForSecureStringFormats(value)
 	not limited_regex(value)
 
 	result := {
@@ -34,7 +34,7 @@ CxPolicy[result] {
 	[path, value] := walk(doc)
 	openapi_lib.is_operation(path) == {}
 	openapi_lib.undefined_field_in_string_type(value, "maxLength")
-	checkForSanitizers(value)
+	checkForSecureStringFormats(value)
 	not limited_regex(value)
 
 	result := {
@@ -54,7 +54,7 @@ limited_regex(value){
 	not regex.match("[^\\\\]{\\d+,}", value.pattern)
 }
 
-checkForSanitizers(value) {
+checkForSecureStringFormats(value) {
 	openapi_lib.undefined_field_in_string_type(value, "enum")   # enums have the maxLength implicit
 	checkStringFormat(value)
 }

--- a/assets/queries/openAPI/general/maximum_length_undefined/test/negative10.yaml
+++ b/assets/queries/openAPI/general/maximum_length_undefined/test/negative10.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                      - status: CURRENT
+                        updated: "2011-01-21T11:33:21Z"
+                        id: v2.0
+                        links:
+                          - href: http://127.0.0.1:8774/v2/
+                            rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          enum:
+            - brown
+            - grey
+            - black
+            - white
+        message:
+          type: string
+          format: date
+        extra:
+          type: string
+          format: date-time
+      required:
+        - petType
+  requestBodies:
+    NewItem:
+      description: A JSON object containing item data
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            $ref: "#/components/schemas/GeneralError"

--- a/assets/queries/openAPI/general/maximum_length_undefined/test/negative11.json
+++ b/assets/queries/openAPI/general/maximum_length_undefined/test/negative11.json
@@ -1,0 +1,50 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "schema": {
+              "discriminator": "petType",
+              "additionalProperties": false,
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "enum": [
+                    "brown",
+                    "grey",
+                    "black",
+                    "white"
+                  ]
+                },
+                "message": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "extra": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              },
+              "required": [
+                "petType"
+              ],
+              "type": "object"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/queries/openAPI/general/maximum_length_undefined/test/negative12.yaml
+++ b/assets/queries/openAPI/general/maximum_length_undefined/test/negative12.yaml
@@ -1,0 +1,32 @@
+swagger: "2.0"
+info:
+  title: Simple API Overview
+  version: 1.0.0
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        "200":
+          description: 200 response
+          schema:
+            type: object
+            discriminator: petType
+            additionalProperties: false
+            properties:
+              code:
+                type: string
+                enum:
+                  - brown
+                  - grey
+                  - black
+                  - white
+              message:
+                type: string
+                format: date
+              extra:
+                type: string
+                format: date-time
+            required:
+              - petType

--- a/assets/queries/openAPI/general/maximum_length_undefined/test/negative9.json
+++ b/assets/queries/openAPI/general/maximum_length_undefined/test/negative9.json
@@ -1,0 +1,94 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Simple API Overview",
+    "version": "1.0.0",
+    "contact": {
+      "name": "contact",
+      "url": "https://www.google.com/",
+      "email": "user@gmail.com"
+    }
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "listVersionsv2",
+        "summary": "List API versions",
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "foo": {
+                    "value": {
+                      "versions": [
+                        {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeneralError": {
+        "type": "object",
+        "discriminator": {
+          "propertyName": "petType"
+        },
+        "additionalProperties": false,
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "brown",
+              "grey",
+              "black",
+              "white"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "format": "date"
+          },
+          "extra": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "petType"
+        ]
+      }
+    },
+    "requestBodies": {
+      "NewItem": {
+        "description": "A JSON object containing item data",
+        "required": true,
+        "content": {
+          "multipart/form-data": {
+            "schema": {
+              "$ref": "#/components/schemas/GeneralError"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Reason for Proposed Changes**
- Enum and Format (when set to 'date' or 'date-time') should be recognized as sanitizers

**Proposed Changes**
- OpenAPI general query maximum_length_undefined updated to consider format (date and date-time) and enum as sanitizers
- Query negative UTs added

I submit this contribution under the Apache-2.0 license.