### PR TITLE
test(fix): Removed the positive7 test

### DIFF
--- a/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive7/positive7.tf
+++ b/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive7/positive7.tf
@@ -1,1 +1,0 @@
-data "azurerm_subscription" "positive7" {}

--- a/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive7/positive_expected_result.json
+++ b/assets/queries/terraform/azure/activity_log_alert_for_service_health_not_configured/test/positive7/positive_expected_result.json
@@ -1,8 +1,0 @@
-[
-  {
-    "queryName": "Beta - Activity Log Alert For Service Health Not Configured",
-    "severity": "MEDIUM",
-    "line": 1,
-    "fileName": "positive7.tf"
-  }
-]


### PR DESCRIPTION
**Reason for Proposed Changes**
- Removed the positive7 test because it ultimately didn't offer any test coverage and it seems a single file can't be on a folder or else it doesn't pass the automatic tests. 

I submit this contribution under the Apache-2.0 license.