### PR TITLE
fix(queries): support all valid CloudWatch Logs retention periods

### DIFF
--- a/assets/queries/ansible/aws/cloudwatch_without_retention_period_specified/query.rego
+++ b/assets/queries/ansible/aws/cloudwatch_without_retention_period_specified/query.rego
@@ -29,7 +29,7 @@ CxPolicy[result] {
 	ansLib.checkState(cloudwatchlogs_log_group)
 	value := cloudwatchlogs_log_group.retention
 
-	validValues = [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+	validValues = [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653]
 
 	not commonLib.inArray(validValues, value)
 

--- a/assets/queries/crossplane/aws/cloudwatch_without_retention_period_specified/query.rego
+++ b/assets/queries/crossplane/aws/cloudwatch_without_retention_period_specified/query.rego
@@ -3,7 +3,7 @@ package Cx
 import data.generic.common as common_lib
 import data.generic.crossplane as cp_lib
 
-validValues = [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+validValues = [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653]
 
 CxPolicy[result] {
 	docs := input.document[i]

--- a/assets/queries/terraform/aws/cloudwatch_without_retention_period_specified/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_without_retention_period_specified/query.rego
@@ -24,7 +24,7 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_cloudwatch_log_group[name]
 	value := resource.retention_in_days
-	validValues := [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+	validValues := [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653]
 	count({x | validValues[x]; validValues[x] == value}) == 0
 
 	result := {


### PR DESCRIPTION
Pulled from latest documentation @ https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group

Closes #

**Reason for Proposed Changes**
- Some valid CloudWatch Logs retention periods are not supported and trigger false positives

**Proposed Changes**
- Adds the full list of valid CloudWatch Logs retention periods

I submit this contribution under the Apache-2.0 license.