### PR TITLE
fix(query): added support for a new case in "elasticsearch domain not encrypted" query

### DIFF
--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/metadata.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/metadata.json
@@ -1,0 +1,12 @@
+{
+  "id": "43ed6fe0-edb6-43c2-97be-6501cf563d53",
+  "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+  "severity": "MEDIUM",
+  "category": "Encryption",
+  "descriptionText": "Elasticsearch Domain encryption should be enabled node to node",
+  "descriptionUrl": "https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-elasticsearch-domain-nodetonodeencryptionoptions.html",
+  "platform": "CloudFormation",
+  "descriptionID": "43ed6fe0",
+  "cloudProvider": "aws",
+  "cwe": "311"
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/query.rego
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/query.rego
@@ -1,0 +1,61 @@
+package Cx 
+
+import data.generic.cloudformation as cf_lib
+import data.generic.common as common_lib
+
+resources := {"AWS::Elasticsearch::Domain", "AWS::OpenSearchService::Domain"} 
+
+CxPolicy[result] {
+    document := input.document[i]
+    resource := document.Resources[name]
+    resource.Type == resources[m]
+
+    node_to_node_block_not_defined(resource.Properties, resources[m])
+
+    result := {
+        "documentId": input.document[i].id,
+        "resourceType": resource.Type,
+        "resourceName": cf_lib.get_resource_name(resource, name),
+        "searchKey": sprintf("Resources.%s.Properties", [name]),
+        "issueType": "MissingAttribute",
+        "keyExpectedValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions' should be defined", [name]),
+        "keyActualValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions' is not defined", [name]),
+    }
+}
+
+CxPolicy[result] {
+    document := input.document[i]
+    resource := document.Resources[name]
+    resource.Type == resources[m]
+
+    common_lib.valid_key(resource.Properties, "NodeToNodeEncryptionOptions")
+    node_to_node_encryption_not_enabled(resource.Properties, resources[m])
+
+    result := {
+        "documentId": input.document[i].id,
+        "resourceType": resource.Type,
+        "resourceName": cf_lib.get_resource_name(resource, name),
+        "searchKey": sprintf("Resources.%s.Properties.NodeToNodeEncryptionOptions.Enabled", [name]),
+        "issueType": "IncorrectValue",
+        "keyExpectedValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions.Enabled' should be defined to true", [name]),
+        "keyActualValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions.Enabled' is not defined to true", [name]),
+    }
+}
+
+node_to_node_encryption_not_enabled(resource, type) {
+    type == "AWS::Elasticsearch::Domain"
+    not resource.NodeToNodeEncryptionOptions.Enabled == true
+} else {
+    type == "AWS::OpenSearchService::Domain"
+    regex.match("^Elasticsearch_[0-9]{1}\\.[0-9]{1,2}$", resource.EngineVersion)
+    not resource.NodeToNodeEncryptionOptions.Enabled == true
+}
+
+node_to_node_block_not_defined(resource, type) {
+    type == "AWS::Elasticsearch::Domain"
+    not common_lib.valid_key(resource, "NodeToNodeEncryptionOptions")
+} else {
+    type == "AWS::OpenSearchService::Domain"
+    regex.match("^Elasticsearch_[0-9]{1}\\.[0-9]{1,2}$", resource.EngineVersion)
+    not common_lib.valid_key(resource, "NodeToNodeEncryptionOptions")
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/query.rego
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/query.rego
@@ -10,16 +10,17 @@ CxPolicy[result] {
     resource := document.Resources[name]
     resource.Type == resources[m]
 
-    node_to_node_block_not_defined(resource.Properties, resources[m])
+    r := node_to_node_block_not_defined(resource.Properties, resources[m], name)
 
     result := {
         "documentId": input.document[i].id,
         "resourceType": resource.Type,
         "resourceName": cf_lib.get_resource_name(resource, name),
-        "searchKey": sprintf("Resources.%s.Properties", [name]),
+        "searchKey": r.sk,
         "issueType": "MissingAttribute",
         "keyExpectedValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions' should be defined", [name]),
-        "keyActualValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions' is not defined", [name]),
+        "keyActualValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions' is null or not defined", [name]),
+        "searchLine": r.sl,
     }
 }
 
@@ -28,7 +29,7 @@ CxPolicy[result] {
     resource := document.Resources[name]
     resource.Type == resources[m]
 
-    common_lib.valid_key(resource.Properties, "NodeToNodeEncryptionOptions")
+    common_lib.valid_key(resource.Properties.NodeToNodeEncryptionOptions, "Enabled")
     node_to_node_encryption_not_enabled(resource.Properties, resources[m])
 
     result := {
@@ -39,6 +40,7 @@ CxPolicy[result] {
         "issueType": "IncorrectValue",
         "keyExpectedValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions.Enabled' should be defined to true", [name]),
         "keyActualValue": sprintf("'Resources.%s.Properties.NodeToNodeEncryptionOptions.Enabled' is not defined to true", [name]),
+        "searchLine": common_lib.build_search_line(["Resources", name, "Properties", "NodeToNodeEncryptionOptions", "Enabled"], []),
     }
 }
 
@@ -51,11 +53,33 @@ node_to_node_encryption_not_enabled(resource, type) {
     not resource.NodeToNodeEncryptionOptions.Enabled == true
 }
 
-node_to_node_block_not_defined(resource, type) {
+node_to_node_block_not_defined(resource, type, name) = r {
     type == "AWS::Elasticsearch::Domain"
-    not common_lib.valid_key(resource, "NodeToNodeEncryptionOptions")
-} else {
+    not common_lib.valid_key(resource, "NodeToNodeEncryptionOptions")    
+    r := {
+        "sk": sprintf("Resources.%s.Properties", [name]),
+        "sl": common_lib.build_search_line(["Resources", name, "Properties"], []),
+    }
+} else = r {
+    type == "AWS::Elasticsearch::Domain"
+    resource.NodeToNodeEncryptionOptions == {} 
+    r := {
+        "sk": sprintf("Resources.%s.Properties.NodeToNodeEncryptionOptions", [name]),
+        "sl": common_lib.build_search_line(["Resources", name, "Properties", "NodeToNodeEncryptionOptions"], []),
+    }
+} else = r {
     type == "AWS::OpenSearchService::Domain"
     regex.match("^Elasticsearch_[0-9]{1}\\.[0-9]{1,2}$", resource.EngineVersion)
     not common_lib.valid_key(resource, "NodeToNodeEncryptionOptions")
+    r := {
+        "sk": sprintf("Resources.%s.Properties", [name]),
+        "sl": common_lib.build_search_line(["Resources", name, "Properties"], []),
+    }
+} else = r {
+    type == "AWS::OpenSearchService::Domain"
+    resource.NodeToNodeEncryptionOptions == {}
+    r := {
+        "sk": sprintf("Resources.%s.Properties.NodeToNodeEncryptionOptions", [name]),
+        "sl": common_lib.build_search_line(["Resources", name, "Properties", "NodeToNodeEncryptionOptions"], []),
+    }
 }

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative1.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative1.yaml
@@ -1,0 +1,49 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyOpenSearchDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: my-sample-domain
+      EngineVersion: Elasticsearch_7.10
+      ClusterConfig:
+        InstanceType: r6g.large.search
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r6g.large.search
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp3
+        VolumeSize: 50
+        Iops: 3000
+        Throughput: 125
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+      NodeToNodeEncryptionOptions:
+        Enabled: true
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 3
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Project
+          Value: OpenSearch

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative2.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative2.json
@@ -1,0 +1,73 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyOpenSearchDomain": {
+            "Type": "AWS::OpenSearchService::Domain",
+            "Properties": {
+                "DomainName": "my-sample-domain",
+                "EngineVersion": "Elasticsearch_7.10",
+                "ClusterConfig": {
+                    "InstanceType": "r6g.large.search",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r6g.large.search",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp3",
+                    "VolumeSize": 50,
+                    "Iops": 3000,
+                    "Throughput": 125
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "NodeToNodeEncryptionOptions": {
+                    "Enabled": true
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 3
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Project",
+                        "Value": "OpenSearch"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative3.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative3.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: my-es-domain
+      ElasticsearchVersion: 7.10
+      ElasticsearchClusterConfig:
+        InstanceType: r5.large.elasticsearch
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r5.large.elasticsearch
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 50
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+      NodeToNodeEncryptionOptions:
+        Enabled: true
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 2
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Department
+          Value: Analytics

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative4.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/negative4.json
@@ -1,0 +1,71 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyElasticsearchDomain": {
+            "Type": "AWS::Elasticsearch::Domain",
+            "Properties": {
+                "DomainName": "my-es-domain",
+                "ElasticsearchVersion": 7.1,
+                "ElasticsearchClusterConfig": {
+                    "InstanceType": "r5.large.elasticsearch",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r5.large.elasticsearch",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp2",
+                    "VolumeSize": 50
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "NodeToNodeEncryptionOptions": {
+                    "Enabled": true
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 2
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Department",
+                        "Value": "Analytics"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive1.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive1.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyOpenSearchDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: my-sample-domain
+      EngineVersion: Elasticsearch_7.10
+      ClusterConfig:
+        InstanceType: r6g.large.search
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r6g.large.search
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp3
+        VolumeSize: 50
+        Iops: 3000
+        Throughput: 125
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 3
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Project
+          Value: OpenSearch

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive10.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive10.json
@@ -1,0 +1,38 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyOpenSearchDomain": {
+            "Type": "AWS::OpenSearchService::Domain",
+            "Properties": {
+                "DomainName": "my-sample-domain",
+                "EngineVersion": "Elasticsearch_7.10",
+                "NodeToNodeEncryptionOptions": {},
+                "EncryptionAtRestOptions": {
+                    "Enabled": false
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 3
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Project",
+                        "Value": "OpenSearch"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive11.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive11.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: my-es-domain
+      ElasticsearchVersion: 7.10
+      NodeToNodeEncryptionOptions:
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 2
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Department
+          Value: Analytics

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive12.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive12.json
@@ -1,0 +1,38 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyElasticsearchDomain": {
+            "Type": "AWS::Elasticsearch::Domain",
+            "Properties": {
+                "DomainName": "my-es-domain",
+                "ElasticsearchVersion": 7.1,
+                "NodeToNodeEncryptionOptions": {},
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 2
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Department",
+                        "Value": "Analytics"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive2.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive2.json
@@ -1,0 +1,70 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyOpenSearchDomain": {
+            "Type": "AWS::OpenSearchService::Domain",
+            "Properties": {
+                "DomainName": "my-sample-domain",
+                "EngineVersion": "Elasticsearch_7.10",
+                "ClusterConfig": {
+                    "InstanceType": "r6g.large.search",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r6g.large.search",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp3",
+                    "VolumeSize": 50,
+                    "Iops": 3000,
+                    "Throughput": 125
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 3
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Project",
+                        "Value": "OpenSearch"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive3.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive3.yaml
@@ -1,0 +1,49 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyOpenSearchDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: my-sample-domain
+      EngineVersion: Elasticsearch_7.10
+      ClusterConfig:
+        InstanceType: r6g.large.search
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r6g.large.search
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp3
+        VolumeSize: 50
+        Iops: 3000
+        Throughput: 125
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+      NodeToNodeEncryptionOptions:
+        Enabled: false
+      EncryptionAtRestOptions:
+        Enabled: false
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 3
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Project
+          Value: OpenSearch

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive4.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive4.json
@@ -1,0 +1,73 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyOpenSearchDomain": {
+            "Type": "AWS::OpenSearchService::Domain",
+            "Properties": {
+                "DomainName": "my-sample-domain",
+                "EngineVersion": "Elasticsearch_7.10",
+                "ClusterConfig": {
+                    "InstanceType": "r6g.large.search",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r6g.large.search",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp3",
+                    "VolumeSize": 50,
+                    "Iops": 3000,
+                    "Throughput": 125
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-sample-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "NodeToNodeEncryptionOptions": {
+                    "Enabled": false
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": false
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 3
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Project",
+                        "Value": "OpenSearch"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive5.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive5.yaml
@@ -1,0 +1,45 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: my-es-domain
+      ElasticsearchVersion: 7.10
+      ElasticsearchClusterConfig:
+        InstanceType: r5.large.elasticsearch
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r5.large.elasticsearch
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 50
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 2
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Department
+          Value: Analytics

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive6.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive6.json
@@ -1,0 +1,68 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyElasticsearchDomain": {
+            "Type": "AWS::Elasticsearch::Domain",
+            "Properties": {
+                "DomainName": "my-es-domain",
+                "ElasticsearchVersion": 7.1,
+                "ElasticsearchClusterConfig": {
+                    "InstanceType": "r5.large.elasticsearch",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r5.large.elasticsearch",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp2",
+                    "VolumeSize": 50
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 2
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Department",
+                        "Value": "Analytics"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive7.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive7.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyElasticsearchDomain:
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      DomainName: my-es-domain
+      ElasticsearchVersion: 7.10
+      ElasticsearchClusterConfig:
+        InstanceType: r5.large.elasticsearch
+        InstanceCount: 2
+        DedicatedMasterEnabled: true
+        DedicatedMasterType: r5.large.elasticsearch
+        DedicatedMasterCount: 3
+        ZoneAwarenessEnabled: true
+        ZoneAwarenessConfig:
+          AvailabilityZoneCount: 2
+      EBSOptions:
+        EBSEnabled: true
+        VolumeType: gp2
+        VolumeSize: 50
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: "es:*"
+            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+      NodeToNodeEncryptionOptions:
+        Enabled: false
+      EncryptionAtRestOptions:
+        Enabled: true
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 2
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Department
+          Value: Analytics

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive8.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive8.json
@@ -1,0 +1,71 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Example",
+    "Resources": {
+        "MyElasticsearchDomain": {
+            "Type": "AWS::Elasticsearch::Domain",
+            "Properties": {
+                "DomainName": "my-es-domain",
+                "ElasticsearchVersion": 7.1,
+                "ElasticsearchClusterConfig": {
+                    "InstanceType": "r5.large.elasticsearch",
+                    "InstanceCount": 2,
+                    "DedicatedMasterEnabled": true,
+                    "DedicatedMasterType": "r5.large.elasticsearch",
+                    "DedicatedMasterCount": 3,
+                    "ZoneAwarenessEnabled": true,
+                    "ZoneAwarenessConfig": {
+                        "AvailabilityZoneCount": 2
+                    }
+                },
+                "EBSOptions": {
+                    "EBSEnabled": true,
+                    "VolumeType": "gp2",
+                    "VolumeSize": 50
+                },
+                "AccessPolicies": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": "*"
+                            },
+                            "Action": "es:*",
+                            "Resource": {
+                                "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/my-es-domain/*"
+                            }
+                        }
+                    ]
+                },
+                "NodeToNodeEncryptionOptions": {
+                    "Enabled": false
+                },
+                "EncryptionAtRestOptions": {
+                    "Enabled": true
+                },
+                "DomainEndpointOptions": {
+                    "EnforceHTTPS": true,
+                    "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+                },
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 2
+                },
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true",
+                    "override_main_response_version": "true"
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": "Production"
+                    },
+                    {
+                        "Key": "Department",
+                        "Value": "Analytics"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive9.yaml
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive9.yaml
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example
+
+Resources:
+  MyOpenSearchDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName: my-sample-domain
+      EngineVersion: Elasticsearch_7.10
+      NodeToNodeEncryptionOptions:
+      EncryptionAtRestOptions:
+        Enabled: false
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: 3
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+        override_main_response_version: "true"
+      Tags:
+        - Key: Environment
+          Value: Production
+        - Key: Project
+          Value: OpenSearch

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive_expected_result.json
@@ -1,0 +1,50 @@
+[
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive1.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive2.json"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 34,
+    "fileName": "positive3.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 44,
+    "fileName": "positive4.json"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive5.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive6.json"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 32,
+    "fileName": "positive7.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 42,
+    "fileName": "positive8.json"
+  }
+]

--- a/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_domain_not_encrypted_node_to_node/test/positive_expected_result.json
@@ -46,5 +46,29 @@
     "severity": "MEDIUM",
     "line": 42,
     "fileName": "positive8.json"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive9.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 10,
+    "fileName": "positive10.json"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive11.yaml"
+  },
+  {
+    "queryName": "Elasticsearch Domain Not Encrypted Node To Node",
+    "severity": "MEDIUM",
+    "line": 7,
+    "fileName": "positive12.json"
   }
 ]


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- The current implementation does not support the cases when the field `Enabled` is not defined inside the `NodeToNodeEncryptionOptions` block.

**Proposed Changes**
- Added two more cases on the helper function called `node_to_node_block_not_defined` for the case that was not taken into account. 
- Added samples for the case mentioned above

I submit this contribution under the Apache-2.0 license.