### PR TITLE
feat(query): implementation of DAX_Cluster_Not_Encrypted for CloudFormation/aws

### DIFF
--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/metadata.json
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/metadata.json
@@ -1,0 +1,12 @@
+{
+  "id": "e5849a68-bdbe-4b70-97c6-6901f39f8094",
+  "queryName": "DAX Cluster Not Encrypted",
+  "severity": "HIGH",
+  "category": "Encryption",
+  "descriptionText": "AWS DAX Cluster should have server-side encryption at rest",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-dax-cluster.html",
+  "platform": "CloudFormation",
+  "descriptionID": "e5849a68",
+  "cloudProvider": "aws",
+  "cwe": "311"
+}

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/query.rego
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/query.rego
@@ -1,0 +1,68 @@
+package Cx
+
+import data.generic.cloudformation as cf_lib
+import data.generic.common as common_lib
+
+CxPolicy[result] {
+    # case of SSEEnabled set to false
+	docs := input.document[i]
+	[path, Resources] := walk(docs)
+	resource := Resources[name]
+	resource.Type == "AWS::DAX::Cluster"
+    common_lib.valid_key(resource.Properties,"SSESpecification")
+    common_lib.valid_key(resource.Properties.SSESpecification,"SSEEnabled")
+    cf_lib.isCloudFormationFalse(resource.Properties.SSESpecification.SSEEnabled)
+    
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resource.Type,
+		"resourceName": cf_lib.get_resource_name(resource, name),
+		"searchKey": sprintf("%s%s.Properties.SSESpecification.SSEEnabled", [cf_lib.getPath(path), name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.SSESpecification.SSEEnabled' should be set to true.", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.SSESpecification.SSEEnabled' is set to false.", [name]),
+	}
+}
+
+CxPolicy[result] {
+    # case of no SSEEnabled defined
+	docs := input.document[i]
+	[path, Resources] := walk(docs)
+	resource := Resources[name]
+	resource.Type == "AWS::DAX::Cluster"
+    common_lib.valid_key(resource.Properties,"SSESpecification")
+    not common_lib.valid_key(resource.Properties.SSESpecification,"SSEEnabled")
+    
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resource.Type,
+		"resourceName": cf_lib.get_resource_name(resource, name),
+		"searchKey": sprintf("%s%s.Properties.SSESpecification", [cf_lib.getPath(path), name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.SSESpecification' should have SSEEnabled declared and set to true.", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.SSESpecification' does not declare SSEEnabled.", [name]),
+	}
+}
+
+CxPolicy[result] {
+    # case of no SSESpecification defined
+	docs := input.document[i]
+	[path, Resources] := walk(docs)
+	resource := Resources[name]
+	resource.Type == "AWS::DAX::Cluster"
+    not common_lib.valid_key(resource.Properties,"SSESpecification")
+    
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resource.Type,
+		"resourceName": cf_lib.get_resource_name(resource, name),
+		"searchKey": sprintf("%s%s.Properties", [cf_lib.getPath(path), name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'Resources.%s.Properties' should have SSESpecification declared.", [name]),
+		"keyActualValue": sprintf("'Resources.%s.Properties' does not declare SSESpecification.", [name]),
+	}
+}
+

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/negative1.yaml
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/negative1.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Create a DAX cluster"
+Resources:
+  daxCluster:
+    Type: AWS::DAX::Cluster
+    Properties:
+      SSESpecification:
+        SSEEnabled: true
+      ClusterName: "MyDAXCluster"
+      NodeType: "dax.r3.large"
+      ReplicationFactor: 1
+      IAMRoleARN: "arn:aws:iam::111122223333:role/DaxAccess"
+      Description: "DAX cluster created with CloudFormation"
+          

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/negative2.yaml
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/negative2.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Create a DAX cluster"
+Resources:
+  daxCluster:
+    Type: AWS::DAX::Cluster
+    Properties:
+      SSESpecification:
+        SSEEnabled: "true"
+      ClusterName: "MyDAXCluster"
+      NodeType: "dax.r3.large"
+      ReplicationFactor: 1
+      IAMRoleARN: "arn:aws:iam::111122223333:role/DaxAccess"
+      Description: "DAX cluster created with CloudFormation"
+      

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/negative3.json
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/negative3.json
@@ -1,0 +1,19 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Create a DAX cluster",
+  "Resources": {
+    "daxCluster": {
+      "Type": "AWS::DAX::Cluster",
+      "Properties": {
+        "SSESpecification": {
+          "SSEEnabled": true
+        },
+        "ClusterName": "MyDAXCluster",
+        "NodeType": "dax.r3.large",
+        "ReplicationFactor": 1,
+        "IAMRoleARN": "arn:aws:iam::111122223333:role/DaxAccess",
+        "Description": "DAX cluster created with CloudFormation"
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/negative4.json
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/negative4.json
@@ -1,0 +1,19 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Create a DAX cluster",
+  "Resources": {
+    "daxCluster": {
+      "Type": "AWS::DAX::Cluster",
+      "Properties": {
+        "SSESpecification": {
+          "SSEEnabled": "true"
+        },
+        "ClusterName": "MyDAXCluster",
+        "NodeType": "dax.r3.large",
+        "ReplicationFactor": 1,
+        "IAMRoleARN": "arn:aws:iam::111122223333:role/DaxAccess",
+        "Description": "DAX cluster created with CloudFormation"
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive1.yaml
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive1.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Create a DAX cluster"
+Resources:
+  daxCluster:
+    Type: AWS::DAX::Cluster
+    Properties:
+      SSESpecification:
+        SSEEnabled: false
+      ClusterName: "MyDAXCluster"
+      NodeType: "dax.r3.large"
+      ReplicationFactor: 1
+      IAMRoleARN: "arn:aws:iam::111122223333:role/DaxAccess"
+      Description: "DAX cluster created with CloudFormation"
+      

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive2.yaml
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive2.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Create a DAX cluster"
+Resources:
+  daxCluster:
+    Type: AWS::DAX::Cluster
+    Properties:
+      SSESpecification:
+        SSEEnabled: "false"
+      ClusterName: "MyDAXCluster"
+      NodeType: "dax.r3.large"
+      ReplicationFactor: 1
+      IAMRoleARN: "arn:aws:iam::111122223333:role/DaxAccess"
+      Description: "DAX cluster created with CloudFormation"
+      

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive3.yaml
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive3.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Create a DAX cluster"
+Resources:
+  daxCluster:
+    Type: AWS::DAX::Cluster
+    Properties:
+      SSESpecification: "no_SSEEnabled"
+      ClusterName: "MyDAXCluster"
+      NodeType: "dax.r3.large"
+      ReplicationFactor: 1
+      IAMRoleARN: "arn:aws:iam::111122223333:role/DaxAccess"
+      Description: "DAX cluster created with CloudFormation"
+      

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive4.yaml
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive4.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "Create a DAX cluster"
+Resources:
+  daxCluster:
+    Type: AWS::DAX::Cluster
+    Properties:
+      ClusterName: "MyDAXCluster"
+      NodeType: "dax.r3.large"
+      ReplicationFactor: 1
+      IAMRoleARN: "arn:aws:iam::111122223333:role/DaxAccess"
+      Description: "DAX cluster created with CloudFormation"
+      

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive5.json
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive5.json
@@ -1,0 +1,19 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Create a DAX cluster",
+  "Resources": {
+    "daxCluster": {
+      "Type": "AWS::DAX::Cluster",
+      "Properties": {
+        "SSESpecification": {
+          "SSEEnabled": false
+        },
+        "ClusterName": "MyDAXCluster",
+        "NodeType": "dax.r3.large",
+        "ReplicationFactor": 1,
+        "IAMRoleARN": "arn:aws:iam::111122223333:role/DaxAccess",
+        "Description": "DAX cluster created with CloudFormation"
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive6.json
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive6.json
@@ -1,0 +1,19 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Create a DAX cluster",
+  "Resources": {
+    "daxCluster": {
+      "Type": "AWS::DAX::Cluster",
+      "Properties": {
+        "SSESpecification": {
+          "SSEEnabled": "false"
+        },
+        "ClusterName": "MyDAXCluster",
+        "NodeType": "dax.r3.large",
+        "ReplicationFactor": 1,
+        "IAMRoleARN": "arn:aws:iam::111122223333:role/DaxAccess",
+        "Description": "DAX cluster created with CloudFormation"
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive7.json
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive7.json
@@ -1,0 +1,17 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Create a DAX cluster",
+  "Resources": {
+    "daxCluster": {
+      "Type": "AWS::DAX::Cluster",
+      "Properties": {
+        "SSESpecification": {},
+        "ClusterName": "MyDAXCluster",
+        "NodeType": "dax.r3.large",
+        "ReplicationFactor": 1,
+        "IAMRoleARN": "arn:aws:iam::111122223333:role/DaxAccess",
+        "Description": "DAX cluster created with CloudFormation"
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive8.json
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive8.json
@@ -1,0 +1,16 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Create a DAX cluster",
+  "Resources": {
+    "daxCluster": {
+      "Type": "AWS::DAX::Cluster",
+      "Properties": {
+        "ClusterName": "MyDAXCluster",
+        "NodeType": "dax.r3.large",
+        "ReplicationFactor": 1,
+        "IAMRoleARN": "arn:aws:iam::111122223333:role/DaxAccess",
+        "Description": "DAX cluster created with CloudFormation"
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive_expected_results.json
+++ b/assets/queries/cloudFormation/aws/dax_cluster_not_encrypted/test/positive_expected_results.json
@@ -1,0 +1,50 @@
+[
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 8,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 8,
+    "fileName": "positive2.yaml"
+  },
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 7,
+    "fileName": "positive3.yaml"
+  },
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 6,
+    "fileName": "positive4.yaml"
+  },
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 9,
+    "fileName": "positive5.json"
+  },
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 9,
+    "fileName": "positive6.json"
+  },
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 8,
+    "fileName": "positive7.json"
+  },
+  {
+    "queryName": "DAX Cluster Not Encrypted",
+    "severity": "HIGH",
+    "line": 7,
+    "fileName": "positive8.json"
+  }
+]


### PR DESCRIPTION
**Reason for Proposed Changes**
- This query flags samples where a [```AWS::DAX::Cluster```](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-dax-cluster.html) type resource does not have [SSE](https://www.paloaltonetworks.com/cyberpedia/what-is-security-service-edge-sse) enabled. (```SSEEnabled``` field set to true)
- It serves an identical purpose to the [Terraform equivalent query](https://docs.kics.io/latest/queries/terraform-queries/aws/f11aec39-858f-4b6f-b946-0a1bf46c0c87/).

**Proposed Changes**
- First i implemented a check for the ```resource.Properties.SSESpecification.SSEEnabled``` to ensure it is not set to false.
- Through the documentation for the [AWS::DAX::Cluster](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-dax-cluster.html#cfn-dax-cluster-ssespecification) and [SSESpecification](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-dax-cluster-ssespecification.html#cfn-dax-cluster-ssespecification-sseenabled) i realised that both the ```SSESpecification``` and ```SSEEnabled``` are optional fields; given this i added case handling for missing either one of these fields.
- For the tests, positive1/2 and positive5/6 represent the most simple ```SSEEnabled``` set to false scenario, in JSON and YAML formats for false/"false" values. 
- The rest of the positive tests are missing either the ```SSESpecification``` or ```SSEEnabled``` field and flag accordingly. 

I submit this contribution under the Apache-2.0 license.