### PR TITLE
fix: Restore CGO_ENABLED=0 for static linking in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN go mod download -x
 COPY . .
 
 # Build the Go app
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
     -a -installsuffix cgo \
     -o bin/kics cmd/console/main.go


### PR DESCRIPTION
Closes [#7396](https://github.com/Checkmarx/kics/issues/7396)

**Reason for Proposed Changes**
- Restore compatibility with Alpine-based images by re-enabling static linking of the KICS binary
- This was previously removed via this [commit](https://github.com/Checkmarx/kics/commit/42272a2421#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L24)

**Proposed Changes**
- Restore CGO_ENABLED=0 flag in the Dockerfile