### PR TITLE
fix(query): allow CloudFormation DB security group /24 CIDRs

### DIFF
--- a/assets/queries/cloudFormation/aws/db_security_group_open_to_large_scope/query.rego
+++ b/assets/queries/cloudFormation/aws/db_security_group_open_to_large_scope/query.rego
@@ -32,7 +32,7 @@ large_scope(ip_address, cidr) {
 	to_number(input_mask[1]) < 120		# should be 120-128
 } else {
 	input_mask := split(ip_address, "/")
-	to_number(input_mask[1]) < 25	# should be 25-32
+	to_number(input_mask[1]) < 24	# should be 24-32
 }
 
 exposed_inline_or_standalone_ingress(res, ing_index, type, resource_index) = results { # inline ingresses

--- a/assets/queries/cloudFormation/aws/db_security_group_open_to_large_scope/test/negative1.yaml
+++ b/assets/queries/cloudFormation/aws/db_security_group_open_to_large_scope/test/negative1.yaml
@@ -13,6 +13,7 @@ Resources:
       GroupDescription: "Ingress for Amazon EC2 security group"
       SecurityGroupIngress:
         - CidrIp: 1.2.3.4/28
+        - CidrIp: 10.0.0.0/24
 
   DbSecurityByEC2SecurityGroup2:
     Type: AWS::EC2::SecurityGroup

--- a/assets/queries/cloudFormation/aws/db_security_group_open_to_large_scope/test/negative2.yaml
+++ b/assets/queries/cloudFormation/aws/db_security_group_open_to_large_scope/test/negative2.yaml
@@ -12,6 +12,12 @@ Resources:
       GroupId: !Ref DbSecurityByEC2SecurityGroup1
       CidrIp: 1.2.3.4/28
 
+  StandaloneIngressIPv4Max256Hosts:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref DbSecurityByEC2SecurityGroup1
+      CidrIp: 10.0.0.0/24
+
   StandaloneIngressIPv6:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:


### PR DESCRIPTION
Closes #7988

**Reason for Proposed Changes**
- The CloudFormation DB Security Group query currently treats IPv4 `/24` CIDRs as larger than 256 hosts.
- A `/24` has exactly 256 addresses, so it should not match the query description: "must not have more than 256 hosts."

**Proposed Changes**
- Update the IPv4 threshold so only prefixes smaller than `/24` are reported.
- Add `/24` negative fixtures for both inline and standalone CloudFormation ingress resources.
- Keep the existing `/23` positive fixtures as the more-than-256-hosts coverage.

**Verification**
- `go test ./test -run "TestQueries/cloudFormation/aws/db_security_group_open_to_large_scope" -count=1`
- `git diff --check` (passed with local CRLF warnings only)

This was implemented with Codex assistance, with the final patch kept focused and manually reviewed.

I submit this contribution under the Apache-2.0 license.