### PR TITLE
feat(queries): implementation of regal for linting rego files

### DIFF
--- a/.github/workflows/validate-rego.yaml
+++ b/.github/workflows/validate-rego.yaml
@@ -1,0 +1,24 @@
+name: validate-rego
+
+on:
+  pull_request:
+    paths:
+      - "assets/**/*.rego"
+
+jobs:
+  lint-rego:
+    name: Run Regal Linter on Rego Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Regal
+        uses: StyraInc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776 #v1.0.0
+        with:
+          version: v0.31.0
+
+      - name: Run Regal Linter
+        run: regal lint --format=github assets --config-file=assets/.regal/config.yml

--- a/assets/.regal/config.yml
+++ b/assets/.regal/config.yml
@@ -1,0 +1,66 @@
+rules:
+  bugs:
+    not-equals-in-loop:
+      # https://docs.styra.com/regal/rules/bugs/not-equals-in-loop
+      level: ignore
+    rule-shadows-builtin:
+      # https://docs.styra.com/regal/rules/bugs/rule-shadows-builtin
+      level: warn
+  idiomatic:
+    no-defined-entrypoint:
+      # https://docs.styra.com/regal/rules/idiomatic/no-defined-entrypoint
+      # No single entrypoint for this project
+      level: ignore
+    # temporary
+    non-raw-regex-pattern:
+      # https://docs.styra.com/regal/rules/idiomatic/non-raw-regex-pattern
+      level: warn
+    use-in-operator:
+      # https://docs.styra.com/regal/rules/idiomatic/use-in-operator
+      level: warn
+    use-some-for-output-vars:
+      # https://docs.styra.com/regal/rules/idiomatic/use-some-for-output-vars
+      # These would be good to address, but would require a concentrated effort
+      level: ignore
+    custom-has-key-construct:
+      # https://docs.styra.com/regal/rules/idiomatic/custom-has-key-construct
+      level: warn
+    equals-pattern-matching:
+      # https://docs.styra.com/regal/rules/idiomatic/equals-pattern-matching
+      level: warn
+  style:
+    avoid-get-and-list-prefix:
+      # https://docs.styra.com/regal/rules/style/avoid-get-and-list-prefix
+      level: ignore
+    external-reference:
+      # https://docs.styra.com/regal/rules/style/external-reference
+      level: ignore
+    file-length:
+      # https://docs.styra.com/regal/rules/style/file-length
+      level: ignore
+    line-length:
+      # https://docs.styra.com/regal/rules/style/line-length
+      level: ignore
+    no-whitespace-comment:
+      # https://docs.styra.com/regal/rules/style/no-whitespace-comment
+      level: warn
+    opa-fmt:
+      # https://docs.styra.com/regal/rules/style/opa-fmt
+      level: warn
+    prefer-some-in-iteration:
+      # https://docs.styra.com/regal/rules/style/prefer-some-in-iteration
+      # 10000+ violations fixed but way more to go
+      level: ignore
+    prefer-snake-case:
+      # https://docs.styra.com/regal/rules/style/prefer-snake-case
+      level: ignore
+    rule-length:
+      # https://docs.styra.com/regal/rules/style/rule-length
+      level: ignore
+    todo-comment:
+      # https://docs.styra.com/regal/rules/style/todo-comment
+      # only one TODO comment in the codebase to fix this issue
+      level: ignore
+    use-assignment-operator:
+      # https://docs.styra.com/regal/rules/style/use-assignment-operator
+      level: ignore


### PR DESCRIPTION
# Integrate Regal Linter for Rego Files in KICS
This PR introduces the Regal linter to enforce best practices, maintainability, and consistency in Rego files within KICS.
Since Rego is extensively used for queries, adding this linter helps ensure high-quality and standardized code.

## Reason for Proposed Changes
- Improve code quality, maintainability, and consistency by adding a structured linter;
- Ensure best practices in Rego queries while allowing future refinements via configuration.

## Proposed Changes
- Add Regal Linter (v1.0.0) as part of the CI pipeline;
- Include a configuration file (assets/.regal/config.yml) to define linter rules;
- Run the linter on Rego files in the assets/ directory during PRs.

**Note:** This PR only integrates the linter, separate PRs will address individual linting issues.

I submit this contribution under the Apache-2.0 license.