### PR TITLE
fix(ubi): update ubi dockerfile go version to 1.24.6

### DIFF
--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -7,7 +7,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 ADD https://golang.org/dl/go1.24.6.linux-amd64.tar.gz .
 RUN yum install git gcc -y \
   && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.6.linux-amd64.tar.gz \
-  && rm -f go1.24.5.linux-amd64.tar.gz
+  && rm -f go1.24.6.linux-amd64.tar.gz
 
 ENV GOPRIVATE=github.com/Checkmarx/*
 ARG VERSION="development"


### PR DESCRIPTION
**Reason for Proposed Changes**
- update go version in all references to version 1.24.6;

**Proposed Changes**
- change ubi8 dockerfile amd go version to 1.24.6;

I submit this contribution under the Apache-2.0 license.