### PR TITLE
fix(engine): allow excluding OpenAPI queries by their override (version-specific) IDs

### DIFF
--- a/pkg/engine/source/filesystem.go
+++ b/pkg/engine/source/filesystem.go
@@ -238,8 +238,22 @@ func checkQueryExcludeField(id interface{}, excludeQueries []string) bool {
 }
 
 func checkQueryExclude(metadata map[string]interface{}, queryParameters *QueryInspectorParameters) bool {
-	return checkQueryExcludeField(metadata["id"], queryParameters.ExcludeQueries.ByIDs) ||
-		checkQueryExcludeField(metadata["category"], queryParameters.ExcludeQueries.ByCategories) ||
+	if checkQueryExcludeField(metadata["id"], queryParameters.ExcludeQueries.ByIDs) {
+		return true
+	}
+
+	// Also check override IDs (e.g. OpenAPI queries with version-specific variants like Swagger 2.0)
+	if override, ok := metadata["override"].(map[string]interface{}); ok {
+		for _, overrideData := range override {
+			if overrideObj, ok := overrideData.(map[string]interface{}); ok {
+				if checkQueryExcludeField(overrideObj["id"], queryParameters.ExcludeQueries.ByIDs) {
+					return true
+				}
+			}
+		}
+	}
+
+	return checkQueryExcludeField(metadata["category"], queryParameters.ExcludeQueries.ByCategories) ||
 		checkQueryExcludeField(metadata["severity"], queryParameters.ExcludeQueries.BySeverities) ||
 		(!queryParameters.BomQueries && metadata["severity"] == model.SeverityTrace)
 }


### PR DESCRIPTION
## Summary

- OpenAPI queries have version-specific variants defined via an `"override"` field in `metadata.json` (e.g. a Swagger 2.0 variant with a different ID than the OpenAPI 3.0 primary query)
- These variant IDs are what get reported in scan results when scanning a Swagger 2.0 file, but `checkQueryExclude` only compared against the top-level `metadata["id"]`
- Passing an override ID to `--exclude-queries` had no effect, making it impossible to suppress findings for those queries
- Fix: extend `checkQueryExclude` to also iterate through `metadata["override"]` and check each version variant's `"id"` against the `ByIDs` exclusion list

**Example** — for a query with this metadata:
```json
{
  "id": "e3f026e8-fdb4-4d5a-bcfd-bd94452073fe",
  "override": {
    "2.0": { "id": "6e96ed39-bf45-4089-99ba-f1fe7cf6966f" }
  }
}
```
Both `e3f026e8-...` and `6e96ed39-...` can now be used with `--exclude-queries`.

Fixes #7574

## Test plan

- [ ] Scan a `swagger.json` file that triggers one of the affected queries (e.g. `6e96ed39-bf45-4089-99ba-f1fe7cf6966f`)
- [ ] Run with `--exclude-queries 6e96ed39-bf45-4089-99ba-f1fe7cf6966f` and verify the query is excluded from results
- [ ] Run with the primary ID `e3f026e8-fdb4-4d5a-bcfd-bd94452073fe` — should still be excluded (existing behaviour preserved)
- [ ] Run `go test ./pkg/engine/source/...` to verify existing tests pass

I submit this contribution under the Apache-2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)