### PR TITLE
refactor(similarityID): the transition type in the transition yaml files similarityID from 2 to 1 in beta queries

### DIFF
--- a/assets/similarityID_transition/terraform_azure.yaml
+++ b/assets/similarityID_transition/terraform_azure.yaml
@@ -6,7 +6,7 @@ similarityIDChangeList:
     - queryId: 9bf1568d-4cd2-4581-81ef-d2efabee1178
       queryName: Beta - Storage Account Without CMK
       observations: ""
-      change: 2
+      change: 1
     - queryId: dafe30ec-325d-4516-85d1-e8e6776f012c
       queryName: Azure Instance Using Basic Authentication
       observations: ""
@@ -14,186 +14,188 @@ similarityIDChangeList:
     - queryId: a5cfef8f-910e-4fd6-8155-f381b236a492
       queryName: Beta - VM Without Admin SSH Public Key Set
       observations: ""
-      change: 2
+      change: 1
     - queryId: 59528fe9-0c8e-4153-8016-445911a2d933
       queryName: Beta - VM With Extension Operations Enabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: 187e6d39-5e1e-4afa-9c0a-b79632eef346
       queryName: Beta - VM With Automatic Updates Disabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: 68403c84-8497-449b-9946-ae848765813f
       queryName: Beta - Disk Encryption On Managed Disk Disabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: fbb8e5e0-6dea-41d3-8739-4f2405b0e22a
       queryName: Beta - Key Vault Without HSM Protection
       observations: ""
-      change: 2
+      change: 1
     - queryId: 30c7c2f1-c048-49ba-81a4-ae465bbb3335
       queryName: Beta - VM Without Encryption At Host
       observations: ""
-      change: 2
+      change: 1
     - queryId: 0745bb3f-60dc-43b6-90ae-67bb01fd1775
       queryName: Beta - SQL Database Without Data Encryption
       observations: ""
-      change: 2
+      change: 1
     - queryId: 0536c90c-714e-4184-991e-3fed8d8b7b46
       queryName: Beta - VM Without Managed Disk
       observations: ""
-      change: 2
+      change: 1
     - queryId: d3ba7d62-bd07-4102-88ca-9668e5f08e7d
       queryName: Beta - Recovery Services Vault With Public Network Access
       observations: ""
-      change: 2
+      change: 1
     - queryId: 0af1814d-23d7-472e-a1b8-b265e7b0d88f
       queryName: Beta - Recovery Services Vault Without Immutability
       observations: ""
-      change: 2
+      change: 1
     - queryId: b373043c-f3bf-40db-b67a-c982732c7781
       queryName: Beta - Recovery Services Vault Without Soft Delete
       observations: ""
-      change: 2
+      change: 1
     - queryId: 7a0164a5-ec6e-40b2-938d-ab3edfd37dcd
       queryName: Beta - Backup Vault Without Immutability
       observations: ""
-      change: 2
+      change: 1
     - queryId: 8d407b28-c746-4650-8bbd-d27df54a795f
       queryName: Beta - Backup Vault Without Soft Delete
       observations: ""
-      change: 2
+      change: 1
     - queryId: 0bd3630a-2ae9-4522-9d66-04049654b1df
       queryName: Beta - Databricks Diagnostic Logging Unconfigured
       observations: ""
-      change: 2
+      change: 1
     - queryId: 21fa1872-47b3-46ec-9775-f41e85d80cb4
       queryName: Beta - Diagnostic Settings Without Appropriate Logging
       observations: ""
-      change: 2
+      change: 1
     - queryId: 50f32d3c-096e-406a-bb26-71b3c91c11c0
       queryName: Beta - Resource Without Diagnostic Settings
       observations: ""
-      change: 2
+      change: 1
     - queryId: 416ac446-9a2e-4f6d-84d2-82add788c7da
       queryName: Beta - Databricks Workspace Without CMK
       observations: ""
-      change: 2
+      change: 1
     - queryId: 8a0628ed-6256-4a24-a1ab-54696fb69197
       queryName: Beta - Service Without Resource Logging
       observations: ""
-      change: 2
+      change: 1
     - queryId: f677bd92-3922-4e75-8f0c-2c0f8fbc9609
       queryName: Beta - Activity Log Alert For Service Health Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: 0cc95bf8-9b98-4278-ad9f-fea4aed3d271
       queryName: Beta - Storage Account Without Delete Lock
       observations: ""
-      change: 2
+      change: 1
     - queryId: 50e0a9e3-7360-483c-9873-ba1ea1a7faf8
       queryName: Beta - Storage Account With Cross Tenant Replication Enabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: 12ecec8a-7961-48db-b644-86be8845d8fd
       queryName: Beta - Containers Without Soft Delete
       observations: ""
-      change: 2
+      change: 1
     - queryId: 45f3e879-f8a7-4102-a3fa-46da5a849870
       queryName: Beta - Storage Account With Shared Access Key
       observations: ""
-      change: 2
+      change: 1
     - queryId: 056d28cc-7ee9-4b12-b2d1-16b7b66db72d
       queryName: Beta - Blob Storage Without Soft Delete
       observations: ""
-      change: 2
+      change: 1
     - queryId: 233ab26d-8f17-4dce-9616-41479da9ffe3
       queryName: Beta - Storage Account Using Unsafe SMB Channel Encryption
       observations: ""
-      change: 2
+      change: 1
     - queryId: 621fc7c5-c342-4223-b3dd-d1530acb43ae
       queryName: Beta - Storage Account Not Using Latest SMB Protocol Version
       observations: ""
-      change: 2
+      change: 1
     - queryId: 54087baa-8719-48a8-8460-9cc0962117aa
       queryName: Beta - File Share Without Soft Delete
       observations: ""
-      change: 2
+      change: 1
     - queryId: b3b9ce2f-c229-4133-9a2b-4e649cf2347e
       queryName: Beta - Activity Log Alert For Delete Public IP Address Rule Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: 99b47957-c575-4555-b8c0-ff92384249b4
       queryName: Beta - Activity Log Alert For Create or Update Public IP Address Rule Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: 8ce5c61f-5cd1-41bc-b7d9-b26b18efd505
       queryName: Beta - Activity Log Alert For Delete SQL Server Firewall Rule Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: 1219a37a-9a2c-420d-8b8c-30bdbc3bfeb1
       queryName: Beta - Activity Log Alert For Create or Update SQL Server Firewall Rule Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: b97a1065-a86b-442f-86c4-f95afd9b3ac6
       queryName: Beta - Activity Log Alert For Delete Security Solution Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: 8553d83f-fe77-4c96-8850-a95c5895b336
       queryName: Beta - Activity Log Alert For Create or Update Security Solution Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: 62d120b1-b1e0-40ef-a81d-a4994ac88b3b
       queryName: Beta - Activity Log Alert For Delete Network Security Group Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: 1ec163d0-a9be-4695-89a8-a4028a2cbae7
       queryName: Beta - Activity Log Alert For Create Or Update Network Security Group Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: a7b422e3-0b2f-4795-a43a-136dbbd6cbb3
       queryName: Beta - Activity Log Alert For Delete Policy Assignment Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: d0514e4b-9e95-4a7a-9bc5-0adb32514122
       queryName: Beta - Activity Log Alert For Create Policy Assignment Not Configured
       observations: ""
-      change: 2
+      change: 1
     - queryId: 05d6b52e-11ca-453d-bb3a-21c7c853ee92
       queryName: Beta - Databricks Workspace Using Default Virtual Network
       observations: ""
-      change: 2
+      change: 1
     - queryId: 03928f0d-bff0-4feb-a31a-615d093e6026
       queryName: Beta - Function App Deployment Slot Not Using Latest TLS Encryption Version
       observations: ""
-      change: 2
+      change: 1
     - queryId: 22cb3507-1ef4-44ac-9c9a-cab31167e31e
       queryName: Beta - MSSQL Not Using Latest TLS Encryption Version
       observations: ""
-      change: 2
+      change: 1
     - queryId: 9f15ecc4-d9df-44ba-bb88-28c97e946114
       queryName: Beta - PostgreSQL Not Using Latest TLS Encryption Version
       observations: ""
-      change: 2
+      change: 1
     - queryId: e22e5620-3679-418e-bb74-c9f71731ab0f
       queryName: Beta - Redis Cache Not Using Latest TLS Encryption Version
       observations: ""
-      change: 2
+      change: 1
     - queryId: 77deea6a-155e-4865-bf04-153d23e488e8
       queryName: Beta - Azure Container Registry With Broad Permissions
+      observations: ""
+      change: 1
     - queryId: 71884fcb-ae03-41c8-87b9-22c90353f256
       queryName: Beta - Container Instances Not Using Private Virtual Networks
       observations: ""
-      change: 2
+      change: 1
     - queryId: cec6e005-9309-46eb-b34b-456f6eae818b
       queryName: Beta - Key Vault Purge Protection Is Enabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: 41d7989b-3be2-4081-8c79-cf903dd174c5
       queryName: Beta - Use Of User Access Administrator Role Is Not Restricted
       observations: ""
-      change: 2
+      change: 1
     - queryId: 0493b840-50e8-430c-93bc-d794d72931a9
       queryName: Beta - AKS Without Audit Logs
       observations: ""
-      change: 2
+      change: 1

--- a/assets/similarityID_transition/terraform_gcp.yaml
+++ b/assets/similarityID_transition/terraform_gcp.yaml
@@ -2,88 +2,88 @@ similarityIDChangeList:
     - queryId: cc9e464e-5abc-4c8f-8077-a9aa7ebe6a05
       queryName: Beta - Google DNS Policy Logging Disabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: 4f60da73-190e-4048-8e1d-cc5a3974cd15
       queryName: Beta - Cloud Asset Inventory Disabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: 69d4f245-d534-479e-8bcc-f6a836276dc8
       queryName: Beta - Logs And Alerts Missing Custom Role Changes
       observations: ""
-      change: 2
+      change: 1
     - queryId: 39d83c5a-2df4-4a2c-8ffb-b96b1bc3a813
       queryName: Beta - Logs And Alerts Missing Audit Configuration Changes
       observations: ""
-      change: 2
+      change: 1
     - queryId: a881b71c-73ac-4358-879c-e3271db5a3c5
       queryName: Beta - Logs And Alerts Missing Project Ownership Assignment And Changes
       observations: ""
-      change: 2
+      change: 1
     - queryId: 13de4e49-d407-4277-ba5a-d7f59283902f
       queryName: Beta - SQL DB Instance With Unrecommended Error Logging Threshold
       observations: ""
-      change: 2
+      change: 1
     - queryId: ecbbe763-95dc-47e6-8660-84ff751e5acf
       queryName: Beta - SQL DB Instance With Unrecommended Logging Threshold
       observations: ""
-      change: 2
+      change: 1
     - queryId: c3655703-569b-42ec-8027-ef8835d989c0
       queryName: Beta - SQL DB Instance With Contained Database Authentication
       observations: ""
-      change: 2
+      change: 1
     - queryId: f5aff735-fd1c-4751-a5e9-98bfe4893fa2
       queryName: Beta - SQL DB Instance With Exposed Trace Logs
       observations: ""
-      change: 2
+      change: 1
     - queryId: d4436ca8-1caf-427c-8911-8b4d31ff6b40
       queryName: Beta - SQL DB Instance With Remote Access Enabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: c8e4444e-d9a9-4426-be8e-9f1b8c43133c
       queryName: Beta - SQL DB Instance With Global User Options
       observations: ""
-      change: 2
+      change: 1
     - queryId: 18cb7d28-57df-4d6b-9fb4-02828cb15660
       queryName: Beta - SQL DB Instance With Limited User Connections
       observations: ""
-      change: 2
+      change: 1
     - queryId: 5a8c5d26-c592-4c98-afac-9762c54cc868
       queryName: Beta - SQL DB Instance With Ownership Chaining Enabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: 1c329b9b-8221-4b55-8d5f-f0959faf9cee
       queryName: Beta - SQL DB Instance With External Scripts Enabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: 245eb024-d08a-449b-a1f2-02f7bba00fc2
       queryName: Beta - SQL DB Instance Without Centralized Logging
       observations: ""
-      change: 2
+      change: 1
     - queryId: 00335e17-674c-442e-a64c-9436e60e6efb
       queryName: Beta - SQL DB Instance With Minimum Log Duration
       observations: ""
-      change: 2
+      change: 1
     - queryId: 8895abb4-6491-4ae6-9c33-c2f360752b7a
       queryName: Beta - SQL DB Instance Without Disconnections Logging
       observations: ""
-      change: 2
+      change: 1
     - queryId: fc7187e5-b9a2-46c0-950d-3bfcaaacc5ca
       queryName: Beta - SQL DB Instance Without Connections Logging
       observations: ""
-      change: 2
+      change: 1
     - queryId: 51a2c34d-dfd0-436f-aa34-e8f796e052fd
       queryName: Beta - SQL DB Instance With Local Data Loading Enabled
       observations: ""
-      change: 2
+      change: 1
     - queryId: b5b70198-2a34-4792-b0d9-ce99abe485bb
       queryName: Beta - SQL DB Instance With Exposed Show Privileges
       observations: ""
-      change: 2
+      change: 1
     - queryId: 700f1049-7fa0-4cb0-971b-3efebfb6a91f
       queryName: Beta - Legacy Networks Do Not Exist For Older Google Projects
       observations: ""
-      change: 2
+      change: 1
     - queryId: 7bd9c6a8-3b1f-495c-9752-a4a9c4e1b29f
       queryName: Beta - Ensure Essential Contacts Is Configured For Organization
       observations: ""
-      change: 2
+      change: 1


### PR DESCRIPTION
**Reason for Proposed Changes**
- Currently, the YAML files for the similarityID transition are incorrectly defining the transition type of similarityID for beta queries to 2(TransitionWithoutChanges) instead of 1(NonGracefullyTransition).

**Proposed Changes**
- Changed the transition type from 2 to 1 for beta queries.

I submit this contribution under the Apache-2.0 license.