### PR TITLE
fix(query): fn for Trusted Microsoft Services Not Enabled  - ARM

### DIFF
--- a/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/query.rego
+++ b/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/query.rego
@@ -60,6 +60,8 @@ path_check(resource) = "" {
   	resource.properties == {} 
   } else = ".properties" {
   	not common_lib.valid_key(resource.properties,"networkAcls")
-  } else = ".properties.networkAcls" {
-  	resource.properties.networkAcls == {} 
-  } else = "there_is_complete_path"
+  } else = "there_is_complete_path" {
+	common_lib.valid_key(resource.properties.networkAcls,"defaultAction")
+  } else = "there_is_complete_path" {
+	common_lib.valid_key(resource.properties.networkAcls,"bypass")
+  } else = ".properties.networkAcls"

--- a/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/query.rego
+++ b/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/query.rego
@@ -55,11 +55,11 @@ contains_azure_service(bypass) {
 }
 
 path_check(resource) = "" {
-  not common_lib.valid_key(resource,"properties")
- } else = ".properties" {
-  resource.properties == {} 
-} else = ".properties" {
-  not common_lib.valid_key(resource.properties,"networkAcls")
-} else = ".properties.networkAcls" {
-  resource.properties.networkAcls == {} 
-} else = "there_is_complete_path"
+  	not common_lib.valid_key(resource,"properties")
+  } else = ".properties" {
+  	resource.properties == {} 
+  } else = ".properties" {
+  	not common_lib.valid_key(resource.properties,"networkAcls")
+  } else = ".properties.networkAcls" {
+  	resource.properties.networkAcls == {} 
+  } else = "there_is_complete_path"

--- a/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive5.bicep
+++ b/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive5.bicep
@@ -1,0 +1,10 @@
+resource storage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'positive5'
+  location: 'location1'
+  sku: {
+    name: 'Standard_LRS'
+    tier: 'Standard'
+  }
+  kind: 'Storage'
+  properties: {}
+}

--- a/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive5.json
+++ b/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive5.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "positive5",
+      "apiVersion": "2019-06-01",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "Storage",
+      "properties": {}
+    }
+  ]
+}
+

--- a/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive6.bicep
+++ b/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive6.bicep
@@ -1,0 +1,9 @@
+resource storage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'positive6'
+  location: 'location1'
+  sku: {
+    name: 'Standard_LRS'
+    tier: 'Standard'
+  }
+  kind: 'StorageV2'
+}

--- a/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive6.json
+++ b/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive6.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "keyVaultName": {
+      "type": "string",
+      "defaultValue": "[concat('kv-', uniqueString(resourceGroup().id))]",
+      "metadata": {
+        "description": "Specifies the name of the key vault."
+      }
+    }
+  },
+  "variables": {
+    "uniqueString": "[uniqueString(subscription().id, resourceGroup().id)]",
+    "diagnosticStorageAccountName": "[toLower( substring( replace( concat( parameters('keyVaultName'), variables('uniqueString'), variables('uniqueString') ), '-', ''), 0, 23) )]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "positive6",
+      "apiVersion": "2019-06-01",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "tags": {
+        "displayName": "concat('Key Vault ', parameters('keyVaultName'), ' diagnostics storage account')"
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive7.bicep
+++ b/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive7.bicep
@@ -1,0 +1,12 @@
+resource storage 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: 'positive7'
+  location: 'location1'
+  sku: {
+    name: 'Standard_LRS'
+    tier: 'Standard'
+  }
+  kind: 'StorageV2'
+  properties: {
+    networkAcls: {}
+  }
+}

--- a/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive7.json
+++ b/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive7.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "positive7",
+      "apiVersion": "2019-06-01",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "Storage",
+      "properties": {
+        "networkAcls": {}
+      }
+    }
+  ]
+}
+

--- a/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/trusted_microsoft_services_not_enabled/test/positive_expected_result.json
@@ -26,6 +26,24 @@
   {
     "queryName": "Trusted Microsoft Services Not Enabled",
     "severity": "MEDIUM",
+    "line": 17,
+    "fileName": "positive5.json"
+  },
+  {
+    "queryName": "Trusted Microsoft Services Not Enabled",
+    "severity": "MEDIUM",
+    "line": 20,
+    "fileName": "positive6.json"
+  },
+  {
+    "queryName": "Trusted Microsoft Services Not Enabled",
+    "severity": "MEDIUM",
+    "line": 18,
+    "fileName": "positive7.json"
+  },
+  {
+    "queryName": "Trusted Microsoft Services Not Enabled",
+    "severity": "MEDIUM",
     "line": 11,
     "fileName": "positive1.bicep"
   },
@@ -46,5 +64,23 @@
     "severity": "MEDIUM",
     "line": 11,
     "fileName": "positive4.bicep"
+  },
+  {
+    "queryName": "Trusted Microsoft Services Not Enabled",
+    "severity": "MEDIUM",
+    "line": 9,
+    "fileName": "positive5.bicep"
+  },
+  {
+    "queryName": "Trusted Microsoft Services Not Enabled",
+    "severity": "MEDIUM",
+    "line": 2,
+    "fileName": "positive6.bicep"
+  },
+  {
+    "queryName": "Trusted Microsoft Services Not Enabled",
+    "severity": "MEDIUM",
+    "line": 10,
+    "fileName": "positive7.bicep"
   }
 ]


### PR DESCRIPTION
**Reason for Proposed Changes**
- Currently this query checks if ```Microsoft.Storage/storageAccounts``` resources by assuring the field ```properties.networkAcls.defaultAction``` is not set as "Allow"  , and that ```properties.networkAcls.bypass``` does not contain "AzureServices" as either of those scenarios would enable "Trusted Microsoft Services". 
- The query , however, does not account for the possibility of the resource missing the ```properties```,```properties.networkAcls``` or ```properties.networkAcls.defaultAction/bypass``` fields entirely. 
 

**Proposed Changes**
- I have implemented a "path_check" function that confirms the path to the ```defaultAction``` and/or ```bypass``` nested fields exists. Moreover the lack of a complete path will properly flag the **Microsoft Services as Not Enabled** and point to the "deepest" field along the path route(either```""```,```"properties"``` or ```"properties.networkAcls"```) on the "searchKey".

Note: I could not find explicit documentation stating the effects of missing "networkAcls" or other fields, but it seems to result in unexpected behavior depending on file/system context which, i feel, still makes this flag pertinent.

I submit this contribution under the Apache-2.0 license.