### PR TITLE
fix(query): fix fp for ecs_cluster_not_encrypted_at_rest

### DIFF
--- a/assets/queries/cloudFormation/aws/ecs_cluster_not_encrypted_at_rest/query.rego
+++ b/assets/queries/cloudFormation/aws/ecs_cluster_not_encrypted_at_rest/query.rego
@@ -7,8 +7,8 @@ CxPolicy[result] {
 	resource := input.document[i].Resources
 	elem := resource[key]
 	elem.Type == "AWS::ECS::Service"
-	clustername := elem.Properties.Cluster
-	taskdefinitionkey := elem.Properties.TaskDefinition
+	elem.Properties.Cluster
+	taskdefinitionkey := getTaskDefinitionName(elem)
 	taskDefinition := resource[taskdefinitionkey]
 
 	count(taskDefinition.Properties.ContainerDefinitions) > 0
@@ -29,8 +29,8 @@ CxPolicy[result] {
 	resource := input.document[i].Resources
 	elem := resource[key]
 	elem.Type == "AWS::ECS::Service"
-	clustername := elem.Properties.Cluster
-	taskdefinitionkey := elem.Properties.TaskDefinition
+	elem.Properties.Cluster
+	taskdefinitionkey := getTaskDefinitionName(elem)
 	not common_lib.valid_key(resource, taskdefinitionkey)
 
 	result := {
@@ -42,4 +42,11 @@ CxPolicy[result] {
 		"keyExpectedValue": sprintf("Resources.%s should be defined", [taskdefinitionkey]),
 		"keyActualValue": sprintf("Resources.%s is not defined.", [taskdefinitionkey]),
 	}
+}
+
+getTaskDefinitionName(resource) := name {
+	name := resource.Properties.TaskDefinition
+	not common_lib.valid_key(name, "Ref")
+} else := name {
+	name := resource.Properties.TaskDefinition.Ref
 }

--- a/assets/queries/cloudFormation/aws/ecs_cluster_not_encrypted_at_rest/test/negative3.yaml
+++ b/assets/queries/cloudFormation/aws/ecs_cluster_not_encrypted_at_rest/test/negative3.yaml
@@ -1,0 +1,231 @@
+Resources:
+  EcsTaskRole8DFA0181:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: "2012-10-17"
+      Description: Role for ECS task
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+      PermissionsBoundary: arn:aws:iam::123456789012:policy/CloudServices-Boundary
+      Tags:
+        - Key: classification
+          Value: internal
+        - Key: component
+          Value: example-nms
+        - Key: env
+          Value: development
+        - Key: owner
+          Value: example@owner.com
+        - Key: product
+          Value: internal_tools
+    Metadata:
+      aws:cdk:path: ExampleNmsInfrastructureStack/EcsTaskRole/Resource
+  EcsTaskRoleDefaultPolicy50882C77:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - ecr:BatchCheckLayerAvailability
+              - ecr:BatchGetImage
+              - ecr:GetDownloadUrlForLayer
+            Effect: Allow
+            Resource: arn:aws:ecr:us-west-2:123456789012:repository/example-nms
+          - Action: ecr:GetAuthorizationToken
+            Effect: Allow
+            Resource: "*"
+        Version: "2012-10-17"
+      PolicyName: EcsTaskRoleDefaultPolicy50882C77
+      Roles:
+        - Ref: EcsTaskRole8DFA0181
+    Metadata:
+      aws:cdk:path: ExampleNmsInfrastructureStack/EcsTaskRole/DefaultPolicy/Resource
+  TaskDef54694570:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Environment:
+            - Name: DEPLOYMENT_TIMESTAMP
+              Value: "2024-08-20T00:41:57.620Z"
+          Essential: true
+          HealthCheck:
+            Command:
+              - CMD-SHELL
+              - curl -f http://localhost:3000/health || exit
+            Interval: 30
+            Retries: 3
+            StartPeriod: 30
+            Timeout: 5
+          Image:
+            Fn::Join:
+              - ""
+              - - 123456789012.dkr.ecr.us-west-2.
+                - Ref: AWS::URLSuffix
+                - /example-nms:latest
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group:
+                Ref: LogGroupF5B46931
+              awslogs-stream-prefix: example-nms
+              awslogs-region: us-west-2
+          MemoryReservation: 128
+          Name: ExampleNameMatchLatest
+          PortMappings:
+            - ContainerPort: 3000
+              Protocol: tcp
+      ExecutionRoleArn:
+        Fn::GetAtt:
+          - TaskDefExecutionRoleB4775C97
+          - Arn
+      Family: ExampleNmsInfrastructureStackTaskDefAF41E55F
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - EC2
+      Tags:
+        - Key: classification
+          Value: internal
+        - Key: component
+          Value: example-nms
+        - Key: env
+          Value: development
+        - Key: owner
+          Value: example@owner.com
+        - Key: product
+          Value: internal_tools
+      TaskRoleArn:
+        Fn::GetAtt:
+          - EcsTaskRole8DFA0181
+          - Arn
+    Metadata:
+      aws:cdk:path: ExampleNmsInfrastructureStack/TaskDef/Resource
+  TaskDefExecutionRoleB4775C97:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: "2012-10-17"
+      PermissionsBoundary: arn:aws:iam::123456789012:policy/CloudServices-Boundary
+      Tags:
+        - Key: classification
+          Value: internal
+        - Key: component
+          Value: example-nms
+        - Key: env
+          Value: development
+        - Key: owner
+          Value: example@owner.com
+        - Key: product
+          Value: internal_tools
+    Metadata:
+      aws:cdk:path: ExampleNmsInfrastructureStack/TaskDef/ExecutionRole/Resource
+  TaskDefExecutionRoleDefaultPolicy0DBB737A:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - ecr:BatchCheckLayerAvailability
+              - ecr:BatchGetImage
+              - ecr:GetDownloadUrlForLayer
+            Effect: Allow
+            Resource: arn:aws:ecr:us-west-2:123456789012:repository/example-nms
+          - Action: ecr:GetAuthorizationToken
+            Effect: Allow
+            Resource: "*"
+          - Action:
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - LogGroupF5B46931
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: TaskDefExecutionRoleDefaultPolicy0DBB737A
+      Roles:
+        - Ref: TaskDefExecutionRoleB4775C97
+    Metadata:
+      aws:cdk:path: ExampleNmsInfrastructureStack/TaskDef/ExecutionRole/DefaultPolicy/Resource
+  LogGroupF5B46931:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /ecs/example-nms
+      RetentionInDays: 1
+      Tags:
+        - Key: classification
+          Value: internal
+        - Key: component
+          Value: example-nms
+        - Key: env
+          Value: development
+        - Key: owner
+          Value: example@owner.com
+        - Key: product
+          Value: internal_tools
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: ExampleNmsInfrastructureStack/LogGroup/Resource
+  ExampleNameMatchService0992A2E7:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: example-ecs
+      DeploymentConfiguration:
+        MaximumPercent: 200
+        MinimumHealthyPercent: 50
+      DesiredCount: 1
+      EnableECSManagedTags: false
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: EC2
+      LoadBalancers:
+        - ContainerName: ExampleNameMatchLatest
+          ContainerPort: 3000
+          TargetGroupArn:
+            Ref: ALBExampleNameMatchListenerExampleNameMatchTargetGroupE2F0920B
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - Fn::GetAtt:
+                - ExampleNameMatchServiceSecurityGroup423FDD45
+                - GroupId
+          Subnets:
+            - subnet-830424f5
+            - subnet-b0c1cfd4
+            - subnet-3ff16967
+      SchedulingStrategy: REPLICA
+      Tags:
+        - Key: classification
+          Value: internal
+        - Key: component
+          Value: example-nms
+        - Key: env
+          Value: development
+        - Key: owner
+          Value: example@owner.com
+        - Key: product
+          Value: internal_tools
+      TaskDefinition:
+        Ref: TaskDef54694570
+    DependsOn:
+      - ALBExampleNameMatchListenerExampleNameMatchTargetGroupE2F0920B
+      - ALBExampleNameMatchListener59259997
+      - EcsTaskRoleDefaultPolicy50882C77
+      - EcsTaskRole8DFA0181
+    Metadata:
+      aws:cdk:path: ExampleNmsInfrastructureStack/ExampleNameMatchService/Service


### PR DESCRIPTION
**Reason for Proposed Changes**
- Currently, in YAML, the query only supports `TaskDefinition` references written as a single line:
```yaml
TaskDefinition: !Ref TaskDef54694570
```
- However, the reference can also be specified using a nested mapping:
```yaml
TaskDefinition:
  Ref: TaskDef54694570
```
- This change is needed to support both styles, ensuring templates using either format are handled correctly.

**Proposed Changes**
- Update the query to support both formats for specifying `TaskDefinition` references.

I submit this contribution under the Apache-2.0 license.