### PR TITLE
test(query): missing tests for  s3_bucket_notifications_disabled

### DIFF
--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/negative3.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/negative3.tf
@@ -3,7 +3,6 @@ resource "aws_iam_role" "iam_for_lambda" {
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
-
 resource "aws_lambda_function" "func" {
   filename      = "your-function.zip"
   function_name = "example_lambda_name"
@@ -25,6 +24,4 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
     filter_prefix       = "AWSLogs/"
     filter_suffix       = ".log"
   }
-
-  depends_on = [aws_lambda_permission.allow_bucket]
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/negative4.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/negative4.tf
@@ -1,4 +1,9 @@
-resource "aws_sns_topic" "topic" {
+resource "aws_sns_topic" "topic1" {
+  name   = "s3-event-notification-topic"
+  policy = data.aws_iam_policy_document.topic.json
+}
+
+resource "aws_sns_topic" "topic2" {
   name   = "s3-event-notification-topic"
   policy = data.aws_iam_policy_document.topic.json
 }
@@ -11,8 +16,14 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.bucket.id
 
   topic {
-    topic_arn     = aws_sns_topic.different_topic.arn
+    topic_arn     = aws_sns_topic.topic1.arn
     events        = ["s3:ObjectCreated:*"]
+    filter_suffix = ".log"
+  }
+
+  topic {
+    topic_arn     = aws_sns_topic.topic2.arn
+    events        = ["s3:ObjectCreated:Post"]
     filter_suffix = ".log"
   }
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/negative5.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/negative5.tf
@@ -1,0 +1,29 @@
+resource "aws_sqs_queue" "queue1" {
+  name   = "s3-event-notification-queue"
+  policy = data.aws_iam_policy_document.queue.json
+}
+
+resource "aws_sqs_queue" "queue2" {
+  name   = "s3-event-notification-queue"
+  policy = data.aws_iam_policy_document.queue.json
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "your-bucket-name"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = aws_s3_bucket.bucket.id
+
+  queue {
+    queue_arn     = aws_sqs_queue.queue1.arn
+    events        = ["s3:ObjectCreated:Post"]
+    filter_prefix = "images/"
+  }
+
+  queue {
+    queue_arn     = aws_sqs_queue.queue2.arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_prefix = "videos/"
+  }
+}

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/negative6.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/negative6.tf
@@ -3,8 +3,16 @@ resource "aws_iam_role" "iam_for_lambda" {
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
-resource "aws_lambda_function" "func" {
-  filename      = "your-function.zip"
+resource "aws_lambda_function" "func1" {
+  filename      = "your-function1.zip"
+  function_name = "example_lambda_name"
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs20.x"
+}
+
+resource "aws_lambda_function" "func2" {
+  filename      = "your-function2.zip"
   function_name = "example_lambda_name"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
@@ -19,9 +27,16 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.bucket.id
 
   lambda_function {
-    lambda_function_arn = aws_lambda_function.different_function.arn
+    lambda_function_arn = aws_lambda_function.func1.arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = "AWSLogs/"
     filter_suffix       = ".log"
-  }
+   }
+ 
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.func2.arn
+    events              = ["s3:ObjectCreated:Post"]
+    filter_prefix       = "OtherLogs/"
+    filter_suffix       = ".json"
+   }
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive1.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive1.tf
@@ -1,4 +1,9 @@
-resource "aws_sns_topic" "topic" {
+resource "aws_sns_topic" "topic1" {
+  name   = "s3-event-notification-topic"
+  policy = data.aws_iam_policy_document.topic.json
+}
+
+resource "aws_sns_topic" "topic2" {
   name   = "s3-event-notification-topic"
   policy = data.aws_iam_policy_document.topic.json
 }
@@ -11,8 +16,14 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.bucket.id
 
   topic {
-    topic_arn     = aws_sns_topic.different_topic.arn
+    topic_arn     = aws_sns_topic.topic1.arn
     events        = ["s3:ObjectCreated:*"]
+    filter_suffix = ".log"
+  }
+
+  topic {
+    topic_arn     = aws_sns_topic.topic1.arn
+    events        = ["s3:ObjectCreated:Post"]
     filter_suffix = ".log"
   }
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive10.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive10.tf
@@ -1,0 +1,4 @@
+resource "aws_sns_topic" "topic1" {
+  name   = "s3-event-notification-topic"
+  policy = data.aws_iam_policy_document.topic.json
+}

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive11.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive11.tf
@@ -1,0 +1,4 @@
+resource "aws_sqs_queue" "queue" {
+  name   = "s3-event-notification-queue"
+  policy = data.aws_iam_policy_document.queue.json
+}

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive12.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive12.tf
@@ -1,0 +1,7 @@
+resource "aws_lambda_function" "func" {
+  filename      = "your-function.zip"
+  function_name = "example_lambda_name"
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs20.x"
+}

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive2.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive2.tf
@@ -1,8 +1,18 @@
-resource "aws_s3_bucket_notification" "bucket_notification" {
-  bucket = aws_s3_bucket.bucket.id
-}
-
 resource "aws_sqs_queue" "queue" {
   name   = "s3-event-notification-queue"
   policy = data.aws_iam_policy_document.queue.json
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "your-bucket-name"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = aws_s3_bucket.bucket.id
+
+  queue {
+    queue_arn     = aws_sqs_queue.different_queue.arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_suffix = ".log"
+  }
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive2.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive2.tf
@@ -1,4 +1,9 @@
-resource "aws_sqs_queue" "queue" {
+resource "aws_sqs_queue" "queue1" {
+  name   = "s3-event-notification-queue"
+  policy = data.aws_iam_policy_document.queue.json
+}
+
+resource "aws_sqs_queue" "queue2" {
   name   = "s3-event-notification-queue"
   policy = data.aws_iam_policy_document.queue.json
 }
@@ -11,8 +16,14 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.bucket.id
 
   queue {
-    queue_arn     = aws_sqs_queue.different_queue.arn
+    queue_arn     = aws_sqs_queue.queue1.arn
+    events        = ["s3:ObjectCreated:Post"]
+    filter_prefix = "images/"
+  }
+
+  queue {
+    queue_arn     = aws_sqs_queue.queue1.arn
     events        = ["s3:ObjectCreated:*"]
-    filter_suffix = ".log"
+    filter_prefix = "videos/"
   }
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive3.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive3.tf
@@ -3,8 +3,16 @@ resource "aws_iam_role" "iam_for_lambda" {
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
-resource "aws_lambda_function" "func" {
-  filename      = "your-function.zip"
+resource "aws_lambda_function" "func1" {
+  filename      = "your-function1.zip"
+  function_name = "example_lambda_name"
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs20.x"
+}
+
+resource "aws_lambda_function" "func2" {
+  filename      = "your-function2.zip"
   function_name = "example_lambda_name"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
@@ -19,9 +27,16 @@ resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.bucket.id
 
   lambda_function {
-    lambda_function_arn = aws_lambda_function.different_function.arn
+    lambda_function_arn = aws_lambda_function.func1.arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = "AWSLogs/"
     filter_suffix       = ".log"
-  }
+   }
+ 
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.func1.arn
+    events              = ["s3:ObjectCreated:Post"]
+    filter_prefix       = "OtherLogs/"
+    filter_suffix       = ".json"
+   }
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive4.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive4.tf
@@ -9,4 +9,10 @@ resource "aws_s3_bucket" "bucket" {
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.bucket.id
+
+  topic {
+    topic_arn     = aws_sns_topic.different_topic.arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_suffix = ".log"
+  }
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive5.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive5.tf
@@ -9,4 +9,10 @@ resource "aws_s3_bucket" "bucket" {
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.bucket.id
+
+  queue {
+    queue_arn     = aws_sqs_queue.different_queue.arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_suffix = ".log"
+  }
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive5.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive5.tf
@@ -1,6 +1,6 @@
-resource "aws_sns_topic" "topic" {
-  name   = "s3-event-notification-topic"
-  policy = data.aws_iam_policy_document.topic.json
+resource "aws_sqs_queue" "queue" {
+  name   = "s3-event-notification-queue"
+  policy = data.aws_iam_policy_document.queue.json
 }
 
 resource "aws_s3_bucket" "bucket" {

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive6.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive6.tf
@@ -17,11 +17,4 @@ resource "aws_s3_bucket" "bucket" {
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.bucket.id
-
-  lambda_function {
-    lambda_function_arn = aws_lambda_function.different_function.arn
-    events              = ["s3:ObjectCreated:*"]
-    filter_prefix       = "AWSLogs/"
-    filter_suffix       = ".log"
-  }
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive6.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive6.tf
@@ -17,4 +17,11 @@ resource "aws_s3_bucket" "bucket" {
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
   bucket = aws_s3_bucket.bucket.id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.different_function.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "AWSLogs/"
+    filter_suffix       = ".log"
+  }
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive7.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive7.tf
@@ -1,0 +1,4 @@
+resource "aws_sns_topic" "topic1" {
+  name   = "s3-event-notification-topic"
+  policy = data.aws_iam_policy_document.topic.json
+}

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive7.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive7.tf
@@ -1,4 +1,12 @@
-resource "aws_sns_topic" "topic1" {
+resource "aws_sns_topic" "topic" {
   name   = "s3-event-notification-topic"
   policy = data.aws_iam_policy_document.topic.json
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "your-bucket-name"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = aws_s3_bucket.bucket.id
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive8.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive8.tf
@@ -1,0 +1,4 @@
+resource "aws_sqs_queue" "queue" {
+  name   = "s3-event-notification-queue"
+  policy = data.aws_iam_policy_document.queue.json
+}

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive8.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive8.tf
@@ -2,3 +2,11 @@ resource "aws_sqs_queue" "queue" {
   name   = "s3-event-notification-queue"
   policy = data.aws_iam_policy_document.queue.json
 }
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "your-bucket-name"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = aws_s3_bucket.bucket.id
+}

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive9.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive9.tf
@@ -1,0 +1,7 @@
+resource "aws_lambda_function" "func" {
+  filename      = "your-function.zip"
+  function_name = "example_lambda_name"
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "exports.example"
+  runtime       = "nodejs20.x"
+}

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive9.tf
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive9.tf
@@ -1,7 +1,20 @@
+resource "aws_iam_role" "iam_for_lambda" {
+  name               = "iam_for_lambda"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
 resource "aws_lambda_function" "func" {
   filename      = "your-function.zip"
   function_name = "example_lambda_name"
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "exports.example"
   runtime       = "nodejs20.x"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "your-bucket-name"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = aws_s3_bucket.bucket.id
 }

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "S3 bucket notifications disabled",
     "severity": "LOW",
-    "line": 1,
+    "line": 6,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "S3 bucket notifications disabled",
     "severity": "LOW",
-    "line": 1,
+    "line": 6,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "S3 bucket notifications disabled",
     "severity": "LOW",
-    "line": 6,
+    "line": 14,
     "fileName": "positive3.tf"
   },
   {
@@ -50,7 +50,25 @@
   {
     "queryName": "S3 bucket notifications disabled",
     "severity": "LOW",
-    "line": 1,
+    "line": 6,
     "fileName": "positive9.tf"
+  },
+  {
+    "queryName": "S3 bucket notifications disabled",
+    "severity": "LOW",
+    "line": 1,
+    "fileName": "positive10.tf"
+  },
+  {
+    "queryName": "S3 bucket notifications disabled",
+    "severity": "LOW",
+    "line": 1,
+    "fileName": "positive11.tf"
+  },
+  {
+    "queryName": "S3 bucket notifications disabled",
+    "severity": "LOW",
+    "line": 1,
+    "fileName": "positive12.tf"
   }
 ]

--- a/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/s3_bucket_notifications_disabled/test/positive_expected_result.json
@@ -2,19 +2,19 @@
   {
     "queryName": "S3 bucket notifications disabled",
     "severity": "LOW",
-    "line": 5,
+    "line": 1,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "S3 bucket notifications disabled",
     "severity": "LOW",
-    "line": 5,
+    "line": 1,
     "fileName": "positive2.tf"
   },
   {
     "queryName": "S3 bucket notifications disabled",
     "severity": "LOW",
-    "line": 5,
+    "line": 6,
     "fileName": "positive3.tf"
   },
   {
@@ -22,5 +22,35 @@
     "severity": "LOW",
     "line": 1,
     "fileName": "positive4.tf"
+  },
+  {
+    "queryName": "S3 bucket notifications disabled",
+    "severity": "LOW",
+    "line": 1,
+    "fileName": "positive5.tf"
+  },
+  {
+    "queryName": "S3 bucket notifications disabled",
+    "severity": "LOW",
+    "line": 6,
+    "fileName": "positive6.tf"
+  },
+  {
+    "queryName": "S3 bucket notifications disabled",
+    "severity": "LOW",
+    "line": 1,
+    "fileName": "positive7.tf"
+  },
+  {
+    "queryName": "S3 bucket notifications disabled",
+    "severity": "LOW",
+    "line": 1,
+    "fileName": "positive8.tf"
+  },
+  {
+    "queryName": "S3 bucket notifications disabled",
+    "severity": "LOW",
+    "line": 1,
+    "fileName": "positive9.tf"
   }
 ]


### PR DESCRIPTION
**Reason for Proposed Changes**
- The newly added query "[s3_bucket_notifications_disabled](https://github.com/Checkmarx/kics/commit/b765991383055a2ee7f3f441b791b5d04ead89f4)" was taking into account instances of ```aws_sns_topic``` ,```aws_sqs_queue``` or ```aws_lambda_function```  as arrays but there were no tests to show this behaviour. 
- Moreover the [positive4](https://github.com/Checkmarx/kics/commit/b765991383055a2ee7f3f441b791b5d04ead89f4#diff-7bae4933fa51606139482970b0646854f76f80613421b2019f988bdb10ac08df) test could be applied to the other fields besides just "aws_sns_topic"
 
**Proposed Changes**
- Added 3 new negative tests to show that arrays of the relevant resources are supported. (multiple of the same resource inside the "[aws_s3_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification)")
- Added 8 new positive tests :
  - 2 missing tests identical to the original positive4 but for the 2 other resources (positive11 and 12), positive4 is now [positive10](https://github.com/Checkmarx/kics/pull/7672/files#diff-038a59f21dc9d564e01111603d66734635869f57d7e149c3c26ff81e2bbb3b1e).
  - positive1-3 now show support for arrays much like the new negative tests
  - positive4-6 show a "aws_s3_bucket_notification" resource with the correct field but with a different reference name like "[different_function](https://github.com/Checkmarx/kics/pull/7672/files#diff-0a57e314988de8f7c9c695d1ef576e204fca120ec7096cac0c01a1baf853ea65R22)" vs the actual name "[func](https://github.com/Checkmarx/kics/pull/7672/files#diff-0a57e314988de8f7c9c695d1ef576e204fca120ec7096cac0c01a1baf853ea65R6)" for positive6.tf
  - positive7-9 are similar to the original positive1-3 tests

I submit this contribution under the Apache-2.0 license.