### PR TITLE
fix(query): fixed typo and added the field assign_public_ip to ecs services assigned with public ip address

### DIFF
--- a/assets/queries/terraform/aws/ecs_services_assigned_with_public_ip_address/query.rego
+++ b/assets/queries/terraform/aws/ecs_services_assigned_with_public_ip_address/query.rego
@@ -15,7 +15,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("aws_ecs_service[%s].network_configuration.assign_public_ip", [name]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'aws_ecs_service[%s].network_configuration.assign_public_ip' should be set to 'false'(default value is 'false')", [name]),
-		"keyActualValue": sprintf("'aws_ecs_service[%s].network_configuration.assign_public_ip' is set defined to true", [name]),
+		"keyActualValue": sprintf("'aws_ecs_service[%s].network_configuration.assign_public_ip' is set to true", [name]),
 		"searchLine": common_lib.build_search_line(["resource", "aws_ecs_service", name, "network_configuration", "assign_public_ip"], []),
 	}
 }
@@ -35,7 +35,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("module[%s].%s.%s.assign_public_ip",[name,block,service]),
 		"issueType": "IncorrectValue",
 		"keyExpectedValue": sprintf("'module[%s].%s.%s.assign_public_ip' should be set to 'false'(default value is 'false')", [name,block,service]),
-		"keyActualValue": sprintf("'module[%s].%s.%s.assign_public_ip' is set defined to true", [name,block,service]),
-		"searchLine": common_lib.build_search_line(["module", name, block, service], []),
+		"keyActualValue": sprintf("'module[%s].%s.%s.assign_public_ip' is set to true", [name,block,service]),
+		"searchLine": common_lib.build_search_line(["module", name, block, service, "assign_public_ip"], []),
 	}
 }


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- The current implementation has a typo on the keyActualValue and does not have the field "assign_public_ip" on the searchLine.

**Proposed Changes**
- Fixed the typo and added the field "assign_public_ip" to the build_search_line function.

I submit this contribution under the Apache-2.0 license.