### PR TITLE
fix(query): fixed FN for the missing resources on "App Service HTTP2 Disabled" query

### DIFF
--- a/assets/queries/terraform/azure/app_service_http2_disabled/query.rego
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/query.rego
@@ -3,58 +3,60 @@ package Cx
 import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
 
+resources := {"azurerm_app_service", "azurerm_linux_web_app", "azurerm_windows_web_app"}
+
 CxPolicy[result] {
-	app := input.document[i].resource.azurerm_app_service[name]
+	app := input.document[i].resource[resources[m]][name]
 
 	not common_lib.valid_key(app, "site_config")
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "azurerm_app_service",
+		"resourceType": resources[m],
 		"resourceName": tf_lib.get_resource_name(app, name),
-		"searchKey": sprintf("azurerm_app_service[%s]", [name]),
+		"searchKey": sprintf("%s[%s]", [resources[m], name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'azurerm_app_service[%s].site_config' should be defined and not null", [name]),
-		"keyActualValue": sprintf("'azurerm_app_service[%s].site_config' is undefined or null", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "azurerm_app_service", name], []),
+		"keyExpectedValue": sprintf("'%s[%s].site_config' should be defined and not null", [resources[m],name]),
+		"keyActualValue": sprintf("'%s[%s].site_config' is undefined or null", [resources[m],name]),
+		"searchLine": common_lib.build_search_line(["resource", "%s", name], []),
 		"remediation": "site_config {\n\t\thttp2_enabled = true\n\t}",
 		"remediationType": "addition",
 	}
 }
 
 CxPolicy[result] {
-	app := input.document[i].resource.azurerm_app_service[name]
+	app := input.document[i].resource[resources[m]][name]
 
 	not common_lib.valid_key(app.site_config, "http2_enabled")
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "azurerm_app_service",
+		"resourceType": resources[m],
 		"resourceName": tf_lib.get_resource_name(app, name),
-		"searchKey": sprintf("azurerm_app_service[%s].site_config", [name]),
+		"searchKey": sprintf("%s[%s].site_config", [resources[m],name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'azurerm_app_service[%s].site_config.http2_enabled' should be defined and not null", [name]),
-		"keyActualValue": sprintf("'azurerm_app_service[%s].site_config.http2_enabled' is undefined or null", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "azurerm_app_service", name, "site_config"], []),
+		"keyExpectedValue": sprintf("'%s[%s].site_config.http2_enabled' should be defined and not null", [resources[m],name]),
+		"keyActualValue": sprintf("'%s[%s].site_config.http2_enabled' is undefined or null", [resources[m],name]),
+		"searchLine": common_lib.build_search_line(["resource", resources[m], name, "site_config"], []),
 		"remediation": "http2_enabled = true",
 		"remediationType": "addition",
 	}
 }
 
 CxPolicy[result] {
-	app := input.document[i].resource.azurerm_app_service[name]
+	app := input.document[i].resource[resources[m]][name]
 
 	app.site_config.http2_enabled == false
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": "azurerm_app_service",
+		"resourceType": resources[m],
 		"resourceName": tf_lib.get_resource_name(app, name),
-		"searchKey": sprintf("azurerm_app_service[%s].site_config.http2_enabled", [name]),
+		"searchKey": sprintf("%s[%s].site_config.http2_enabled", [name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'azurerm_app_service[%s].site_config.http2_enabled' should be set to true", [name]),
-		"keyActualValue": sprintf("'azurerm_app_service[%s].site_config.http2_enabled' is set to false", [name]),
-		"searchLine": common_lib.build_search_line(["resource", "azurerm_app_service", name, "site_config", "http2_enabled"], []),
+		"keyExpectedValue": sprintf("'%s[%s].site_config.http2_enabled' should be set to true", [resources[m],name]),
+		"keyActualValue": sprintf("'%s[%s].site_config.http2_enabled' is set to false", [resources[m],name]),
+		"searchLine": common_lib.build_search_line(["resource", resources[m], name, "site_config", "http2_enabled"], []),
 		"remediation": json.marshal({
 			"before": "false",
 			"after": "true"

--- a/assets/queries/terraform/azure/app_service_http2_disabled/query.rego
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/query.rego
@@ -6,19 +6,19 @@ import data.generic.terraform as tf_lib
 resources := {"azurerm_app_service", "azurerm_linux_web_app", "azurerm_windows_web_app"}
 
 CxPolicy[result] {
-	app := input.document[i].resource[resources[m]][name]
+	app := input.document[i].resource.azurerm_app_service[name]
 
 	not common_lib.valid_key(app, "site_config")
 
 	result := {
 		"documentId": input.document[i].id,
-		"resourceType": resources[m],
+		"resourceType": "azurerm_app_service",
 		"resourceName": tf_lib.get_resource_name(app, name),
-		"searchKey": sprintf("%s[%s]", [resources[m], name]),
+		"searchKey": sprintf("azurerm_app_service[%s]", [name]),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'%s[%s].site_config' should be defined and not null", [resources[m],name]),
-		"keyActualValue": sprintf("'%s[%s].site_config' is undefined or null", [resources[m],name]),
-		"searchLine": common_lib.build_search_line(["resource", "%s", name], []),
+		"keyExpectedValue": sprintf("'azurerm_app_service[%s].site_config' should be defined and not null", [name]),
+		"keyActualValue": sprintf("'azurerm_app_service[%s].site_config' is undefined or null", [name]),
+		"searchLine": common_lib.build_search_line(["resource", "azurerm_app_service", name], []),
 		"remediation": "site_config {\n\t\thttp2_enabled = true\n\t}",
 		"remediationType": "addition",
 	}

--- a/assets/queries/terraform/azure/app_service_http2_disabled/query.rego
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/query.rego
@@ -6,7 +6,7 @@ import data.generic.terraform as tf_lib
 resources := {"azurerm_app_service", "azurerm_linux_web_app", "azurerm_windows_web_app"}
 
 CxPolicy[result] {
-	app := input.document[i].resource.azurerm_app_service[name]
+	app := input.document[i].resource[resources[m]][name]
 
 	not common_lib.valid_key(app, "site_config")
 

--- a/assets/queries/terraform/azure/app_service_http2_disabled/test/negative1.tf
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/test/negative1.tf
@@ -1,0 +1,23 @@
+resource "azurerm_app_service" "negative1" {
+  name                = "example-app-service"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  app_service_plan_id = azurerm_app_service_plan.example.id
+
+  app_settings = {
+    "SOME_KEY" = "some-value"
+  }
+
+  connection_string {
+    name  = "Database"
+    type  = "SQLServer"
+    value = "Server=some-server.mydomain.com;Integrated Security=SSPI"
+  }
+
+  site_config {
+    dotnet_framework_version = "v4.0"
+    scm_type                 = "LocalGit"
+    min_tls_version = 1.2
+    http2_enabled = true
+  }
+}

--- a/assets/queries/terraform/azure/app_service_http2_disabled/test/negative2.tf
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/test/negative2.tf
@@ -1,0 +1,10 @@
+resource "azurerm_linux_web_app" "negative2" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+
+  site_config {
+    http2_enabled = true
+  }
+}

--- a/assets/queries/terraform/azure/app_service_http2_disabled/test/negative3.tf
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/test/negative3.tf
@@ -1,0 +1,10 @@
+resource "azurerm_windows_web_app" "negative3" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+
+  site_config {
+    http2_enabled = true
+  }
+}

--- a/assets/queries/terraform/azure/app_service_http2_disabled/test/positive4.tf
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/test/positive4.tf
@@ -1,0 +1,12 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_linux_web_app" "positive4" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+
+  site_config {}
+}

--- a/assets/queries/terraform/azure/app_service_http2_disabled/test/positive5.tf
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/test/positive5.tf
@@ -1,0 +1,14 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_linux_web_app" "positive5" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+
+  site_config {
+    http2_enabled = false
+  }
+}

--- a/assets/queries/terraform/azure/app_service_http2_disabled/test/positive6.tf
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/test/positive6.tf
@@ -1,0 +1,10 @@
+resource "azurerm_windows_web_app" "positive6" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+
+  site_config {
+    http2_enabled = false
+  }
+}

--- a/assets/queries/terraform/azure/app_service_http2_disabled/test/positive7.tf
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/test/positive7.tf
@@ -1,0 +1,8 @@
+resource "azurerm_windows_web_app" "positive7" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_service_plan.example.location
+  service_plan_id     = azurerm_service_plan.example.id
+
+  site_config {}
+}

--- a/assets/queries/terraform/azure/app_service_http2_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/app_service_http2_disabled/test/positive_expected_result.json
@@ -16,5 +16,29 @@
     "severity": "MEDIUM",
     "line": 21,
     "fileName": "positive3.tf"
+  },
+  {
+    "queryName": "App Service HTTP2 Disabled",
+    "severity": "MEDIUM",
+    "line": 11,
+    "fileName": "positive4.tf"
+  },
+  {
+    "queryName": "App Service HTTP2 Disabled",
+    "severity": "MEDIUM",
+    "line": 12,
+    "fileName": "positive5.tf"
+  },
+  {
+    "queryName": "App Service HTTP2 Disabled",
+    "severity": "MEDIUM",
+    "line": 8,
+    "fileName": "positive6.tf"
+  },
+  {
+    "queryName": "App Service HTTP2 Disabled",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive7.tf"
   }
 ]


### PR DESCRIPTION
**Reason for Proposed Changes**
- The query `App Service HTTP2 Disabled` was not taking into consideration the resources `azure_rm_linux_web_app` and `azurerm_windows_web_app`, which should be given the necessary support besides the `azurerm_app_service`.

**Proposed Changes**
- After reading carefully the documentation of the resources `azurerm_linux_web_app`, `azure_windows_web_app` and `azurerm_app_service`, I came to a conclusion that the field's which are necessary to analyse regarding the scope of this query have, all of them, the same names and are defined inside the same fields (`http2_enabled` is aways inside a `site_config` block for all of them).
- For all policies, I only made small changes, in order to make the same verifications for the three types of resources through the `resources` variable present on top of this query, changing the first line of each policy to `app := input.document[i].resource[resources[m]][name]`. 
- On top of that I also, provided more four positive samples, two for each of the new resource's that are being analyzed on the query, one of them not having the `http2_enabled` field defined and the other one having the field defined to `false`.
- Also, added two more negative test each one of them having the `site_config.http2_enabled` field defined to `true` for the resources `azurerm_windows_web_app and azurerm_linux_web_app`.

I submit this contribution under the Apache-2.0 license.