### PR TITLE
fix(cloudformation): add TLSv1.2_2025 and TLSv1.3_2025 to recommended TLS versions

### DIFF
--- a/assets/libraries/common.rego
+++ b/assets/libraries/common.rego
@@ -482,7 +482,7 @@ any_principal(statement) {
 }
 
 is_recommended_tls(field) {
-	inArray({"TLSv1.2_2018", "TLSv1.2_2019", "TLSv1.2_2021"}, field)
+	inArray({"TLSv1.2_2018", "TLSv1.2_2019", "TLSv1.2_2021", "TLSv1.2_2025", "TLSv1.3_2025"}, field)
 }
 
 is_unrestricted(sourceRange) {

--- a/assets/queries/cloudFormation/aws/cloudfront_without_minimum_protocol_tls_1.2/test/negative1.yaml
+++ b/assets/queries/cloudFormation/aws/cloudfront_without_minimum_protocol_tls_1.2/test/negative1.yaml
@@ -21,7 +21,7 @@ Resources:
             AcmCertificateArn: String
             CloudFrontDefaultCertificate: true
             IamCertificateId: String
-            MinimumProtocolVersion: "TLSv1.2_2018"
+            MinimumProtocolVersion: "TLSv1.2_2025"
             SslSupportMethod: String
       Tags:
         - Key: string-value

--- a/assets/queries/cloudFormation/aws/cloudfront_without_minimum_protocol_tls_1.2/test/negative2.json
+++ b/assets/queries/cloudFormation/aws/cloudfront_without_minimum_protocol_tls_1.2/test/negative2.json
@@ -34,7 +34,7 @@
           ],
           "ViewerCertificate": {
             "IamCertificateId": "String",
-            "MinimumProtocolVersion": "TLSv1.2_2018",
+            "MinimumProtocolVersion": "TLSv1.3_2025",
             "SslSupportMethod": "String",
             "AcmCertificateArn": "String",
             "CloudFrontDefaultCertificate": true


### PR DESCRIPTION
## Summary

- AWS released new TLS policy versions in 2025 (`TLSv1.2_2025`, `TLSv1.3_2025`) that were missing from the `is_recommended_tls()` allowlist in `common.rego`
- CloudFront distributions using these modern TLS configurations were incorrectly flagged as violations (false positive)
- Added both new versions to the allowlist and updated negative test fixtures to cover them

Fixes #7932

## Test plan

- [ ] `negative1.yaml` now uses `TLSv1.2_2025` — should produce no finding
- [ ] `negative2.json` now uses `TLSv1.3_2025` — should produce no finding
- [ ] Existing positive test cases (older insecure TLS versions) still produce findings
- [ ] Run `go test ./test/... -run TestQueries` to verify all query tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)