### PR TITLE
fix(query): fix fp for s3_bucket_logging_disabled

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_logging_disabled/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_logging_disabled/query.rego
@@ -8,6 +8,7 @@ CxPolicy[result] {
 
     not common_lib.valid_key(s3, "logging")  # version before TF AWS 4.0
     not tf_lib.has_target_resource(bucketName, "aws_s3_bucket_logging") # version after TF AWS 4.0
+    not is_logging_target(bucketName) 
 
     result := {
         "documentId": input.document[i].id,
@@ -37,4 +38,10 @@ CxPolicy[result] {
         "keyActualValue": "'logging' is undefined or null",
         "searchLine": common_lib.build_search_line(["module", name], []),
     }
+}
+
+is_logging_target(bucketName) {
+  some name
+  logging := input.document[i].resource.aws_s3_bucket_logging[name]
+  logging.target_bucket == sprintf("${aws_s3_bucket.%s.id}", [bucketName])
 }

--- a/assets/queries/terraform/aws/s3_bucket_logging_disabled/test/negative4.tf
+++ b/assets/queries/terraform/aws/s3_bucket_logging_disabled/test/negative4.tf
@@ -1,0 +1,14 @@
+resource "aws_s3_bucket" "attachments_bucket" {
+  bucket = "${local.env_app_name}-attachments"
+}
+
+resource "aws_s3_bucket" "log_bucket" {
+  bucket = "${local.env_app_name}-attachments-logs"
+}
+
+resource "aws_s3_bucket_logging" "logging" {
+  bucket = aws_s3_bucket.attachments_bucket.id
+
+  target_bucket = aws_s3_bucket.log_bucket.id
+  target_prefix = "log/"
+}


### PR DESCRIPTION
Closes #7515 

**Reason for Proposed Changes**
- This query must guarantee bucket logging is enabled, however it does not currently account for buckets which are themselves  logging buckets in the first place. 
- Given this, logging buckets are getting wrongfully flagged. Many false positives might result from this lack of case handling, moreover enforcing this condition could easily result in recursive logging loops.

**Proposed Changes**
- I have implemented a simple ```is_logging_target``` policy that ensures buckets that are referenced as logging targets for another bucket do not get flagged. 
- Test \"**negative4**\" has been added to exemplify that logging buckets will not be flagged.


**Note** : There could be a need for a similar implementation on \"module\" type bucket declaration (**negative2 / positive2**), but i could not replicate this false positive detection with that declaration structure.

I submit this contribution under the Apache-2.0 license.