### PR TITLE
fix(dockerfile): update debian dockerfile image with stable-slim version

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -41,7 +41,7 @@ HEALTHCHECK CMD wget -q --method=HEAD localhost/system-status.txt
 # be sure to use /app/bin/kics as a path to the binary
 #
 # runtime image
-FROM debian:buster-slim
+FROM debian:stable-slim
 
 RUN groupadd checkmarx && useradd -g checkmarx -M -s /bin/bash checkmarx
 


### PR DESCRIPTION
**Reason for Proposed Changes**
- debian e2e tests were failing due to changes on the docker image `buster-slim`;

**Proposed Changes**
- change Dockerfile.debian image to `stable-slim`;

I submit this contribution under the Apache-2.0 license.