### PR TITLE
fix(perms): revert file permission changes on reports

### DIFF
--- a/.github/scripts/report/e2e-html.go
+++ b/.github/scripts/report/e2e-html.go
@@ -78,7 +78,7 @@ func generateE2EReport(path, filename string, body interface{}) error {
 	fullPath := filepath.Join(path, filename)
 	t := template.Must(template.New("report.tmpl").Funcs(templateFuncs).Parse(htmlTemplate))
 
-	f, err := os.OpenFile(filepath.Clean(fullPath), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(filepath.Clean(fullPath), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0777)
 	if err != nil {
 		return err
 	}

--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -29,7 +29,7 @@ var (
 const (
 	scanCommandStr = "scan"
 	initError      = "initialization error - "
-	dirPerms       = 0750
+	dirPerms       = 0777
 )
 
 // NewScanCmd creates a new instance of the scan Command

--- a/pkg/kuberneter/utils.go
+++ b/pkg/kuberneter/utils.go
@@ -37,7 +37,7 @@ type K8sAPIOptions struct {
 
 const (
 	kuberneterPathLength = 3
-	dirPerms             = 0750
+	dirPerms             = 0777
 	filePerms            = 0777
 )
 

--- a/pkg/printer/options.go
+++ b/pkg/printer/options.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	dirPerm   = 0750
+	dirPerm   = 0777
 	filePerms = 0777
 )
 

--- a/pkg/remediation/remediation.go
+++ b/pkg/remediation/remediation.go
@@ -154,7 +154,7 @@ func addition(r *Remediation, lines *[]string) []string {
 }
 
 const (
-	FilePermMode = 0600 // File permissions mode with read and write only
+	FilePermMode = 0777 // File permissions mode with read and write only
 )
 
 func (s *Summary) writeRemediation(remediatedLines, lines []string, filePath, similarityID string) []string {


### PR DESCRIPTION
**Reason for Proposed Changes**
- "results_sarif.json" and other scan reports were not being written because of `Permission Denied` problem. 

**Proposed Changes**
- revert permissions changes to ``0777`;

I submit this contribution under the Apache-2.0 license.