### PR TITLE
fix(test): fixed indentation on a test case for instance uses metadata service imdsv1 query for CloudFormation platform 

### DIFF
--- a/assets/queries/cloudFormation/aws/instance_uses_metadata_service_IMDSv1/test/negative5.yaml
+++ b/assets/queries/cloudFormation/aws/instance_uses_metadata_service_IMDSv1/test/negative5.yaml
@@ -20,4 +20,4 @@ Resources:
         InstanceType: t3.micro
         MetadataOptions:
           HttpEndpoint: disabled
-        HttpTokens: optional
+          HttpTokens: optional


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- The file negative5.yaml for the query "Instance Uses Metadata Service IMDSv1" has an incorrect indentation

**Proposed Changes**
- Fixed indentation

I submit this contribution under the Apache-2.0 license.