### PR TITLE
fix(query): fp for ECS Cluster with Container Insights Disabled -- cloudformation/aws

### DIFF
--- a/assets/queries/cloudFormation/aws/ecs_cluster_container_insights_disabled/query.rego
+++ b/assets/queries/cloudFormation/aws/ecs_cluster_container_insights_disabled/query.rego
@@ -47,3 +47,8 @@ container_insights(settings){
 	settings[0].Name == "containerInsights"
 	settings[0].Value == "enabled"
 }
+
+container_insights(settings){
+	settings[0].Name == "containerInsights"
+	settings[0].Value == "enchanced"
+}

--- a/assets/queries/cloudFormation/aws/ecs_cluster_container_insights_disabled/query.rego
+++ b/assets/queries/cloudFormation/aws/ecs_cluster_container_insights_disabled/query.rego
@@ -50,5 +50,5 @@ container_insights(settings){
 
 container_insights(settings){
 	settings[0].Name == "containerInsights"
-	settings[0].Value == "enchanced"
+	settings[0].Value == "enhanced"
 }

--- a/assets/queries/cloudFormation/aws/ecs_cluster_container_insights_disabled/test/negative3.yaml
+++ b/assets/queries/cloudFormation/aws/ecs_cluster_container_insights_disabled/test/negative3.yaml
@@ -1,0 +1,11 @@
+Resources:
+  ECSCluster:
+    Type: 'AWS::ECS::Cluster'
+    Properties:
+      ClusterName: MyCluster
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enchanced
+      Tags:
+        - Key: environment
+          Value: production

--- a/assets/queries/cloudFormation/aws/ecs_cluster_container_insights_disabled/test/negative3.yaml
+++ b/assets/queries/cloudFormation/aws/ecs_cluster_container_insights_disabled/test/negative3.yaml
@@ -5,7 +5,7 @@ Resources:
       ClusterName: MyCluster
       ClusterSettings:
         - Name: containerInsights
-          Value: enchanced
+          Value: enhanced
       Tags:
         - Key: environment
           Value: production


### PR DESCRIPTION
Closes #7338

Reason for Proposed Changes

- As disclosed in [7338](https://github.com/Checkmarx/kics/issues/7338), currently the query wrongfully flags instances of "ClusterSettings"`s value being set to "enhanced". 
- "enhanced" is supported by official [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-ecs-cluster-clustersettings.html) which explicitly states this value is "To use Container Insights with enhanced observability"

Proposed Changes
- Simple expansion to the "container_insigths" helper function.
- New negative3 test to assure "enhanced" value does not flag.

I submit this contribution under the Apache-2.0 license.