### PR TITLE
fix(terraform): skip label validation for unresolved Terraform references

### DIFF
--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/query.rego
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/query.rego
@@ -8,6 +8,8 @@ CxPolicy[result] {
 
 	labels := resource[name].metadata.labels
 
+	is_string(labels[key])
+	not contains(labels[key], "${")
 	regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", labels[key]) == false
 
 	result := {
@@ -16,8 +18,8 @@ CxPolicy[result] {
 		"resourceName": tf_lib.get_resource_name(resource, name),
 		"searchKey": sprintf("%s[%s].metadata.labels", [resourceType, name]),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("%s[%s].metada.labels[%s] has valid label", [resourceType, name, key]),
-		"keyActualValue": sprintf("%s[%s].metada.labels[%s] has invalid label", [resourceType, name, key]),
+		"keyExpectedValue": sprintf("%s[%s].metadata.labels[%s] has valid label", [resourceType, name, key]),
+		"keyActualValue": sprintf("%s[%s].metadata.labels[%s] has invalid label", [resourceType, name, key]),
 		"searchLine": common_lib.build_search_line(["resource", resourceType, name, "metadata"], ["labels", key]),
 	}
 }

--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/negative.tf
@@ -3,7 +3,9 @@ resource "kubernetes_pod" "test2" {
     name = "terraform-example"
 
     labels = {
-      app = "MyApp"
+      app                                   = "MyApp"
+      "gateway.istio.io/defaults-for-class" = "something"
+      environment                           = local.env_name
     }
   }
 


### PR DESCRIPTION
## Summary

- KICS's HCL converter wraps bare Terraform references (`local.*`, `var.*`, `data.*`, etc.) in `${...}` notation since it cannot resolve them at parse time
- These wrapped strings (e.g. `"${local.resource_name}"`) fail the Kubernetes label value regex because `$`, `{`, `}` are not valid K8s label characters, causing false positives
- Added two guards before the regex check:
  1. `is_string(labels[key])` — skips non-string values (e.g. nested objects that appear from HCL keys containing dots or slashes — also fixes #7938)
  2. `not contains(labels[key], "${")` — skips any value containing an unresolved Terraform reference wrapper
- Fixed a pre-existing typo in result messages: `"metada"` → `"metadata"`
- Added negative test cases: a `local.*` reference and a prefixed label key (`gateway.istio.io/defaults-for-class`)

Fixes #7944  
Also fixes #7938

## Root cause trace

```
# HCL input
labels = { app = local.resource_name }

# KICS converter output (wrapExpr in default.go)
"labels": { "app": "${local.resource_name}" }

# Regex check (before fix)
regex.match("^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", "${local.resource_name}")
# => false  ($ is not in the allowed charset)
# => false == false => true  => FALSE POSITIVE
```

## Test plan

- [ ] Scan a Terraform resource with `app = local.resource_name` — should produce **no** finding
- [ ] Scan a resource with label key `"gateway.istio.io/defaults-for-class"` — should produce **no** finding
- [ ] Scan a resource with `app = "g**dy.l+bel"` — should still produce a finding
- [ ] Run `go test ./test/... -run TestQueries` to verify all query tests pass

I submit this contribution under the Apache-2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)