### PR TITLE
fix(query): rename deprecated enable_https_traffic_only to https_traffic_only_enabled

### DIFF
--- a/assets/queries/terraform/azure/storage_account_not_forcing_https/query.rego
+++ b/assets/queries/terraform/azure/storage_account_not_forcing_https/query.rego
@@ -5,7 +5,7 @@ import data.generic.terraform as tf_lib
 
 CxPolicy[result] {
 	resource := input.document[i].resource.azurerm_storage_account[var0]
-	not common_lib.valid_key(resource, "enable_https_traffic_only")
+	not common_lib.valid_key(resource, "https_traffic_only_enabled")
 
 	result := {
 		"documentId": input.document[i].id,
@@ -13,27 +13,27 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(resource, var0),
 		"searchKey": sprintf("azurerm_storage_account[%s]", [var0]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'azurerm_storage_account.%s.enable_https_traffic_only' equals 'true'", [var0]),
-		"keyActualValue": sprintf("'azurerm_storage_account.%s.enable_https_traffic_only' does not exist", [var0]),
-		"searchLine": common_lib.build_search_line(["resource","azurerm_storage_account" ,var0, "enable_https_traffic_only" ], []),
-		"remediation": "enable_https_traffic_only = true",
+		"keyExpectedValue": sprintf("'azurerm_storage_account.%s.https_traffic_only_enabled ' equals 'true'", [var0]),
+		"keyActualValue": sprintf("'azurerm_storage_account.%s.https_traffic_only_enabled ' does not exist", [var0]),
+		"searchLine": common_lib.build_search_line(["resource","azurerm_storage_account" ,var0, "https_traffic_only_enabled"], []),
+		"remediation": "https_traffic_only_enabled = true",
 		"remediationType": "addition",
 	}
 }
 
 CxPolicy[result] {
 	resource := input.document[i].resource.azurerm_storage_account[var0]
-	resource.enable_https_traffic_only == false
+	resource.https_traffic_only_enabled == false
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "azurerm_storage_account",
 		"resourceName": tf_lib.get_resource_name(resource, var0),
-		"searchKey": sprintf("azurerm_storage_account[%s].enable_https_traffic_only", [var0]),
+		"searchKey": sprintf("azurerm_storage_account[%s].https_traffic_only_enabled", [var0]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'azurerm_storage_account.%s.enable_https_traffic_only' equals 'true'", [var0]),
-		"keyActualValue": sprintf("'azurerm_storage_account.%s.enable_https_traffic_only' equals 'false'", [var0]),
-		"searchLine": common_lib.build_search_line(["resource","azurerm_storage_account" ,var0, "enable_https_traffic_only" ], []),
+		"keyExpectedValue": sprintf("'azurerm_storage_account.%s.https_traffic_only_enabled' equals 'true'", [var0]),
+		"keyActualValue": sprintf("'azurerm_storage_account.%s.https_traffic_only_enabled' equals 'false'", [var0]),
+		"searchLine": common_lib.build_search_line(["resource","azurerm_storage_account" ,var0, "https_traffic_only_enabled"], []),
 		"remediation": json.marshal({
 			"before": "false",
 			"after": "true"

--- a/assets/queries/terraform/azure/storage_account_not_forcing_https/test/negative.tf
+++ b/assets/queries/terraform/azure/storage_account_not_forcing_https/test/negative.tf
@@ -4,5 +4,5 @@ resource "azurerm_storage_account" "negative1" {
   location                  = data.azurerm_resource_group.example.location
   account_tier              = "Standard"
   account_replication_type  = "GRS"
-  enable_https_traffic_only = true
+  https_traffic_only_enabled = true
 }

--- a/assets/queries/terraform/azure/storage_account_not_forcing_https/test/positive.tf
+++ b/assets/queries/terraform/azure/storage_account_not_forcing_https/test/positive.tf
@@ -4,7 +4,7 @@ resource "azurerm_storage_account" "positive1" {
   location                  = data.azurerm_resource_group.example.location
   account_tier              = "Standard"
   account_replication_type  = "GRS"
-  enable_https_traffic_only = false
+  https_traffic_only_enabled = false
 }
 
 resource "azurerm_storage_account" "positive2" {

--- a/assets/queries/terraform/azure/storage_account_not_forcing_https/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/storage_account_not_forcing_https/test/positive_expected_result.json
@@ -2,11 +2,13 @@
   {
     "queryName": "Storage Account Not Forcing HTTPS",
     "severity": "MEDIUM",
-    "line": 7
+    "line": 7,
+    "filename": "positive.tf"
   },
   {
     "queryName": "Storage Account Not Forcing HTTPS",
     "severity": "MEDIUM",
-    "line": 10
+    "line": 10,
+    "filename": "positive.tf"
   }
 ]

--- a/assets/queries/terraform/azure/storage_account_not_forcing_https/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/storage_account_not_forcing_https/test/positive_expected_result.json
@@ -2,13 +2,11 @@
   {
     "queryName": "Storage Account Not Forcing HTTPS",
     "severity": "MEDIUM",
-    "line": 7,
-    "filename": "positive.tf"
+    "line": 7
   },
   {
     "queryName": "Storage Account Not Forcing HTTPS",
     "severity": "MEDIUM",
-    "line": 10,
-    "filename": "positive.tf"
+    "line": 10
   }
 ]


### PR DESCRIPTION
Closes #7239

**Reason for Proposed Changes**
- Since terraform version 4.0, the param `enable_https_traffic_only` was deprecated and renamed to `https_traffic_only_enabled` - [Official Deprecation Documentation](https://registry.terraform.io/providers/hashicorp/Azurerm/4.17.0/docs/guides/4.0-upgrade-guide#:~:text=azurerm_storage_account-,The%20deprecated%20enable_https_traffic_only%20property%20has%20been%20removed%20in%20favour%20of%20the%20https_traffic_only_enabled%20property.,-The%20large_file_share_enabled%20property);

**Proposed Changes**
- Rename `enable_https_traffic_only` to `https_traffic_only_enabled`;
- Update test cases to reflect the new param naming;

I submit this contribution under the Apache-2.0 license.