### PR TITLE
fix(query): missing support for resource in SQL Server Database With Alerts Disabled - ARM

### DIFF
--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/query.rego
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/query.rego
@@ -2,8 +2,7 @@ package Cx
 
 import data.generic.common as common_lib
 
-
-types := ["Microsoft.Sql/servers/databases/securityAlertPolicies", "securityAlertPolicies"]
+types := ["Microsoft.Sql/servers/databases/securityAlertPolicies", "securityAlertPolicies", "Microsoft.Sql/servers/securityAlertPolicies"]
 
 CxPolicy[result] {
   # case of no security alert policy
@@ -74,4 +73,4 @@ CxPolicy[result] {
 any_security_alert_policy(doc, types)  {
   [_, value] := walk(doc)
   value.type == types[_]
-} 
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative10.bicep
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative10.bicep
@@ -1,0 +1,8 @@
+resource sample_server_securityAlert 'Microsoft.Sql/servers/securityAlertPolicies@2021-02-01-preview' = {
+  name: 'sampleServer/default'
+  properties: {
+    state: 'Enabled'
+    disabledAlerts: []
+    emailAccountAdmins: true
+  }
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative10.json
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative10.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "8371526641644790449"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/securityAlertPolicies",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sampleServer/Default",
+      "properties": {
+        "state": "Enabled",
+        "disabledAlerts": [],
+        "emailAccountAdmins": true
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative5.bicep
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative5.bicep
@@ -1,0 +1,15 @@
+resource sample_database 'Microsoft.Sql/servers/databases@2021-02-01-preview' = {
+  name: 'sampleServer/sampleDatabase'
+  location: 'Sample'
+  properties: {
+    sampleName: 'AdventureWorksLT'
+  }
+}
+
+resource sample_databases_default 'Microsoft.Sql/servers/databases/securityAlertPolicies@2021-02-01-preview' = {
+  name: 'sample/databases/default'
+  location: 'Sample'
+  properties: {
+    disabledAlerts: []
+    state: 'Enabled'
+}}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative5.json
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative5.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "6537157491087265147"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/databases",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sampleServer/sampleDatabase",
+      "location": "Sample",
+      "properties": {
+        "sampleName": "AdventureWorksLT"
+      }
+    },
+    {
+      "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sample/databases/Default",
+      "location": "Sample",
+      "properties": {
+        "disabledAlerts": [],
+        "state": "Enabled"
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative6.bicep
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative6.bicep
@@ -1,0 +1,14 @@
+resource sample_database 'Microsoft.Sql/servers/databases@2021-02-01-preview' = {
+  name: 'sampleServer/sampleDatabase'
+  location: 'Sample'
+  properties: {
+    sampleName: 'AdventureWorksLT'
+  }
+}
+
+resource sample_databases_default 'Microsoft.Sql/servers/databases/securityAlertPolicies@2021-02-01-preview' = {
+  name: 'sample/databases/default'
+  location: 'Sample'
+  properties: {
+    state: 'Enabled'
+}}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative6.json
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative6.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "3186770193589075684"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/databases",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sampleServer/sampleDatabase",
+      "location": "Sample",
+      "properties": {
+        "sampleName": "AdventureWorksLT"
+      }
+    },
+    {
+      "type": "Microsoft.Sql/servers/databases/securityAlertPolicies",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sample/databases/Default",
+      "location": "Sample",
+      "properties": {
+        "state": "Enabled"
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative7.bicep
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative7.bicep
@@ -1,0 +1,17 @@
+resource sample_server 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: 'sampleServer'
+  location: resourceGroup().location
+  properties: {
+    administratorLogin: 'sqladminuser'
+    administratorLoginPassword: 'P@ssw0rd123!' 
+  }
+}
+
+resource sample_server_securityAlert 'Microsoft.Sql/servers/securityAlertPolicies@2021-02-01-preview' = {
+  name: 'sampleServer/default'
+  properties: {
+    state: 'Enabled'
+    disabledAlerts: []
+    emailAccountAdmins: true
+  }
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative7.json
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative7.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "7042966288860294010"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sampleServer",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "administratorLogin": "sqladminuser",
+        "administratorLoginPassword": "P@ssw0rd123!"
+      }
+    },
+    {
+      "type": "Microsoft.Sql/servers/securityAlertPolicies",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sampleServer/Default",
+      "properties": {
+        "state": "Enabled",
+        "disabledAlerts": [],
+        "emailAccountAdmins": true
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative8.bicep
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative8.bicep
@@ -1,0 +1,16 @@
+resource sample_server 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: 'sampleServer'
+  location: resourceGroup().location
+  properties: {
+    administratorLogin: 'sqladminuser'
+    administratorLoginPassword: 'P@ssw0rd123!' 
+  }
+}
+
+resource sample_server_securityAlert 'Microsoft.Sql/servers/securityAlertPolicies@2021-02-01-preview' = {
+  name: 'sampleServer/default'
+  properties: {
+    state: 'Enabled'
+    emailAccountAdmins: true
+  }
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative8.json
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative8.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "6333281479513473266"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sampleServer",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "administratorLogin": "sqladminuser",
+        "administratorLoginPassword": "P@ssw0rd123!"
+      }
+    },
+    {
+      "type": "Microsoft.Sql/servers/securityAlertPolicies",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sampleServer/Default",
+      "properties": {
+        "state": "Enabled",
+        "emailAccountAdmins": true
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative9.bicep
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative9.bicep
@@ -1,0 +1,7 @@
+resource sample_server_securityAlert 'Microsoft.Sql/servers/securityAlertPolicies@2021-02-01-preview' = {
+  name: 'sampleServer/default'
+  properties: {
+    state: 'Enabled'
+    emailAccountAdmins: true
+  }
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative9.json
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/negative9.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "4912734550592086719"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/securityAlertPolicies",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sampleServer/Default",
+      "properties": {
+        "state": "Enabled",
+        "emailAccountAdmins": true
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive6.bicep
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive6.bicep
@@ -1,0 +1,10 @@
+resource sample_server_securityAlert 'Microsoft.Sql/servers/securityAlertPolicies@2021-02-01-preview' = {
+  name: 'sampleServer/default'
+  properties: {
+    disabledAlerts: ['Sql_Injection']
+    emailAccountAdmins: true
+    emailAddresses: ['sample@email.com']
+    retentionDays: 4
+    state: 'Enabled'
+  }
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive6.json
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive6.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "9432867529760988896"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/securityAlertPolicies",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sampleServer/default",
+      "properties": {
+        "disabledAlerts": ["Sql_Injection"],
+        "emailAccountAdmins": true,
+        "emailAddresses": [
+          "sample@email.com"
+        ],
+        "retentionDays": 4,
+        "state": "Enabled"
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive7.bicep
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive7.bicep
@@ -1,0 +1,10 @@
+resource sample_server_securityAlert 'Microsoft.Sql/servers/securityAlertPolicies@2021-02-01-preview' = {
+  name: 'sampleServer/default'
+  properties: {
+    disabledAlerts: ['Sql_Injection']
+    emailAccountAdmins: true
+    emailAddresses: ['sample@email.com']
+    retentionDays: 4
+    state: 'Disabled'
+  }
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive7.json
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive7.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "6052430267505263681"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers/securityAlertPolicies",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sampleServer/default",
+      "properties": {
+        "disabledAlerts": ["Sql_Injection"],
+        "emailAccountAdmins": true,
+        "emailAddresses": [
+          "sample@email.com"
+        ],
+        "retentionDays": 4,
+        "state": "Disabled"
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive8.bicep
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive8.bicep
@@ -1,0 +1,10 @@
+resource sqlServer 'Microsoft.Sql/servers@2021-02-01-preview' = {
+  name: 'sample'
+  location: resourceGroup().location
+  properties: {
+    administratorLogin: 'sqladminuser'
+    administratorLoginPassword: 'P@ssw0rd123!' 
+    minimalTlsVersion: '1.2'
+    publicNetworkAccess: 'Enabled'
+  }
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive8.json
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive8.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.37.4.10188",
+      "templateHash": "15083796068864284852"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-02-01-preview",
+      "name": "sample",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "administratorLogin": "sqladminuser",
+        "administratorLoginPassword": "P@ssw0rd123!",
+        "minimalTlsVersion": "1.2",
+        "publicNetworkAccess": "Enabled"
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/sql_server_database_with_alerts_disabled/test/positive_expected_result.json
@@ -32,6 +32,24 @@
   {
     "queryName": "SQL Server Database With Alerts Disabled",
     "severity": "MEDIUM",
+    "line": 17,
+    "filename": "positive6.json"
+  },
+  {
+    "queryName": "SQL Server Database With Alerts Disabled",
+    "severity": "MEDIUM",
+    "line": 23,
+    "filename": "positive7.json"
+  },
+  {
+    "queryName": "SQL Server Database With Alerts Disabled",
+    "severity": "MEDIUM",
+    "line": 13,
+    "filename": "positive8.json"
+  },
+  {
+    "queryName": "SQL Server Database With Alerts Disabled",
+    "severity": "MEDIUM",
     "line": 4,
     "filename": "positive1.bicep"
   },
@@ -58,5 +76,23 @@
     "severity": "MEDIUM",
     "line": 1,
     "filename": "positive5.bicep"
+  },
+  {
+    "queryName": "SQL Server Database With Alerts Disabled",
+    "severity": "MEDIUM",
+    "line": 4,
+    "filename": "positive6.bicep"
+  },
+  {
+    "queryName": "SQL Server Database With Alerts Disabled",
+    "severity": "MEDIUM",
+    "line": 8,
+    "filename": "positive7.bicep"
+  },
+  {
+    "queryName": "SQL Server Database With Alerts Disabled",
+    "severity": "MEDIUM",
+    "line": 1,
+    "filename": "positive8.bicep"
   }
 ]


### PR DESCRIPTION
**Reason for Proposed Changes**
- The [original fix](https://github.com/Checkmarx/kics/pull/7584) for the SQL Server Database With Alerts Disabled query did not include the "Microsoft.Sql/servers/securityAlertPolicies" that should have been included.

**Proposed Changes**
-
-
-

I submit this contribution under the Apache-2.0 license.