### PR TITLE
fix(vulnerabilities): update go version to fix grype vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM checkmarx/go:1.24.4-r0-ae7309142bb6bd@sha256:ae7309142bb6bd82e0272c3624ec53c0c68d855f6b63e985c5caaff5c1705644 AS build_env
+FROM checkmarx/go:1.24.5-r2-36b5e3994e500b@sha256:36b5e3994e500b9c46c72884930af004a29170a679188c97a6ed1fe0c48486f4 AS build_env
 
 # Copy the source from the current directory to the Working Directory inside the container
 WORKDIR /app
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 # Runtime image
 # Ignore no User Cmd since KICS container is stopped afer scan
 # kics-scan ignore-line
-FROM checkmarx/git:2.49.0-r2-d7ebbe7c56dc47@sha256:d7ebbe7c56dc478c08aba611c35b30689090d28605d83130ce4d1e15a84f0389
+FROM checkmarx/git:2.49.0-r2-37196b58d09795@sha256:37196b58d09795a9d068a57cd019cfe90f2de49cae52e0f6675e658fca1e7ba3
 
 ENV TERM xterm-256color
 

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -3,7 +3,7 @@
 # it does not define an ENTRYPOINT as this is a requirement described here:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops#linux-based-containers
 #
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.24.4-bookworm as build_env
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.24.5-bookworm as build_env
 # Create a group and user
 RUN groupadd checkmarx && useradd -g checkmarx -M -s /bin/bash checkmarx
 USER checkmarx

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -4,10 +4,10 @@ WORKDIR /build
 
 ENV PATH=$PATH:/usr/local/go/bin
 
-ADD https://golang.org/dl/go1.24.4.linux-amd64.tar.gz .
+ADD https://golang.org/dl/go1.24.5.linux-amd64.tar.gz .
 RUN yum install git gcc -y \
-  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz \
-  && rm -f go1.24.4.linux-amd64.tar.gz
+  && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.5.linux-amd64.tar.gz \
+  && rm -f go1.24.5.linux-amd64.tar.gz
 
 ENV GOPRIVATE=github.com/Checkmarx/*
 ARG VERSION="development"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Checkmarx/kics/v2
 
-go 1.24.1
+go 1.24.5
 
 require (
 	code.cloudfoundry.org/bytefmt v0.35.0


### PR DESCRIPTION
**Reason for Proposed Changes**
- Grype is complaining of multiple vulnerabilities;

<img width="366" height="212" alt="image" src="https://github.com/user-attachments/assets/0c2b98c9-67f7-4321-891f-5a0e5cdd9c45" />

**Proposed Changes**
- Update go version to 1.24.5;
- Update dockerfile images to latest;

I submit this contribution under the Apache-2.0 license.