### PR TITLE
feat(query): add "RDS Deletion Protection Disabled" query for Terraform/AWS

### DIFF
--- a/assets/queries/terraform/aws/rds_deletion_protection_disabled/metadata.json
+++ b/assets/queries/terraform/aws/rds_deletion_protection_disabled/metadata.json
@@ -1,0 +1,13 @@
+{
+  "id": "26d982ac-b86d-4915-9372-e723b1c0b886",
+  "queryName": "RDS Deletion Protection Disabled",
+  "severity": "MEDIUM",
+  "category": "Insecure Configurations",
+  "descriptionText": "Amazon RDS instances and Aurora clusters should have deletion protection enabled to prevent accidental or malicious deletion of the database",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#deletion_protection",
+  "platform": "Terraform",
+  "descriptionID": "41f3fc5b",
+  "cloudProvider": "aws",
+  "cwe": "693",
+  "riskScore": "3"
+}

--- a/assets/queries/terraform/aws/rds_deletion_protection_disabled/query.rego
+++ b/assets/queries/terraform/aws/rds_deletion_protection_disabled/query.rego
@@ -1,0 +1,49 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
+
+rdsResources := {"aws_db_instance", "aws_rds_cluster"}
+
+CxPolicy[result] {
+	resourceType := rdsResources[_]
+	resource := input.document[i].resource[resourceType][name]
+
+	not common_lib.valid_key(resource, "deletion_protection")
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resourceType,
+		"resourceName": tf_lib.get_resource_name(resource, name),
+		"searchKey": sprintf("%s[%s]", [resourceType, name]),
+		"issueType": "MissingAttribute",
+		"keyExpectedValue": sprintf("'%s[%s].deletion_protection' should be defined and set to true", [resourceType, name]),
+		"keyActualValue": sprintf("'%s[%s].deletion_protection' is undefined or null", [resourceType, name]),
+		"searchLine": common_lib.build_search_line(["resource", resourceType, name], []),
+		"remediation": "deletion_protection = true",
+		"remediationType": "addition",
+	}
+}
+
+CxPolicy[result] {
+	resourceType := rdsResources[_]
+	resource := input.document[i].resource[resourceType][name]
+
+	resource.deletion_protection == false
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": resourceType,
+		"resourceName": tf_lib.get_resource_name(resource, name),
+		"searchKey": sprintf("%s[%s].deletion_protection", [resourceType, name]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": sprintf("'%s[%s].deletion_protection' should be set to true", [resourceType, name]),
+		"keyActualValue": sprintf("'%s[%s].deletion_protection' is set to false", [resourceType, name]),
+		"searchLine": common_lib.build_search_line(["resource", resourceType, name, "deletion_protection"], []),
+		"remediation": json.marshal({
+			"before": "false",
+			"after": "true",
+		}),
+		"remediationType": "replacement",
+	}
+}

--- a/assets/queries/terraform/aws/rds_deletion_protection_disabled/test/negative.tf
+++ b/assets/queries/terraform/aws/rds_deletion_protection_disabled/test/negative.tf
@@ -1,0 +1,14 @@
+resource "aws_db_instance" "negative1" {
+  allocated_storage   = 10
+  engine              = "mysql"
+  instance_class      = "db.t3.micro"
+  deletion_protection = true
+}
+
+resource "aws_rds_cluster" "negative2" {
+  cluster_identifier  = "aurora-cluster-negative2"
+  engine              = "aurora-mysql"
+  master_username     = "foo"
+  master_password     = "barbarbar"
+  deletion_protection = true
+}

--- a/assets/queries/terraform/aws/rds_deletion_protection_disabled/test/positive.tf
+++ b/assets/queries/terraform/aws/rds_deletion_protection_disabled/test/positive.tf
@@ -1,0 +1,27 @@
+resource "aws_db_instance" "positive1" {
+  allocated_storage   = 10
+  engine              = "mysql"
+  instance_class      = "db.t3.micro"
+  deletion_protection = false
+}
+
+resource "aws_db_instance" "positive2" {
+  allocated_storage = 10
+  engine            = "mysql"
+  instance_class    = "db.t3.micro"
+}
+
+resource "aws_rds_cluster" "positive3" {
+  cluster_identifier  = "aurora-cluster-positive3"
+  engine              = "aurora-mysql"
+  master_username     = "foo"
+  master_password     = "barbarbar"
+  deletion_protection = false
+}
+
+resource "aws_rds_cluster" "positive4" {
+  cluster_identifier = "aurora-cluster-positive4"
+  engine             = "aurora-mysql"
+  master_username    = "foo"
+  master_password    = "barbarbar"
+}

--- a/assets/queries/terraform/aws/rds_deletion_protection_disabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/rds_deletion_protection_disabled/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "RDS Deletion Protection Disabled",
+    "severity": "MEDIUM",
+    "line": 5,
+    "fileName": "positive.tf"
+  },
+  {
+    "queryName": "RDS Deletion Protection Disabled",
+    "severity": "MEDIUM",
+    "line": 8,
+    "fileName": "positive.tf"
+  },
+  {
+    "queryName": "RDS Deletion Protection Disabled",
+    "severity": "MEDIUM",
+    "line": 19,
+    "fileName": "positive.tf"
+  },
+  {
+    "queryName": "RDS Deletion Protection Disabled",
+    "severity": "MEDIUM",
+    "line": 22,
+    "fileName": "positive.tf"
+  }
+]


### PR DESCRIPTION
## Description
Adds a new KICS query that flags Amazon RDS databases provisioned **without deletion protection**. It covers both `aws_db_instance` and `aws_rds_cluster` (Aurora), reporting when `deletion_protection` is either set to `false` (IncorrectValue) or omitted entirely (MissingAttribute — the Terraform/AWS default is `false`, i.e. unprotected).

## Motivation
KICS already ships `ALB Deletion Protection Disabled` (`aws_lb`/`aws_alb`), but there is **no equivalent coverage for RDS**, despite RDS holding persistent data where accidental or malicious deletion is far more damaging. Confirmed gap: no existing query references `deletion_protection` on `aws_db_instance`/`aws_rds_cluster`.

## What the query checks
| Resource | Condition flagged | issueType |
|----------|-------------------|-----------|
| `aws_db_instance` | `deletion_protection = false` | IncorrectValue |
| `aws_db_instance` | `deletion_protection` undefined | MissingAttribute |
| `aws_rds_cluster` | `deletion_protection = false` | IncorrectValue |
| `aws_rds_cluster` | `deletion_protection` undefined | MissingAttribute |

Secure configurations (`deletion_protection = true`) are covered by the negative tests and produce no findings.

## Metadata
- Severity: **MEDIUM**, riskScore **3** (per the contributor guide severity→score mapping)
- Category: Insecure Configurations · CWE-693 (Protection Mechanism Failure)
- `descriptionUrl` → Terraform AWS provider `db_instance#deletion_protection`

## Testing
- `make test-unit` — new query positive/negative tests pass; full suite green (55 packages, 0 failures).
- Validated end-to-end with `./bin/kics scan` on both samples (positive → 4 MEDIUM findings, negative → 0).
- `metadata.json` validated against `.github/scripts/queries-validator/metadata-schema.json`.

---

I submit this contribution under the Apache-2.0 license.
