### PR TITLE
fix(terraform): scope CloudWatch S3 policy alarm query

### DIFF
--- a/assets/queries/terraform/aws/cloudwatch_s3_policy_change_alarm_missing/query.rego
+++ b/assets/queries/terraform/aws/cloudwatch_s3_policy_change_alarm_missing/query.rego
@@ -58,9 +58,9 @@ expressionArr := [
 #{ ($.eventSource = \"s3.amazonaws.com\") && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }
 CxPolicy[result] {
 	doc := input.document[i]
-	_ := doc.resource.aws_cloudwatch_log_metric_filter[name]
+	filterResource := doc.resource.aws_cloudwatch_log_metric_filter[name]
+	is_s3_policy_change_filter(filterResource)
 
-	
 	count([alarm | alarm := doc.resource.aws_cloudwatch_metric_alarm[_]; contains(alarm.metric_name, name)]) == 0 
 	
 	result := {
@@ -73,6 +73,10 @@ CxPolicy[result] {
 		"keyActualValue": "aws_cloudwatch_log_metric_filter not associated with any aws_cloudwatch_metric_alarm",
 		"searchLine": common_lib.build_search_line(["resource","aws_cloudwatch_log_metric_filter", name], []),
 	}
+}
+
+is_s3_policy_change_filter(filter) {
+	contains(filter.pattern, "s3.amazonaws.com")
 }
 
 
@@ -90,6 +94,7 @@ CxPolicy[result] {
 	resources := doc.resource.aws_cloudwatch_log_metric_filter
 
 	resourceNames := [resourceName | [path, value] := walk(resources);
+	    is_s3_policy_change_filter(value);
 	    filter := common_lib.json_unmarshal(value.pattern);
 	    not check_expression_missing(filter);
 	    resourceName := path[count(path)-1]

--- a/assets/queries/terraform/aws/cloudwatch_s3_policy_change_alarm_missing/test/negative1.tf
+++ b/assets/queries/terraform/aws/cloudwatch_s3_policy_change_alarm_missing/test/negative1.tf
@@ -49,3 +49,15 @@ resource "aws_cloudwatch_metric_alarm" "cis_no_mfa_console_signin_cw_alarm" {
   alarm_actions             = [aws_sns_topic.CIS_Alerts_SNS_Topic.arn]
   insufficient_data_actions = []
 }
+
+resource "aws_cloudwatch_log_metric_filter" "custom_application_metric_filter" {
+  name           = "CustomApplicationMetric"
+  pattern        = "[MYTEXT]"
+  log_group_name = aws_cloudwatch_log_group.Application_CloudWatch_LogsGroup.name
+
+  metric_transformation {
+    name      = "CustomApplicationMetric"
+    namespace = "Application_Metric_Alarm_Namespace"
+    value     = "1"
+  }
+}

--- a/assets/queries/terraform/aws/cloudwatch_s3_policy_change_alarm_missing/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/cloudwatch_s3_policy_change_alarm_missing/test/positive_expected_result.json
@@ -14,12 +14,6 @@
   {
     "queryName": "CloudWatch S3 policy Change Alarm Missing",
     "severity": "MEDIUM",
-    "line": 30,
-    "fileName": "positive1.tf"
-  },
-  {
-    "queryName": "CloudWatch S3 policy Change Alarm Missing",
-    "severity": "MEDIUM",
     "line": 3,
     "fileName": "positive2.tf"
   },
@@ -44,7 +38,7 @@
   {
     "queryName": "CloudWatch S3 policy Change Alarm Missing",
     "severity": "MEDIUM",
-    "line": 31,
+    "line": 4,
     "fileName": "positive5.tf"
   }
 ]


### PR DESCRIPTION
Closes #8045

**Reason for Proposed Changes**
- The CloudWatch S3 policy change alarm query was evaluating every `aws_cloudwatch_log_metric_filter` pattern, so unrelated filters such as `[MYTEXT]` were reported as wrong S3 policy-change filters.

**Proposed Changes**
- Scope both query branches to metric filters whose pattern references `s3.amazonaws.com`.
- Add a negative Terraform sample for the reported `[MYTEXT]` custom metric filter case.
- Remove the unrelated MFA console sign-in filter findings from the expected positive results.

**Verification**
- `go run ./cmd/console scan -p <query test dir> -q <repo>/assets/queries -b <repo>/assets/libraries -i 27c6a499-895a-4dc7-9617-5c485218db13 --no-progress --ignore-on-exit all --report-formats json --silent`
- `git diff --check`

Note: I also tried the focused query harness with `go test ./test -run 'TestQueries/terraform/aws/cloudwatch_s3_policy_change_alarm_missing' -count=1`, but it did not finish within a 5 minute local timeout on Windows.

I submit this contribution under the Apache-2.0 license.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed.