### PR TITLE
add support for folder-based query test cases

### DIFF
--- a/test/main_test.go
+++ b/test/main_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/Checkmarx/kics/v2/pkg/parser"
 	ansibleConfigParser "github.com/Checkmarx/kics/v2/pkg/parser/ansible/ini/config"
 	ansibleHostsParser "github.com/Checkmarx/kics/v2/pkg/parser/ansible/ini/hosts"
+	bicepParser "github.com/Checkmarx/kics/v2/pkg/parser/bicep"
 	buildahParser "github.com/Checkmarx/kics/v2/pkg/parser/buildah"
-    bicepParser "github.com/Checkmarx/kics/v2/pkg/parser/bicep"
-	dockerParser "github.com/Checkmarx/kics/v2/pkg/parser/docker" 
+	dockerParser "github.com/Checkmarx/kics/v2/pkg/parser/docker"
 	protoParser "github.com/Checkmarx/kics/v2/pkg/parser/grpc"
 	jsonParser "github.com/Checkmarx/kics/v2/pkg/parser/json"
 	terraformParser "github.com/Checkmarx/kics/v2/pkg/parser/terraform"
@@ -99,11 +99,11 @@ type queryEntry struct {
 	platform string
 }
 
-func (q queryEntry) getSampleFiles(tb testing.TB, filePattern string) []string {
+func (q queryEntry) getSampleFiles(tb testing.TB, directory, filePattern string) []string {
 	var files []string
 	for _, kinds := range q.kind {
-		kindFiles, err := filepath.Glob(path.Join(q.dir, fmt.Sprintf(filePattern, strings.ToLower(string(kinds)))))
-		positiveExpectedResultsFilepath := filepath.FromSlash(path.Join(q.dir, "test", ExpectedResultsFilename))
+		kindFiles, err := filepath.Glob(path.Join(q.dir, directory, fmt.Sprintf(filePattern, strings.ToLower(string(kinds)))))
+		positiveExpectedResultsFilepath := q.ExpectedPositiveResultFile(directory)
 		for i, check := range kindFiles {
 			if check == positiveExpectedResultsFilepath {
 				kindFiles = append(kindFiles[:i], kindFiles[i+1:]...)
@@ -116,15 +116,41 @@ func (q queryEntry) getSampleFiles(tb testing.TB, filePattern string) []string {
 }
 
 func (q queryEntry) PositiveFiles(tb testing.TB) []string {
-	return q.getSampleFiles(tb, "test/positive*.%s")
+	return q.getSampleFiles(tb, "test", "positive*.%s")
 }
 
 func (q queryEntry) NegativeFiles(tb testing.TB) []string {
-	return q.getSampleFiles(tb, "test/negative*.%s")
+	return q.getSampleFiles(tb, "test", "negative*.%s")
 }
 
-func (q queryEntry) ExpectedPositiveResultFile() string {
-	return filepath.FromSlash(path.Join(q.dir, "test", ExpectedResultsFilename))
+func (q queryEntry) ExpectedPositiveResultFile(directory string) string {
+	return filepath.FromSlash(path.Join(q.dir, directory, ExpectedResultsFilename))
+}
+
+func (q queryEntry) getSampleDirectories(tb testing.TB, dirPattern string) map[string][]string {
+	matches, err := filepath.Glob(path.Join(q.dir, dirPattern))
+	require.Nil(tb, err)
+
+	dirs := make(map[string][]string)
+	for _, match := range matches {
+		info, err := os.Stat(match)
+		require.Nil(tb, err)
+		if info.IsDir() {
+			relativePath, err := filepath.Rel(q.dir, match)
+			require.Nil(tb, err)
+			base := filepath.Base(relativePath)
+			dirs[base] = q.getSampleFiles(tb, relativePath, base+"*.%s")
+		}
+	}
+	return dirs
+}
+
+func (q queryEntry) PositiveDirectories(tb testing.TB) map[string][]string {
+	return q.getSampleDirectories(tb, "test/positive*")
+}
+
+func (q queryEntry) NegativeDirectories(tb testing.TB) map[string][]string {
+	return q.getSampleDirectories(tb, "test/negative*")
 }
 
 func appendQueries(queriesDir []queryEntry, dirName string, kind []model.FileKind, platform string) []queryEntry {
@@ -304,3 +330,4 @@ func getQueryFilter() *source.QueryInspectorParameters {
 		InputDataPath:  "",
 	}
 }
+

--- a/test/queries_content_test.go
+++ b/test/queries_content_test.go
@@ -171,7 +171,21 @@ func testQueryHasAllRequiredFiles(t *testing.T, entry queryEntry) {
 	for _, negativeFile := range entry.NegativeFiles(t) {
 		require.FileExists(t, negativeFile)
 	}
-	require.FileExists(t, entry.ExpectedPositiveResultFile())
+	require.FileExists(t, entry.ExpectedPositiveResultFile("test"))
+
+	for positiveDirectory, positiveFiles := range entry.PositiveDirectories(t) {
+		require.True(t, len(positiveFiles) > 0, "No positive samples found for query %s, directory %s", entry.dir, positiveDirectory)
+		for _, positiveFile := range positiveFiles {
+			require.FileExists(t, positiveFile)
+		}
+		require.FileExists(t, entry.ExpectedPositiveResultFile("test/"+positiveDirectory))
+	}
+	for negativeDirectory, negativeFiles := range entry.NegativeDirectories(t) {
+		require.True(t, len(negativeFiles) > 0, "No negative samples found for query %s, directory %s", entry.dir, negativeDirectory)
+		for _, negativeFile := range negativeFiles {
+			require.FileExists(t, negativeFile)
+		}
+	}
 }
 
 func testQueryHasGoodReturnParams(t *testing.T, entry queryEntry) { //nolint

--- a/test/queries_test.go
+++ b/test/queries_test.go
@@ -161,9 +161,15 @@ func testPositiveAndNegativeQueries(t *testing.T, entry queryEntry) {
 	name := strings.TrimPrefix(entry.dir, BaseTestsScanPath)
 	t.Run(name+"_positive", func(t *testing.T) {
 		testQuery(t, entry, entry.PositiveFiles(t), getExpectedVulnerabilities(t, entry))
+		for dir, files := range entry.PositiveDirectories(t) {
+			testQuery(t, entry, files, getExpectedVulnerabilitiesInDirectory(t, entry, "test/"+dir))
+		}
 	})
 	t.Run(name+"_negative", func(t *testing.T) {
 		testQuery(t, entry, entry.NegativeFiles(t), []model.Vulnerability{})
+		for _, files := range entry.NegativeDirectories(t) {
+			testQuery(t, entry, files, []model.Vulnerability{})
+		}
 	})
 }
 
@@ -171,21 +177,31 @@ func benchmarkPositiveAndNegativeQueries(b *testing.B, entry queryEntry) {
 	name := strings.TrimPrefix(entry.dir, BaseTestsScanPath)
 	b.Run(name+"_positive", func(b *testing.B) {
 		testQuery(b, entry, entry.PositiveFiles(b), getExpectedVulnerabilities(b, entry))
+		for dir, files := range entry.PositiveDirectories(b) {
+			testQuery(b, entry, files, getExpectedVulnerabilitiesInDirectory(b, entry, "test/"+dir))
+		}
 	})
 	b.Run(name+"_negative", func(b *testing.B) {
 		testQuery(b, entry, entry.NegativeFiles(b), []model.Vulnerability{})
+		for _, files := range entry.NegativeDirectories(b) {
+			testQuery(b, entry, files, []model.Vulnerability{})
+		}
 	})
 }
 
-func getExpectedVulnerabilities(tb testing.TB, entry queryEntry) []model.Vulnerability {
-	content, err := os.ReadFile(entry.ExpectedPositiveResultFile())
-	require.NoError(tb, err, "can't read expected result file %s", entry.ExpectedPositiveResultFile())
+func getExpectedVulnerabilitiesInDirectory(tb testing.TB, entry queryEntry, directory string) []model.Vulnerability {
+	content, err := os.ReadFile(entry.ExpectedPositiveResultFile(directory))
+	require.NoError(tb, err, "can't read expected result file %s", entry.ExpectedPositiveResultFile(directory))
 
 	var expectedVulnerabilities []model.Vulnerability
 	err = json.Unmarshal(content, &expectedVulnerabilities)
-	require.NoError(tb, err, "can't unmarshal expected result file %s", entry.ExpectedPositiveResultFile())
+	require.NoError(tb, err, "can't unmarshal expected result file %s", entry.ExpectedPositiveResultFile(directory))
 
 	return expectedVulnerabilities
+}
+
+func getExpectedVulnerabilities(tb testing.TB, entry queryEntry) []model.Vulnerability {
+	return getExpectedVulnerabilitiesInDirectory(tb, entry, "test")
 }
 
 func testQuery(tb testing.TB, entry queryEntry, filesPath []string, expectedVulnerabilities []model.Vulnerability) {


### PR DESCRIPTION
**Reason for Proposed Changes**
- The current Query File Tree structure looks like:
    ```
    - <technology>/
      |- <provider>/
      |  |- <queryfolder>/
      |  |  |- test/
      |  |  |  |- positive[1..]<.ext>
      |  |  |  |- negative[1..]<.ext>
      |  |  |  |- positive_extended_result.json
      |  |  |- metadata.json
      |  |  |- query.rego
    ```
- Limitation: Some queries access multiple resources, which can be located in different files but the current structure forces all related resources into the same file

**Proposed Changes**
- Update the KICS test framework to support organizing test cases in folders, enabling better structuring of complex test scenarios.
- The new Query File Tree structure extends on the existing one and looks like:
    ```
    - <technology>/
      |- <provider>/
      |  |- <queryfolder>/
      |  |  |- test/
      |  |  |  |- positive[1..]<.ext>
      |  |  |  |- negative[1..]<.ext>
      |  |  |  |- positive_extended_result.json
      |  |  |  |- positive[1..]/ (= <folder_name>/)
      |  |  |  |  |- <folder_name>_[1..]<.ext>
      |  |  |  |  |- positive_extended_result.json
      |  |  |  |- negative[1..]/ (= <folder_name>/)
      |  |  |  |  |- <folder_name>_[1..]<.ext>
      |  |  |- metadata.json
      |  |  |- query.rego
    ```

I submit this contribution under the Apache-2.0 license.