### PR TITLE
fix(dockerfile): flag unpinned dnf packages followed by a flag

### DIFF
--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/query.rego
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/query.rego
@@ -52,15 +52,7 @@ CxPolicy[result] {
 }
 
 analyzePackages(j, currentPackage, packages, length) {
-	j == length - 1
 	regex.match("^[a-zA-Z]", currentPackage) == true
-	not dockerLib.withVersion(currentPackage)
-}
-
-analyzePackages(j, currentPackage, packages, length) {
-	j != length - 1
-	regex.match("^[a-zA-Z]", currentPackage) == true
-	packages[plus(j, 1)] != "-v"
 	not dockerLib.withVersion(currentPackage)
 }
 

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/negative.dockerfile
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/negative.dockerfile
@@ -1,6 +1,7 @@
 FROM fedora:latest
 RUN dnf -y update && dnf -y install httpd-2.24.2 && dnf clean all
 RUN ["dnf", "install", "httpd-2.24.2"]
+RUN dnf install -v zip-3.0
 COPY index.html /var/www/html/index.html
 EXPOSE 80
 ENTRYPOINT /usr/sbin/httpd -DFOREGROUND

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive.dockerfile
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive.dockerfile
@@ -1,6 +1,8 @@
 FROM fedora:latest
 RUN dnf -y update && dnf -y install httpd && dnf clean all
 RUN ["dnf", "install", "httpd"]
+RUN dnf install -v -y zip
+RUN dnf install zip -v
 COPY index.html /var/www/html/index.html
 EXPOSE 80
 ENTRYPOINT /usr/sbin/httpd -DFOREGROUND

--- a/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/missing_version_specification_in_dnf_install/test/positive_expected_result.json
@@ -8,5 +8,15 @@
     "queryName": "Missing Version Specification In dnf install",
     "severity": "MEDIUM",
     "line": 3
+  },
+  {
+    "queryName": "Missing Version Specification In dnf install",
+    "severity": "MEDIUM",
+    "line": 4
+  },
+  {
+    "queryName": "Missing Version Specification In dnf install",
+    "severity": "MEDIUM",
+    "line": 5
   }
 ]


### PR DESCRIPTION
Closes #7306

**Reason for Proposed Changes**
- The `missing_version_specification_in_dnf_install` query has a package-parsing rule that special-cases the token `-v`. The second `analyzePackages` clause requires `packages[plus(j, 1)] != "-v"`, which treats a package as version-pinned whenever the next token happens to be `-v`. In `dnf`, `-v` is the verbose flag, not a version marker, so this is a false negative: an unpinned package followed by `-v` silently passes the check.
- Reproduced on current `master`. `RUN dnf install zip -v` is not flagged even though `zip` has no pinned version, because `zip` is followed by `-v` and the clause skips it. `RUN dnf install -y zip -v` has the same problem.

**Proposed Changes**
- Removed the `-v` special case from `analyzePackages`. A package is now decided solely on whether it carries a version (`dockerLib.withVersion`), regardless of the next token. The two former clauses (`j == length - 1` and `j != length - 1`) collapse into one, since the only difference between them was the bogus `-v` check.
- Added a positive case `RUN dnf install zip -v` (the unpinned-package-before-a-flag form the old rule missed) to `test/positive.dockerfile` and its expected finding to `test/positive_expected_result.json`.
- Added a negative case `RUN dnf install -v zip-3.0` to `test/negative.dockerfile` to confirm a genuinely pinned package followed by `-v` still passes, so the fix does not introduce a false positive.
- Verified with the query test harness: `go test ./test/ -run 'TestQueries$/dockerfile/missing_version_specification_in_dnf_install'` passes for both positive and negative, and the content/metadata tests stay green (Rego coverage is now 100% for this query since the dead branch is gone).

I submit this contribution under the Apache-2.0 license.
