### PR TITLE
fix(makefile): update CONSTANTS_PATH in Makefile for v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ VERSION := snapshot-$(shell echo ${COMMIT} | cut -c1-8)
 LIB = $(shell pwd)/lib
 IMAGE_TAG := dev
 TARGET_BIN ?= bin/kics
-CONSTANTS_PATH = github.com/Checkmarx/kics/internal/constants
+CONSTANTS_PATH = github.com/Checkmarx/kics/v2/internal/constants
 
 .PHONY: clean
 clean: ## remove files created during build


### PR DESCRIPTION
Closes #7763 

**Reason for Proposed Changes**

Running `make build` does not inject the correct version

**Proposed Changes**
- Update the `CONSTANTS_PATH` variable in the Makefile to reflect the update to v2

I submit this contribution under the Apache-2.0 license.