### PR TITLE
test(query): mini fix for negative7 test on query elastic_search_without_audit_logs - coudformation/aws

### DIFF
--- a/assets/queries/cloudFormation/aws/elasticsearch_without_audit_logs/test/negative7.json
+++ b/assets/queries/cloudFormation/aws/elasticsearch_without_audit_logs/test/negative7.json
@@ -11,7 +11,7 @@
         "LogPublishingOptions": {
           "AUDIT_LOGS": {
             "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs",
-            "Enabled": true
+            "Enabled": "true"
           }
         }
       }


### PR DESCRIPTION
**Reason for Proposed Changes**
- The elastic_search_without_audit_logs query's negative7 test was meant to have quotes n the ```true``` value.

**Proposed Changes**
- Added the missing quotes. 


I submit this contribution under the Apache-2.0 license.