### PR TITLE
fix(query): fn for ssh_is_exposed_to_the_internet and rdp_is_exposed_to_the_internet

### DIFF
--- a/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/query.rego
+++ b/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/query.rego
@@ -22,6 +22,30 @@ CxPolicy[result] {
 	}
 }
 
+CxPolicy[result] {
+  group := input.document[i].resource.azurerm_network_security_group[groupName]
+  rule := group.security_rule[idx]
+
+  upper(rule.access) == "ALLOW"
+  upper(rule.direction) == "INBOUND"
+
+  isRelevantProtocol(rule.protocol)
+  isRelevantPort(rule.destination_port_range)
+  isRelevantAddressPrefix(rule.source_address_prefix)
+
+  result := {
+    "documentId": input.document[i].id,
+    "resourceType": "azurerm_network_security_group",
+    "resourceName": tf_lib.get_resource_name(rule, [groupName, "security_rule", idx]),
+    "searchKey": sprintf("azurerm_network_security_group[%s].security_rule.name={{%s}}.destination_port_range", [groupName, rule.name]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": "'destination_port_range' cannot be 3389",
+    "keyActualValue": "'destination_port_range' might be 3389",
+  }
+}
+
+
+
 isRelevantProtocol(protocol) = allow {
 	upper(protocol) != "UDP"
 	upper(protocol) != "ICMP"

--- a/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/test/negative.tf
+++ b/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/test/negative.tf
@@ -157,3 +157,169 @@ resource "azurerm_network_security_rule" "negative11" {
      resource_group_name         = azurerm_resource_group.example.name
      network_security_group_name = azurerm_network_security_group.example.name
 }
+
+resource azurerm_network_security_group "negative12-22" {
+  location            = var.location
+  name                = "terragoat-${var.environment}"
+  resource_group_name = azurerm_resource_group.example.name
+
+     security_rule {
+          name                        = "negative12"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Deny"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3389"
+          source_address_prefix       = "*"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+
+     security_rule {
+          name                        = "negative13"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "UDP"
+          source_port_range           = "*"
+          destination_port_range      = "2000-5000"
+          source_address_prefix       = "*"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+
+
+     security_rule {
+          name                        = "negative14"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "4030-5100"
+          source_address_prefix       = "0.0.0.0"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+
+
+     security_rule {
+          name                        = "negative15"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "2100-5300"
+          source_address_prefix       = "192.168.0.0"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+
+
+     security_rule {
+          name                        = "negative16"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3389"
+          source_address_prefix       = "/1"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+
+     security_rule {
+          name                        = "negative17"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "*"
+          source_port_range           = "*"
+          destination_port_range      = "3388"
+          source_address_prefix       = "/0"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+
+
+     security_rule {
+          name                        = "negative18"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "UDP"
+          source_port_range           = "*"
+          destination_port_range      = "3389"
+          source_address_prefix       = "internet"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+
+
+     security_rule {
+          name                        = "negative19"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "*"
+          source_port_range           = "*"
+          destination_port_range      = "3388, 3390,1000-2000"
+          source_address_prefix       = "any"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+
+
+     security_rule {
+          name                        = "negative20"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "UDP"
+          source_port_range           = "*"
+          destination_port_range      = "3389"
+          source_address_prefix       = "/0"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+
+     security_rule {
+          name                        = "negative20"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3389 ,  3390"
+          source_address_prefix       = "0.0.1.0"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+
+     security_rule {
+          name                        = "negative21"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "338,389"
+          source_address_prefix       = "0.0.0.0"
+          destination_address_prefix  = "*"
+          resource_group_name         = azurerm_resource_group.example.name
+          network_security_group_name = azurerm_network_security_group.example.name
+     }
+}

--- a/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/test/positive.tf
+++ b/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/test/positive.tf
@@ -137,3 +137,129 @@ resource "azurerm_network_security_rule" "positive10" {
      resource_group_name         = azurerm_resource_group.example.name
      network_security_group_name = azurerm_network_security_group.example.name
 }
+
+resource azurerm_network_security_group "positive11-20" {
+  location            = var.location
+  name                = "terragoat-${var.environment}"
+  resource_group_name = azurerm_resource_group.example.name
+
+     security_rule {
+          name                        = "positive11"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3389"
+          source_address_prefix       = "*"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive12"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3389-3390"
+          source_address_prefix       = "*"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive13"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3388-3389"
+          source_address_prefix       = "*"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive14"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3389"
+          source_address_prefix       = "0.0.0.0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive15"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3389,3391"
+          source_address_prefix       = "34.15.11.3/0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive16"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3389"
+          source_address_prefix       = "/0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive17"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3388-3390, 23000"
+          source_address_prefix       = "internet"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive18"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "3387, 3389 , 3391 "
+          source_address_prefix       = "any"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive19"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "*"
+          source_port_range           = "*"
+          destination_port_range      = "3388, 3389-3390,2250"
+          source_address_prefix       = "/0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive20"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "*"
+          source_port_range           = "*"
+          destination_port_range      = "111-211, 2000-4430, 1-2 , 3"
+          source_address_prefix       = "internet"
+          destination_address_prefix  = "*"
+     }
+}

--- a/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/rdp_is_exposed_to_the_internet/test/positive_expected_result.json
@@ -48,5 +48,55 @@
 		"queryName": "RDP Is Exposed To The Internet",
 		"severity": "HIGH",
 		"line": 134
+	},
+	{
+		"queryName": "SSH Is Exposed To The Internet",
+		"severity": "MEDIUM",
+		"line": 153
+	},
+	{
+		"queryName": "SSH Is Exposed To The Internet",
+		"severity": "MEDIUM",
+		"line": 165
+	},
+	{
+		"queryName": "SSH Is Exposed To The Internet",
+		"severity": "MEDIUM",
+		"line": 177
+	},
+	{
+		"queryName": "SSH Is Exposed To The Internet",
+		"severity": "MEDIUM",
+		"line": 189
+	},
+	{
+		"queryName": "SSH Is Exposed To The Internet",
+		"severity": "MEDIUM",
+		"line": 201
+	},
+	{
+		"queryName": "SSH Is Exposed To The Internet",
+		"severity": "MEDIUM",
+		"line": 213
+	},
+	{
+		"queryName": "SSH Is Exposed To The Internet",
+		"severity": "MEDIUM",
+		"line": 225
+	},
+	{
+		"queryName": "SSH Is Exposed To The Internet",
+		"severity": "MEDIUM",
+		"line": 237
+	},
+	{
+		"queryName": "SSH Is Exposed To The Internet",
+		"severity": "MEDIUM",
+		"line": 249
+	},
+	{
+		"queryName": "SSH Is Exposed To The Internet",
+		"severity": "MEDIUM",
+		"line": 261
 	}
 ]

--- a/assets/queries/terraform/azure/ssh_is_exposed_to_the_internet/query.rego
+++ b/assets/queries/terraform/azure/ssh_is_exposed_to_the_internet/query.rego
@@ -22,6 +22,28 @@ CxPolicy[result] {
 	}
 }
 
+CxPolicy[result] {
+  group := input.document[i].resource.azurerm_network_security_group[groupName]
+  rule := group.security_rule[idx]
+
+  upper(rule.access) == "ALLOW"
+  upper(rule.direction) == "INBOUND"
+
+  isRelevantProtocol(rule.protocol)
+  isRelevantPort(rule.destination_port_range)
+  isRelevantAddressPrefix(rule.source_address_prefix)
+
+  result := {
+    "documentId": input.document[i].id,
+    "resourceType": "azurerm_network_security_group",
+    "resourceName": tf_lib.get_resource_name(rule, [groupName, "security_rule", idx]),
+    "searchKey": sprintf("azurerm_network_security_group[%s].security_rule.name={{%s}}.destination_port_range", [groupName, rule.name]),
+    "issueType": "IncorrectValue",
+    "keyExpectedValue": "'destination_port_range' cannot be 22",
+    "keyActualValue": "'destination_port_range' might be 22",
+  }
+}
+
 isRelevantProtocol(protocol) = allow {
 	upper(protocol) != "UDP"
 	upper(protocol) != "ICMP"

--- a/assets/queries/terraform/azure/ssh_is_exposed_to_the_internet/test/negative.tf
+++ b/assets/queries/terraform/azure/ssh_is_exposed_to_the_internet/test/negative.tf
@@ -157,3 +157,143 @@ resource "azurerm_network_security_rule" "negative11" {
      resource_group_name         = azurerm_resource_group.example.name
      network_security_group_name = azurerm_network_security_group.example.name
 }
+
+
+resource azurerm_network_security_group "negative12-22" {
+  location            = var.location
+  name                = "terragoat-${var.environment}"
+  resource_group_name = azurerm_resource_group.example.name
+
+  security_rule {
+          name                        = "negative12"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Deny"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "22"
+          source_address_prefix       = "*"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "negative13"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "UDP"
+          source_port_range           = "*"
+          destination_port_range      = "20-50"
+          source_address_prefix       = "*"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "negative14"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "30-50"
+          source_address_prefix       = "0.0.0.0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "negative15"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "20-50"
+          source_address_prefix       = "192.168.0.0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "negative16"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "22"
+          source_address_prefix       = "/1"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "negative17"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "*"
+          source_port_range           = "*"
+          destination_port_range      = "21"
+          source_address_prefix       = "/0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "negative18"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "UDP"
+          source_port_range           = "*"
+          destination_port_range      = "22"
+          source_address_prefix       = "internet"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "negative19"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "*"
+          source_port_range           = "*"
+          destination_port_range      = "21, 23,10-20"
+          source_address_prefix       = "any"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "negative20"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "UDP"
+          source_port_range           = "*"
+          destination_port_range      = "22"
+          source_address_prefix       = "/0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "negative21"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "22 ,  23"
+          source_address_prefix       = "0.0.1.0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "negative22"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "220,230"
+          source_address_prefix       = "0.0.0.0"
+          destination_address_prefix  = "*"
+     }
+}
+

--- a/assets/queries/terraform/azure/ssh_is_exposed_to_the_internet/test/positive.tf
+++ b/assets/queries/terraform/azure/ssh_is_exposed_to_the_internet/test/positive.tf
@@ -137,3 +137,129 @@ resource "azurerm_network_security_rule" "positive10" {
      resource_group_name         = azurerm_resource_group.example.name
      network_security_group_name = azurerm_network_security_group.example.name
 }
+
+resource azurerm_network_security_group "positive11-20" {
+  location            = var.location
+  name                = "group_example"
+  resource_group_name = azurerm_resource_group.example.name
+
+     security_rule {
+          name                        = "positive11"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "22"
+          source_address_prefix       = "*"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive12"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "22-23"
+          source_address_prefix       = "*"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive13"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "21-53"
+          source_address_prefix       = "*"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive14"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "22"
+          source_address_prefix       = "0.0.0.0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive15"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "22,24"
+          source_address_prefix       = "34.15.11.3/0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive16"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "22"
+          source_address_prefix       = "/0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive17"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "21-24, 230"
+          source_address_prefix       = "internet"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive18"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "TCP"
+          source_port_range           = "*"
+          destination_port_range      = "21, 22 , 24 "
+          source_address_prefix       = "any"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive19"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "*"
+          source_port_range           = "*"
+          destination_port_range      = "21, 22-23,2250"
+          source_address_prefix       = "/0"
+          destination_address_prefix  = "*"
+     }
+
+     security_rule {
+          name                        = "positive20"
+          priority                    = 100
+          direction                   = "Inbound"
+          access                      = "Allow"
+          protocol                    = "*"
+          source_port_range           = "*"
+          destination_port_range      = "111-211, 20-30, 1-2 , 3"
+          source_address_prefix       = "internet"
+          destination_address_prefix  = "*"
+     }
+}

--- a/assets/queries/terraform/azure/ssh_is_exposed_to_the_internet/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/ssh_is_exposed_to_the_internet/test/positive_expected_result.json
@@ -48,5 +48,55 @@
     "queryName": "SSH Is Exposed To The Internet",
     "severity": "MEDIUM",
     "line": 134
+  },
+  {
+    "queryName": "SSH Is Exposed To The Internet",
+    "severity": "MEDIUM",
+    "line": 153
+  },
+  {
+    "queryName": "SSH Is Exposed To The Internet",
+    "severity": "MEDIUM",
+    "line": 165
+  },
+  {
+    "queryName": "SSH Is Exposed To The Internet",
+    "severity": "MEDIUM",
+    "line": 177
+  },
+  {
+    "queryName": "SSH Is Exposed To The Internet",
+    "severity": "MEDIUM",
+    "line": 189
+  },
+  {
+    "queryName": "SSH Is Exposed To The Internet",
+    "severity": "MEDIUM",
+    "line": 201
+  },
+  {
+    "queryName": "SSH Is Exposed To The Internet",
+    "severity": "MEDIUM",
+    "line": 213
+  },
+  {
+    "queryName": "SSH Is Exposed To The Internet",
+    "severity": "MEDIUM",
+    "line": 225
+  },
+  {
+    "queryName": "SSH Is Exposed To The Internet",
+    "severity": "MEDIUM",
+    "line": 237
+  },
+  {
+    "queryName": "SSH Is Exposed To The Internet",
+    "severity": "MEDIUM",
+    "line": 249
+  },
+  {
+    "queryName": "SSH Is Exposed To The Internet",
+    "severity": "MEDIUM",
+    "line": 261
   }
 ]


### PR DESCRIPTION

**Reason for Proposed Changes**
- These queries are meant to detect azurerm network rules that expose sensitive ports: ```port 22(ssh)``` and ```port 3389(rdp)```, however they are not taking into account ```azurerm_network_security_group´s```. 
- This has bestowed upon the queries a massive blind spot for this dangerous vulnerabilities.

**Proposed Changes**
- To allow for complete thorough search for network rules i have implemented an extra valid pattern for detecting these statements when inside a ```azurerm_network_security_group``` block. 
- All the tests have been updated to ensure logic is consistently whether rules are defined inside or outside of a group.


**Note:** The searchKey uses rule names for traceability. This approach was chosen over index-based referencing due to consistent misalignment between ```idx``` values and the actual rule objects, which led to duplicate or misplaced warnings. 

I submit this contribution under the Apache-2.0 license.