### PR TITLE
fix(flags): sanitizing leading and trailing spaces from multi string flags

### DIFF
--- a/internal/console/flags/flags.go
+++ b/internal/console/flags/flags.go
@@ -151,7 +151,11 @@ func GetStrFlag(flagName string) string {
 // GetMultiStrFlag get a slice of strings flag by its name
 func GetMultiStrFlag(flagName string) []string {
 	if value, ok := flagsMultiStrReferences[flagName]; ok {
-		return *value
+		res := make([]string, len(*value))
+		for i, s := range *value {
+			res[i] = strings.TrimSpace(s)
+		}
+		return res
 	}
 	log.Debug().Msgf("Could not find string slice flag %s", flagName)
 	return []string{}

--- a/internal/console/flags/validate_multi_str.go
+++ b/internal/console/flags/validate_multi_str.go
@@ -52,7 +52,6 @@ func validateMultiStrEnum(flagName string) error {
 		caseInsensitiveMap[strings.ToLower(key)] = value
 	}
 	for _, enum := range enums {
-		enum = strings.TrimSpace(enum)
 		if _, ok := caseInsensitiveMap[strings.ToLower(enum)]; enum != "" && !ok {
 			invalidEnum = append(invalidEnum, enum)
 		}

--- a/internal/console/flags/validate_multi_str_test.go
+++ b/internal/console/flags/validate_multi_str_test.go
@@ -80,8 +80,8 @@ func TestFlags_validateMultiStrEnum(t *testing.T) {
 		{
 			name:      "should execute fine when values have leading or trailing spaces",
 			flagName:  "exclude-categories",
-			flagValue: &[]string{"Ansible ", "  Terraform  "},
-			wantErr:   true,
+			flagValue: &[]string{"Backup ", "  Encryption  "},
+			wantErr:   false,
 		},
 	}
 	for _, test := range tests {
@@ -108,6 +108,12 @@ func TestFlags_allQueriesID(t *testing.T) {
 			name:      "should execute fine",
 			flagName:  "exclude-queries",
 			flagValue: &[]string{"f81d63d2-c5d7-43a4-a5b5-66717a41c895"},
+			wantErr:   false,
+		},
+		{
+			name:      "should execute fine when value has leading or trailing spaces",
+			flagName:  "exclude-queries",
+			flagValue: &[]string{"f81d63d2-c5d7-43a4-a5b5-66717a41c895", " 4728cd65-a20c-49da-8b31-9c08b423e4db "},
 			wantErr:   false,
 		},
 		{


### PR DESCRIPTION
**Proposed Changes**
- Added sanitization to multi string flags when arguments have spaces separating them
- Added unit test to multi string flags test

I submit this contribution under the Apache-2.0 license.