### PR TITLE
docs(queries): update universal JSON creation to docker command

### DIFF
--- a/docs/creating-queries.md
+++ b/docs/creating-queries.md
@@ -3,13 +3,13 @@
 The queries are written in Rego and our internal parser transforms every IaC file that supports into a universal JSON format. This way anyone can start working on a query by picking up a small sample of the vulnerability that the query should target, and convert this sample, which can be a .tf or .yaml file, to our JSON structure JSON. To convert the sample you can run the following command:
 
 ```bash
-go run ./cmd/console/main.go scan -p "pathToTestData" -d "pathToGenerateJson"
+docker run -t -v ./:/path checkmarx/kics scan -p "pathToTestData" -d "pathToGenerateJson"
 ```
 
-So for example, if we wanted to transform a .tf file in ./code/test we could type:
+So for example, if we wanted to transform a .tf file in ./src/test we could type:
 
 ```bash
-go run ./cmd/console/main.go scan -p  "./src/test" -d "src/test/input.json"
+docker run -t -v ./:/path checkmarx/kics scan -p  "/path/src/test" -d "/path/src/test/input.json"
 ```
 
 Example of input.json


### PR DESCRIPTION
**Reason for Proposed Changes**
- Other docs use docker for sample commands. This update brings the creation of the universal json inline with other sample commands.

**Proposed Changes**
- update command samples to be a docker command
- fix discrepancy between `./code/test` and `./src/test`

I submit this contribution under the Apache-2.0 license.