### PR TITLE
fix(sarif): deduplicate CWE taxa entries to fix schema validation failure

### DIFF
--- a/pkg/report/sarif.go
+++ b/pkg/report/sarif.go
@@ -18,12 +18,16 @@ func PrintSarifReport(path, filename string, body interface{}) error {
 		}
 
 		sarifReport := reportModel.NewSarifReport()
+		seenCWEs := map[string]bool{}
 		auxID := []string{}
 		auxGUID := map[string]string{}
 		for idx := range summary.Queries {
 			x := sarifReport.BuildSarifIssue(&summary.Queries[idx])
 			if x != "" {
-				auxID = append(auxID, x)
+				if !seenCWEs[x] {
+					seenCWEs[x] = true
+					auxID = append(auxID, x)
+				}
 				guid := sarifReport.GetGUIDFromRelationships(idx, x)
 				auxGUID[x] = guid
 			}


### PR DESCRIPTION
## Summary

- Multiple queries sharing the same CWE ID (e.g. CWE-798) caused duplicate entries in `runs[0].taxonomies[1].taxa` of the SARIF output
- This triggered `instance.runs[0].taxonomies[1].taxa contains duplicate item` schema validation errors, blocking SARIF upload to GitHub and other consumers
- Root cause: `auxID []string` in `PrintSarifReport` accumulated all CWE IDs without deduplication across queries
- Fix: add a `seenCWEs` map so each CWE ID is only appended to `auxID` once before being passed to `RebuildTaxonomies`

Fixes #7588

## Test plan

- [ ] Run KICS on a Terraform file with multiple resources that trigger the same CWE (e.g. several `@Microsoft.KeyVault(...)` references triggering CWE-798) and verify the SARIF output passes schema validation
- [ ] Upload the generated `.sarif` file to GitHub via `github/codeql-action/upload-sarif` — should succeed without duplicate taxa errors
- [ ] Run `go test ./pkg/report/...` to verify existing tests still pass

I submit this contribution under the Apache-2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)