### PR TITLE
fix(query): skip Terraform references in metadata label validation

### DIFF
--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/query.rego
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/query.rego
@@ -8,6 +8,7 @@ CxPolicy[result] {
 
 	labels := resource[name].metadata.labels
 
+	not is_terraform_reference(labels[key])
 	regex.match("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$", labels[key]) == false
 
 	result := {
@@ -20,4 +21,10 @@ CxPolicy[result] {
 		"keyActualValue": sprintf("%s[%s].metada.labels[%s] has invalid label", [resourceType, name, key]),
 		"searchLine": common_lib.build_search_line(["resource", resourceType, name, "metadata"], ["labels", key]),
 	}
+}
+
+is_terraform_reference(label) {
+	regex.match("^\\$\\{(local|var|data)\\.[^}]+\\}$", label)
+} else {
+	regex.match("^(local|var|data)\\.[A-Za-z0-9_][A-Za-z0-9_.-]*$", label)
 }

--- a/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/negative.tf
+++ b/assets/queries/terraform/kubernetes/metadata_label_is_invalid/test/negative.tf
@@ -54,3 +54,29 @@ resource "kubernetes_pod" "test2" {
     dns_policy = "None"
   }
 }
+
+locals {
+  resource_name = "my-app-service"
+}
+
+resource "kubernetes_service_v1" "test3" {
+  metadata {
+    name      = "terraform-service-example"
+    namespace = "default"
+
+    labels = {
+      app = local.resource_name
+    }
+  }
+
+  spec {
+    selector = {
+      app = local.resource_name
+    }
+
+    port {
+      port        = 80
+      target_port = 8080
+    }
+  }
+}


### PR DESCRIPTION
Closes #7944

**Reason for Proposed Changes**
- The `Metadata Label Is Invalid` query currently validates unresolved Terraform references such as `local.resource_name` as literal Kubernetes label values.
- That creates a false positive before Terraform resolves the value to a valid label.

**Proposed Changes**
- Skip metadata label validation when the value is a Terraform `local.*`, `var.*`, or `data.*` reference/interpolation.
- Add a negative Terraform fixture with a Kubernetes service label using `local.resource_name`.

**Verification**
- Before the fix, direct scan of the negative fixture returned one `Metadata Label Is Invalid` result at the `labels` block.
- After the fix, direct scan of the negative fixture returned `TOTAL: 0`.
- Direct scan of the existing positive fixture still returned `TOTAL: 1` for `g**dy.l+bel`.
- `git diff --check` passed with local CRLF warnings only.

Focused Go query harness timed out locally on Windows, so I used direct CLI scans for this query.

This was implemented with Codex assistance, with the final patch kept focused and manually reviewed.

I submit this contribution under the Apache-2.0 license.