### PR TITLE
test(query): better testing for security group rules without description

### DIFF
--- a/assets/queries/terraform/aws/security_group_rules_without_description/query.rego
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/query.rego
@@ -60,7 +60,7 @@ CxPolicy[result] {
 		"resourceType": "n/a",
 		"resourceName": "n/a",
 		"searchKey": sprintf("module[%s].%s.%d", [name, key, i2]),
-		"issueType": "IncorrectValue",
+		"issueType": "MissingAttribute",
 		"keyExpectedValue": sprintf("module[%s].%s.%d.description should be defined and not null",[name, key, i2]),
 		"keyActualValue": sprintf("module[%s].%s.%d.description is undefined or null",[name, key, i2]),
 		"searchLine": common_lib.build_search_line(["module", name, key, i2], []),

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/negative1.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/negative1.tf
@@ -1,10 +1,7 @@
 resource "aws_security_group" "negative1" {
-  name        = "allow_tls"
-  description = "Allow TLS inbound traffic"
-  vpc_id      = aws_vpc.main.id
 
   ingress {
-    description      = "TLS from VPC"
+    description      = "sample_description"
     from_port        = 443
     to_port          = 443
     protocol         = "tcp"
@@ -12,7 +9,13 @@ resource "aws_security_group" "negative1" {
     ipv6_cidr_blocks = [aws_vpc.main.ipv6_cidr_block]
   }
 
-  tags = {
-    Name = "allow_tls"
+  egress {
+    description      = "sample_description"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
+
 }

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/negative2.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/negative2.tf
@@ -1,11 +1,7 @@
-resource "aws_security_group" "negative2" {
-
-  name        = "${var.prefix}-external-http-https"
-  description = "Allow main HTTP / HTTPS"
-  vpc_id      = local.vpc_id
+resource "aws_security_group" "negative2-1" {
 
   ingress {
-    description = "Enable HTTP access for select VMs"
+    description = "sample_description"
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
@@ -13,14 +9,29 @@ resource "aws_security_group" "negative2" {
   }
 
   ingress {
-    description = "Enable HTTPS access for select VMs"
+    description = "sample_description"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+}
 
-  tags = {
-    Name = "${var.prefix}-external-http-https"
+resource "aws_security_group" "negative2-2" {
+
+  egress {
+    description = "sample_description"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "sample_description"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/negative3.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/negative3.tf
@@ -1,23 +1,11 @@
-resource "aws_security_group" "negative3" {
-
-  name        = "${var.prefix}-external-http-https"
-  description = "Allow main HTTP / HTTPS"
-  vpc_id      = local.vpc_id
-
-  tags = {
-    Name = "${var.prefix}-external-http-https"
-  }
-}
-
 resource "aws_security_group_rule" "negative3-1" {
 
   from_port         = 80
   to_port           = 80
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.negative3.id
   type              = "ingress"
-  description       = "Enable HTTP access for select VMs"
+  description       = "sample_description"
 }
 
 resource "aws_security_group_rule" "negative3-2" {
@@ -26,7 +14,6 @@ resource "aws_security_group_rule" "negative3-2" {
   to_port           = 443
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.negative3.id
-  type              = "ingress"
-  description       = "Enable HTTPS access for select VMs"
+  type              = "egress"
+  description       = "sample_description"
 }

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/negative4.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/negative4.tf
@@ -1,12 +1,5 @@
-resource "aws_security_group" "example" {
-  name        = "example-sg"
-  description = "Example security group"
-  vpc_id      = aws_vpc.main.id
-}
-
 resource "aws_vpc_security_group_ingress_rule" "negative4-1" {
   description       = "sample_description"
-  security_group_id = aws_security_group.example.id
   cidr_ipv4         = "192.168.1.0/24"
   from_port         = 80
   to_port           = 80
@@ -15,7 +8,6 @@ resource "aws_vpc_security_group_ingress_rule" "negative4-1" {
 
 resource "aws_vpc_security_group_egress_rule" "negative4-2" {
   description       = "sample_description"
-  security_group_id = aws_security_group.example.id
   cidr_ipv4         = "0.0.0.0/0"
   from_port         = 0
   to_port           = 0

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/negative5.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/negative5.tf
@@ -1,150 +1,75 @@
-module "vote_service_sg_ipv4" {
+module "negative5_ipv4_array" {
   source  = "terraform-aws-modules/security-group/aws"
 
   ingress_with_cidr_blocks = [
     {
-      description = "TLS from VPC"
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = ["1.2.3.4"]
-    }
-  ]
-
-  egress_with_cidr_blocks = [
-    {
-      description = "TLS from VPC"
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = ["1.2.3.4"]
-    }
-  ]
-}
-
-module "vote_service_sg_ipv4_array" {
-  source  = "terraform-aws-modules/security-group/aws"
-
-  ingress_with_cidr_blocks = [
-    {
-      description = "TLS from VPC"
+      description = "sample_description"
       from_port   = 2383
       to_port     = 2383
       protocol    = "udp"
       cidr_blocks = ["0.1.1.1/21", "8.8.8.8/24"]
     },
     {
-      description = "TLS from VPC"
+      description = "sample_description"
       from_port   = 28000
       to_port     = 28001
       protocol    = "tcp"
       cidr_blocks = ["10.0.0.0/16"]
-    },
-    {
-      description = "TLS from VPC"
-      from_port   = 20
-      to_port     = 22
-      protocol    = "tcp"
-      cidr_blocks = ["192.01.01.02/23"]
     }
   ]
 
   egress_with_cidr_blocks = [
     {
-      description = "TLS from VPC"
+      description = "sample_description"
       from_port   = 2383
       to_port     = 2383
       protocol    = "udp"
       cidr_blocks = ["0.1.1.1/21", "8.8.8.8/24"]
     },
     {
-      description = "TLS from VPC"
+      description = "sample_description"
       from_port   = 28000
       to_port     = 28001
       protocol    = "tcp"
       cidr_blocks = ["10.0.0.0/16"]
-    },
-    {
-      description = "TLS from VPC"
-      from_port   = 20
-      to_port     = 22
-      protocol    = "tcp"
-      cidr_blocks = ["192.01.01.02/23"]
     }
   ]
 }
 
-module "vote_service_sg_ipv6" {
+module "negative5_ipv6_array" {
   source  = "terraform-aws-modules/security-group/aws"
 
   ingress_with_ipv6_cidr_blocks = [
     {
-      description      = "TLS from VPC"
-      from_port        = 0
-      to_port          = 0
-      protocol         = "-1"
-      ipv6_cidr_blocks = ["2001:db8::/32"]
-    }
-  ]
-
-  egress_with_ipv6_cidr_blocks = [
-    {
-      description      = "TLS from VPC"
-      from_port        = 0
-      to_port          = 0
-      protocol         = "-1"
-      ipv6_cidr_blocks = ["2001:db8::/32"]
-    }
-  ]
-}
-
-module "vote_service_sg_ipv6_array" {
-  source  = "terraform-aws-modules/security-group/aws"
-
-  ingress_with_ipv6_cidr_blocks = [
-    {
-      description      = "TLS from VPC"
+      description      = "sample_description"
       from_port        = 2383
       to_port          = 2383
       protocol         = "udp"
       ipv6_cidr_blocks = ["fd00::/8", "2001:4860:4860::8888/64"]
     },
     {
-      description      = "TLS from VPC"
+      description      = "sample_description"
       from_port        = 28000
       to_port          = 28001
       protocol         = "tcp"
       ipv6_cidr_blocks = ["fc00::/7"]
-    },
-    {
-      description      = "TLS from VPC"
-      from_port        = 20
-      to_port          = 22
-      protocol         = "tcp"
-      ipv6_cidr_blocks = ["2001:db8:abcd:0012::/64"]
     }
   ]
 
   egress_with_ipv6_cidr_blocks = [
     {
-      description      = "TLS from VPC"
+      description      = "sample_description"
       from_port        = 2383
       to_port          = 2383
       protocol         = "udp"
       ipv6_cidr_blocks = ["fd00::/8", "2001:4860:4860::8888/64"]
     },
     {
-      description      = "TLS from VPC"
+      description      = "sample_description"
       from_port        = 28000
       to_port          = 28001
       protocol         = "tcp"
       ipv6_cidr_blocks = ["fc00::/7"]
-    },
-    {
-      description      = "TLS from VPC"
-      to_port          = 22
-      protocol         = "tcp"
-      ipv6_cidr_blocks = ["2001:db8:abcd:0012::/64"]
     }
   ]
 }

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/positive1.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/positive1.tf
@@ -1,7 +1,4 @@
 resource "aws_security_group" "positive1" {
-  name        = "positive1"
-  description = "Allow TLS inbound traffic"
-  vpc_id      = aws_vpc.main.id
 
   ingress {
     from_port        = 443
@@ -17,9 +14,5 @@ resource "aws_security_group" "positive1" {
     protocol         = "-1"
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
-  }
-
-  tags = {
-    Name = "positive1"
   }
 }

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/positive2.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/positive2.tf
@@ -1,11 +1,6 @@
-resource "aws_security_group" "positive2" { 
-
-  name        = "${var.prefix}-external-http-https"
-  description = "Allow main HTTP / HTTPS"
-  vpc_id      = local.vpc_id
+resource "aws_security_group" "positive2-1" {
 
   ingress {
-    description = "Enable HTTP access for select VMs"
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
@@ -18,8 +13,21 @@ resource "aws_security_group" "positive2" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+}
 
-  tags = {
-    Name = "${var.prefix}-external-http-https"
+resource "aws_security_group" "positive2-2" {
+
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/positive3.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/positive3.tf
@@ -1,22 +1,9 @@
-resource "aws_security_group" "positive3" {
-
-  name        = "${var.prefix}-external-http-https"
-  description = "Allow main HTTP / HTTPS"
-  vpc_id      = local.vpc_id
-
-  tags = {
-    Name = "${var.prefix}-external-http-https"
-  }
-}
-
 resource "aws_security_group_rule" "positive3-1" {
 
-  description       = "Enable HTTP access for select VMs"
   from_port         = 80
   to_port           = 80
-  cidr_blocks       = ["0.0.0.0/0"]
   protocol          = "tcp"
-  security_group_id = aws_security_group.positive3.id
+  cidr_blocks       = ["0.0.0.0/0"]
   type              = "ingress"
 }
 
@@ -24,8 +11,7 @@ resource "aws_security_group_rule" "positive3-2" {
 
   from_port         = 443
   to_port           = 443
-  cidr_blocks       = ["0.0.0.0/0"]
   protocol          = "tcp"
-  security_group_id = aws_security_group.positive3.id
-  type              = "ingress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  type              = "egress"
 }

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/positive4.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/positive4.tf
@@ -1,11 +1,4 @@
-resource "aws_security_group" "positive4" {
-  name        = "example-sg"
-  description = "Example security group"
-  vpc_id      = aws_vpc.main.id
-}
-
 resource "aws_vpc_security_group_ingress_rule" "positive4-1" {
-  security_group_id = aws_security_group.example.id
   cidr_ipv4         = "192.168.1.0/24"
   from_port         = 80
   to_port           = 80
@@ -13,7 +6,6 @@ resource "aws_vpc_security_group_ingress_rule" "positive4-1" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "positive4-2" {
-  security_group_id = aws_security_group.example.id
   cidr_ipv4         = "0.0.0.0/0"
   from_port         = 0
   to_port           = 0

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/positive5.tf
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/positive5.tf
@@ -1,143 +1,67 @@
-module "vote_service_sg_ipv4" {
+module "positive5_ipv4_array" {
   source  = "terraform-aws-modules/security-group/aws"
 
   ingress_with_cidr_blocks = [
     {
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = ["1.2.3.4"]
-    }
-  ]
-
-  egress_with_cidr_blocks = [
-    {
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = ["1.2.3.4"]
-    }
-  ]
-}
-
-module "vote_service_sg_ipv4_array" {
-  source  = "terraform-aws-modules/security-group/aws"
-
-  ingress_with_cidr_blocks = [
-    {
-      description = null
       from_port   = 2383
       to_port     = 2383
       protocol    = "udp"
       cidr_blocks = ["0.1.1.1/21", "8.8.8.8/24"]
     },
     {
-      description = "TLS from VPC"
       from_port   = 28000
       to_port     = 28001
       protocol    = "tcp"
       cidr_blocks = ["10.0.0.0/16"]
-    },
-    {
-      from_port   = 20
-      to_port     = 22
-      protocol    = "tcp"
-      cidr_blocks = ["192.01.01.02/23"]
     }
   ]
 
   egress_with_cidr_blocks = [
     {
-      description = null
       from_port   = 2383
       to_port     = 2383
       protocol    = "udp"
       cidr_blocks = ["0.1.1.1/21", "8.8.8.8/24"]
     },
     {
-      description = "TLS from VPC"
       from_port   = 28000
       to_port     = 28001
       protocol    = "tcp"
       cidr_blocks = ["10.0.0.0/16"]
-    },
-    {
-      from_port   = 20
-      to_port     = 22
-      protocol    = "tcp"
-      cidr_blocks = ["192.01.01.02/23"]
     }
   ]
 }
 
-module "vote_service_sg_ipv6" {
+module "positive5_ipv6_array" {
   source  = "terraform-aws-modules/security-group/aws"
 
   ingress_with_ipv6_cidr_blocks = [
     {
-      from_port        = 0
-      to_port          = 0
-      protocol         = "-1"
-      ipv6_cidr_blocks = ["2001:db8::/32"]
-    }
-  ]
-
-  egress_with_ipv6_cidr_blocks = [
-    {
-      from_port        = 0
-      to_port          = 0
-      protocol         = "-1"
-      ipv6_cidr_blocks = ["2001:db8::/32"]
-    }
-  ]
-}
-
-module "vote_service_sg_ipv6_array" {
-  source  = "terraform-aws-modules/security-group/aws"
-
-  ingress_with_ipv6_cidr_blocks = [
-    {
-      description      = null
       from_port        = 2383
       to_port          = 2383
       protocol         = "udp"
       ipv6_cidr_blocks = ["fd00::/8", "2001:4860:4860::8888/64"]
     },
     {
-      description      = "TLS from VPC"
       from_port        = 28000
       to_port          = 28001
       protocol         = "tcp"
       ipv6_cidr_blocks = ["fc00::/7"]
-    },
-    {
-      from_port        = 20
-      to_port          = 22
-      protocol         = "tcp"
-      ipv6_cidr_blocks = ["2001:db8:abcd:0012::/64"]
     }
   ]
 
   egress_with_ipv6_cidr_blocks = [
     {
-      description      = null
       from_port        = 2383
       to_port          = 2383
       protocol         = "udp"
       ipv6_cidr_blocks = ["fd00::/8", "2001:4860:4860::8888/64"]
     },
     {
-      description      = "TLS from VPC"
       from_port        = 28000
       to_port          = 28001
       protocol         = "tcp"
       ipv6_cidr_blocks = ["fc00::/7"]
-    },
-    {
-      from_port        = 20
-      to_port          = 22
-      protocol         = "tcp"
-      ipv6_cidr_blocks = ["2001:db8:abcd:0012::/64"]
     }
   ]
 }

--- a/assets/queries/terraform/aws/security_group_rules_without_description/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/security_group_rules_without_description/test/positive_expected_result.json
@@ -2,37 +2,61 @@
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 6,
+    "line": 3,
     "filename": "positive1.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 14,
+    "line": 11,
     "filename": "positive1.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 15,
+    "line": 3,
     "filename": "positive2.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 23,
+    "line": 10,
+    "filename": "positive2.tf"
+  },
+  {
+    "queryName": "Security Group Rule Without Description",
+    "severity": "INFO",
+    "line": 20,
+    "filename": "positive2.tf"
+  },
+  {
+    "queryName": "Security Group Rule Without Description",
+    "severity": "INFO",
+    "line": 27,
+    "filename": "positive2.tf"
+  },
+  {
+    "queryName": "Security Group Rule Without Description",
+    "severity": "INFO",
+    "line": 1,
     "filename": "positive3.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 7,
+    "line": 10,
+    "filename": "positive3.tf"
+  },
+  {
+    "queryName": "Security Group Rule Without Description",
+    "severity": "INFO",
+    "line": 1,
     "filename": "positive4.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 15,
+    "line": 8,
     "filename": "positive4.tf"
   },
   {
@@ -56,55 +80,55 @@
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 42,
+    "line": 34,
     "filename": "positive5.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 51,
+    "line": 43,
     "filename": "positive5.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 65,
+    "line": 49,
     "filename": "positive5.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 78,
+    "line": 62,
     "filename": "positive5.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 87,
+    "line": 71,
     "filename": "positive5.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 100,
+    "line": 84,
     "filename": "positive5.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 114,
+    "line": 90,
     "filename": "positive5.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 123,
+    "line": 99,
     "filename": "positive5.tf"
   },
   {
     "queryName": "Security Group Rule Without Description",
     "severity": "INFO",
-    "line": 137,
+    "line": 105,
     "filename": "positive5.tf"
   }
 ]


### PR DESCRIPTION
**Reason for Proposed Changes**
- The [original fix](https://github.com/Checkmarx/kics/pull/7646) for this query was missing a negative tests for an "aws_security_group" egress field. 
- Additionally the CxPolicy for modules was flagging as an "IncorrectValue" for the "issueType" when it should be "MissingAttribute".

**Proposed Changes**
- Added the missing test scenario 
-
-

I submit this contribution under the Apache-2.0 license.