### PR TITLE
test(missing): added missing tests for gcp query "ensure_essential_contacts_is_configured_for_organization"

### DIFF
--- a/assets/queries/terraform/gcp/ensure_essential_contacts_is_configured_for_organization/test/negative5.tf
+++ b/assets/queries/terraform/gcp/ensure_essential_contacts_is_configured_for_organization/test/negative5.tf
@@ -1,0 +1,7 @@
+resource "google_essential_contacts_contact" "negative5" {
+  parent = "folders/987654321"       # Not organization-level
+  email  = "foo@bar.com"
+  language_tag = "en-GB"
+
+  notification_category_subscriptions = ["ALL"]
+}

--- a/assets/queries/terraform/gcp/ensure_essential_contacts_is_configured_for_organization/test/negative6.tf
+++ b/assets/queries/terraform/gcp/ensure_essential_contacts_is_configured_for_organization/test/negative6.tf
@@ -1,0 +1,12 @@
+resource "google_essential_contacts_contact" "negative6" {
+  parent = "organizations/123456789012"
+  email = "foo@bar.com"
+  language_tag = "en-GB"
+  notification_category_subscriptions = [
+    "LEGAL",
+    "SECURITY",
+    "SUSPENSION",
+    "BILLING",
+    "TECHNICAL"
+  ]
+}

--- a/assets/queries/terraform/gcp/ensure_essential_contacts_is_configured_for_organization/test/negative7.tf
+++ b/assets/queries/terraform/gcp/ensure_essential_contacts_is_configured_for_organization/test/negative7.tf
@@ -1,0 +1,16 @@
+data "google_organization" "org" {
+  organization = "123456789012"
+}
+
+resource "google_essential_contacts_contact" "positive1" {
+  parent = data.google_organization.org.name
+  email  = "foo@bar.com"
+  language_tag = "en-GB"
+
+  notification_category_subscriptions = [
+    "LEGAL",
+    "SECURITY",
+    "SUSPENSION",
+    "ALL"
+  ]
+}


### PR DESCRIPTION
**Reason for Proposed Changes**
- The tests added for this query did not cover all detection flows.

**Proposed Changes**
- Added a test in a **folder level** instead of an **organization level**.
- Added a test where the `notification_category_subscriptions` field contains the four mandatory notification categories plus one more category. 
- Added a test where the `notification_category_subscriptions` field contains the `ALL` category plus one more category.

I submit this contribution under the Apache-2.0 license.