### PR TITLE
fix(query): FN for S3 Bucket Allows Public Policy

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/metadata.json
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/metadata.json
@@ -1,9 +1,9 @@
 {
   "id": "1a4bc881-9f69-4d44-8c9a-d37d08f54c50",
   "queryName": "S3 Bucket Allows Public Policy",
-  "severity": "HIGH",
+  "severity": "MEDIUM",
   "category": "Access Control",
-  "descriptionText": "S3 bucket allows public policy",
+  "descriptionText": "Checks whether the block_public_policy configuration is set - wether explicitly or implicitly - to a unsafe value at the account level('aws_s3_account_public_access_block') o bucket level ('aws_s3_bucket_public_access_block'). The 'block_public_policy' acts as a defense-in-depth mechanism to prevent the application of S3 bucket policies that allow public access. If disabled, even unintentionally, it opens the possibility for buckets to become publicly accessible through policy misconfiguration. This increases the risk of accidental data exposure and weakens the organization’s cloud security posture.",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block",
   "platform": "Terraform",
   "descriptionID": "a8924b3b",

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/query.rego
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/query.rego
@@ -3,31 +3,90 @@ package Cx
 import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
 
-# checks if aws_s3_account_public_access_block and aws_s3_bucket_public_access_block resources exist
-# checks if block_public_policy is set to false on bucket-level and account-level is set to false or missing
-CxPolicy[result] {
-	pubACL := input.document[i].resource.aws_s3_account_public_access_block[account_name]
-    pubBucket := input.document[_].resource.aws_s3_bucket_public_access_block[bucket_name]
+CxPolicy[result] { # checks account-level configurations
+	pubACL := input.document[i].resource.aws_s3_account_public_access_block[name]
 
-    is_false_or_missing(pubACL,pubBucket)
+	res := prepare_issue_account(pubACL, name)
 
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": "aws_s3_account_public_access_block",
-		"resourceName": tf_lib.get_resource_name(pubACL, account_name),
-		"searchKey": sprintf("aws_s3_account_public_access_block[%s].block_public_policy", [account_name]),
-		"issueType": "IncorrectValue",
-		"keyExpectedValue": "'block_public_policy' should be set to 'true' at both account and bucket level",
-		"keyActualValue": "'block_public_policy' is missing or equal to 'false' at both account and bucket level",
-		"searchLine": common_lib.build_search_line(["resource", "aws_s3_account_public_access_block", account_name, "block_public_policy"], []),
+		"resourceName": tf_lib.get_resource_name(pubACL, name),
+		"searchKey": res["sk"],
+		"issueType": res["it"],
+		"keyExpectedValue": res["kev"],
+		"keyActualValue": res["kav"],
+		"searchLine": res["sl"],
 	}
 }
 
-is_false_or_missing(pubACL, pubBucket) {
-    is_false_or_undefined(pubACL, "block_public_policy")
-    is_false_or_undefined(pubBucket, "block_public_policy")
+CxPolicy[result] { # checks bucket-level-configurations
+	resources := input.document[i].resource
+	pubBucket := resources.aws_s3_bucket_public_access_block[name]
+	
+	not is_block_public_policy_defined_to_true_at_account_level(resources)
+
+	res := prepare_issue_bucket(pubBucket, name)	
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "aws_s3_bucket_public_access_block",
+		"resourceName": tf_lib.get_resource_name(pubBucket, name),
+		"searchKey": res["sk"],
+		"issueType": res["it"],
+		"keyExpectedValue": res["kev"],
+		"keyActualValue": res["kav"],
+		"searchLine": res["sl"],
+	}
 }
 
-is_false_or_undefined(obj, key) {
-    not obj[key]
+is_block_public_policy_defined_to_true_at_account_level(resources) {
+	common_lib.valid_key(resources, "aws_s3_account_public_access_block")
+	resources.aws_s3_account_public_access_block[_].block_public_policy == true
+}
+
+prepare_issue_account(pubACL, name) = res {
+	common_lib.valid_key(pubACL, "block_public_policy")
+	not pubACL.block_public_policy == true
+
+	res := {
+		"sk": sprintf("aws_s3_account_public_access_block[%s].block_public_policy", [name]),
+		"it": "IncorrectValue",
+		"kev": sprintf("'aws_s3_account_public_access_block[%s].block_public_policy' should be defined to 'true'", [name]),
+		"kav": sprintf("'aws_s3_account_public_access_block[%s].block_public_policy' is not defined to 'true'", [name]),
+		"sl": common_lib.build_search_line(["resource", "aws_s3_account_public_access_block", name, "block_public_policy"], []),
+	}
+} else = res {
+	not common_lib.valid_key(pubACL, "block_public_policy")
+
+	res := {
+		"sk": sprintf("aws_s3_account_public_access_block[%s]", [name]),
+		"it": "MissingAttribute",
+		"kev": sprintf("'aws_s3_account_public_access_block[%s]' should have the 'block_public_policy' field set to 'true'", [name]),
+		"kav": sprintf("'aws_s3_account_public_access_block[%s]' does not have the 'block_public_policy' defined (defaults to 'false')", [name]),
+		"sl": common_lib.build_search_line(["resource", "aws_s3_account_public_access_block", name], []),
+	}
+}
+
+prepare_issue_bucket(pubBucket, name) = res {
+	common_lib.valid_key(pubBucket, "block_public_policy")
+	not pubBucket.block_public_policy == true
+
+	res := {
+		"sk": sprintf("aws_s3_bucket_public_access_block[%s].block_public_policy", [name]),
+		"it": "IncorrectValue",
+		"kev": sprintf("'aws_s3_bucket_public_access_block[%s].block_public_policy' should be defined to 'true'", [name]),
+		"kav": sprintf("'aws_s3_bucket_public_access_block[%s].block_public_policy' is not defined to 'true'", [name]),
+		"sl": common_lib.build_search_line(["resource", "aws_s3_bucket_public_access_block", name, "block_public_policy"], []),
+	}
+} else = res {
+	not common_lib.valid_key(pubBucket, "block_public_policy")
+
+	res := {
+		"sk": sprintf("aws_s3_bucket_public_access_block[%s]", [name]),
+		"it": "MissingAttribute",
+		"kev": sprintf("'aws_s3_bucket_public_access_block[%s]' should have the 'block_public_policy' field set to 'true'", [name]),
+		"kav": sprintf("'aws_s3_bucket_public_access_block[%s]' does not have the 'block_public_policy' defined (defaults to 'false')", [name]),
+		"sl": common_lib.build_search_line(["resource", "aws_s3_bucket_public_access_block", name], []),
+	}
 }

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/negative2.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/negative2.tf
@@ -1,9 +1,3 @@
-// `aws_s3_account_public_access_block` is NOT defined
-// bucket resource is defined and sets `block_public_policy` to `false`
-resource "aws_s3_bucket_public_access_block" "allow_public" {
-  bucket = aws_s3_bucket.public_bucket.id
-  block_public_acls   = false
-  block_public_policy = false
-  ignore_public_acls  = false
-  restrict_public_buckets = false
+resource "aws_s3_bucket" "public_bucket" {
+  bucket = "test-bucket-public-policy"
 }

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive3.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive3.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_account_public_access_block" "allow_public_acc" {
+  // insecure - account resource block is defined, block_public_access is not set 
+}
+
+resource "aws_s3_bucket" "public_bucket" {
+  bucket = "test-bucket-public-policy"
+}
+
+resource "aws_s3_bucket_public_access_block" "allow_public" {
+  bucket                  = aws_s3_bucket.public_bucket.id
+  /* insecure - bucket resource block is defined, block_public_access is not set */
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive4.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive4.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_account_public_access_block" "allow_public_acc" {
+  block_public_policy = false /* insecure - explicitly unsafe value */
+}
+
+resource "aws_s3_bucket" "public_bucket" {
+  bucket = "test-bucket-public-policy"
+}
+
+resource "aws_s3_bucket_public_access_block" "allow_public" {
+  bucket                  = aws_s3_bucket.public_bucket.id
+  /* insecure - bucket resource block is defined, block_public_access is not set */
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive5.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive5.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_account_public_access_block" "allow_public_acc" {
+  // insecure - account resource block is defined, block_public_access is not set 
+}
+
+resource "aws_s3_bucket" "public_bucket" {
+  bucket = "test-bucket-public-policy"
+}
+
+resource "aws_s3_bucket_public_access_block" "allow_public" {
+  bucket              = aws_s3_bucket.public_bucket.id
+  block_public_policy = false /* insecure - explicitly unsafe value */
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive6.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive6.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket" "public_bucket" {
+  bucket = "test-bucket-public-policy"
+}
+
+resource "aws_s3_bucket_public_access_block" "allow_public" {
+  bucket                  = aws_s3_bucket.public_bucket.id
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive7.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive7.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "public_bucket" {
+  bucket = "test-bucket-public-policy"
+}
+
+resource "aws_s3_bucket_public_access_block" "allow_public" {
+  bucket                  = aws_s3_bucket.public_bucket.id
+  block_public_policy     = false
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive8.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive8.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_account_public_access_block" "allow_public_acc" {
+  block_public_policy = false /* insecure - explicitly unsafe value */
+}
+
+resource "aws_s3_bucket" "public_bucket" {
+  bucket = "test-bucket-public-policy"
+}
+
+resource "aws_s3_bucket_public_access_block" "allow_public" {
+  bucket              = aws_s3_bucket.public_bucket.id
+  block_public_policy = false /* insecure - explicitly unsafe value */
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive9.tf
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive9.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_account_public_access_block" "allow_public_acc" {
+  block_public_policy = false /* insecure - explicitly unsafe value */
+}

--- a/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_with_public_policy/test/positive_expected_result.json
@@ -1,14 +1,92 @@
 [
   {
     "queryName": "S3 Bucket Allows Public Policy",
-    "severity": "HIGH",
+    "severity": "MEDIUM",
+    "line": 3,
+    "filename": "positive1.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
     "line": 11,
     "filename": "positive1.tf"
   },
   {
     "queryName": "S3 Bucket Allows Public Policy",
-    "severity": "HIGH",
+    "severity": "MEDIUM",
     "line": 5,
     "filename": "positive2.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive2.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 1,
+    "filename": "positive3.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 9,
+    "filename": "positive3.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 2,
+    "filename": "positive4.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 9,
+    "filename": "positive4.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 1,
+    "filename": "positive5.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 11,
+    "filename": "positive5.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 5,
+    "filename": "positive6.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 7,
+    "filename": "positive7.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 2,
+    "filename": "positive8.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 11,
+    "filename": "positive8.tf"
+  },
+  {
+    "queryName": "S3 Bucket Allows Public Policy",
+    "severity": "MEDIUM",
+    "line": 2,
+    "filename": "positive9.tf"
   }
 ]


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- A different approach to this query was requested, in order to flag any insecure value at bucket and account levels.
- It was also asked to change the query severity to Medium.

**Proposed Changes**
- In this bug , I changed the query deeply in order to fulfill all the query logic required. 
- In this query, I made two policies, the first one checks the account-level configurations and the second one checks the bucket level configurations.
- For each one of the policies I used different helper functions, in order to make it easier to understand the code and to have a clear separation between the bucket and the account level.
- For each one of this helper functions, I handled the same cases for the two levels. In each one, first of all, I checked the cases when the field `block_public_policy` is defined but not defined to `true` and also to the cases when the field is not defined at all (is a vulnerability because the default value is `false`).
- On the two policies I used the value returned on the `res` variable to deliver the response.
- The only diference is on the second policy, that as a extra verification (`not is_block_public_policy_defined_to_true_at_account_level(resources)`) that only checks if there is a resource `aws_s3_account_public_access_block` defined explicitly to `true` in which case, according to the information provided on the research linked to the bug's card on Jira, should not return a positive result even when, at the bucket level, the field `aws_s3_bucket_public_access_block.block_public_policy` is not defined to `true` explicitly.
- One more difference it that now, if the sample has insecure configurations at the account-level and at the bucket-level it return's a vulnerability for both.
- I added all the positive samples provided on the research page and the negative sample that is also provided.
- Changed the file `negative2.tf` file in order to have a correct negative result as it should, because with the new implementation it would detect a vulnerability.
- Reduced the severity from `High` to `Medium` as it was asked to do.
- Changed the query description with the text provided on the research.


I submit this contribution under the Apache-2.0 license.