### PR TITLE
fix(terraform): fix inverted logic in Workload Host Port Not Specified query

### DIFF
--- a/assets/queries/terraform/kubernetes/workload_host_port_not_specified/query.rego
+++ b/assets/queries/terraform/kubernetes/workload_host_port_not_specified/query.rego
@@ -10,15 +10,15 @@ CxPolicy[result] {
 
 	path := checkPath(resource)
 
-	not common_lib.valid_key(path.port, "host_port")
+	common_lib.valid_key(path.port, "host_port")
 	result := {
 		"documentId": input.document[i].id,
 		"resourceType": x,
 		"resourceName": tf_lib.get_resource_name(resource, name),
 		"searchKey": sprintf("%s[%s].%s.port", [x, name, resource_prefix]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "Attribute 'host_port' should be defined and not null",
-		"keyActualValue": "Attribute 'host_port' is undefined or null",
+		"keyExpectedValue": "Attribute 'host_port' should not be defined",
+		"keyActualValue": "Attribute 'host_port' is defined",
 	}
 }
 

--- a/assets/queries/terraform/kubernetes/workload_host_port_not_specified/test/negative1.tf
+++ b/assets/queries/terraform/kubernetes/workload_host_port_not_specified/test/negative1.tf
@@ -15,7 +15,6 @@ resource "kubernetes_pod" "test" {
 
       port {
         container_port = 8080
-        host_port = 2
       }
 
       liveness_probe {

--- a/assets/queries/terraform/kubernetes/workload_host_port_not_specified/test/negative2.tf
+++ b/assets/queries/terraform/kubernetes/workload_host_port_not_specified/test/negative2.tf
@@ -40,7 +40,6 @@ resource "kubernetes_deployment" "example" {
           }
           port {
             container_port = 8080
-            host_port = 2
           }
 
           liveness_probe {

--- a/assets/queries/terraform/kubernetes/workload_host_port_not_specified/test/positive1.tf
+++ b/assets/queries/terraform/kubernetes/workload_host_port_not_specified/test/positive1.tf
@@ -15,6 +15,7 @@ resource "kubernetes_pod" "test" {
 
       port {
         container_port = 8080
+        host_port = 2
       }
 
       liveness_probe {

--- a/assets/queries/terraform/kubernetes/workload_host_port_not_specified/test/positive2.tf
+++ b/assets/queries/terraform/kubernetes/workload_host_port_not_specified/test/positive2.tf
@@ -40,6 +40,7 @@ resource "kubernetes_deployment" "example" {
           }
           port {
             container_port = 8080
+            host_port = 2
           }
 
           liveness_probe {


### PR DESCRIPTION
## Summary

- The Terraform query for **Workload Host Port Not Specified** had its logic inverted compared to the equivalent K8s query
- It was flagging containers that did **not** have `host_port` defined — but the actual security concern is the opposite: defining `host_port` exposes the port on the host node's network interface, increasing the attack surface
- The K8s query correctly flags when `hostPort` IS defined; the Terraform query had `not common_lib.valid_key(path.port, "host_port")` which fired when it was absent
- Changes:
  - Removed `not` from the `valid_key` check so the rule fires when `host_port` IS defined
  - Updated result messages (`keyExpectedValue` / `keyActualValue`) to reflect the correct intent
  - Swapped positive/negative test file contents to match the corrected logic (positive files now contain `host_port`, negative files do not)

Fixes #7939

## Test plan

- [ ] Scan a container with `host_port` defined — should produce a finding
- [ ] Scan a container without `host_port` — should produce **no** finding (was previously a false positive)
- [ ] Run `go test ./test/... -run TestQueries` to verify all query tests pass

I submit this contribution under the Apache-2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)