### PR TITLE
docs(typo): fix creating queries documentation page

### DIFF
--- a/docs/creating-queries.md
+++ b/docs/creating-queries.md
@@ -81,7 +81,7 @@ As a first step, it is important to be familiar with the libraries available (ch
 
 For example, if we want to verify if the AWS CloudTrail has MultiRegion disabled in a Terraform sample, we need to focus on the attribute `is_multi_region_trail` of the resource `aws_cloudtrail`. Since this attribute is optional and false by default, we have two cases: (1) `is_multi_region_trail` is undefined and (2) `is_multi_region_trail` is set to false. Observe the following implementation as an example and check the Guidelines below.
 
-:rotating_light: **Make sure you use ```package Cx```. If you give another name, the query will not load.** :rotating_light:
+🚨 **Make sure you use ```package Cx```. If you give another name, the query will not load.** 🚨
 
 ```
 package Cx
@@ -121,8 +121,7 @@ To test the query in the [Rego playground](https://play.openpolicyagent.org/), p
 5. In the output, check if the results are as expected.
 
 
-<img alt="RegoPlayground" src="img/rego_playground_example_tf.PNG">
-
+![rego_playground_example_tf.PNG](img/rego_playground_example_tf.PNG)
 
 👨‍💻 **Metadata File**
 

--- a/docs/integrations_terraformer.md
+++ b/docs/integrations_terraformer.md
@@ -169,7 +169,7 @@ docker run -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -e AWS_SESSION_TOKEN ch
 docker run -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -e AWS_SESSION_TOKEN -v ${PWD}:/path/ checkmarx/kics:latest scan -p "terraformer::aws:vpc:eu-west-2" -v --no-progress -o /path/results
 ```
 
-<img src="./img/docker_terraformer.gif" />
+![docker_terraformer.gif](img/docker_terraformer.gif)
 
 ### [AZURE] Run KICS Terraformer integration with Docker
 To run KICS Terraformer integration with Docker simply pass the AZURE Credentials that were set as environment variables to the docker run command and use the terraformer path syntax. Choose one of the following options:


### PR DESCRIPTION
**Reason for Proposed Changes**
- The "_Creating Queries_" documentation page has 2 typos that can be seen in the image bellow: 
![image](https://github.com/user-attachments/assets/89da55b5-b374-41be-801f-4a81ef927c13)

- Same problem on "_Running KICS with Terraformer (Deprecated after 1.7.13)_":
![image](https://github.com/user-attachments/assets/1c00d41d-0755-4e15-b748-7aa847b56612)


**Proposed Changes**
- Fix rego_playground image and emojis;
![image](https://github.com/user-attachments/assets/06334dc3-b88a-4dcf-a852-3deed394dc69)
- Fix terraformer gif example: 
![image](https://github.com/user-attachments/assets/1d326ffb-1c83-4793-a335-8b625c85b162)

I submit this contribution under the Apache-2.0 license.