### PR TITLE
fix(query): fix dockerfile queries producing duplicate similarityIDs

### DIFF
--- a/assets/queries/dockerfile/missing_flag_from_dnf_install/query.rego
+++ b/assets/queries/dockerfile/missing_flag_from_dnf_install/query.rego
@@ -1,13 +1,13 @@
 package Cx
 
 import data.generic.common as common_lib
-import data.generic.dockerfile as dockerLib
+import data.generic.dockerfile as docker_lib
 
 CxPolicy[result] {
 	resource := input.document[i].command[name][cmd]
 	resource.Cmd == "run"
 	values := resource.Value[0]
-	commands = dockerLib.getCommands(values)
+	commands = docker_lib.getCommands(values)
 
 	some k
 	c := hasInstallCommandWithoutFlag(commands[k])

--- a/assets/queries/dockerfile/missing_flag_from_dnf_install/query.rego
+++ b/assets/queries/dockerfile/missing_flag_from_dnf_install/query.rego
@@ -1,9 +1,10 @@
 package Cx
 
+import data.generic.common as common_lib
 import data.generic.dockerfile as dockerLib
 
 CxPolicy[result] {
-	resource := input.document[i].command[name][_]
+	resource := input.document[i].command[name][cmd]
 	resource.Cmd == "run"
 	values := resource.Value[0]
 	commands = dockerLib.getCommands(values)
@@ -16,9 +17,11 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.RUN={{%s}}", [name, resource.Value[0]]),
+		"searchValue": trim_space(c),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "When running `dnf install`, `-y` or `--assumeyes` switch should be set to avoid build failure ",
 		"keyActualValue": sprintf("Command `RUN={{%s}}` doesn't have the `-y` or `--assumeyes` switch set", [trim_space(commands[k])]),
+		"searchLine": common_lib.build_search_line(["command", name, cmd], []),
 	}
 }
 

--- a/assets/queries/dockerfile/unpinned_package_version_in_apk_add/query.rego
+++ b/assets/queries/dockerfile/unpinned_package_version_in_apk_add/query.rego
@@ -1,9 +1,10 @@
 package Cx
 
-import data.generic.dockerfile as dockerLib
+import data.generic.common as common_lib
+import data.generic.dockerfile as docker_lib
 
 CxPolicy[result] {
-	resource := input.document[i].command[name][_]
+	resource := input.document[i].command[name][cmd]
 	resource.Cmd == "run"
 
 	count(resource.Value) == 1
@@ -14,7 +15,7 @@ CxPolicy[result] {
 	apk := regex.find_n("apk (-(-)?[a-zA-Z]+ *)*add", commands_trim, -1)
 	apk != null
 
-	packages = dockerLib.getPackages(commands_trim, apk)
+	packages = docker_lib.getPackages(commands_trim, apk)
 
 	length := count(packages)
 
@@ -27,11 +28,12 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "RUN instruction with 'apk add <package>' should use package pinning form 'apk add <package>=<version>'",
 		"keyActualValue": sprintf("RUN instruction %s does not use package pinning form", [resource.Value[0]]),
+		"searchLine": common_lib.build_search_line(["command", name, cmd], []),
 	}
 }
 
 CxPolicy[result] {
-	resource := input.document[i].command[name][_]
+	resource := input.document[i].command[name][cmd]
 	resource.Cmd == "run"
 
 	count(resource.Value) == 1
@@ -42,7 +44,7 @@ CxPolicy[result] {
 	apk := regex.find_n("apk (-(-)?[a-zA-Z]+ *)*add", commands_trim, -1)
 	apk != null
 
-	packages = dockerLib.getPackages(commands_trim, apk)
+	packages = docker_lib.getPackages(commands_trim, apk)
 
 	length := count(packages)
 
@@ -55,11 +57,12 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "RUN instruction with 'apk add <package>' should use package pinning form 'apk add <package>=<version>'",
 		"keyActualValue": sprintf("RUN instruction %s does not use package pinning form", [resource.Value[0]]),
+		"searchLine": common_lib.build_search_line(["command", name, cmd], []),
 	}
 }
 
 CxPolicy[result] {
-	resource := input.document[i].command[name][_]
+	resource := input.document[i].command[name][cmd]
 	resource.Cmd == "run"
 
 	count(resource.Value) == 1
@@ -69,7 +72,7 @@ CxPolicy[result] {
 	apk := regex.find_n("apk (-(-)?[a-zA-Z]+ *)*add", commands, -1)
 	apk != null
 
-	packages = dockerLib.getPackages(commands, apk)
+	packages = docker_lib.getPackages(commands, apk)
 
 	length := count(packages)
 
@@ -82,41 +85,44 @@ CxPolicy[result] {
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "RUN instruction with 'apk add <package>' should use package pinning form 'apk add <package>=<version>'",
 		"keyActualValue": sprintf("RUN instruction %s does not use package pinning form", [resource.Value[0]]),
+		"searchLine": common_lib.build_search_line(["command", name, cmd], []),
 	}
 }
 
 CxPolicy[result] {
-	resource := input.document[i].command[name][_]
+	resource := input.document[i].command[name][cmd]
 	resource.Cmd == "run"
 
-	count(resource.Value) > 1 
+	count(resource.Value) > 1
 
-    dockerLib.arrayContains(resource.Value, {"apk", "add"})
+	docker_lib.arrayContains(resource.Value, {"apk", "add"})
 
 	resource.Value[j] != "apk"
 	resource.Value[j] != "add"
 
-	regex.match("^[a-zA-Z]", resource.Value[j]) == true
-	not dockerLib.withVersion(resource.Value[j])
+	regex.match("^[a-zA-Z]", resource.Value[j])
+	not docker_lib.withVersion(resource.Value[j])
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"searchValue": resource.Value[j],
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "RUN instruction with 'apk add <package>' should use package pinning form 'apk add <package>=<version>'",
 		"keyActualValue": sprintf("RUN instruction %s does not use package pinning form", [resource.Value[j]]),
+		"searchLine": common_lib.build_search_line(["command", name, cmd], []),
 	}
 }
 
 analyzePackages(j, currentPackage, packages, length) {
 	j == length - 1
-	regex.match("^[a-zA-Z]", currentPackage) == true
-	not dockerLib.withVersion(currentPackage)
+	regex.match("^[a-zA-Z]", currentPackage)
+	not docker_lib.withVersion(currentPackage)
 }
 
 analyzePackages(j, currentPackage, packages, length) {
 	j != length - 1
-	regex.match("^[a-zA-Z]", currentPackage) == true
+	regex.match("^[a-zA-Z]", currentPackage)
 	packages[plus(j, 1)] != "-v"
-	not dockerLib.withVersion(currentPackage)
+	not docker_lib.withVersion(currentPackage)
 }

--- a/assets/queries/dockerfile/yum_install_without_version/query.rego
+++ b/assets/queries/dockerfile/yum_install_without_version/query.rego
@@ -1,9 +1,10 @@
 package Cx
 
-import data.generic.dockerfile as dockerLib
+import data.generic.common as common_lib
+import data.generic.dockerfile as docker_lib
 
 CxPolicy[result] {
-	resource := input.document[i].command[name][_]
+	resource := input.document[i].command[name][cmd]
 	resource.Cmd == "run"
 
 	count(resource.Value) == 1
@@ -12,7 +13,7 @@ CxPolicy[result] {
 	yum := regex.find_n("yum (-(-)?[a-zA-Z]+ *)*(group|local)?install", commands, -1)
 	yum != null
 
-	packages = dockerLib.getPackages(commands, yum)
+	packages = docker_lib.getPackages(commands, yum)
 	length := count(packages)
 
 	some j
@@ -21,43 +22,47 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"searchValue": packages[j],
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "The package version should always be specified when using yum install",
 		"keyActualValue": sprintf("No version is specified in package '%s'", [packages[j]]),
+		"searchLine": common_lib.build_search_line(["command", name, cmd], []),
 	}
 }
 
 CxPolicy[result] {
-	resource := input.document[i].command[name][_]
+	resource := input.document[i].command[name][cmd]
 	resource.Cmd == "run"
 
 	count(resource.Value) > 1
 
-    dockerLib.arrayContains(resource.Value, {"yum", "install"})
+	docker_lib.arrayContains(resource.Value, {"yum", "install"})
 
 	resource.Value[j] != "install"
 	resource.Value[j] != "yum"
 	regex.match("^[a-zA-Z]", resource.Value[j]) == true
-	not dockerLib.withVersion(resource.Value[j])
+	not docker_lib.withVersion(resource.Value[j])
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"searchValue": resource.Value[j],
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "The package version should always be specified when using yum install",
 		"keyActualValue": sprintf("No version is specified in package '%s'", [resource.Value[j]]),
+		"searchLine": common_lib.build_search_line(["command", name, cmd], []),
 	}
 }
 
 analyzePackages(j, currentPackage, packages, length) {
 	j == length - 1
 	regex.match("^[a-zA-Z]", currentPackage) == true
-	not dockerLib.withVersion(currentPackage)
+	not docker_lib.withVersion(currentPackage)
 }
 
 analyzePackages(j, currentPackage, packages, length) {
 	j != length - 1
 	regex.match("^[a-zA-Z]", currentPackage) == true
 	packages[plus(j, 1)] != "-v"
-	not dockerLib.withVersion(currentPackage)
+	not docker_lib.withVersion(currentPackage)
 }

--- a/assets/queries/dockerfile/zypper_install_without_version/query.rego
+++ b/assets/queries/dockerfile/zypper_install_without_version/query.rego
@@ -1,9 +1,10 @@
 package Cx
 
-import data.generic.dockerfile as dockerLib
+import data.generic.common as common_lib
+import data.generic.dockerfile as docker_lib
 
 CxPolicy[result] {
-	resource := input.document[i].command[name][_]
+	resource := input.document[i].command[name][cmd]
 	resource.Cmd == "run"
 
 	count(resource.Value) == 1
@@ -12,7 +13,7 @@ CxPolicy[result] {
 	zypper := regex.find_n("zypper (-(-)?[a-zA-Z]+ *)*in(stall)?", commands, -1)
 	zypper != null
 
-	packages = dockerLib.getPackages(commands, zypper)
+	packages = docker_lib.getPackages(commands, zypper)
 	length := count(packages)
 
 	some j
@@ -21,43 +22,47 @@ CxPolicy[result] {
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"searchValue": packages[j],
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "The package version should always be specified when using zypper install",
 		"keyActualValue": sprintf("No version is specified in package '%s'", [packages[j]]),
+		"searchLine": common_lib.build_search_line(["command", name, cmd], []),
 	}
 }
 
 CxPolicy[result] {
-	resource := input.document[i].command[name][_]
+	resource := input.document[i].command[name][cmd]
 	resource.Cmd == "run"
 
 	count(resource.Value) > 1
 
-    dockerLib.arrayContains(resource.Value, {"zypper", "install"})
+	docker_lib.arrayContains(resource.Value, {"zypper", "install"})
 
 	resource.Value[j] != "install"
 	resource.Value[j] != "zypper"
 	regex.match("^[a-zA-Z]", resource.Value[j]) == true
-	not dockerLib.withVersion(resource.Value[j])
+	not docker_lib.withVersion(resource.Value[j])
 
 	result := {
 		"documentId": input.document[i].id,
 		"searchKey": sprintf("FROM={{%s}}.{{%s}}", [name, resource.Original]),
+		"searchValue": resource.Value[j],
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "The package version should always be specified when using zypper install",
 		"keyActualValue": sprintf("No version is specified in package '%s'", [resource.Value[j]]),
+		"searchLine": common_lib.build_search_line(["command", name, cmd], []),
 	}
 }
 
 analyzePackages(j, currentPackage, packages, length) {
 	j == length - 1
 	regex.match("^[a-zA-Z]", currentPackage) == true
-	not dockerLib.withVersion(currentPackage)
+	not docker_lib.withVersion(currentPackage)
 }
 
 analyzePackages(j, currentPackage, packages, length) {
 	j != length - 1
 	regex.match("^[a-zA-Z]", currentPackage) == true
 	packages[plus(j, 1)] != "-v"
-	not dockerLib.withVersion(currentPackage)
+	not docker_lib.withVersion(currentPackage)
 }

--- a/pkg/detector/search_line_detector.go
+++ b/pkg/detector/search_line_detector.go
@@ -98,6 +98,7 @@ func (d *searchLineDetector) getResult() int {
 		d.resolvedPath + "." + d.targetObj + "._kics_lines._kics__default._kics_line",
 		d.resolvedArrayPath + "." + d.targetObj + "._kics__default._kics_line",
 		d.resolvedArrayPath + "._kics_" + d.targetObj + "._kics_line",
+		d.resolvedPath + "." + d.targetObj + "._kics_line",
 	}
 
 	result := -1


### PR DESCRIPTION
**Reason for Proposed Changes**
- Some Dockerfile queries were producing the same `similarityID` despite representing different issues.
- Several queries were missing `searchLine`, making it harder to precisely locate vulnerabilities.

**Proposed Changes**
- Updated multiple Dockerfile queries by adding or modifying `searchValue`, and/or `searchLine` to ensure each detected vulnerability generates a unique `similarityID`.
- Add another option to search_line_detector to support `searchLine` in dockerfile queries.
- Removed the test restriction that only certain queries could use `searchValue`, allowing support for these new cases.
- The updated queries include:
  - Missing Flag From Dnf Install: Added Search Line & Added Search Value
  - Shell Running A Pipe Without Pipefail Flag: Added Search Line & Added Search Value. The query matched multiple times when the shell name contained substrings of other shells (e.g., '/bin/bash' matched both 'bash' and 'ash').
  - Unpinned Package Version in Apk Add: Added Search Line & Added Search Value.
  - Yum install Without Version: Added Search Line & Added Search Value.
  - Zypper Install Without Version: Added Search Line & Added Search Value.

I submit this contribution under the Apache-2.0 license.