### PR TITLE
fix(query): exclude private CIDRs from AWS small-public-network query

### DIFF
--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/query.rego
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/query.rego
@@ -120,11 +120,17 @@ small_network_affix := ["/25","/26","/27","/28","/29"]
 ipv6_small_network_affix := ["/121","/122","/123","/124","/125"]
 
 isSmallPublicNetwork(resource) {
-	endswith(resource.cidr_blocks[_], small_network_affix[_])
+	cidr := resource.cidr_blocks[_]
+	endswith(cidr, small_network_affix[_])
+	not common_lib.isPrivateIP(cidr)
 } else {
-	endswith(resource.ipv6_cidr_blocks[_], ipv6_small_network_affix[_])
+	cidr := resource.ipv6_cidr_blocks[_]
+	endswith(cidr, ipv6_small_network_affix[_])
+	not common_lib.isPrivateIP(cidr)
 } else {
 	endswith(resource.cidr_ipv4, small_network_affix[_])
+	not common_lib.isPrivateIP(resource.cidr_ipv4)
 } else {
 	endswith(resource.cidr_ipv6, ipv6_small_network_affix[_])
+	not common_lib.isPrivateIP(resource.cidr_ipv6)
 }

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/negative1.tf
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/negative1.tf
@@ -71,6 +71,37 @@ resource "aws_security_group" "negative1_array_test_ipv6" {
     from_port         = 5000
     to_port           = 5000
     protocol          = "icmpv6"
-    ipv6_cidr_blocks  = ["fd03:5678::/64", "2400:cb00::/32"] 
+    ipv6_cidr_blocks  = ["fd03:5678::/64", "2400:cb00::/32"]
+  }
+}
+
+# correct port and protocol, but the cidr is a small PRIVATE network (RFC1918 / ULA), so it must not be flagged
+resource "aws_security_group" "negative1_private_ipv4_1" {
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/25"]
+  }
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["192.168.0.0/26"]
+  }
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["172.16.0.0/27"]
+  }
+}
+
+resource "aws_security_group" "negative1_private_ipv6_1" {
+  ingress {
+    from_port         = 22
+    to_port           = 22
+    protocol          = "tcp"
+    ipv6_cidr_blocks  = ["fd00::/121"]
   }
 }

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/negative2.tf
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/negative2.tf
@@ -64,3 +64,25 @@ resource "aws_vpc_security_group_ingress_rule" "negative2_ipv6_4" {
   ip_protocol       = "icmpv6"
   cidr_ipv6         = "2400:cb00::/32"
 }
+
+# correct port and protocol, but the cidr is a small PRIVATE network (RFC1918 / ULA), so it must not be flagged
+resource "aws_vpc_security_group_ingress_rule" "negative2_private_ipv4_1" {
+  from_port    = 22
+  to_port      = 22
+  ip_protocol  = "tcp"
+  cidr_ipv4    = "10.0.0.0/25"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "negative2_private_ipv4_2" {
+  from_port    = 22
+  to_port      = 22
+  ip_protocol  = "tcp"
+  cidr_ipv4    = "172.16.0.0/27"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "negative2_private_ipv6_1" {
+  from_port    = 22
+  to_port      = 22
+  ip_protocol  = "tcp"
+  cidr_ipv6    = "fd00::/121"
+}

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/negative3.tf
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/negative3.tf
@@ -72,3 +72,28 @@ resource "aws_security_group_rule" "negative3_ipv6_4" {
   ipv6_cidr_blocks  = ["fd03:5678::/64", "2400:cb00::/32"]
   type              = "ingress"
 }
+
+# correct port and protocol, but the cidr is a small PRIVATE network (RFC1918 / ULA), so it must not be flagged
+resource "aws_security_group_rule" "negative3_private_ipv4_1" {
+  from_port    = 22
+  to_port      = 22
+  protocol     = "tcp"
+  cidr_blocks  = ["10.0.0.0/25"]
+  type         = "ingress"
+}
+
+resource "aws_security_group_rule" "negative3_private_ipv4_2" {
+  from_port    = 22
+  to_port      = 22
+  protocol     = "tcp"
+  cidr_blocks  = ["192.168.0.0/26"]
+  type         = "ingress"
+}
+
+resource "aws_security_group_rule" "negative3_private_ipv6_1" {
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  ipv6_cidr_blocks  = ["fd00::/121"]
+  type              = "ingress"
+}

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/negative4.tf
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/negative4.tf
@@ -61,7 +61,38 @@ module "negative4_ipv6_1" {
       from_port         = 5000
       to_port           = 5000
       protocol          = "icmpv6"
-      ipv6_cidr_blocks  = ["fd03:5678::/64", "2400:cb00::/32"] 
+      ipv6_cidr_blocks  = ["fd03:5678::/64", "2400:cb00::/32"]
+    }
+  ]
+}
+
+# correct port and protocol, but the cidr is a small PRIVATE network (RFC1918 / ULA), so it must not be flagged
+module "negative4_private_ipv4_1" {
+  source  = "terraform-aws-modules/security-group/aws"
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = ["10.0.0.0/25"]
+    },
+    {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = ["172.16.0.0/27"]
+    }
+  ]
+}
+
+module "negative4_private_ipv6_1" {
+  source  = "terraform-aws-modules/security-group/aws"
+  ingress_with_ipv6_cidr_blocks = [
+    {
+      from_port         = 22
+      to_port           = 22
+      protocol          = "tcp"
+      ipv6_cidr_blocks  = ["fd00::/121"]
     }
   ]
 }

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/positive1.tf
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/positive1.tf
@@ -4,7 +4,7 @@ resource "aws_security_group" "positive1_ipv4_1" {
     from_port   = 22
     to_port     = 22
     protocol    = "-1"
-    cidr_blocks = ["10.0.0.0/25"]
+    cidr_blocks = ["203.0.113.0/25"]
   }
 }
 
@@ -13,7 +13,7 @@ resource "aws_security_group" "positive1_ipv4_2" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["192.168.0.0/26"]
+    cidr_blocks = ["198.51.100.0/26"]
   }
 }
 
@@ -22,13 +22,13 @@ resource "aws_security_group" "positive1_array_test_ipv4" {
     from_port   = 22
     to_port     = 22
     protocol    = "udp"
-    cidr_blocks = ["172.16.0.0/27"]
+    cidr_blocks = ["8.8.8.0/27"]
   }
   ingress {
     from_port   = 110
     to_port     = 110
     protocol    = "udp"
-    cidr_blocks = ["10.68.0.0", "172.16.0.0/27"]
+    cidr_blocks = ["10.68.0.0", "1.1.1.0/27"]
   }
 }
 
@@ -39,7 +39,7 @@ resource "aws_security_group" "positive1_ipv6_1" {
     from_port         = 22
     to_port           = 22
     protocol          = "-1"
-    ipv6_cidr_blocks  = ["fd00::/121"]
+    ipv6_cidr_blocks  = ["2400:cb00::/121"]
   }
 }
 
@@ -48,7 +48,7 @@ resource "aws_security_group" "positive1_ipv6_2" {
     from_port         = 22
     to_port           = 22
     protocol          = "tcp"
-    ipv6_cidr_blocks  = ["fd12:3456:789a::1/122"]
+    ipv6_cidr_blocks  = ["2606:4700:4700::1/122"]
   }
 }
 
@@ -57,13 +57,13 @@ resource "aws_security_group" "positive1_array_test_ipv6" {
     from_port         = 22
     to_port           = 22
     protocol          = "udp"
-    ipv6_cidr_blocks  = ["fd00:abcd:1234::42/123"] 
+    ipv6_cidr_blocks  = ["2001:4860:4860::42/123"]
   }
 
   ingress {
     from_port         = 110
     to_port           = 110
     protocol          = "udp"
-    ipv6_cidr_blocks  = ["fd03:5678::/64", "fd00:abcd:1234::42/123"] 
+    ipv6_cidr_blocks  = ["fd03:5678::/64", "2001:4860:4860::42/123"]
   }
 }

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/positive2.tf
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/positive2.tf
@@ -3,28 +3,28 @@ resource "aws_vpc_security_group_ingress_rule" "positive2_ipv4_1" {
   from_port         = 22
   to_port           = 22
   ip_protocol       = "-1"
-  cidr_ipv4         = "10.0.0.0/25"
+  cidr_ipv4         = "203.0.113.0/25"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "positive2_ipv4_2" {
   from_port         = 22
   to_port           = 22
   ip_protocol       = "tcp"
-  cidr_ipv4         = "192.168.0.0/26"
+  cidr_ipv4         = "198.51.100.0/26"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "positive2_ipv4_3" {
   from_port         = 22
   to_port           = 22
   ip_protocol       = "udp"
-  cidr_ipv4         = "172.16.0.0/27"
+  cidr_ipv4         = "8.8.8.0/27"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "positive2_ipv4_4" {
   from_port         = 110
   to_port           = 110
   ip_protocol       = "udp"
-  cidr_ipv4         = "172.16.0.0/27"
+  cidr_ipv4         = "1.1.1.0/27"
 }
 
 # ipv6
@@ -33,26 +33,26 @@ resource "aws_vpc_security_group_ingress_rule" "positive2_ipv6_1" {
   from_port         = 22
   to_port           = 22
   ip_protocol       = "-1"
-  cidr_ipv6         = "fd00::/121" 
+  cidr_ipv6         = "2400:cb00::/121"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "positive2_ipv6_2" {
   from_port         = 22
   to_port           = 22
   ip_protocol       = "tcp"
-  cidr_ipv6         = "fd12:3456:789a::1/122"
+  cidr_ipv6         = "2606:4700:4700::1/122"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "positive2_ipv6_3" {
   from_port         = 22
   to_port           = 22
   ip_protocol       = "udp"
-  cidr_ipv6         = "fd00:abcd:1234::42/123"
+  cidr_ipv6         = "2001:4860:4860::42/123"
 }
 
 resource "aws_vpc_security_group_ingress_rule" "positive2_ipv6_4" {
   from_port         = 110
   to_port           = 110
   ip_protocol       = "udp"
-  cidr_ipv6         = "fd00:abcd:1234::42/123"
+  cidr_ipv6         = "2001:4860:4860::42/123"
 }

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/positive3.tf
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/positive3.tf
@@ -3,7 +3,7 @@ resource "aws_security_group_rule" "positive3_ipv4_1" {
   from_port    = 22
   to_port      = 22
   protocol     = "-1"
-  cidr_blocks  = ["10.0.0.0/25"]
+  cidr_blocks  = ["203.0.113.0/25"]
   type         = "ingress"
 }
 
@@ -11,7 +11,7 @@ resource "aws_security_group_rule" "positive3_ipv4_2" {
   from_port    = 22
   to_port      = 22
   protocol     = "tcp"
-  cidr_blocks  = ["192.168.0.0/26"]
+  cidr_blocks  = ["198.51.100.0/26"]
   type         = "ingress"
 }
 
@@ -19,7 +19,7 @@ resource "aws_security_group_rule" "positive3_ipv4_3" {
   from_port    = 22
   to_port      = 22
   protocol     = "udp"
-  cidr_blocks  = ["172.16.0.0/27"]
+  cidr_blocks  = ["8.8.8.0/27"]
   type         = "ingress"
 }
 
@@ -27,7 +27,7 @@ resource "aws_security_group_rule" "positive3_ipv4_4" {
   from_port    = 110
   to_port      = 110
   protocol     = "udp"
-  cidr_blocks  = ["10.68.0.0", "172.16.0.0/27"]
+  cidr_blocks  = ["10.68.0.0", "1.1.1.0/27"]
   type         = "ingress"
 }
 
@@ -37,7 +37,7 @@ resource "aws_security_group_rule" "positive3_ipv6_1" {
   from_port         = 22
   to_port           = 22
   protocol          = "-1"
-  ipv6_cidr_blocks  = ["fd00::/121"]
+  ipv6_cidr_blocks  = ["2400:cb00::/121"]
   type              = "ingress"
 }
 
@@ -45,7 +45,7 @@ resource "aws_security_group_rule" "positive3_ipv6_2" {
   from_port         = 22
   to_port           = 22
   protocol          = "tcp"
-  ipv6_cidr_blocks  = ["fd12:3456:789a::1/122"]
+  ipv6_cidr_blocks  = ["2606:4700:4700::1/122"]
   type              = "ingress"
 }
 
@@ -53,7 +53,7 @@ resource "aws_security_group_rule" "positive3_ipv6_3" {
   from_port         = 22
   to_port           = 22
   protocol          = "udp"
-  ipv6_cidr_blocks  = ["fd00:abcd:1234::42/123"]
+  ipv6_cidr_blocks  = ["2001:4860:4860::42/123"]
   type              = "ingress"
 }
 
@@ -61,6 +61,6 @@ resource "aws_security_group_rule" "positive3_ipv6_4" {
   from_port         = 110
   to_port           = 110
   protocol          = "udp"
-  ipv6_cidr_blocks  = ["fd03:5678::/64", "fd00:abcd:1234::42/123"] 
+  ipv6_cidr_blocks  = ["fd03:5678::/64", "2001:4860:4860::42/123"]
   type              = "ingress"
 }

--- a/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/positive4.tf
+++ b/assets/queries/terraform/aws/sensitive_port_is_exposed_to_small_public_network/test/positive4.tf
@@ -5,25 +5,25 @@ module "positive4_ipv4_1" {
       from_port   = 22
       to_port     = 22
       protocol    = "-1"
-      cidr_blocks = ["10.0.0.0/25"]
+      cidr_blocks = ["203.0.113.0/25"]
     },
     {
       from_port   = 22
       to_port     = 22
       protocol    = "tcp"
-      cidr_blocks = ["192.168.0.0/26"]
+      cidr_blocks = ["198.51.100.0/26"]
     },
     {
       from_port   = 22
       to_port     = 22
       protocol    = "udp"
-      cidr_blocks = ["172.16.0.0/27"]
+      cidr_blocks = ["8.8.8.0/27"]
     },
     {
       from_port   = 110
       to_port     = 110
       protocol    = "udp"
-      cidr_blocks = ["10.68.0.0", "172.16.0.0/27"]
+      cidr_blocks = ["10.68.0.0", "1.1.1.0/27"]
     }
   ]
 }
@@ -35,25 +35,25 @@ module "positive4_ipv6_1" {
       from_port         = 22
       to_port           = 22
       protocol          = "-1"
-      ipv6_cidr_blocks  = ["fd00::/121"]
+      ipv6_cidr_blocks  = ["2400:cb00::/121"]
     },
     {
       from_port         = 22
       to_port           = 22
       protocol          = "tcp"
-      ipv6_cidr_blocks  = ["fd12:3456:789a::1/122"]
+      ipv6_cidr_blocks  = ["2606:4700:4700::1/122"]
     },
     {
       from_port         = 22
       to_port           = 22
       protocol          = "udp"
-      ipv6_cidr_blocks  = ["fd00:abcd:1234::42/123"]
+      ipv6_cidr_blocks  = ["2001:4860:4860::42/123"]
     },
     {
       from_port         = 110
       to_port           = 110
       protocol          = "udp"
-      ipv6_cidr_blocks  = ["fd03:5678::/64", "fd00:abcd:1234::42/123"]
+      ipv6_cidr_blocks  = ["fd03:5678::/64", "2001:4860:4860::42/123"]
     }
   ]
 }


### PR DESCRIPTION
Closes #8032

**Reason for Proposed Changes**
- The Terraform query `aws/sensitive_port_is_exposed_to_small_public_network` only looked at the CIDR suffix (`/25`-`/29` for IPv4, `/121`-`/125` for IPv6) to decide a range was a "small public network". It never checked whether the range was actually public.
- Because of that, private RFC1918 ranges such as `10.0.0.0/25`, `192.168.0.0/26` and `172.16.0.0/27`, as well as IPv6 ULA ranges like `fd00::/121`, were reported as small public networks. That is a false positive: exposing a sensitive port to a small private subnet is not the risk this query is meant to catch, and #8032 reports the rule as too broad for exactly this reason.

**Proposed Changes**
- `isSmallPublicNetwork` now requires the CIDR to be small AND not private. The private check reuses the existing `common_lib.isPrivateIP` helper (RFC1918 `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` and IPv6 ULA `fc00::/8`, `fd00::/8`), which is the same helper the sibling `sensitive_port_is_exposed_to_wide_private_network` query already uses, so the public/private boundary stays consistent across the two queries.
- Genuinely public small ranges still flag. The positive fixtures were updated to use public small CIDRs (`203.0.113.0/25`, `198.51.100.0/26`, `8.8.8.0/27`, public IPv6 GUA, etc.); they previously used private RFC1918/ULA ranges, which is the false positive itself, so they no longer belong in the positive set.
- Added negative fixtures with private `/25`-`/27` and ULA `/121` ranges on a sensitive port and TCP, across all four resource shapes (`aws_security_group`, `aws_vpc_security_group_ingress_rule`, `aws_security_group_rule`, and the `terraform-aws-modules/security-group/aws` module), so the false positive is locked in.

Tests run locally with `go test ./test/ -run 'TestQueries/terraform/aws/sensitive_port_is_exposed_to_small_public_network'`, plus `TestQueriesContent` and `TestQueriesMetadata`, all green. I also confirmed the new negative cases fail against the pre-fix query, so they are a real regression guard rather than vacuous.

Note: #8032 mentions the Azure twin `azure/sensitive_port_is_exposed_to_small_public_network` has the same issue. I scoped this PR to AWS only to keep the review focused; I am happy to follow up with the matching Azure fix in a separate PR.

I submit this contribution under the Apache-2.0 license.
