### PR TITLE
feat(version): add dynamic kics version detection for cli command

### DIFF
--- a/e2e/testcases/e2e-cli-024_version.go
+++ b/e2e/testcases/e2e-cli-024_version.go
@@ -13,7 +13,7 @@ func init() { //nolint
 			},
 		},
 		Validation: func(outputText string) bool {
-			match, _ := regexp.MatchString(`Keeping Infrastructure as Code Secure [0-9a-zA-Z]+`, outputText)
+			match, _ := regexp.MatchString(`Keeping Infrastructure as Code Secure, version: [0-9a-zA-Z.-]+`, outputText)
 			return match
 		},
 		WantStatus: []int{0},

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -1,8 +1,10 @@
 package constants
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,12 +12,29 @@ import (
 
 func TestConstants_GetRelease(t *testing.T) {
 	got := GetRelease()
-	require.Equal(t, "kics@development", got)
+
+	if Version == "development" {
+		require.True(t,
+			got == "kics@development" || strings.HasPrefix(got, "kics@"),
+			"Expected release to be kics@development or kics@<version>, got: %s", got)
+	} else {
+		expected := fmt.Sprintf("kics@%s", Version)
+		require.Equal(t, expected, got)
+	}
 }
 
 func TestConstants_GetVersion(t *testing.T) {
 	got := GetVersion()
-	require.Equal(t, "Keeping Infrastructure as Code Secure development", got)
+
+	if Version == "development" {
+		require.True(t,
+			got == "Keeping Infrastructure as Code Secure, version: development" ||
+				strings.HasPrefix(got, "Keeping Infrastructure as Code Secure, version: "),
+			"Expected version to be development or a valid version string, got: %s", got)
+	} else {
+		expected := fmt.Sprintf("Keeping Infrastructure as Code Secure, version: %s", Version)
+		require.Equal(t, expected, got)
+	}
 }
 
 func TestConstants_GetDefaultLogPath(t *testing.T) {


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- Currently, when running the `version` command, KICS outputs the hardcoded string: "Keeping Infrastructure as Code Secure development", which does not reflect the actual version in use.

**Proposed Changes**
- Dynamically calculate and display the actual version used by KICS in the CLI output;
- Update e2e test to match the new behavior.

I submit this contribution under the Apache-2.0 license.