### PR TITLE
fix(query): allow Terraform local secret references

### DIFF
--- a/assets/queries/common/passwords_and_secrets/regex_rules.json
+++ b/assets/queries/common/passwords_and_secrets/regex_rules.json
@@ -403,6 +403,10 @@
       "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*=\\s*['\"]?(var\\.)['\"]?"
     },
     {
+      "description": "Avoiding TF local references",
+      "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*=\\s*['\"]?(local\\.[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*|\\[[^\\]]+\\])*)['\"]?\\s*$"
+    },
+    {
       "description": "!Ref is a cloudFormation reference",
       "regex": "(?i)['\"]?[a-zA-Z_]+['\"]?\\s*:\\s+!Ref\\s+\\.*"
     },

--- a/assets/queries/common/passwords_and_secrets/test/negative60.tf
+++ b/assets/queries/common/passwords_and_secrets/test/negative60.tf
@@ -1,0 +1,15 @@
+locals {
+  rds_password = jsondecode(data.aws_secretsmanager_secret_version.rds_secrets.secret_string)["password"]
+}
+
+module "dummydb" {
+  source   = "terraform-aws-modules/rds/aws"
+  password = local.rds_password
+}
+
+module "orchestrator" {
+  source                              = "foo"
+  services_environment_variables      = local.services_environment_variables
+  services_environment_variables_ssm  = local.services_environment_variables_ssm
+  services_environment_variables_secret = local.services_environment_variables_secret
+}


### PR DESCRIPTION
Closes #7277

**Reason for Proposed Changes**
- Terraform local references such as `password = local.rds_password` and `services_environment_variables_secret = local.services_environment_variables_secret` are currently treated as literal password/secret values by the generic password and secret regex checks.

**Proposed Changes**
- Add a focused global allow rule for plain Terraform `local.*` references.
- Keep the existing positive conditional-local fixture flagged by requiring the local reference to be the whole assigned value.
- Add a negative Terraform fixture covering the issue examples.

Verification:
- `go test ./test -run TestSecretsQuery -count=1`
- `git diff --check`

This was implemented with Codex assistance, with the final patch manually reviewed and kept focused.

I submit this contribution under the Apache-2.0 license.