### PR TITLE
fix(terraform): fix false positive for Kubernetes labels with prefixed keys (slash)

### DIFF
--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/query.rego
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/query.rego
@@ -8,6 +8,7 @@ CxPolicy[result] {
 
 	labels := resource[name].metadata.labels
 
+	is_string(labels[key])
 	regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", labels[key]) == false
 
 	result := {
@@ -16,8 +17,8 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(resource, name),
 		"searchKey": sprintf("%s[%s].metadata.labels", [resourceType, name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s[%s].metada.labels[%s] has valid label", [resourceType, name, key]),
-		"keyActualValue": sprintf("%s[%s].metada.labels[%s] has invalid label", [resourceType, name, key]),
+		"keyExpectedValue": sprintf("%s[%s].metadata.labels[%s] has valid label", [resourceType, name, key]),
+		"keyActualValue": sprintf("%s[%s].metadata.labels[%s] has invalid label", [resourceType, name, key]),
 		"searchLine": common_lib.build_search_line(["resource", resourceType, name, "metadata"], ["labels", key]),
 	}
 }

--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/negative.tf
@@ -3,7 +3,8 @@ resource "kubernetes_pod" "test2" {
     name = "terraform-example"
 
     labels = {
-      app = "MyApp"
+      app                                   = "MyApp"
+      "gateway.istio.io/defaults-for-class" = "something"
     }
   }
 


### PR DESCRIPTION
## Summary

- Labels with a DNS-subdomain-prefixed key (e.g. `gateway.istio.io/defaults-for-class`) were incorrectly flagged as **Metadata Label Is Invalid**
- Root cause: the `/` in the label key causes the KICS HCL parser to produce a nested object instead of a flat string value; calling `regex.match` on a non-string returns `false`, triggering the `== false` condition as a false positive
- Fix: add `is_string(labels[key])` guard before the regex so non-string values (parser artefacts) are silently skipped
- Also fixed a pre-existing typo in the result messages: `"metada"` → `"metadata"`
- Added `"gateway.istio.io/defaults-for-class" = "something"` to the negative test fixture to cover this case going forward

Fixes #7938

## Test plan

- [ ] Scan a Terraform file with `"gateway.istio.io/defaults-for-class" = "something"` — should produce **no** finding
- [ ] Scan the existing positive test case (`app = "g**dy.l+bel"`) — should still produce a finding
- [ ] Run `go test ./test/... -run TestQueries` to verify all query tests pass

I submit this contribution under the Apache-2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)