### PR TITLE
fix(terraform): exclude NLBs and GWLBs from ALB WAF integration check

### DIFF
--- a/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/query.rego
+++ b/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/query.rego
@@ -11,6 +11,7 @@ CxPolicy[result] {
 	lb := {"aws_alb", "aws_lb"}
 	resource := input.document[i].resource[lb[idx]][name]
 	not is_internal_alb(resource)
+	not is_nlb(resource)
 	count({x | x := associated_waf(name)}) == 0
 
 	result := {
@@ -26,6 +27,11 @@ CxPolicy[result] {
 
 is_internal_alb(resource) {
 	resource.internal == true
+}
+
+is_nlb(resource) {
+	non_alb_types := {"network", "gateway"}
+	non_alb_types[resource.load_balancer_type]
 }
 
 associated_waf(name) {

--- a/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/test/negative3.tf
+++ b/assets/queries/terraform/aws/alb_is_not_integrated_with_waf/test/negative3.tf
@@ -1,0 +1,6 @@
+resource "aws_lb" "nlb" {
+  name               = "test-nlb-tf"
+  internal           = false
+  load_balancer_type = "network"
+  subnets            = [for subnet in aws_subnet.public : subnet.id]
+}


### PR DESCRIPTION
## Summary

- Network Load Balancers (`load_balancer_type = "network"`) and Gateway Load Balancers (`load_balancer_type = "gateway"`) do not support AWS WAF integration — only Application Load Balancers do
- The query was flagging any `aws_lb` / `aws_alb` resource without a WAF association regardless of type, producing false positives for NLBs
- Added `is_nlb()` helper (mirroring the existing `is_internal_alb()` pattern) that returns true for `"network"` and `"gateway"` load balancer types
- Added `not is_nlb(resource)` condition to `CxPolicy` so only ALBs are checked
- Added `negative3.tf` test case: an NLB without WAF that should produce no finding

Fixes #7964

## Test plan

- [ ] Scan an `aws_lb` with `load_balancer_type = "network"` and no WAF — should produce **no** finding
- [ ] Scan an `aws_lb` with `load_balancer_type = "application"` and no WAF — should still produce a finding
- [ ] Scan an `aws_lb` with no `load_balancer_type` set (defaults to application) and no WAF — should still produce a finding
- [ ] Run `go test ./test/... -run TestQueries` to verify all query tests pass

I submit this contribution under the Apache-2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)