### PR TITLE
test(missing): added missing tests for gcp query "legacy_networks_do_not_exist_for_older_google_projects"

### DIFF
--- a/assets/queries/terraform/gcp/legacy_networks_do_not_exist_for_older_google_projects/test/negative4.tf
+++ b/assets/queries/terraform/gcp/legacy_networks_do_not_exist_for_older_google_projects/test/negative4.tf
@@ -1,0 +1,11 @@
+resource "google_project" "example_project" {
+  name       = "My Project"
+  project_id = "bad"
+  org_id     = "1234567"
+}
+
+resource "google_compute_network" "vpc_network_network" {
+  name = "vpc-legacy"
+  project = google_project.not_example_project.id
+  auto_create_subnetworks = true
+}

--- a/assets/queries/terraform/gcp/legacy_networks_do_not_exist_for_older_google_projects/test/negative5.tf
+++ b/assets/queries/terraform/gcp/legacy_networks_do_not_exist_for_older_google_projects/test/negative5.tf
@@ -1,0 +1,4 @@
+resource "google_compute_network" "vpc_network_network" {
+  name = "vpc-legacy"
+  auto_create_subnetworks = true
+}


### PR DESCRIPTION
**Reason for Proposed Changes**
- The tests added for this query did not cover all detection flows.

**Proposed Changes**
- Added a test with an incorrect association via the project field.
- Added a test were there is only a google_compute_network resource with the auto_create_subnetworks field set to "true", but it's not associated with a google_project nor there is a provider.

I submit this contribution under the Apache-2.0 license.