### PR TITLE
fix(query): correct keyActualValue and keyExpectedValue for maxItems validation

### DIFF
--- a/assets/queries/openAPI/general/array_without_maximum_number_items/query.rego
+++ b/assets/queries/openAPI/general/array_without_maximum_number_items/query.rego
@@ -17,8 +17,8 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
-		"keyActualValue": "Array schema has 'maxItems' set",
-		"keyExpectedValue": "Array schema has 'maxItems' undefined",
+		"keyExpectedValue": "Array schema has 'maxItems' set",
+		"keyActualValue": "Array schema has 'maxItems' undefined",
 		"searchLine": common_lib.build_search_line(path, []) ,
 		"overrideKey": version,
 	}
@@ -37,8 +37,8 @@ CxPolicy[result] {
 		"documentId": doc.id,
 		"searchKey": sprintf("%s.type", [openapi_lib.concat_path(path)]),
 		"issueType": "MissingAttribute",
-		"keyActualValue": "Array schema has 'maxItems' set",
-		"keyExpectedValue": "Array schema has 'maxItems' undefined",
+		"keyExpectedValue": "Array schema has 'maxItems' set",
+		"keyActualValue": "Array schema has 'maxItems' undefined",
 		"searchLine": common_lib.build_search_line(path, []) ,
 		"overrideKey": version,
 	}


### PR DESCRIPTION
**Reason for Proposed Changes**
- Actual and Expected values are swapped.

**Proposed Changes**
- Swap Actual and Expected values on query results.

I submit this contribution under the Apache-2.0 license.