### PR TITLE
fix(link): update descriptionUrl with correct link for NPM Install Command Without Pinned Version dockerfile query

### DIFF
--- a/assets/queries/dockerfile/npm_install_without_pinned_version/metadata.json
+++ b/assets/queries/dockerfile/npm_install_without_pinned_version/metadata.json
@@ -4,8 +4,9 @@
   "severity": "MEDIUM",
   "category": "Supply-Chain",
   "descriptionText": "Check if packages installed by npm are pinning a specific version.",
-  "descriptionUrl": "https://docs.docker.com/engine/reference/builder/#run",
+  "descriptionUrl": "https://docs.docker.com/reference/dockerfile/#run",
   "platform": "Dockerfile",
   "descriptionID": "8bd60033",
-  "cwe": "1357"
+  "cwe": "1357",
+  "cloudProvider": "common"
 }


### PR DESCRIPTION
Closes #7747

**Reason for Proposed Changes**
- The query metadata was pointing to a stale Docker documentation link.
- The cloudProvider field was missing in the query metadata.

**Proposed Changes**
- Update the descriptionUrl to the right link: https://docs.docker.com/reference/dockerfile/#run;
- Added the missing cloudProvider field to the query.

I submit this contribution under the Apache-2.0 license.