### PR TITLE
fix(query): fix fp in password and secrets Generic Private Key

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -251,6 +251,10 @@
         {
           "description": "Avoiding bash variables",
           "regex": "(?i)['\"]?\\$\\s*\\{[^\\s\\}]+\\}['\"]?"
+        },
+        {
+          "description": "Avoid Docker Compose secrets paths",
+          "regex": "(?i)['\"]?private[_]?key['\"]?\\s*[:=]\\s*['\"]?/run/secrets/\\w+['\"]?"
         }
       ]
     },
@@ -396,10 +400,6 @@
     {
       "description": "Avoiding sha-hashed mysql native passwords",
       "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*[=:]\\s*['\"]?(\\*[0-9A-F]{40})['\"]?"
-    },
-    {
-      "description": "Avoiding secrets path",
-      "regex": "(['\"]?\\w+['\"]?)\\s*[:=]\\s*(['\"]?/(\\w+/)+secrets(/\\w+)+['\"]?)"
     }
   ]
 }

--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -396,6 +396,10 @@
     {
       "description": "Avoiding sha-hashed mysql native passwords",
       "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*[=:]\\s*['\"]?(\\*[0-9A-F]{40})['\"]?"
+    },
+    {
+      "description": "Avoiding secrets path",
+      "regex": "(['\"]?\\w+['\"]?)\\s*[:=]\\s*(['\"]?/(\\w+/)+secrets(/\\w+)+['\"]?)"
     }
   ]
 }

--- a/assets/queries/common/passwords_and_secrets/test/negative49.yml
+++ b/assets/queries/common/passwords_and_secrets/test/negative49.yml
@@ -1,0 +1,16 @@
+version: '3.7'
+
+services:
+  apis:
+    image: ""
+    env_file:
+      - .env
+    environment:
+      env: "dev"
+
+      PrivateKey: /run/secrets/SOME_AUTHORIZATION_PRIVATE_KEY
+
+secrets:
+  SOME_AUTHORIZATION_PRIVATE_KEY:
+    external: true
+  

--- a/assets/queries/common/passwords_and_secrets/test/negative49.yml
+++ b/assets/queries/common/passwords_and_secrets/test/negative49.yml
@@ -8,9 +8,10 @@ services:
     environment:
       env: "dev"
 
+      # this value is a Docker Compose secrets path, its contents are not exposed
       PrivateKey: /run/secrets/SOME_AUTHORIZATION_PRIVATE_KEY
 
 secrets:
   SOME_AUTHORIZATION_PRIVATE_KEY:
     external: true
-  
+


### PR DESCRIPTION
**Reason for Proposed Changes**
- The query is flagging references to Docker Compose secrets (`/run/secrets/SECRET_NAME`).
- These are valid paths and should not be considered exposed values.

**Proposed Changes**
- Add an additional `allowRule` to permit the use of secrets in `/run/secrets/`.

I submit this contribution under the Apache-2.0 license.