### PR TITLE
fix(query): adding support for CloudFormation queries not supporting ingress/egress resources

### DIFF
--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/query.rego
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/query.rego
@@ -4,44 +4,41 @@ import data.generic.cloudformation as cf_lib
 import data.generic.common as common_lib
 
 CxPolicy[result] {
-	resource := input.document[i].Resources[name]
+	doc := input.document[i]
+	resource := doc.Resources[name]
 
 	cf_lib.isLoadBalancer(resource)
 	securityGroups := resource.Properties.SecurityGroups
-
-	some sg
-	securityGroup := securityGroups[sg]
-	value := withoutOutboundRules(securityGroup)
+	
+	securityGroup_name := cf_lib.get_name(securityGroups[sg])
+	not has_standalone_ingress(securityGroup_name, doc)
+	value := withoutOutboundRules(doc.Resources[securityGroup_name],securityGroup_name)
+	value != ""
 
 	result := {
-		"documentId": input.document[i].id,
+		"documentId": doc.id,
 		"resourceType": resource.Type,
 		"resourceName": cf_lib.get_resource_name(resource, name),
-		"searchKey": sprintf("Resources.%s.Properties%s", [securityGroup, value.path]),
+		"searchKey": sprintf("Resources.%s.Properties%s", [securityGroup_name, value.path]),
 		"issueType": value.issue,
-		"keyExpectedValue": sprintf("'Resources.%s.Properties.SecurityGroupIngress' is %s", [securityGroup, value.expected]),
-		"keyActualValue": sprintf("'Resources.%s.Properties.SecurityGroupIngress' is %s", [securityGroup, value.actual]),
+		"keyExpectedValue": sprintf("'Resources.%s.Properties.SecurityGroupIngress' should %s", [securityGroup_name, value.expected]),
+		"keyActualValue": sprintf("'Resources.%s.Properties.SecurityGroupIngress' is %s", [securityGroup_name, value.actual]),
+		"searchLine": common_lib.build_search_line(value.searchlineArray,[])
 	}
 }
 
-withoutOutboundRules(securityGroupName) = result {
-	securityGroup := input.document[i].Resources[securityGroupName]
+withoutOutboundRules(securityGroup,name) = results {
 	not common_lib.valid_key(securityGroup.Properties, "SecurityGroupIngress")
-	result := {"expected": "defined", "actual": "undefined", "path": "", "issue": "MissingAttribute"}
-}
-
-withoutOutboundRules(securityGroupName) = result {
-	securityGroup := input.document[i].Resources[securityGroupName]
+	results := {"expected": "be defined", "actual": "undefined", "path": "", "issue": "MissingAttribute",
+				"searchlineArray": ["Resources", name, "Properties"]}
+} else = results {
 	securityGroup.Properties.SecurityGroupIngress == []
-	result := {"expected": "not empty", "actual": "empty", "path": ".SecurityGroupIngress", "issue": "IncorrectValue"}
-}
+	results := {"expected": "not be empty", "actual": "empty", "path": ".SecurityGroupIngress", "issue": "IncorrectValue",
+				"searchlineArray": ["Resources", name, "Properties", "SecurityGroupIngress"]}
+} 
 
-withoutOutboundRules(securityGroupName) = result {
-    some j
-        resource := input.document[i].Resources[j]
-        resource.Type == "AWS::EC2::SecurityGroupIngress"
-        groupId := resource.Properties.GroupId
-        id := replace(groupId, "!Ref ", "")
-        not id == securityGroupName
-    result := {"expected": "defined", "actual": "undefined", "path": "", "issue": "MissingAttribute"}
+has_standalone_ingress(securityGroup_name,doc) {
+	resource := doc.Resources[j]
+	resource.Type == "AWS::EC2::SecurityGroupIngress"
+	cf_lib.get_name(resource.Properties.GroupId) == securityGroup_name
 }

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/test/negative3.yaml
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/test/negative3.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  sgwithingress:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Limits security group egress traffic
+
+  sgIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref sgwithingress
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      CidrIp: 0.0.0.0/0
+
+  MyLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      SecurityGroups:
+        - !Ref sgwithingress

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/test/negative4.json
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/test/negative4.json
@@ -1,0 +1,33 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
+  "Resources": {
+    "sgwithingress": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Limits security group egress traffic"
+      }
+    },
+    "sgIngressRule": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "sgwithingress"
+        },
+        "IpProtocol": "tcp",
+        "FromPort": 80,
+        "ToPort": 80,
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
+    "MyLoadBalancer": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "SecurityGroups": [
+          {
+            "Ref": "sgwithingress"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/test/positive3.yaml
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/test/positive3.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  sgwithingress:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Limits security group egress traffic
+
+  sgIngressRule:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref wrong_ref
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      CidrIp: 0.0.0.0/0
+
+  MyLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      SecurityGroups:
+        - !Ref sgwithingress

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/test/positive4.json
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/test/positive4.json
@@ -1,0 +1,33 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
+  "Resources": {
+    "sgwithingress": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Limits security group egress traffic"
+      }
+    },
+    "sgIngressRule": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "wrong_ref"
+        },
+        "IpProtocol": "tcp",
+        "FromPort": 80,
+        "ToPort": 80,
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
+    "MyLoadBalancer": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "SecurityGroups": [
+          {
+            "Ref": "sgwithingress"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_inbound_rules/test/positive_expected_result.json
@@ -1,14 +1,26 @@
 [
   {
-    "line": 5,
-    "fileName": "positive1.yaml",
     "queryName": "ELB With Security Group Without Inbound Rules",
-    "severity": "MEDIUM"
+    "severity": "MEDIUM",
+    "line": 5,
+    "fileName": "positive1.yaml"
   },
   {
     "queryName": "ELB With Security Group Without Inbound Rules",
     "severity": "MEDIUM",
     "line": 6,
     "fileName": "positive2.json"
+  },
+  {
+    "queryName": "ELB With Security Group Without Inbound Rules",
+    "severity": "MEDIUM",
+    "line": 5,
+    "fileName": "positive3.yaml"
+  },
+  {
+    "queryName": "ELB With Security Group Without Inbound Rules",
+    "severity": "MEDIUM",
+    "line": 6,
+    "fileName": "positive4.json"
   }
 ]

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/negative2.json
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/negative2.json
@@ -2,18 +2,18 @@
   "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
   "Resources": {
     "sgwithegress": {
+      "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
         "GroupDescription": "Limits security group egress traffic",
         "SecurityGroupEgress": [
           {
-            "IpProtocol": "tcp",
-            "FromPort": 80,
             "ToPort": 80,
-            "CidrIp": "0.0.0.0/0"
+            "CidrIp": "0.0.0.0/0",
+            "IpProtocol": "tcp",
+            "FromPort": 80
           }
         ]
-      },
-      "Type": "AWS::EC2::SecurityGroup"
+      }
     },
     "MyLoadBalancer": {
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer",

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/negative3.yaml
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/negative3.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  sgwithegress:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Limits security group egress traffic
+
+  sgEgressRule:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref sgwithegress
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      CidrIp: 0.0.0.0/0
+
+  MyLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      SecurityGroups:
+        - !Ref sgwithegress

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/negative4.json
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/negative4.json
@@ -1,0 +1,33 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
+  "Resources": {
+    "sgwithegress": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Limits security group egress traffic"
+      }
+    },
+    "sgEgressRule": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "sgwithegress"
+        },
+        "IpProtocol": "tcp",
+        "FromPort": 80,
+        "ToPort": 80,
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
+    "MyLoadBalancer": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "SecurityGroups": [
+          {
+            "Ref": "sgwithegress"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/positive3.yaml
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/positive3.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  sgwithegress:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Limits security group egress traffic
+
+  sgEgressRule:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref wrong_ref
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      CidrIp: 0.0.0.0/0
+
+  MyLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      SecurityGroups:
+        - !Ref sgwithegress

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/positive4.json
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/positive4.json
@@ -1,0 +1,33 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09T00:00:00Z",
+  "Resources": {
+    "sgwithegress": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Limits security group egress traffic"
+      }
+    },
+    "sgEgressRule": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "wrong_ref"
+        },
+        "IpProtocol": "tcp",
+        "FromPort": 80,
+        "ToPort": 80,
+        "CidrIp": "0.0.0.0/0"
+      }
+    },
+    "MyLoadBalancer": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "SecurityGroups": [
+          {
+            "Ref": "sgwithegress"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/positive_expected_result.json
+++ b/assets/queries/cloudFormation/aws/elb_with_security_group_without_outbound_rules/test/positive_expected_result.json
@@ -10,5 +10,17 @@
     "severity": "MEDIUM",
     "line": 6,
     "fileName": "positive2.json"
+  },
+  {
+    "queryName": "ELB With Security Group Without Outbound Rules",
+    "severity": "MEDIUM",
+    "line": 5,
+    "fileName": "positive3.yaml"
+  },
+  {
+    "queryName": "ELB With Security Group Without Outbound Rules",
+    "severity": "MEDIUM",
+    "line": 6,
+    "fileName": "positive4.json"
   }
 ]


### PR DESCRIPTION
Closes #7303
[**Parent PR**](https://github.com/Checkmarx/kics/pull/7646)

**Reason for Proposed Changes**

- Currently some CloudFormation queries do not  support the newer "[AWS::EC2::SecurityGroupIngress](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-ec2-securitygroupingress.html)" and "[AWS::EC2::SecurityGroupEgress](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-ec2-securitygroupegress.html)" resources, only working for samples with the legacy "[AWS::EC2::SecurityGroup](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-ec2-securitygroup.html)" resource. 



| Query Name                                      | Query ID                                  | Query Logic |
|------------------------------------------------|-------------------------------------------|-------------|
| ELB With Security Group Without Outbound Rules | 01d5a458-a6c4-452a-ac50-054d59275b7c      | query 1     |
| DB Security Group With Public Scope            | 9564406d-e761-4e61-b8d7-5926e3ab8e79      | query 2     |
| Default Security Groups With Unrestricted Traffic | ea33fcf7-394b-4d11-a228-985c5d08f205    | query 3     |
| EC2 Sensitive Port Is Publicly Exposed         | 494b03d3-bf40-4464-8524-7c56ad0700ed      | query 4     |
| ELB Sensitive Port Is Exposed To Entire Network| 78055456-f670-4d2e-94d5-392d1cf4f5e4      | query 5     |
| HTTP Port Open To Internet                     | ddfc4eaa-af23-409f-b96c-bf5c45dc4daa      | query 6     |
| Remote Desktop Port Open To Internet           | c9846969-d066-431f-9b34-8c4abafe422a      | query 7     |
| Security Groups Allows Unrestricted Outbound Traffic | 66f2d8f9-a911-4ced-ae27-34f09690bb2c  | query 8     |
| Security Group Unrestricted Access To RDP      | 3ae83918-7ec7-4cb8-80db-b91ef0f94002      | query 9     |
| Security Groups With Exposed Admin Ports       | cdbb0467-2957-4a77-9992-7b55b29df7b7      | query 10    |
| Security Groups With Meta IP                   | adcd0082-e90b-4b63-862b-21899f6e6a48      | query 11    |
| Security Group With Unrestricted Access To SSH | 6e856af2-62d7-4ba2-adc1-73b62cef9cc1      | query 12    |
| Unknown Port Exposed To Internet               | 829ce3b8-065c-41a3-ad57-e0accfea82d2      | query 13    |
| DB Security Group Open To Large Scope          | 0104165b-02d5-426f-abc9-91fb48189899      | query 14    |


**Proposed Changes**
-
-
-

I submit this contribution under the Apache-2.0 license.