### PR TITLE
refactor(scan): rename executeScan to ExecuteScan for consistency

### DIFF
--- a/internal/console/scan.go
+++ b/internal/console/scan.go
@@ -96,7 +96,7 @@ func run(cmd *cobra.Command) error {
 	// save the scan parameters into the ScanParameters struct
 	scanParams := getScanParameters(changedDefaultQueryPath, changedDefaultLibrariesPath)
 
-	return ExecuteScan(scanParams)
+	return executeScan(scanParams)
 }
 
 func updateReportFormats() {
@@ -151,7 +151,7 @@ func getScanParameters(changedDefaultQueryPath, changedDefaultLibrariesPath bool
 	return &scanParams
 }
 
-func ExecuteScan(scanParams *scan.Parameters) error {
+func executeScan(scanParams *scan.Parameters) error {
 	log.Debug().Msg("console.scan()")
 
 	console := newConsole()

--- a/pkg/scan/client.go
+++ b/pkg/scan/client.go
@@ -87,11 +87,11 @@ func NewClient(params *Parameters, proBarBuilder *progress.PbBuilder, customPrin
 	}, nil
 }
 
-// PerformScan executes executeScan and postScan
+// PerformScan executes ExecuteScan and postScan
 func (c *Client) PerformScan(ctx context.Context) error {
 	c.ScanStartTime = time.Now()
 
-	scanResults, err := c.executeScan(ctx)
+	scanResults, err := c.ExecuteScan(ctx)
 
 	if err != nil {
 		log.Err(err)

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -131,7 +131,7 @@ func (c *Client) initScan(ctx context.Context) (*executeScanParameters, error) {
 	}, nil
 }
 
-func (c *Client) executeScan(ctx context.Context) (*Results, error) {
+func (c *Client) ExecuteScan(ctx context.Context) (*Results, error) {
 	executeScanParameters, err := c.initScan(ctx)
 
 	if err != nil {

--- a/pkg/scan/scan_test.go
+++ b/pkg/scan/scan_test.go
@@ -52,7 +52,7 @@ func Test_ExecuteScan(t *testing.T) {
 				t.Fatalf(`NewClient failed for path %s with error: %v`, tt.scanParams.Path[0], err)
 			}
 
-			r, err := c.executeScan(tt.ctx)
+			r, err := c.ExecuteScan(tt.ctx)
 
 			if err != nil {
 				t.Fatalf(`ExecuteScan failed for path %s with error: %v`, tt.scanParams.Path[0], err)


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
-

**Proposed Changes**
-
-
-

I submit this contribution under the Apache-2.0 license.