### PR TITLE
fix(query): fix azure resource manager queries producing duplicate similarityIDs

### DIFF
--- a/assets/queries/azureResourceManager/storage_logging_for_read_write_delete_requests_disabled/query.rego
+++ b/assets/queries/azureResourceManager/storage_logging_for_read_write_delete_requests_disabled/query.rego
@@ -12,20 +12,20 @@ CxPolicy[result] {
 
 	#array containing data that will be used to help build the following objects
 	valSlice:= [x | x := {
-    	sprintf("%s", [value.properties.logs[n].category]): [value.properties.logs[n].enabled, n]
-        }]
+		sprintf("%s", [value.properties.logs[n].category]): [value.properties.logs[n].enabled, n]
+	}]
 
 	#object that maps category names to their respective enabled values
 	unionObject := {k: v |
 		some i, k
-    	v := valSlice[i][k][0]
-      }
+		v := valSlice[i][k][0]
+	}
 
 	#object that maps category names to their respective index values in the document
 	catIndexObject := {k: v |
 		some i, k
-    	v := valSlice[i][k][1]
-      }
+		v := valSlice[i][k][1]
+	}
 
 	issue := actual_issue(unionObject, catIndexObject, cats[l])
 
@@ -34,6 +34,7 @@ CxPolicy[result] {
 		"resourceType": value.type,
 		"resourceName": value.name,
 		"searchKey": sprintf("%s.name=%s.properties.logs.%s", [common_lib.concat_path(path), value.name, cats[l]]),
+		"searchValue": issue.sv,
 		"issueType": issue.type,
 		"keyExpectedValue": issue.expected_value,
 		"keyActualValue": issue.actual_value,
@@ -44,17 +45,19 @@ CxPolicy[result] {
 actual_issue(obj, catIndexObject, key) = issue {
 	not common_lib.valid_key(obj, key)
 	issue := {
-    	"expected_value": sprintf("'Storage Logging' in 'diagnosticsettings' needs '%s' method", [key]),
-        "actual_value": sprintf("'Storage Logging' in 'diagnosticsettings' doesn't have a '%s' method", [key]),
-        "type": "MissingAttribute",
-        "sl": ["properties", "logs"]
-      }
+		"expected_value": sprintf("'Storage Logging' in 'diagnosticsettings' needs '%s' method", [key]),
+		"actual_value": sprintf("'Storage Logging' in 'diagnosticsettings' doesn't have a '%s' method", [key]),
+		"type": "MissingAttribute",
+		"sl": ["properties", "logs"],
+		"sv": key,
+	}
 } else = issue {
 	obj[key] == false
 	issue := {
-    	"expected_value": sprintf("Storage Logging in 'diagnosticsettings' should be enabled for '%s' method", [replace(key, "Storage", "")]),
-    	"actual_value": sprintf("Storage Logging in 'diagnosticsettings' is disabled for '%s' method", [replace(key, "Storage", "")]),
-    	"type": "IncorrectValue",
-        "sl": ["properties", "logs", catIndexObject[key], "enabled"]
-    }
+		"expected_value": sprintf("Storage Logging in 'diagnosticsettings' should be enabled for '%s' method", [replace(key, "Storage", "")]),
+		"actual_value": sprintf("Storage Logging in 'diagnosticsettings' is disabled for '%s' method", [replace(key, "Storage", "")]),
+		"type": "IncorrectValue",
+		"sl": ["properties", "logs", catIndexObject[key], "enabled"],
+		"sv": "",
+	}
 }

--- a/assets/queries/azureResourceManager/website_with_http20enabled_disabled/query.rego
+++ b/assets/queries/azureResourceManager/website_with_http20enabled_disabled/query.rego
@@ -37,7 +37,7 @@ CxPolicy[result] {
 		"issueType": "MissingAttribute",
 		"keyExpectedValue": "resource with type 'Microsoft.Web/sites' should have the 'http20Enabled' property defined in siteConfig",
 		"keyActualValue": "resource with type 'Microsoft.Web/sites' doesn't have 'http20Enabled' property defined in siteConfig",
-		"searchLine": common_lib.build_search_line(path, ["properties"]),
+		"searchLine": common_lib.build_search_line(path, ["properties", "siteConfig"]),
 	}
 }
 
@@ -58,6 +58,6 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("resource with type 'Microsoft.Web/sites' should have the 'http20Enabled' %s set to true in siteConfig", [val_type]),
 		"keyActualValue": "resource with type 'Microsoft.Web/sites' doesn't have 'http20Enabled' set to true in siteConfig",
-		"searchLine": common_lib.build_search_line(path, ["properties"]),
+		"searchLine": common_lib.build_search_line(path, ["properties", "siteConfig", "http20Enabled"]),
 	}
 }

--- a/assets/queries/azureResourceManager/website_with_http20enabled_disabled/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/website_with_http20enabled_disabled/test/positive_expected_result.json
@@ -8,13 +8,13 @@
   {
     "queryName": "Website with 'Http20Enabled' Disabled",
     "severity": "LOW",
-    "line": 15,
+    "line": 19,
     "fileName": "positive2.json"
   },
   {
     "queryName": "Website with 'Http20Enabled' Disabled",
     "severity": "LOW",
-    "line": 15,
+    "line": 18,
     "fileName": "positive3.json"
   },
   {
@@ -26,13 +26,13 @@
   {
     "queryName": "Website with 'Http20Enabled' Disabled",
     "severity": "LOW",
-    "line": 17,
+    "line": 21,
     "fileName": "positive5.json"
   },
   {
     "queryName": "Website with 'Http20Enabled' Disabled",
     "severity": "LOW",
-    "line": 17,
+    "line": 20,
     "fileName": "positive6.json"
   },
   {
@@ -44,13 +44,13 @@
   {
     "queryName": "Website with 'Http20Enabled' Disabled",
     "severity": "LOW",
-    "line": 5,
+    "line": 9,
     "fileName": "positive2.bicep"
   },
   {
     "queryName": "Website with 'Http20Enabled' Disabled",
     "severity": "LOW",
-    "line": 5,
+    "line": 8,
     "fileName": "positive3.bicep"
   },
   {
@@ -62,13 +62,13 @@
   {
     "queryName": "Website with 'Http20Enabled' Disabled",
     "severity": "LOW",
-    "line": 5,
+    "line": 9,
     "fileName": "positive5.bicep"
   },
   {
     "queryName": "Website with 'Http20Enabled' Disabled",
     "severity": "LOW",
-    "line": 5,
+    "line": 8,
     "fileName": "positive6.bicep"
   }
 ]

--- a/test/queries_content_test.go
+++ b/test/queries_content_test.go
@@ -44,22 +44,6 @@ var (
 		"resourceName",
 	}
 
-	searchValueAllowedQueriesPath = []string{
-		"../assets/queries/ansible/azure/sensitive_port_is_exposed_to_entire_network",
-		"../assets/queries/cloudFormation/aws/ec2_sensitive_port_is_publicly_exposed",
-		"../assets/queries/cloudFormation/aws/elb_sensitive_port_is_exposed_to_entire_network",
-		"../assets/queries/terraform/aws/sensitive_port_is_exposed_to_entire_network",
-		"../assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network",
-		"../assets/queries/terraform/azure/sensitive_port_is_exposed_to_entire_network",
-		"../assets/queries/terraform/azure/sensitive_port_is_exposed_to_small_public_network",
-		"../assets/queries/dockerfile/apt_get_install_pin_version_not_defined",
-		"../assets/queries/terraform/aws/redshift_cluster_without_vpc",
-		"../assets/queries/openAPI/general/response_code_missing",
-		"../assets/queries/cicd/github/run_block_injection",
-		"../assets/queries/cicd/github/script_block_injection",
-		"../assets/queries/azureResourceManager/key_vault_not_recoverable",
-	}
-
 	// TODO uncomment this test once all metadata are fixed
 	availablePlatforms = initPlatforms()
 	platformKeys       = MapToStringSlice(availablePlatforms)
@@ -221,22 +205,6 @@ func testQueryHasGoodReturnParams(t *testing.T, entry queryEntry) { //nolint
 					"query '%s' doesn't include parameter '%s' in response",
 					path.Base(entry.dir),
 					requiredProperty,
-				))
-			}
-
-			if sliceContains(searchValueAllowedQueriesPath, filepath.ToSlash(entry.dir)) {
-				_, ok := m[searchValueProperty]
-				require.True(t, ok, fmt.Sprintf(
-					"query '%s' doesn't include parameter '%s' in response",
-					path.Base(entry.dir),
-					searchValueProperty,
-				))
-			} else {
-				_, ok := m[searchValueProperty]
-				require.False(t, ok, fmt.Sprintf(
-					"query '%s' should not include parameter '%s' in response",
-					path.Base(entry.dir),
-					searchValueProperty,
 				))
 			}
 


### PR DESCRIPTION
**Reason for Proposed Changes**
- Some Azure Resource Manager queries were producing the same `similarityID` despite representing different issues.
- Several queries were missing `searchLine`, making it harder to precisely locate vulnerabilities.

**Proposed Changes**
- Updated multiple Azure Resource Manager queries by adding or modifying `searchValue`, and/or `searchLine` to ensure each detected vulnerability generates a unique `similarityID`.
- Removed the test restriction that only certain queries could use `searchValue`, allowing support for these new cases.
- The updated queries include:
  - Storage Logging For Read Write And Delete Requests Disabled: Added Search Value.
  - Website with 'Http20Enabled' Disabled: Modified Search Line

I submit this contribution under the Apache-2.0 license.