### PR TITLE
fix(vulnerabilities): add snooze to OPA server Data API HTTP path injection of Rego vulnerability

### DIFF
--- a/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
+++ b/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
@@ -82,7 +82,6 @@ if [[ $vuln_count -eq 0 ]]; then
     echo -e "${YELLOW}All vulnerabilities were ignored (ignored: $IGNORE_PATTERN)."
     exit 1
   fi
-  exit 0
 elif [[ $vuln_count -eq $unfixed_count ]]; then
   echo -e "${YELLOW}All found vulnerabilities ($vuln_count) have no fix available."
   ((ignored_count > 0)) && echo -e "${YELLOW}$ignored_count vulnerabilities were ignored."

--- a/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
+++ b/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
@@ -13,8 +13,7 @@ if [[ ! -f "./results.txt" || -z "$(cat ./results.txt)" ]]; then
 fi
 
 # Define ignored vulnerability IDs
-#IGNORED_IDS=("GO-2025-3660")
-IGNORED_IDS=("GO-9999-9999")
+IGNORED_IDS=("GO-2025-3660")
 
 # Convert ignore list to grep pattern (e.g., "GO-2025-3660|GO-2024-1234")
 IGNORE_PATTERN=$(IFS="|"; echo "${IGNORED_IDS[*]}")

--- a/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
+++ b/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
@@ -77,8 +77,10 @@ done <<< "$filtered_output"
 if [[ $vuln_count -eq 0 ]]; then
   if grep -q "No vulnerabilities found." <<< "$filtered_output"; then
     echo -e "${GREEN}No vulnerabilities found."
+    exit 0
   else
     echo -e "${YELLOW}All vulnerabilities were ignored (ignored: $IGNORE_PATTERN)."
+    exit 1
   fi
   exit 0
 elif [[ $vuln_count -eq $unfixed_count ]]; then

--- a/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
+++ b/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
@@ -13,7 +13,8 @@ if [[ ! -f "./results.txt" || -z "$(cat ./results.txt)" ]]; then
 fi
 
 # Define ignored vulnerability IDs
-IGNORED_IDS=("GO-2025-3660")
+#IGNORED_IDS=("GO-2025-3660")
+IGNORED_IDS=("GO-9999-9999")
 
 # Convert ignore list to grep pattern (e.g., "GO-2025-3660|GO-2024-1234")
 IGNORE_PATTERN=$(IFS="|"; echo "${IGNORED_IDS[*]}")

--- a/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
+++ b/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
@@ -13,7 +13,7 @@ if [[ ! -f "./results.txt" || -z "$(cat ./results.txt)" ]]; then
 fi
 
 # Define ignored vulnerability IDs
-IGNORED_IDS=("GO-2025-3660")
+IGNORED_IDS=("GO-2025-3660,GO-2022-0646,GO-2022-0635")
 
 # Convert ignore list to grep pattern (e.g., "GO-2025-3660|GO-2024-1234")
 IGNORE_PATTERN=$(IFS="|"; echo "${IGNORED_IDS[*]}")

--- a/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
+++ b/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
@@ -13,7 +13,7 @@ if [[ ! -f "./results.txt" || -z "$(cat ./results.txt)" ]]; then
 fi
 
 # Define ignored vulnerability IDs
-IGNORED_IDS=("GO-2025-3660, GO-2022-0646, GO-2022-0635")
+IGNORED_IDS=("GO-2025-3660" "GO-2022-0646" "GO-2022-0635")
 
 # Convert ignore list to grep pattern (e.g., "GO-2025-3660|GO-2024-1234")
 IGNORE_PATTERN=$(IFS="|"; echo "${IGNORED_IDS[*]}")

--- a/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
+++ b/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
@@ -13,7 +13,7 @@ if [[ ! -f "./results.txt" || -z "$(cat ./results.txt)" ]]; then
 fi
 
 # Define ignored vulnerability IDs
-IGNORED_IDS=("GO-2025-3660" "GO-2022-0646" "GO-2022-0635")
+IGNORED_IDS=("GO-2025-3660")
 
 # Convert ignore list to grep pattern (e.g., "GO-2025-3660|GO-2024-1234")
 IGNORE_PATTERN=$(IFS="|"; echo "${IGNORED_IDS[*]}")

--- a/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
+++ b/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
@@ -13,7 +13,7 @@ if [[ ! -f "./results.txt" || -z "$(cat ./results.txt)" ]]; then
 fi
 
 # Define ignored vulnerability IDs
-IGNORED_IDS=("GO-2025-3660,GO-2022-0646,GO-2022-0635")
+IGNORED_IDS=("GO-2025-3660, GO-2022-0646, GO-2022-0635")
 
 # Convert ignore list to grep pattern (e.g., "GO-2025-3660|GO-2024-1234")
 IGNORE_PATTERN=$(IFS="|"; echo "${IGNORED_IDS[*]}")

--- a/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
+++ b/.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh
@@ -20,9 +20,10 @@ IGNORE_PATTERN=$(IFS="|"; echo "${IGNORED_IDS[*]}")
 
 # Filter the results: remove blocks starting with an ignored ID
 filtered_output=$(awk -v pattern="$IGNORE_PATTERN" '
-  /^Vulnerability ID:/ {
+  /^Vulnerability #[0-9]+: (GO-[0-9]{4}-[0-9]+)/ {
     block = $0 "\n"
-    if ($3 ~ pattern) {
+    match($0, /(GO-[0-9]{4}-[0-9]+)/, m)
+    if (m[1] ~ pattern) {
       skip = 1
     } else {
       skip = 0

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -7,5 +7,6 @@ ignore:
       location: "/usr/bin/terraform"
   - package:
       location: "/usr/local/bin/terraform"
+  - vulnerability: GHSA-6m8w-jc87-6cr7 # Not Exploitable -> we don't run OPA as a server on KICS (opa run --server)
 exclude:
   - './.github/scripts/**' # test files

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Ignore misconfigurations
+CVE-2025-46569 exp:2025-07-01 # github.com/open-policy-agent/opa v0.68.0 -> Not Exploitable, we don't run OPA as a server on KICS (opa run --server)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM checkmarx/go:1.24.2-r0-65d03ab0d9330e@sha256:65d03ab0d9330e757f320e72dc68413a3750ee1a410624d4f73463f4c9c8d60b AS build_env
+FROM checkmarx/go:1.24.2-r0-eb8f4417abadd8@sha256:eb8f4417abadd8dde97b32cd1c03453920a6d3600e5c4bde2fcac262346ab71c AS build_env
 
 # Copy the source from the current directory to the Working Directory inside the container
 WORKDIR /app
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM checkmarx/git:2.47.0-r0-aa7a4adca5ebf6@sha256:c7f9397d24f0cebac91ce75d4448cbd982e2ccde91c91f970e9113970fddb4ab
+FROM checkmarx/git:2.47.0-r0-34262eab6f43ae@sha256:34262eab6f43ae5bd4296bbc9c12fde6e5837a1b576e1978f979753f95b363dc
 
 ENV TERM xterm-256color
 

--- a/trivy-ignore.rego
+++ b/trivy-ignore.rego
@@ -9,5 +9,3 @@ ignore {
     packageValue := packageUse[input.PkgName]
 	input.VulnerabilityID == packageValue[_]
 }
-
-

--- a/trivy.vex
+++ b/trivy.vex
@@ -1,22 +1,23 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-685261c01e907a07114f2953353f39503e2c11783b124cb74833f6cfcd34436b",
-  "author": "Fernando Nogueira",
-  "timestamp": "2024-03-22T10:34:54.6859785-04:00",
+  "author": "Artur Ribeiro",
+  "timestamp": "2025-05-06T11:40:15.050414+01:00",
   "version": 1,
   "statements": [
     {
       "vulnerability": {
-        "name": "CVE-2019-25210"
+        "name": "CVE-2025-46569"
       },
-      "timestamp": "2024-03-22T10:34:54.68598-04:00",
+      "timestamp": "2025-05-06T11:40:15.050414+01:00",
       "products": [
         {
-          "@id": "pkg:golang/helm.sh/helm/v3@v3.14.2"
+          "@id": "pkg:golang/github.com/open-policy-agent/opa@v0.68.0"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path"
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "KICS does not use the OPA server mode or expose its RESTful APIs. As such, the vulnerable code related to HTTP path-based injection of Rego is never executed in this product."
     }
   ]
 }

--- a/trivy.vex
+++ b/trivy.vex
@@ -12,7 +12,7 @@
       "timestamp": "2025-05-06T11:40:15.050414+01:00",
       "products": [
         {
-          "@id": "pkg:golang/github.com/open-policy-agent/opa@v0.68.0"
+          "@id": "pkg:github.com/open-policy-agent/opa@v0.68.0"
         }
       ],
       "status": "not_affected",


### PR DESCRIPTION
**Reason for Proposed Changes**
- Found vulnerability on github.com/open-policy-agent/opa@v0.68.0 (https://github.com/open-policy-agent/opa/security/advisories/GHSA-6m8w-jc87-6cr7).

**Proposed Changes**
- Add grype ignore file;
- Add trivy ignore file;
- Update dockerfile images with the latest version;
- Update trivy.vex file with new vulnerability;
- Refactor `.github/scripts/sec-checks/govulncheck-ignore-unfixed.sh` adding new ignore files to the script;

**Vulnerability Explanation**
The flagged vulnerability relates to the OPA (Open Policy Agent) server mode (`opa run --server`). However, KICS does not run OPA in server mode. KICS embeds OPA in "library" mode, using it internally to execute queries. As such, the vulnerable code paths are not exercised in our use case.
Additionally, updating to OPA v1.x is not currently feasible, as KICS relies on custom queries written using OPA v0 syntax. Migrating all queries to v1-compatible syntax is an ongoing process. Once that is complete, we will update the OPA engine accordingly and address any related vulnerabilities.

**Documentation links**
- https://github.com/openvex/spec;
- https://github.com/open-policy-agent/opa/security/advisories/GHSA-6m8w-jc87-6cr7;

I submit this contribution under the Apache-2.0 license.