### PR TITLE
fix(parse): rename resource name to fix "failed to parse file content" error

### DIFF
--- a/assets/queries/terraform/azure/sql_database_without_data_encryption/test/negative.tf
+++ b/assets/queries/terraform/azure/sql_database_without_data_encryption/test/negative.tf
@@ -12,9 +12,9 @@ resource "azurerm_mssql_database" "example" {
   # missing "transparent_data_encryption_enabled" - defaults to true
 }
 
-resource "azurerm_mssql_database" "example1" {
+resource "azurerm_mssql_database" "example2" {
   name           = "example-db"
-  server_id      = azurerm_mssql_server.example1.id
+  server_id      = azurerm_mssql_server.example2.id
   collation      = "SQL_Latin1_General_CP1_CI_AS"
   license_type   = "LicenseIncluded"
   max_size_gb    = 4


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- While scanning kics `assets/queries` folder, we encounter the error "failed to parse file content" for the file assets/queries/terraform/azure/sql_database_without_data_encryption/test/negative.tf;
- This is due to the resources having the same name in that specific file, which is not permitted by terraform.

**Proposed Changes**
- rename the second resource name to example2;

I submit this contribution under the Apache-2.0 license.