### PR TITLE
fix(query): fixed allowRule's on Generic Token and Generic Secret from Passwords and Secrets query

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -90,7 +90,7 @@
         }, 
         {
           "description": "Allow secrets retrieved from Bicep getSecret built in function",
-          "regex": "(?i)['\"]?secret[_]?(key|value)?['\"]?\\s*(:|=)\\s*[a-zA-Z]*\\.getSecret\\(\\s*[\"']?([A-Za-z0-9/~^_!@#&%(){};=?*+-<>,:;[\\]%$]*)[\"']?"
+          "regex": "(?i)['\"]?secret[_]?(key|value)?['\"]?\\s*(:|=)\\s*[a-zA-Z]*\\.getSecret\\(\\s*[\"']([A-Za-z0-9/~^_!@#&%(){};=?*+-<>,:;[\\]%$]+)[\"']\\)"
         }
       ],
       "specialMask": "(?i)['\"]?secret[_]?(key)?['\"]?\\s*(:|=)\\s*"
@@ -353,7 +353,7 @@
         },
         {
           "description": "Avoiding references to module outputs in Bicep",
-          "regex": "(?i)['\"]?token(_)?(key)?\\s*[:=]\\s*([a-zA-Z][a-zA-Z0-9_]*)\\.outputs\\.([a-zA-Z][a-zA-Z0-9_]*)"
+          "regex": "(?i)token(_)?(key)?\\s*[:=]\\s*([a-zA-Z][a-zA-Z0-9_]*)\\.outputs\\.([a-zA-Z][a-zA-Z0-9_]*)"
         }
       ],
       "specialMask": "(?i)['\"]?token(_)?(key)?['\"]?\\s*[:=]\\s*"


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- On the current implementation, in the allowRule below, the regex covers the cases when there are no parentheses at the end, it also allows the built in function getSecret not to have any argument, which is not valid according to its documentation and the usage of the characters " or ' was not mandatory which is not valid since, according to the built-in function documentation, the argument must be a string thus, it should have the characters " or ' .
```
{
          "description": "Allow secrets retrieved from Bicep getSecret built in function",
          "regex": "(?i)['\"]?secret[_]?(key|value)?['\"]?\\s*(:|=)\\s*[a-zA-Z]*\\.getSecret\\(\\s*[\"']?([A-Za-z0-9/~^_!@#&%(){};=?*+-<>,:;[\\]%$]*)[\"']?"
}
```
- On the other allowRule, that was made to ignore the cases when a module output is referenced on Bicep format files, the ['\"]? should be removed since the target file type does not use quotes to declare variables.
```
{
          "description": "Avoiding references to module outputs in Bicep",
          "regex": "(?i)['\"]?token(_)?(key)?\\s*[:=]\\s*([a-zA-Z][a-zA-Z0-9_]*)\\.outputs\\.([a-zA-Z][a-zA-Z0-9_]*)"
}
```
**Proposed Changes**
- Changed the first allowRule from `(?i)['\"]?secret[_]?(key|value)?['\"]?\\s*(:|=)\\s*[a-zA-Z]*\\.getSecret\\(\\s*[\"']?([A-Za-z0-9/~^_!@#&%(){};=?*+-<>,:;[\\]%$]*)[\"']?` to `(?i)['\"]?secret[_]?(key|value)?['\"]?\\s*(:|=)\\s*[a-zA-Z]*\\.getSecret\\(\\s*[\"']([A-Za-z0-9/~^_!@#&%(){};=?*+-<>,:;[\\]%$]+)[\"']\\)`.

- Removed the ['\"] from the beginning of the second allowRule, changing the allowRule from `(?i)['\"]?token(_)?(key)?\\s*[:=]\\s*([a-zA-Z][a-zA-Z0-9_]*)\\.outputs\\.([a-zA-Z][a-zA-Z0-9_]*)` to `(?i)token(_)?(key)?\\s*[:=]\\s*([a-zA-Z][a-zA-Z0-9_]*)\\.outputs\\.([a-zA-Z][a-zA-Z0-9_]*)`.


I submit this contribution under the Apache-2.0 license.