### PR TITLE
fix(query): added missing support for "aws_launch_template" resource to "Instance Uses Metadata Service IMDSv1"

### DIFF
--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/query.rego
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/query.rego
@@ -3,7 +3,7 @@ package Cx
 import data.generic.common as common_lib
 import data.generic.terraform as tf_lib
 
-types := ["aws_instance","aws_launch_configuration"]
+types := ["aws_instance", "aws_launch_configuration", "aws_launch_template"]
 
 CxPolicy[result] {
     resource := input.document[i].resource[types[i2]][name]
@@ -47,7 +47,7 @@ CxPolicy[result] {
 }
 
 is_metadata_service_enabled (resource) {
-    resource.metadata_options.http_endpoint == "enabled" 
+    resource.metadata_options.http_endpoint == "enabled"
 } else {
     not common_lib.valid_key(resource, "metadata_options")
 } else {

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/negative1.tf
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/negative1.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "negative1" {
+resource "aws_instance" "negative1_1" {
   ami           = "ami-12345678"
   instance_type = "t2.micro"
 
@@ -12,7 +12,17 @@ resource "aws_instance" "negative1" {
   }
 }
 
-resource "aws_launch_configuration" "negative1" {
+resource "aws_launch_configuration" "negative1_2" {
+  image_id      = "ami-12345678"
+  instance_type = "t2.micro"
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+}
+
+resource "aws_launch_template" "negative1_3" {
   image_id      = "ami-12345678"
   instance_type = "t2.micro"
 

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/negative2.tf
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/negative2.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "negative2" {
+resource "aws_instance" "negative2_1" {
   ami           = "ami-12345678"
   instance_type = "t2.micro"
 
@@ -11,7 +11,16 @@ resource "aws_instance" "negative2" {
   }
 }
 
-resource "aws_launch_configuration" "negative2" {
+resource "aws_launch_configuration" "negative2_2" {
+  image_id      = "ami-12345678"
+  instance_type = "t2.micro"
+
+  metadata_options {
+    http_tokens   = "required"
+  }
+}
+
+resource "aws_launch_template" "negative2_3" {
   image_id      = "ami-12345678"
   instance_type = "t2.micro"
 

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/negative3.tf
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/negative3.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "negative3" {
+resource "aws_instance" "negative3_1" {
   ami           = "ami-12345678"
   instance_type = "t2.micro"
 
@@ -12,7 +12,17 @@ resource "aws_instance" "negative3" {
   }
 }
 
-resource "aws_launch_configuration" "negative3" {
+resource "aws_launch_configuration" "negative3_2" {
+  image_id      = "ami-12345678"
+  instance_type = "t2.micro"
+
+  metadata_options {
+    http_endpoint = "disabled"
+    http_tokens   = "optional"
+  }
+}
+
+resource "aws_launch_template" "negative3_3" {
   image_id      = "ami-12345678"
   instance_type = "t2.micro"
 

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/negative4.tf
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/negative4.tf
@@ -21,4 +21,3 @@ module "negative4_launch_config" {
     http_tokens   = "required"
   }
 }
-

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/negative6.tf
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/negative6.tf
@@ -21,4 +21,3 @@ module "negative6_launch_config" {
     http_tokens   = "optional"
   }
 }
-

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive1.tf
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive1.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "positive1" {
+resource "aws_instance" "positive1_1" {
   ami           = "ami-12345678"
   instance_type = "t2.micro"
 
@@ -11,7 +11,16 @@ resource "aws_instance" "positive1" {
   }
 }
 
-resource "aws_launch_configuration" "positive1" {
+resource "aws_launch_configuration" "positive1_2" {
+  image_id      = "ami-12345678"
+  instance_type = "t2.micro"
+
+  metadata_options {
+    http_tokens   = "optional"
+  }
+}
+
+resource "aws_launch_template" "positive1_3" {
   image_id      = "ami-12345678"
   instance_type = "t2.micro"
 

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive2.tf
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive2.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "positive2" {
+resource "aws_instance" "positive2_1" {
   ami           = "ami-12345678"
   instance_type = "t2.micro"
 
@@ -12,7 +12,17 @@ resource "aws_instance" "positive2" {
   }
 }
 
-resource "aws_launch_configuration" "positive2" {
+resource "aws_launch_configuration" "positive2_2" {
+  image_id      = "ami-12345678"
+  instance_type = "t2.micro"
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "optional"
+  }
+}
+
+resource "aws_launch_template" "positive2_3" {
   image_id      = "ami-12345678"
   instance_type = "t2.micro"
 

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive3.tf
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive3.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "positive3" {
+resource "aws_instance" "positive3_1" {
   ami           = "ami-12345678"
   instance_type = "t2.micro"
 
@@ -11,7 +11,16 @@ resource "aws_instance" "positive3" {
   }
 }
 
-resource "aws_launch_configuration" "positive3" {
+resource "aws_launch_configuration" "positive3_2" {
+  image_id      = "ami-12345678"
+  instance_type = "t2.micro"
+
+  metadata_options {
+    instance_metadata_tags = "enabled"
+  }
+}
+
+resource "aws_launch_template" "positive3_3" {
   image_id      = "ami-12345678"
   instance_type = "t2.micro"
 

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive4.tf
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive4.tf
@@ -2,12 +2,17 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "positive4" {
+resource "aws_instance" "positive4_1" {
   ami           = "ami-12345678"
   instance_type = "t2.micro"
 }
 
-resource "aws_launch_configuration" "positive4" {
+resource "aws_launch_configuration" "positive4_2" {
+  image_id      = "ami-12345678"
+  instance_type = "t2.micro"
+}
+
+resource "aws_launch_template" "positive4_3" {
   image_id      = "ami-12345678"
   instance_type = "t2.micro"
 }

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive5.tf
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive5.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_instance" "positive5" {
+resource "aws_instance" "positive5_1" {
   ami           = "ami-12345678"
   instance_type = "t2.micro"
 
@@ -11,7 +11,16 @@ resource "aws_instance" "positive5" {
   }
 }
 
-resource "aws_launch_configuration" "positive5" {
+resource "aws_launch_configuration" "positive5_2" {
+  image_id      = "ami-12345678"
+  instance_type = "t2.micro"
+
+  metadata_options {
+    http_endpoint = "enabled"
+  }
+}
+
+resource "aws_launch_template" "positive5_3" {
   image_id      = "ami-12345678"
   instance_type = "t2.micro"
 

--- a/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1/test/positive_expected_result.json
@@ -14,6 +14,12 @@
     {
         "queryName": "Instance Uses Metadata Service IMDSv1",
         "severity": "LOW",
+        "line": 28,
+        "fileName": "positive1.tf"
+    },
+    {
+        "queryName": "Instance Uses Metadata Service IMDSv1",
+        "severity": "LOW",
         "line": 11,
         "fileName": "positive2.tf"
     },
@@ -26,6 +32,12 @@
     {
         "queryName": "Instance Uses Metadata Service IMDSv1",
         "severity": "LOW",
+        "line": 31,
+        "fileName": "positive2.tf"
+    },
+    {
+        "queryName": "Instance Uses Metadata Service IMDSv1",
+        "severity": "LOW",
         "line": 9,
         "fileName": "positive3.tf"
     },
@@ -33,6 +45,12 @@
         "queryName": "Instance Uses Metadata Service IMDSv1",
         "severity": "LOW",
         "line": 18,
+        "fileName": "positive3.tf"
+    },
+    {
+        "queryName": "Instance Uses Metadata Service IMDSv1",
+        "severity": "LOW",
+        "line": 27,
         "fileName": "positive3.tf"
     },
     {
@@ -50,6 +68,12 @@
     {
         "queryName": "Instance Uses Metadata Service IMDSv1",
         "severity": "LOW",
+        "line": 15,
+        "fileName": "positive4.tf"
+    },
+    {
+        "queryName": "Instance Uses Metadata Service IMDSv1",
+        "severity": "LOW",
         "line": 9,
         "fileName": "positive5.tf"
     },
@@ -57,6 +81,12 @@
         "queryName": "Instance Uses Metadata Service IMDSv1",
         "severity": "LOW",
         "line": 18,
+        "fileName": "positive5.tf"
+    },
+    {
+        "queryName": "Instance Uses Metadata Service IMDSv1",
+        "severity": "LOW",
+        "line": 27,
         "fileName": "positive5.tf"
     },
     {


### PR DESCRIPTION
**Reason for Proposed Changes**
- The recently implemented query "[Instance Uses Metadata Service IMDSv1](https://github.com/Checkmarx/kics/tree/master/assets/queries/terraform/aws/instance_uses_metadata_service_IMDSv1)" was supporting 2 resources : "[aws_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance)" and "[aws_launch_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration)". The "aws_launch_template" resource was missing support entirely, which is the modern version of the outdated "aws_launch_configuration". 

**Proposed Changes**
- Added support for the relevant resource and added improved tests to account for the change. 

I submit this contribution under the Apache-2.0 license.