### PR TITLE
feat(query): elasticsearch domain encryption should be enabled node to node query implementation for CloudFormation/AWS

### DIFF
--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/metadata.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/metadata.json
@@ -1,0 +1,12 @@
+{
+  "id": "43ed6fe0-edb6-43c2-97be-6501cf563d53",
+  "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "Elasticsearch Domain encryption should be enabled node to node",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-elasticsearch-domain-nodetonodeencryptionoptions.html",
+  "platform": "CloudFormation",
+  "descriptionID": "43ed6fe0",
+  "cloudProvider": "aws",
+  "cwe": "311"
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/query.rego
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/query.rego
@@ -1,0 +1,61 @@
+package Cx 
+
+import data.generic.cloudformation as cf_lib
+import data.generic.common as common_lib
+
+resources := {"AWS::Elasticsearch::Domain", "AWS::OpenSearchService::Domain"} 
+
+CxPolicy[result] {
+    document := input.document[i]
+    resource := document.Resources[name]
+    resource.Type == resources[m]
+
+    node_to_node_block_not_defined(resource.Properties, resources[m])
+
+    result := {
+        "documentId": input.document[i].id,
+        "resourceType": resource.Type,
+        "resourceName": cf_lib.get_resource_name(resource, name),
+        "searchKey": sprintf("Resources.%s.Properties", [name]),
+        "issueType": "MissingAttribute",
+        "keyExpectedValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions' should be defined", [name]),
+        "keyActualValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions' is not defined", [name]),
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    resource := document.Resources[name]
+    resource.Type == resources[m]
+
+    common_lib.valid_key(resource.Properties, "NodeToNodeEncryptionOptions")
+    node_to_node_encryption_not_enabled(resource.Properties, resources[m])
+
+    result := {
+        "documentId": input.document[i].id,
+        "resourceType": resource.Type,
+        "resourceName": cf_lib.get_resource_name(resource, name),
+        "searchKey": sprintf("Resources.%s.Properties.NodeToNodeEncryptionOptions.Enabled", [name]),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions.Enabled' should be defined to true", [name]),
+        "keyActualValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions.Enabled' is not defined to true", [name]),
+    }
+}
+
+node_to_node_encryption_not_enabled(resource, type) {
+    type == "AWS::Elasticsearch::Domain"
+    not resource.NodeToNodeEncryptionOptions.Enabled == true
+} else {
+    type == "AWS::OpenSearchService::Domain"
+    regex.match("^Elasticsearch_[0-9]{1}\\.[0-9]{1,2}$", resource.EngineVersion)
+    not resource.NodeToNodeEncryptionOptions.Enabled == true
+}
+
+node_to_node_block_not_defined(resource, type) {
+    type == "AWS::Elasticsearch::Domain"
+    not common_lib.valid_key(resource, "NodeToNodeEncryptionOptions")
+} else {
+    type == "AWS::OpenSearchService::Domain"
+    regex.match("^Elasticsearch_[0-9]{1}\\.[0-9]{1,2}$", resource.EngineVersion)
+    not common_lib.valid_key(resource, "NodeToNodeEncryptionOptions")
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative1.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative1.yaml
@@ -1,0 +1,49 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyOpenSearchDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: my-sample-domain
+      EngineVersion: Elasticsearch_7.10
+      ClusterConfig:
+        InstanceType: r6g.large.search
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r6g.large.search
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp3
+        VolumeSize: 50
+        Iops: 3000
+        Throughput: 125
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+      NodeToNodeEncryptionOptions:
+        Enabled: true
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 3
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Project
+          Value: OpenSearch

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative2.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative2.json
@@ -1,0 +1,73 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyOpenSearchDomain": {
+            "Type": "AWS::OpenSearchService::Domain",
+            "Properties": {
+                "DomainName": "my-sample-domain",
+                "EngineVersion": "Elasticsearch_7.10",
+                "ClusterConfig": {
+                    "InstanceType": "r6g.large.search",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r6g.large.search",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp3",
+                    "VolumeSize": 50,
+                    "Iops": 3000,
+                    "Throughput": 125
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "NodeToNodeEncryptionOptions": {
+                    "Enabled": true
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 3
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Project",
+                        "Value": "OpenSearch"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative3.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative3.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: my-es-domain
+      ElasticsearchVersion: 7.10
+      ElasticsearchClusterConfig:
+        InstanceType: r5.large.elasticsearch
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r5.large.elasticsearch
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 50
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+      NodeToNodeEncryptionOptions:
+        Enabled: true
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 2
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Department
+          Value: Analytics

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative4.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative4.json
@@ -1,0 +1,71 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyElasticsearchDomain": {
+            "Type": "AWS::Elasticsearch::Domain",
+            "Properties": {
+                "DomainName": "my-es-domain",
+                "ElasticsearchVersion": 7.1,
+                "ElasticsearchClusterConfig": {
+                    "InstanceType": "r5.large.elasticsearch",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r5.large.elasticsearch",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp2",
+                    "VolumeSize": 50
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "NodeToNodeEncryptionOptions": {
+                    "Enabled": true
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 2
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Department",
+                        "Value": "Analytics"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive1.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive1.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyOpenSearchDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: my-sample-domain
+      EngineVersion: Elasticsearch_7.10
+      ClusterConfig:
+        InstanceType: r6g.large.search
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r6g.large.search
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp3
+        VolumeSize: 50
+        Iops: 3000
+        Throughput: 125
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 3
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Project
+          Value: OpenSearch

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive2.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive2.json
@@ -1,0 +1,70 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyOpenSearchDomain": {
+            "Type": "AWS::OpenSearchService::Domain",
+            "Properties": {
+                "DomainName": "my-sample-domain",
+                "EngineVersion": "Elasticsearch_7.10",
+                "ClusterConfig": {
+                    "InstanceType": "r6g.large.search",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r6g.large.search",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp3",
+                    "VolumeSize": 50,
+                    "Iops": 3000,
+                    "Throughput": 125
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 3
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Project",
+                        "Value": "OpenSearch"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive3.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive3.yaml
@@ -1,0 +1,49 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyOpenSearchDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: my-sample-domain
+      EngineVersion: Elasticsearch_7.10
+      ClusterConfig:
+        InstanceType: r6g.large.search
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r6g.large.search
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp3
+        VolumeSize: 50
+        Iops: 3000
+        Throughput: 125
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+      NodeToNodeEncryptionOptions:
+        Enabled: false
+      EncryptionAtRestOptions:
+        Enabled: false
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 3
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Project
+          Value: OpenSearch

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive4.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive4.json
@@ -1,0 +1,73 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyOpenSearchDomain": {
+            "Type": "AWS::OpenSearchService::Domain",
+            "Properties": {
+                "DomainName": "my-sample-domain",
+                "EngineVersion": "Elasticsearch_7.10",
+                "ClusterConfig": {
+                    "InstanceType": "r6g.large.search",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r6g.large.search",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp3",
+                    "VolumeSize": 50,
+                    "Iops": 3000,
+                    "Throughput": 125
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "NodeToNodeEncryptionOptions": {
+                    "Enabled": false
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": false
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 3
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Project",
+                        "Value": "OpenSearch"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive5.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive5.yaml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: my-es-domain
+      ElasticsearchVersion: 7.10
+      ElasticsearchClusterConfig:
+        InstanceType: r5.large.elasticsearch
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r5.large.elasticsearch
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 50
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 2
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Department
+          Value: Analytics

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive6.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive6.json
@@ -1,0 +1,68 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyElasticsearchDomain": {
+            "Type": "AWS::Elasticsearch::Domain",
+            "Properties": {
+                "DomainName": "my-es-domain",
+                "ElasticsearchVersion": 7.1,
+                "ElasticsearchClusterConfig": {
+                    "InstanceType": "r5.large.elasticsearch",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r5.large.elasticsearch",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp2",
+                    "VolumeSize": 50
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 2
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Department",
+                        "Value": "Analytics"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive7.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive7.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: my-es-domain
+      ElasticsearchVersion: 7.10
+      ElasticsearchClusterConfig:
+        InstanceType: r5.large.elasticsearch
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r5.large.elasticsearch
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 50
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+      NodeToNodeEncryptionOptions:
+        Enabled: false
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 2
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Department
+          Value: Analytics

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive8.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive8.json
@@ -1,0 +1,71 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyElasticsearchDomain": {
+            "Type": "AWS::Elasticsearch::Domain",
+            "Properties": {
+                "DomainName": "my-es-domain",
+                "ElasticsearchVersion": 7.1,
+                "ElasticsearchClusterConfig": {
+                    "InstanceType": "r5.large.elasticsearch",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r5.large.elasticsearch",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp2",
+                    "VolumeSize": 50
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "NodeToNodeEncryptionOptions": {
+                    "Enabled": false
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 2
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Department",
+                        "Value": "Analytics"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive_expected_result.json
@@ -1,0 +1,50 @@
+[
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive2.json"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 34,
+    "fileName": "positive3.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 44,
+    "fileName": "positive4.json"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive5.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive6.json"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 32,
+    "fileName": "positive7.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 42,
+    "fileName": "positive8.json"
+  }
+]


### PR DESCRIPTION
**Reason for Proposed Changes**
- Currently, we have no support in CloudFormation for `Elasticsearch Domain Not Encrypted Node To Node`. This query was already implemented for Terraform.

**Proposed Changes**
- In this query, we have to cover two types of resources called `AWS::Elasticsearch::Domain` and `AWS::OpenSearchService::Domain`. For the second resource type, it is only valid to do the verifications if the field `EngineVersion` matches the pattern `^Elasticsearch_[0-9]{1}\\.[0-9]{1,2}$` in order to stay on the scope of the query.
- On the implementation of this query, I used two policies.
- The first policy check's for both of the resource types, if they do not have the field `NodeToNodeEncryptionOptions` defined, using a helper function called `node_to_node_block_not_defined`.
- The second policy checks the cases when the field `NodeToNodeEncryptionOptions.Enabled` is not defined to `true`, using an helper function called `node_to_node_encryption_not_enabled`.
- Provided eight positive samples that provides all the variations regarding the fields that return's the vulnerabilities that this query tackles.
- Provided four negative samples. All these samples have the field's with non vulnerable values for both of the resource types mentioned above.

I submit this contribution under the Apache-2.0 license.