### PR TITLE
test(fix): Fixed the negative7 test

### DIFF
--- a/assets/queries/terraform/gcp/ensure_essential_contacts_is_configured_for_organization/test/negative7.tf
+++ b/assets/queries/terraform/gcp/ensure_essential_contacts_is_configured_for_organization/test/negative7.tf
@@ -2,7 +2,7 @@ data "google_organization" "org" {
   organization = "123456789012"
 }
 
-resource "google_essential_contacts_contact" "positive1" {
+resource "google_essential_contacts_contact" "negative7" {
   parent = data.google_organization.org.name
   email  = "foo@bar.com"
   language_tag = "en-GB"


### PR DESCRIPTION
**Reason for Proposed Changes**
- The negative7 test had the resource named `positive1` instead of `negative7`.

I submit this contribution under the Apache-2.0 license.