### PR TITLE
fix(query): ignore anonymous compose volumes

### DIFF
--- a/assets/queries/dockerCompose/volume_has_sensitive_host_directory/query.rego
+++ b/assets/queries/dockerCompose/volume_has_sensitive_host_directory/query.rego
@@ -8,6 +8,7 @@ CxPolicy[result] {
     volumes := service_parameters.volumes
     volume := volumes[v]
     path := split(volume,":")
+    count(path) > 1
     host_path := path[0]
  	common_lib.isOSDir(host_path)
 

--- a/assets/queries/dockerCompose/volume_has_sensitive_host_directory/test/negative4.yaml
+++ b/assets/queries/dockerCompose/volume_has_sensitive_host_directory/test/negative4.yaml
@@ -1,0 +1,7 @@
+version: "3.9"
+
+services:
+  frontend:
+    image: node:20
+    volumes:
+      - /usr/src/app/node_modules

--- a/assets/queries/dockerCompose/volume_has_sensitive_host_directory/test/positive1.yaml
+++ b/assets/queries/dockerCompose/volume_has_sensitive_host_directory/test/positive1.yaml
@@ -8,7 +8,7 @@ services:
   backup:
     image: backup-service
     volumes:
-      - /var/lib/backup/data
+      - /var/lib/backup/data:/backup/data
 
 volumes:
   data-volume:


### PR DESCRIPTION
Closes #8047

**Reason for Proposed Changes**
- Docker Compose short syntax with a single path, such as `/usr/src/app/node_modules`, creates an anonymous volume rather than binding a host directory.
- The query split every string volume on `:` and treated the first segment as a host path even when no `:` was present, which caused false positives for anonymous volumes.

**Proposed Changes**
- Only evaluate short-syntax string volumes as host binds when the split volume has a host/container separator.
- Keep positive coverage for sensitive host binds by making the existing positive sample explicit.
- Add the reported anonymous-volume shape as a negative regression sample.

Verification:
- `go test ./test -run "TestQueries/dockerCompose/volume_has_sensitive_host_directory" -count=1`
- `git diff --check`

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.

I submit this contribution under the Apache-2.0 license.