### PR TITLE
fix(query): fix fn in password and secrets Dockerfile ENV variable cases

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -354,6 +354,11 @@
         "detectLineGroup": 1
       },
       "specialMask": ".*password\\s*:[\\n|\\r]\\s*value:"
+    },
+    {
+      "id": "f05f238a-2ef0-4c39-9a36-951de1ba6dc9",
+      "name": "Dockerfile ENV hardcoded password with omitted equals",
+      "regex": "(?i)ENV\\s+[A-Za-z0-9/~^_!@&%()=?*+-.]*password[A-Za-z0-9/~^_!@&%()=?*+-.]*\\s+['\"]?([A-Za-z0-9/~^_!@&%()=?*+-. ]{4,})['\"]?"
     }
   ],
   "allowRules": [

--- a/assets/queries/common/passwords_and_secrets/test/negative49.dockerfile
+++ b/assets/queries/common/passwords_and_secrets/test/negative49.dockerfile
@@ -1,0 +1,10 @@
+FROM baseImage
+
+ENV ARTEMIS_USER artemis
+
+RUN apk add --no-cache git \
+    && git config \
+    --global \
+    url."https://${GIT_USER}:${GIT_TOKEN}@github.com".insteadOf \
+    "https://github.com"
+

--- a/assets/queries/common/passwords_and_secrets/test/negative50.dockerfile
+++ b/assets/queries/common/passwords_and_secrets/test/negative50.dockerfile
@@ -1,0 +1,10 @@
+FROM baseImage
+
+ENV ARTEMIS_USER=artemis
+
+RUN apk add --no-cache git \
+    && git config \
+    --global \
+    url."https://${GIT_USER}:${GIT_TOKEN}@github.com".insteadOf \
+    "https://github.com"
+

--- a/assets/queries/common/passwords_and_secrets/test/positive51.dockerfile
+++ b/assets/queries/common/passwords_and_secrets/test/positive51.dockerfile
@@ -1,0 +1,10 @@
+FROM baseImage
+
+ENV ARTEMIS_USER artemis
+ENV ARTEMIS_PASSWORD artemis
+
+RUN apk add --no-cache git \
+    && git config \
+    --global \
+    url."https://${GIT_USER}:${GIT_TOKEN}@github.com".insteadOf \
+    "https://github.com"

--- a/assets/queries/common/passwords_and_secrets/test/positive52.dockerfile
+++ b/assets/queries/common/passwords_and_secrets/test/positive52.dockerfile
@@ -1,0 +1,10 @@
+FROM baseImage
+
+ENV ARTEMIS_USER=artemis
+ENV ARTEMIS_PASSWORD=artemis
+
+RUN apk add --no-cache git \
+    && git config \
+    --global \
+    url."https://${GIT_USER}:${GIT_TOKEN}@github.com".insteadOf \
+    "https://github.com"

--- a/assets/queries/common/passwords_and_secrets/test/positive_expected_result.json
+++ b/assets/queries/common/passwords_and_secrets/test/positive_expected_result.json
@@ -424,5 +424,17 @@
     "severity": "HIGH",
     "line": 68,
     "fileName": "positive50.yaml"
+  },
+  {
+    "queryName": "Passwords And Secrets - Dockerfile ENV hardcoded password with omitted equals",
+    "severity": "HIGH",
+    "line": 4,
+    "fileName": "positive51.yaml"
+  },
+  {
+    "queryName": "Passwords And Secrets - Generic Password",
+    "severity": "HIGH",
+    "line": 4,
+    "fileName": "positive52.yaml"
   }
 ]


### PR DESCRIPTION
**Reason for Proposed Changes**
- The query currently only catches hardcoded passwords with "=" or ":" between key and value.
- However, in Dockerfiles is possible to define environment variables with the "=" omitted (ex., ENV PASSWORD testPassword).

**Proposed Changes**
- Added new Passwords and Secrets query for Dockerfile ENV hardcoded password with omitted equals cases

I submit this contribution under the Apache-2.0 license.