### PR TITLE
feat(report): add level field to SARIF result output

### DIFF
--- a/pkg/report/model/sarif.go
+++ b/pkg/report/model/sarif.go
@@ -149,6 +149,7 @@ type sarifResult struct {
 	ResultRuleID    string          `json:"ruleId"`
 	ResultRuleIndex int             `json:"ruleIndex"`
 	ResultKind      string          `json:"kind"`
+	ResultLevel     string          `json:"level,omitempty"`
 	ResultMessage   sarifMessage    `json:"message"`
 	ResultLocations []sarifLocation `json:"locations"`
 }
@@ -634,8 +635,9 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult) string {
 		}
 		ruleIndex := sr.buildSarifRule(&metadata, cisDescriptions)
 
+		level := severityLevelEquivalence[issue.Severity]
 		kind := "fail"
-		if severityLevelEquivalence[issue.Severity] == "none" {
+		if level == "none" {
 			kind = "informational"
 		}
 		for idx := range issue.Files {
@@ -654,6 +656,7 @@ func (sr *sarifReport) BuildSarifIssue(issue *model.QueryResult) string {
 				ResultRuleID:    issue.QueryID,
 				ResultRuleIndex: ruleIndex,
 				ResultKind:      kind,
+				ResultLevel:     level,
 				ResultMessage: sarifMessage{
 					Text:              issue.Files[idx].KeyActualValue,
 					MessageProperties: messageProperties,

--- a/pkg/report/model/sarif_test.go
+++ b/pkg/report/model/sarif_test.go
@@ -98,6 +98,7 @@ var sarifTests = []sarifTest{
 							ResultRuleID:    "1",
 							ResultRuleIndex: 0,
 							ResultKind:      "fail",
+							ResultLevel:     "error",
 							ResultMessage:   sarifMessage{Text: "test", MessageProperties: sarifProperties{"platform": "", "riskScore": "6"}},
 							ResultLocations: []sarifLocation{
 								{
@@ -248,6 +249,7 @@ var sarifTests = []sarifTest{
 							ResultRuleID:    "1",
 							ResultRuleIndex: 0,
 							ResultKind:      "fail",
+							ResultLevel:     "error",
 							ResultMessage: sarifMessage{
 								Text:              "test",
 								MessageProperties: sarifProperties{"platform": "", "riskScore": "6"},
@@ -265,6 +267,7 @@ var sarifTests = []sarifTest{
 							ResultRuleID:    "2",
 							ResultRuleIndex: 1,
 							ResultKind:      "informational",
+							ResultLevel:     "none",
 							ResultMessage: sarifMessage{
 								Text:              "test",
 								MessageProperties: sarifProperties{"platform": "", "riskScore": "6"},


### PR DESCRIPTION
## Summary
Add the `level` field to the `result` entries in the SARIF report output, aligning with the SARIF 2.1.0 specification.
## Motivation
The SARIF spec defines a `level` field on result objects that indicates the severity of the finding (`error`, `warning`, `note`, `none`). Previously, KICS only set `level` on the rule's `defaultConfiguration` but omitted it from individual results. Some SARIF consumers (IDE integrations, CI/CD tools, dashboards) rely on the result-level `level` field to filter or prioritize findings.
## Changes
- **`pkg/report/model/sarif.go`**: Added `ResultLevel` (`json:"level,omitempty"`) to the `sarifResult` struct. The value is derived from the existing `severityLevelEquivalence` mapping (HIGH/CRITICAL → `error`, MEDIUM → `warning`, LOW → `note`, INFO → `none`). The field is omitted for informational results via `omitempty`.
- **`pkg/report/model/sarif_test.go`**: Updated all expected test results to include the `ResultLevel` field.
## Example output
```json
{
  "ruleId": "...",
  "ruleIndex": 0,
  "kind": "fail",
  "level": "warning",
  "message": { ... },
  "locations": [ ... ]
}
```

I submit this contribution under the Apache-2.0 license.