### PR TITLE
fix(query): fix FP in openAPI Invalid Media Type Value query

### DIFF
--- a/assets/queries/openAPI/3.0/invalid_media_type_value/query.rego
+++ b/assets/queries/openAPI/3.0/invalid_media_type_value/query.rego
@@ -4,18 +4,19 @@ import data.generic.openapi as openapi_lib
 
 CxPolicy[result] {
 	doc := input.document[i]
-	openapi_lib.check_openapi(doc) == "3.0"
+    openapi_lib.check_openapi(doc) == "3.0"
 
-	[path, value] := walk(doc)
-	content = value.content[mime]
+    [path, value] := walk(doc)
+    content = value.content[mime]
 
-	not openapi_lib.is_valid_mime(mime)
+    is_object(content)
+    not openapi_lib.is_valid_mime(mime)
 
-	result := {
-		"documentId": doc.id,
-		"searchKey": sprintf("%s.content.%s", [openapi_lib.concat_path(path), mime]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "The Media Type should be a valid value",
-		"keyActualValue": "The Media Type is a invalid value",
-	}
+    result := {
+        "documentId": doc.id,
+        "searchKey": sprintf("%s.content.%s", [openapi_lib.concat_path(path), mime]),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": "The Media Type should be a valid value",
+        "keyActualValue": "The Media Type is an invalid value",
+    }
 }

--- a/assets/queries/openAPI/3.0/invalid_media_type_value/test/negative3.yaml
+++ b/assets/queries/openAPI/3.0/invalid_media_type_value/test/negative3.yaml
@@ -1,0 +1,71 @@
+openapi: 3.0.0
+info:
+  title: Pet Store API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /pets:
+    get:
+      summary: Get a list of pets
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              example: { "pets": ["dog", "cat"] }
+    post:
+      summary: Add a new pet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: "Fido"
+                  pattern: "^[A-Za-z]{1,20}$"
+                species:
+                  type: string
+                  example: "dog"
+                color:
+                  type: string
+                  enum:
+                    - brown
+                    - grey
+                    - black
+                    - white
+                birthDate:
+                  type: string
+                  format: date
+                weight:
+                  type: integer
+                  format: int32
+                someSubType:
+                  type: 'object'
+                  properties:
+                    content:
+                      type: string
+
+
+      responses:
+        '201':
+          description: Pet added successfully
+  /pets/{petId}:
+    get:
+      summary: Get details of a specific pet
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              example: { "name": "Fido", "species": "dog" }
+

--- a/assets/queries/openAPI/3.0/invalid_media_type_value/test/negative4.json
+++ b/assets/queries/openAPI/3.0/invalid_media_type_value/test/negative4.json
@@ -1,0 +1,108 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Pet Store API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.example.com/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "Get a list of pets",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "example": { "pets": ["dog", "cat"] }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a new pet",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "Fido",
+                    "pattern": "^[A-Za-z]{1,20}$"
+                  },
+                  "species": {
+                    "type": "string",
+                    "example": "dog"
+                  },
+                  "color": {
+                    "type": "string",
+                    "enum": [
+                      "brown",
+                      "grey",
+                      "black",
+                      "white"
+                    ]
+                  },
+                  "birthDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "weight": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "someSubType": {
+                    "type": "object",
+                    "properties": {
+                      "content": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Pet added successfully"
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Get details of a specific pet",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "example": { "name": "Fido", "species": "dog" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/queries/openapi-queries/cf4a5f45-a27b-49df-843a-9911dbfe71d4.md
+++ b/docs/queries/openapi-queries/cf4a5f45-a27b-49df-843a-9911dbfe71d4.md
@@ -24,7 +24,7 @@ hide:
 -   **URL:** [Github](https://github.com/Checkmarx/kics/tree/master/assets/queries/openAPI/3.0/invalid_media_type_value)
 
 ### Description
-The Media Type value should match the following format: <type>/<subtype>[+suffix][;parameters]<br>
+The Media Type value should match the following format: `<type>/<subtype>[+suffix][;parameters]`<br>
 [Documentation](https://swagger.io/specification/#media-type-object)
 
 ### Code samples


### PR DESCRIPTION
**Reason for Proposed Changes**
- Invalid Media Type Value openAPI query was incorrectly flagging when `content` was not an object;

**Proposed Changes**
- fix FP on Invalid Media Type Value openAPI query which now checks if the content is an object or not;
- fix documentation to properly explain how a media type should be constructed;
- add negative unit tests to ensure no regression issues;
- fix typo on expectedValue (from `a` to `an`);

I submit this contribution under the Apache-2.0 license.