### PR TITLE
fix(query): fix fn for cloudTrail_multi_region_disabled

### DIFF
--- a/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/query.rego
+++ b/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/query.rego
@@ -20,3 +20,22 @@ CxPolicy[result] {
 		"keyActualValue": "cloudtrail.is_multi_region_trail is false",
 	}
 }
+
+CxPolicy[result] {
+	task := ansLib.tasks[id][t]
+	modules := {"community.aws.cloudtrail", "cloudtrail"}
+	cloudtrail := task[modules[m]]
+	ansLib.checkState(cloudtrail)
+
+	not cloudtrail.is_multi_region_trail
+
+	result := {
+		"documentId": id,
+		"resourceType": modules[m],
+		"resourceName": task.name,
+		"searchKey": sprintf("name={{%s}}.{{%s}}.is_multi_region_trail", [task.name, modules[m]]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "cloudtrail.is_multi_region_trail should be true",
+		"keyActualValue": "cloudtrail.is_multi_region_trail is false",
+	}
+}

--- a/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/test/negative.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/test/negative.yaml
@@ -1,5 +1,6 @@
 - name: example1
-  community.aws.cloudtrail:
+  community.aws.cloudtrail: 
+    sns_topic_name: random
     state: present
     name: default
     s3_bucket_name: mylogbucket

--- a/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/test/positive.yaml
+++ b/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/test/positive.yaml
@@ -8,7 +8,21 @@
     enable_log_file_validation: true
     cloudwatch_logs_role_arn: "arn:aws:iam::123456789012:role/CloudTrail_CloudWatchLogs_Role"
     cloudwatch_logs_log_group_arn: "arn:aws:logs:us-east-1:123456789012:log-group:CloudTrail/DefaultLogGroup:*"
+    sns_topic_name: random1
     kms_key_id: "alias/MyAliasName"
     tags:
       environment: dev
       Name: default
+
+- name: example2
+  community.aws.cloudtrail:
+    state: present
+    name: default
+    s3_bucket_name: mylogbucket
+    s3_key_prefix: cloudtrail
+    region: us-east-1
+    cloudwatch_logs_role_arn: "arn:aws:iam::123456789012:role/CloudTrail_CloudWatchLogs_Role"
+    cloudwatch_logs_log_group_arn: "arn:aws:logs:us-east-1:123456789012:log-group:CloudTrail/DefaultLogGroup:*"
+    sns_topic_name: random2
+    enable_log_file_validation: true
+    kms_key_id: "alias/MyAliasName"

--- a/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/test/positive_expected_result.json
+++ b/assets/queries/ansible/aws/cloudtrail_multi_region_disabled/test/positive_expected_result.json
@@ -3,5 +3,10 @@
     "queryName": "CloudTrail Multi Region Disabled",
     "severity": "LOW",
     "line": 7
+  },
+  {
+    "queryName": "CloudTrail Multi Region Disabled",
+    "severity": "LOW",
+    "line": 18
   }
 ]


### PR DESCRIPTION
**Reason for Proposed Changes**
- This query is meant to identify ansible tasks that configure an AWS CloudTrail trail with the ```is_multi_region_trail``` flag set to false.
- In its current implementation it does not treat the lack of the relevant field (```is_multi_region_trail```) as false, it should do so because that is its default value.
- This behavior leads to false negatives.

**Proposed Changes**
- Refinement of the query`s ```CxPolicy``` logic to flag whether the field is set explicitly to false or missing altogether from the ansible task.

I submit this contribution under the Apache-2.0 license.