### PR TITLE
test(missing): added missing tests for azure query "activity_log_alert_for_service_health_not_configured"

### DIFF
--- a/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/negative1.tf
+++ b/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/negative1.tf
@@ -18,9 +18,34 @@ resource "azurerm_monitor_activity_log_alert" "negative1" {
   }
 }
 
+resource "azurerm_monitor_activity_log_alert" "negative2" {
+  name                = "ServiceHealthActivityLogAlert"
+  resource_group_name = var.resource_group_name
+  scopes              = [data.azurerm_subscription.current.id]
+  description         = "Alert for Azure Service Health events"
+  enabled             = true
+
+  criteria {
+    category = "ServiceHealth"
+
+     service_health {
+      events = [
+        "Incident",
+        "Maintenance",
+        "Security",
+        "Informational"
+      ]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.notify_team.id
+  }
+}
+
 data "azurerm_subscription" "current" {}
 
-resource "azurerm_monitor_activity_log_alert" "negative2" {
+resource "azurerm_monitor_activity_log_alert" "negative3" {
   name                = "ServiceHealthActivityLogAlert"
   resource_group_name = var.resource_group_name
   scopes              = [data.azurerm_subscription.secondary.id]
@@ -42,4 +67,16 @@ resource "azurerm_monitor_activity_log_alert" "negative2" {
 
 data "azurerm_subscription" "secondary" {
   subscription_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+
+resource "azurerm_monitor_activity_log_alert" "negative4" {
+  name                = "ServiceHealthActivityLogAlert"
+  resource_group_name = var.resource_group_name
+  scopes = [azurerm_resource_group.example.id] # The scope needs to be a subscription
+  description         = "Alert for Azure Service Health events"
+  enabled             = true
+
+  action {
+    action_group_id = azurerm_monitor_action_group.notify_team.id
+  }
 }

--- a/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive2/positive2_1.tf
+++ b/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive2/positive2_1.tf
@@ -26,7 +26,7 @@ resource "azurerm_monitor_activity_log_alert" "positive2_2" {
   enabled             = true
 
   criteria {
-    category = "ServiceHealth"  # Wrong category
+    category = "ServiceHealth"
 
      service_health {
       # Missing 'events'

--- a/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive2/positive2_2.tf
+++ b/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive2/positive2_2.tf
@@ -6,7 +6,7 @@ resource "azurerm_monitor_activity_log_alert" "positive2_3" {
   enabled             = true
 
   criteria {
-    category = "ServiceHealth"  # Wrong category
+    category = "ServiceHealth"
 
       # Missing 'service_health'
   }

--- a/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive7/positive7.tf
+++ b/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive7/positive7.tf
@@ -1,0 +1,1 @@
+data "azurerm_subscription" "positive7" {}

--- a/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive7/positive_expected_result.json
+++ b/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive7/positive_expected_result.json
@@ -1,0 +1,8 @@
+[
+  {
+    "queryName": "Beta - Activity Log Alert For Service Health Not Configured",
+    "severity": "MEDIUM",
+    "line": 3,
+    "fileName": "positive7.tf"
+  }
+]


### PR DESCRIPTION
**Reason for Proposed Changes**
- The tests added for this query did not cover all detection flows.

**Proposed Changes**
- Added a test with multiple values inside the **events** field.
- Added a test for a resource with a different scope other then subscription.
- Added a test with just one subscription, to see if it detects the fact that's not being used even when there is no resource on the folder.
- Removed wrong comments inside the positive2 test.

I submit this contribution under the Apache-2.0 license.