### PR TITLE
fix(query): allow for string interpolation in `lambda_iam_invokefunction_miscongifured` regex

### DIFF
--- a/assets/queries/terraform/aws/lambda_iam_invokefunction_misconfigured/query.rego
+++ b/assets/queries/terraform/aws/lambda_iam_invokefunction_misconfigured/query.rego
@@ -36,7 +36,7 @@ check_iam_resource(statement) {
 	regex.match("(^arn:aws:lambda:.*:.*:function:[a-zA-Z0-9_-]+$)", statement.Resource[_])
 } else {
     is_array(statement.resources)
-    regex.match("(^\"\\$\\{\\s*aws_lambda_function\\.[^.]+\\.arn\\\\s*}:[*]\"$)", statement.resources[_])
+    regex.match("(^\"\\$\\{\\s*aws_lambda_function\\.[^.]+\\.arn\\s*\\}:[*]\"$)", statement.resources[_])
     regex.match("(^aws_lambda_function\\.[^.]+\\.arn$)", statement.resources[_])
 }
 


### PR DESCRIPTION
The current regex implies that we should have something like:

```hcl
data "aws_iam_policy_document" "example" {
  statement {
    actions = ["lambda:InvokeFunction"]
    resources = [
      aws_lambda_function.example.arn,
      aws_lambda_function.example.arn:*   # <-- this is not legal syntax
    ]
  }
}
```

In fact we would need something like this instead, using Terraform's [string interpolation](https://developer.hashicorp.com/terraform/language/expressions/strings#interpolation) syntax:

```hcl
data "aws_iam_policy_document" "example" {
  statement {
    actions = ["lambda:InvokeFunction"]
    resources = [
      aws_lambda_function.example.arn,
      "${aws_lambda_function.example.arn}:*"
    ]
  }
}
```

I've amended the regex to match the corrected example.

---

I submit this contribution under the Apache-2.0 license.