### PR TITLE
test(query): fix for positive4 test to "Unknown Port Exposed To Internet" query

### DIFF
--- a/assets/queries/terraform/aws/unknown_port_exposed_to_internet/test/positive4.tf
+++ b/assets/queries/terraform/aws/unknown_port_exposed_to_internet/test/positive4.tf
@@ -45,7 +45,7 @@ module "vote_service_sg_ipv4_array" {
       from_port   = 2000
       to_port     = 2500
       protocol    = "tcp"
-      ipv6_cidr_blocks = ["::/0"]
+      cidr_blocks = ["0.0.0.0/0"]
     }
   ]
 }


### PR DESCRIPTION
**Reason for Proposed Changes**
- The positive4 test of the "Unknown Port Exposed To Internet" query had a "ipv6_cidr_blocks" field set to ["::/0"] inside an "ingress_with_cidr_blocks" of the "terraform-aws-modules/security-group/aws" module. 
- This was untended since the supported value is actually "cidr_blocks", the ipv4 version of the field. The mistake is not present in the near identical negative4 sample.

**Proposed Changes**
- Fixed the field naming and value.

I submit this contribution under the Apache-2.0 license.