### PR TITLE
fix(azure): accept cilium as a valid AKS network_policy

### DIFF
--- a/assets/queries/terraform/azure/aks_network_policy_misconfigured/query.rego
+++ b/assets/queries/terraform/azure/aks_network_policy_misconfigured/query.rego
@@ -17,7 +17,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("azurerm_kubernetes_cluster[%s].network_profile.network_policy", [name]),
 		"searchLine": common_lib.build_search_line(["resource","azurerm_kubernetes_cluster", name, "network_profile", "network_policy"], []),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": sprintf("'azurerm_kubernetes_cluster[%s].network_profile.network_policy' should be either 'azure' or 'calico'", [name]),
+		"keyExpectedValue": sprintf("'azurerm_kubernetes_cluster[%s].network_profile.network_policy' should be either 'azure', 'calico' or 'cilium'", [name]),
 		"keyActualValue": sprintf("'azurerm_kubernetes_cluster[%s].network_profile.network_policy' is %s", [name, policy]),
 		"remediation": json.marshal({
 			"before": sprintf("%s", [policy]),
@@ -39,7 +39,7 @@ CxPolicy[result] {
 		"searchKey": sprintf("azurerm_kubernetes_cluster[%s].network_profile", [name]),
 		"searchLine": common_lib.build_search_line(["resource","azurerm_kubernetes_cluster", name, "network_profile"], []),
 		"issueType": "MissingAttribute",
-		"keyExpectedValue": sprintf("'azurerm_kubernetes_cluster[%s].network_profile.network_policy' should be set to either 'azure' or 'calico'", [name]),
+		"keyExpectedValue": sprintf("'azurerm_kubernetes_cluster[%s].network_profile.network_policy' should be set to either 'azure', 'calico' or 'cilium'", [name]),
 		"keyActualValue": sprintf("'azurerm_kubernetes_cluster[%s].network_profile.network_policy' is undefined", [name]),
 		"remediation": "network_policy = \"azure\"",
 		"remediationType": "addition",
@@ -67,3 +67,5 @@ CxPolicy[result] {
 validPolicy("azure") = true
 
 validPolicy("calico") = true
+
+validPolicy("cilium") = true

--- a/assets/queries/terraform/azure/aks_network_policy_misconfigured/test/negative.tf
+++ b/assets/queries/terraform/azure/aks_network_policy_misconfigured/test/negative.tf
@@ -47,3 +47,28 @@ resource "azurerm_kubernetes_cluster" "negative2" {
     network_policy = "calico"
   }
 }
+
+resource "azurerm_kubernetes_cluster" "negative3" {
+  name                = "example-aks3"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  dns_prefix          = "exampleaks3"
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    Environment = "Production"
+  }
+
+  network_profile {
+    network_policy = "cilium"
+  }
+}


### PR DESCRIPTION
Closes #7297

### Problem

The `AKS Network Policy Misconfigured` query (`terraform/azure/aks_network_policy_misconfigured`) only accepts `azure` and `calico` as valid values for `network_profile.network_policy`. Azure AKS also supports `cilium` as a network policy (the Azure CNI powered by Cilium / Cilium data plane), so a cluster configured with `network_policy = "cilium"` is reported as an `IncorrectValue` result. That is a false positive, as raised in #7297.

### Fix

- Add `validPolicy("cilium") = true` so `cilium` is no longer flagged as an incorrect value.
- Update the two `keyExpectedValue` messages from "should be either 'azure' or 'calico'" to "should be either 'azure', 'calico' or 'cilium'" so the guidance matches what the query now accepts.
- Add a negative sample (`negative3`) to `test/negative.tf` using `network_policy = "cilium"` to lock in the expected behaviour.

The existing positive samples are unchanged: an invalid value (`network_policy = "roxanne"`) is still flagged, and the missing-attribute / missing-network_profile cases still flag, so the only behavioural change is that `cilium` stops being reported.

### Testing

Ran locally against `master`:

```
go test ./test/ -run 'TestQueries$/terraform/azure/aks_network_policy_misconfigured'
go test ./test/ -run 'TestQueriesContent/^aks_network_policy_misconfigured$'
go test ./test/ -run 'TestQueriesMetadata/^aks_network_policy_misconfigured$'
```

All pass. As a regression check I reverted only the `query.rego` change while keeping the new `cilium` negative sample, and the query test failed (the `cilium` cluster was reported as `IncorrectValue`), confirming the new sample actually exercises the fix.

### Reference

Azure docs list `cilium` as a supported `network_policy` value for AKS (Azure CNI powered by Cilium): https://learn.microsoft.com/en-us/azure/aks/azure-cni-powered-by-cilium
