### PR TITLE
fix(query): fixed searchLine and added new test case for web app not using tls last version query for azureResourceManager

### DIFF
--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/query.rego
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/query.rego
@@ -56,6 +56,6 @@ prepare_issue(resource) = issue {
 		"keyActualValue": "'siteConfig.minTlsVersion' is undefined",
 		"keyExpectedValue": "'siteConfig.minTlsVersion' should be defined",
 		"sk": ".properties",
-		"sl": ["name"],
+		"sl": ["properties"],
 	}
 }

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive4.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive4.bicep
@@ -1,0 +1,7 @@
+resource App 'Microsoft.Web/sites@2020-12-01' = {
+  name: 'App'
+  location: resourceGroup().location
+  properties: {
+    siteConfig: {}
+  }
+}

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive4.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive4.json
@@ -1,0 +1,24 @@
+{
+  "properties": {
+    "template": {
+      "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+      "contentVersion": "1.0.0.0",
+      "resources": [
+        {
+          "type": "Microsoft.Web/sites",
+          "apiVersion": "2020-12-01",
+          "name": "App",
+          "location": "[resourceGroup().location]",
+          "properties": {
+            "siteConfig": {}
+          }
+        }
+      ],
+      "outputs": {}
+    },
+    "parameters": {}
+  },
+  "kind": "template",
+  "type": "Microsoft.Blueprint/blueprints/artifacts",
+  "name": "myTemplate"
+}

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive_expected_result.json
@@ -8,7 +8,7 @@
   {
     "queryName": "Web App Not Using TLS Last Version",
     "severity": "MEDIUM",
-    "line": 10,
+    "line": 12,
     "filename": "positive2.json"
   },
   {
@@ -20,13 +20,19 @@
   {
     "queryName": "Web App Not Using TLS Last Version",
     "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive4.json"
+  },
+  {
+    "queryName": "Web App Not Using TLS Last Version",
+    "severity": "MEDIUM",
     "line": 6,
     "filename": "positive1.bicep"
   },
   {
     "queryName": "Web App Not Using TLS Last Version",
     "severity": "MEDIUM",
-    "line": 2,
+    "line": 4,
     "filename": "positive2.bicep"
   },
   {
@@ -34,5 +40,11 @@
     "severity": "MEDIUM",
     "line": 6,
     "filename": "positive3.bicep"
+  },
+  {
+    "queryName": "Web App Not Using TLS Last Version",
+    "severity": "MEDIUM",
+    "line": 4,
+    "filename": "positive4.bicep"
   }
 ]


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- The current query implementation has the searchLine pointing to the resource name, which could be improved by pointing to the field of the vulnerability itself. 
- Also, the case when the block siteConfig is defined without a `minTlsVersion` defined was not covered by the test cases.

**Proposed Changes**
- Changed the sl return value on the `prepare_issue` helper function.
- Added the missing case(positive4.json and positive4.bicep)

I submit this contribution under the Apache-2.0 license.