### PR TITLE
fix(query): fix docker compose queries producing duplicate similarityIDs

### DIFF
--- a/assets/queries/dockerCompose/shared_volumes_between_containers/query.rego
+++ b/assets/queries/dockerCompose/shared_volumes_between_containers/query.rego
@@ -10,7 +10,6 @@ CxPolicy[result] {
 	volumes := service_parameters.volumes
 	volume2 := volumes[v2]
 	startswith(volume2, sprintf("%s:", [v1]))
-	#startswith(volume2, v1)
 
 	result := {
 		"documentId": sprintf("%s", [resource.id]),

--- a/assets/queries/dockerCompose/shared_volumes_between_containers/query.rego
+++ b/assets/queries/dockerCompose/shared_volumes_between_containers/query.rego
@@ -7,13 +7,15 @@ CxPolicy[result] {
 	volumes_shared := resource.volumes
 	_:= volumes_shared[v1]
 	service_parameters := resource.services[name]
-    volumes := service_parameters.volumes
-    volume2 := volumes[v2]
-	startswith(volume2, v1)
+	volumes := service_parameters.volumes
+	volume2 := volumes[v2]
+	startswith(volume2, sprintf("%s:", [v1]))
+	#startswith(volume2, v1)
 
 	result := {
 		"documentId": sprintf("%s", [resource.id]),
 		"searchKey": sprintf("services.%s.volumes",[name]),
+		"searchValue": "created-and-shared",
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "There shouldn't be volumes created and shared between containers",
 		"keyActualValue": sprintf("Volume %s created and shared between containers", [v1]),
@@ -24,14 +26,15 @@ CxPolicy[result] {
 CxPolicy[result] {
 	resource := input.document[i]
 	service_parameters := resource.services[name]
-    volumes := service_parameters.volumes
-    volume := volumes[v]
-    
-    dup(resource, name, volume)
+	volumes := service_parameters.volumes
+	volume := volumes[v]
+
+	dup(resource, name, volume)
 
 	result := {
 		"documentId": sprintf("%s", [resource.id]),
 		"searchKey": sprintf("services.%s.volumes",[name]),
+		"searchValue": "shared",
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": "There shouldn't be volumes shared between containers",
 		"keyActualValue": sprintf("Volume %s shared between containers", [volume]),
@@ -41,8 +44,8 @@ CxPolicy[result] {
 
 dup(resource, resource_name, volume_name){
 	service_parameters := resource.services[name]
-    name != resource_name
-    volumes := service_parameters.volumes
-    vname := volumes[_]
-    vname == volume_name
+	name != resource_name
+	volumes := service_parameters.volumes
+	vname := volumes[_]
+	vname == volume_name
 }

--- a/test/queries_content_test.go
+++ b/test/queries_content_test.go
@@ -44,22 +44,6 @@ var (
 		"resourceName",
 	}
 
-	searchValueAllowedQueriesPath = []string{
-		"../assets/queries/ansible/azure/sensitive_port_is_exposed_to_entire_network",
-		"../assets/queries/cloudFormation/aws/ec2_sensitive_port_is_publicly_exposed",
-		"../assets/queries/cloudFormation/aws/elb_sensitive_port_is_exposed_to_entire_network",
-		"../assets/queries/terraform/aws/sensitive_port_is_exposed_to_entire_network",
-		"../assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network",
-		"../assets/queries/terraform/azure/sensitive_port_is_exposed_to_entire_network",
-		"../assets/queries/terraform/azure/sensitive_port_is_exposed_to_small_public_network",
-		"../assets/queries/dockerfile/apt_get_install_pin_version_not_defined",
-		"../assets/queries/terraform/aws/redshift_cluster_without_vpc",
-		"../assets/queries/openAPI/general/response_code_missing",
-		"../assets/queries/cicd/github/run_block_injection",
-		"../assets/queries/cicd/github/script_block_injection",
-		"../assets/queries/azureResourceManager/key_vault_not_recoverable",
-	}
-
 	// TODO uncomment this test once all metadata are fixed
 	availablePlatforms = initPlatforms()
 	platformKeys       = MapToStringSlice(availablePlatforms)
@@ -221,22 +205,6 @@ func testQueryHasGoodReturnParams(t *testing.T, entry queryEntry) { //nolint
 					"query '%s' doesn't include parameter '%s' in response",
 					path.Base(entry.dir),
 					requiredProperty,
-				))
-			}
-
-			if sliceContains(searchValueAllowedQueriesPath, filepath.ToSlash(entry.dir)) {
-				_, ok := m[searchValueProperty]
-				require.True(t, ok, fmt.Sprintf(
-					"query '%s' doesn't include parameter '%s' in response",
-					path.Base(entry.dir),
-					searchValueProperty,
-				))
-			} else {
-				_, ok := m[searchValueProperty]
-				require.False(t, ok, fmt.Sprintf(
-					"query '%s' should not include parameter '%s' in response",
-					path.Base(entry.dir),
-					searchValueProperty,
 				))
 			}
 


### PR DESCRIPTION
**Reason for Proposed Changes**
- Some Docker Compose queries were producing the same `similarityID` despite representing different issues.

**Proposed Changes**
- Updated Docker Compose query "Shared Volumes Between Containers" by adding `searchValue` to ensure each detected vulnerability generates a unique `similarityID`.
- Removed the test restriction that only certain queries could use `searchValue`, allowing support for these new cases.

I submit this contribution under the Apache-2.0 license.