### PR TITLE
fix(query): fp for security_groups_not_used - terraform/aws

### DIFF
--- a/assets/queries/terraform/aws/security_groups_not_used/query.rego
+++ b/assets/queries/terraform/aws/security_groups_not_used/query.rego
@@ -21,36 +21,8 @@ CxPolicy[result] {
 
 is_used(securityGroupName, doc, resource) {
 	[path, value] := walk(doc)
-	securityGroupUsed := value.security_groups[_]
-	contains(securityGroupUsed, sprintf("aws_security_group.%s", [securityGroupName]))
-}
-
-# check in modules for module terraform-aws-modules/security-group/aws
-is_used(securityGroupName, doc, resource) {
-	[path, value] := walk(doc)
-	securityGroupUsed := value.security_group_id
-	contains(securityGroupUsed, sprintf("aws_security_group.%s", [securityGroupName]))
-}
-
-# check security groups assigned to aws_elasticache_instance resources
-is_used(securityGroupName, doc, resource) {
-	[path, value] := walk(doc)
-	securityGroupUsed := value.security_group_ids[_]
-	contains(securityGroupUsed, sprintf("aws_security_group.%s", [securityGroupName]))
-}
-
-# check security groups assigned to aws_instance resources
-is_used(securityGroupName, doc, resource) {
-	[path, value] := walk(doc)
-	securityGroupUsed := value.vpc_security_group_ids[_]
-	contains(securityGroupUsed, sprintf("aws_security_group.%s", [securityGroupName]))
-}
-
-# check security groups assigned to aws_eks_cluster resources
-is_used(securityGroupName, doc, resource) {
-	[path, value] := walk(doc)
-	securityGroupUsed := value.vpc_config.security_group_ids[_]
-	contains(securityGroupUsed, sprintf("aws_security_group.%s", [securityGroupName]))
+	securityGroupUsed := get_security_groups_if_exists(value)[_]
+	contains(securityGroupUsed, sprintf("aws_security_group.%s.", [securityGroupName]))
 }
 
 is_used(securityGroupName, doc, resource) {
@@ -59,3 +31,34 @@ is_used(securityGroupName, doc, resource) {
 	securityGroupUsed := value.security_groups[_]
 	sec_group_used == securityGroupUsed
 }
+
+
+get_security_groups_if_exists(resource) = security_group {
+	security_group := resource.security_groups
+} else = security_group {
+	# check in modules for module terraform-aws-modules/security-group/aws (array)
+	is_array(resource.security_group_id)
+	security_group := resource.security_group_id
+} else = security_group {
+	# terraform-aws-modules/security-group/aws (not an array)
+	not is_array(resource.security_group_id)
+	security_group := [resource.security_group_id]
+} else = security_group {
+	# check security groups assigned to aws_elasticache_instance resources
+	security_group := resource.security_group_ids
+} else = security_group {
+	# check security groups assigned to aws_instance resources
+	security_group := resource.vpc_security_group_ids
+} else = security_group {
+	# check security groups assigned to aws_eks_cluster resources
+	security_group := resource.vpc_config.security_group_ids
+}
+
+
+
+
+
+
+
+	
+	

--- a/assets/queries/terraform/aws/security_groups_not_used/test/negative7.tf
+++ b/assets/queries/terraform/aws/security_groups_not_used/test/negative7.tf
@@ -1,0 +1,9 @@
+resource "aws_security_group" "test" {
+  name = "test"
+  load_balancer_type = "application"
+}
+
+module "fake" {
+  source = "modules/fake"
+  security_group_id = [aws_security_group.test.id]
+}

--- a/assets/queries/terraform/aws/security_groups_not_used/test/positive6.tf
+++ b/assets/queries/terraform/aws/security_groups_not_used/test/positive6.tf
@@ -1,0 +1,11 @@
+resource "aws_security_group" "default_name" {
+  name        = "default_name"
+}
+
+resource "aws_lb" "test" {
+  name = "test"
+  load_balancer_type = "application"
+  subnets = [aws_subnet.subnet1.id, aws_subnet.subnet2.id]
+  internal = true
+  security_groups = [aws_security_group.default_name_to_prevent_prefix_False_Negative.id]
+}

--- a/assets/queries/terraform/aws/security_groups_not_used/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/security_groups_not_used/test/positive_expected_result.json
@@ -28,5 +28,11 @@
     "severity": "INFO",
     "line": 1,
     "filename": "positive5.tf"
+  },
+  {
+    "queryName": "Security Group Not Used",
+    "severity": "INFO",
+    "line": 1,
+    "filename": "positive6.tf"
   }
 ]


### PR DESCRIPTION
Closes #7212

**Reason for Proposed Changes**
- This query is meant to ensure all security groups that exist are used, but, currently, it only supports single values for ```security_group_id``` declarations inside modules. 
- These modules support array based declaration of this sort : ```security_group_id = [aws_security_group.test.id]``` so the query should be ajusted to prevent **FP** due to lack of proper array case handling.

**Proposed Changes**
- TODO
-
-

I submit this contribution under the Apache-2.0 license.