### PR TITLE
better negative tests

### DIFF
--- a/assets/queries/terraform/aws/unknown_port_exposed_to_internet/test/negative1.tf
+++ b/assets/queries/terraform/aws/unknown_port_exposed_to_internet/test/negative1.tf
@@ -1,13 +1,11 @@
 resource "aws_security_group" "negative1-1" {
-  name        = "allow_tls"
-  description = "Allow TLS inbound traffic"
-  vpc_id      = aws_vpc.main.id
 
   ingress {
-    description = "TLS from VPC"
-    from_port   = 443
-    to_port     = 443
+    description = "Remote desktop open private"
+    from_port   = 2383
+    to_port     = 2383
     protocol    = "tcp"
+    cidr_blocks = ["192.168.0.0/24", "0.0.0.0/0"]
   }
 }
 
@@ -15,10 +13,10 @@ resource "aws_security_group" "negative1-2" {
 
   ingress {
     description = "Remote desktop open private"
-    from_port   = 2383
-    to_port     = 2383
+    from_port   = 20
+    to_port     = 20
     protocol    = "tcp"
-    cidr_blocks = ["192.168.0.0/24", "192.162.0.0/24"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 }
 
@@ -26,8 +24,19 @@ resource "aws_security_group" "negative1-3" {
 
   ingress {
     description = "Remote desktop open private"
-    from_port   = 20
-    to_port     = 20
+    from_port   = 0
+    to_port     = 10000
+    protocol    = "tcp"
+    cidr_blocks = ["192.168.0.0/24", "192.201.0.0/12"]
+  }
+}
+
+resource "aws_security_group" "negative1-4" {
+
+  ingress {
+    description = "Remote desktop open private"
+    from_port   = 0
+    to_port     = 10000
     protocol    = "tcp"
     ipv6_cidr_blocks = ["2001:db8:abcd:0012::/64"]
   }

--- a/assets/queries/terraform/aws/unknown_port_exposed_to_internet/test/negative2.tf
+++ b/assets/queries/terraform/aws/unknown_port_exposed_to_internet/test/negative2.tf
@@ -6,26 +6,37 @@ resource "aws_security_group" "negative2" {
 
 resource "aws_vpc_security_group_ingress_rule" "negative2-1" {
   security_group_id = aws_security_group.negative3.id
-  from_port         = 443
-  to_port           = 443
+  from_port         = 2383
+  to_port           = 2383
   ip_protocol       = "tcp"
-  description       = "TLS from VPC"
+  cidr_ipv4         = "0.0.0.0/0"
+  description       = "Remote desktop open private"
 }
+
 
 resource "aws_vpc_security_group_ingress_rule" "negative2-2" {
   security_group_id = aws_security_group.negative3.id
-  from_port         = 2383
-  to_port           = 2383
+  from_port         = 20
+  to_port           = 20
+  ip_protocol       = "tcp"
+  cidr_ipv6         = "::/0"
+  description       = "Remote desktop open private"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "negative2-3" {
+  security_group_id = aws_security_group.negative3.id
+  from_port         = 0
+  to_port           = 10000
   ip_protocol       = "tcp"
   cidr_ipv4         = "192.168.0.0/24"
   description       = "Remote desktop open private"
 }
 
 
-resource "aws_vpc_security_group_ingress_rule" "negative2-3" {
+resource "aws_vpc_security_group_ingress_rule" "negative2-4" {
   security_group_id = aws_security_group.negative3.id
-  from_port         = 20
-  to_port           = 20
+  from_port         = 0
+  to_port           = 10000
   ip_protocol       = "tcp"
   cidr_ipv6         = "2001:db8:abcd:0012::/64"
   description       = "Remote desktop open private"

--- a/assets/queries/terraform/aws/unknown_port_exposed_to_internet/test/negative3.tf
+++ b/assets/queries/terraform/aws/unknown_port_exposed_to_internet/test/negative3.tf
@@ -6,25 +6,35 @@ resource "aws_security_group" "negative3" {
 
 resource "aws_security_group_rule" "negative3-1" {
   type              = "ingress"
-  from_port         = 443
-  to_port           = 443
+  from_port         = 2383
+  to_port           = 2383
   protocol          = "tcp"
+  cidr_blocks       = ["192.168.0.0/24", "0.0.0.0/0"]
   security_group_id = aws_security_group.negative3.id
 }
 
 resource "aws_security_group_rule" "negative3-2" {
   type              = "ingress"
-  from_port         = 2383
-  to_port           = 2383
+  from_port         = 20
+  to_port           = 20
   protocol          = "tcp"
-  cidr_blocks       = ["192.168.0.0/24", "192.162.0.0/24"]
+  ipv6_cidr_blocks  = ["::/0"]
   security_group_id = aws_security_group.negative3.id
 }
 
 resource "aws_security_group_rule" "negative3-3" {
   type              = "ingress"
-  from_port         = 20
-  to_port           = 20
+  from_port         = 0
+  to_port           = 10000
+  protocol          = "tcp"
+  cidr_blocks       = ["192.168.0.0/24", "192.162.0.0/24"]
+  security_group_id = aws_security_group.negative3.id
+}
+
+resource "aws_security_group_rule" "negative3-4" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 10000
   protocol          = "tcp"
   ipv6_cidr_blocks  = ["2001:db8:abcd:0012::/64"]
   security_group_id = aws_security_group.negative3.id


### PR DESCRIPTION
**Reason for Proposed Changes**
- The first 3 negative tests for the "Unknown Port Exposed To Internet" query were lackluster in the sense that they did not properly show that the query can fail to flag for 2 reasons:
  - The from/to port range not including an unknown port
  - The ports not being exposed to the whole internet ("0.0.0.0/0" or "::/0")
 
- The examples currently fulfill both conditions simultaneously and it would be better to have each example fulfill a single one of the conditions to test that each of them individually is enough for a negative result.

**Proposed Changes**
- Updated negative1-3 tests accordingly.

I submit this contribution under the Apache-2.0 license.