### PR TITLE
fix(parser): kics-scan ignore-line/ignore-block misapplied in YAML files with resolved references

### DIFF
--- a/pkg/engine/secrets/inspector.go
+++ b/pkg/engine/secrets/inspector.go
@@ -631,10 +631,6 @@ func validateCustomSecretsQueriesID(allRegexQueries []RegexQuery) error {
 }
 
 func (c *Inspector) checkContent(i, idx int, basePaths []string, files model.FileMetadatas) {
-	// lines ignore can have the lines from the resolved files
-	// since inspector secrets only looks to original data, the lines ignore should be replaced
-	files[idx].LinesIgnore = model.GetIgnoreLines(&files[idx])
-
 	wg := &sync.WaitGroup{}
 	// check file content line by line
 	if c.regexQueries[i].Multiline == (MultilineResult{}) {

--- a/pkg/kics/sink.go
+++ b/pkg/kics/sink.go
@@ -63,6 +63,17 @@ func (s *Service) sink(ctx context.Context, filename, scanID string,
 	}
 	s.Tracker.TrackFileFoundCountLines(linesResolved)
 
+	if len(documents.ResolvedFiles) > 0 {
+		// ignore lines were collected while parsing the resolved content, so they can have
+		// the lines from the resolved files; since results are reported on the original
+		// file lines, the lines ignore should be replaced with ones based on the original data
+		documents.IgnoreLines = model.GetIgnoreLines(&model.FileMetadata{
+			FilePath:     filename,
+			OriginalData: documents.Content,
+			LinesIgnore:  documents.IgnoreLines,
+		})
+	}
+
 	fileCommands := s.Parser.CommentsCommands(filename, *content)
 
 	for idx, document := range documents.Docs {

--- a/pkg/kics/sink_test.go
+++ b/pkg/kics/sink_test.go
@@ -1,10 +1,18 @@
 package kics
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/Checkmarx/kics/v2/internal/storage"
+	"github.com/Checkmarx/kics/v2/internal/tracker"
 	"github.com/Checkmarx/kics/v2/pkg/model"
+	"github.com/Checkmarx/kics/v2/pkg/parser"
+	yamlParser "github.com/Checkmarx/kics/v2/pkg/parser/yaml"
 	"github.com/stretchr/testify/require"
 )
 
@@ -148,4 +156,59 @@ func compareJSONLine(t *testing.T, test1 interface{}, test2 string) {
 	stringefiedJSON, err := json.Marshal(&test1)
 	require.NoError(t, err)
 	require.JSONEq(t, test2, string(stringefiedJSON))
+}
+
+// TestKics_sinkIgnoreLinesWithResolvedFiles ensures that the ignore lines stored in the
+// file metadata keep the original file coordinates, even when the file references other
+// files (e.g. a docker-compose "include") and its parsed content has shifted lines
+func TestKics_sinkIgnoreLinesWithResolvedFiles(t *testing.T) {
+	tests := []struct {
+		name              string
+		filePath          string
+		wantIgnoreLines   []int
+		wantResolvedFiles bool
+	}{
+		{
+			name:              "yaml with include should keep ignore lines on the original file coordinates",
+			filePath:          filepath.Join("..", "..", "test", "fixtures", "resolve_ignore_lines", "docker-compose.yaml"),
+			wantIgnoreLines:   []int{6, 7},
+			wantResolvedFiles: true,
+		},
+		{
+			name:              "yaml without include should keep the parser ignore lines",
+			filePath:          filepath.Join("..", "..", "test", "fixtures", "resolve_ignore_lines", "no-include.yaml"),
+			wantIgnoreLines:   []int{4, 5},
+			wantResolvedFiles: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, err := os.ReadFile(tt.filePath)
+			require.NoError(t, err)
+
+			file := sinkFile(t, tt.filePath, content)
+			require.Equal(t, tt.wantResolvedFiles, len(file.ResolvedFiles) > 0)
+			require.Equal(t, tt.wantIgnoreLines, file.LinesIgnore)
+		})
+	}
+}
+
+func sinkFile(t *testing.T, filename string, content []byte) model.FileMetadata {
+	yamlOnlyParser, err := parser.NewBuilder().Add(&yamlParser.Parser{}).Build([]string{""}, []string{""})
+	require.NoError(t, err)
+
+	ciTracker, err := tracker.NewTracker(3)
+	require.NoError(t, err)
+
+	s := &Service{
+		Parser:      yamlOnlyParser[0],
+		Storage:     storage.NewMemoryStorage(),
+		Tracker:     ciTracker,
+		MaxFileSize: 5,
+	}
+	err = s.sink(context.Background(), filename, "scanID", bytes.NewReader(content), make([]byte, mbConst), false, 15)
+	require.NoError(t, err)
+	require.Len(t, s.files, 1)
+	return s.files[0]
 }

--- a/test/fixtures/resolve_ignore_lines/docker-compose.yaml
+++ b/test/fixtures/resolve_ignore_lines/docker-compose.yaml
@@ -1,0 +1,12 @@
+include:
+  - included.yaml
+services:
+  alpha:
+    image: alpine
+    # kics-scan ignore-line
+    ports:
+      - "1111:1111"
+  beta:
+    image: alpine
+    ports:
+      - "2222:2222"

--- a/test/fixtures/resolve_ignore_lines/included.yaml
+++ b/test/fixtures/resolve_ignore_lines/included.yaml
@@ -1,0 +1,7 @@
+services:
+  rabbit:
+    image: rabbitmq:3
+    environment:
+      K0: "0"
+      K1: "1"
+      K2: "2"

--- a/test/fixtures/resolve_ignore_lines/no-include.yaml
+++ b/test/fixtures/resolve_ignore_lines/no-include.yaml
@@ -1,0 +1,10 @@
+services:
+  alpha:
+    image: alpine
+    # kics-scan ignore-line
+    ports:
+      - "1111:1111"
+  beta:
+    image: alpine
+    ports:
+      - "2222:2222"


### PR DESCRIPTION
Closes #8078

**Reason for for this change**

- `kics-scan ignore-line` / `ignore-block` comments are broken in YAML files that resolve other files (e.g. docker-compose `include:`): ignore positions are collected while parsing the resolved (combined) content, so they are shifted by the inlined lines, while results are reported on the original file lines. The ignore then does nothing or can even shift the ignores to a wrong line.

**Proposed change**

- In the sink, when a file has resolved references, replace `documents.IgnoreLines` with lines recomputed from the original file content via the existing `model.GetIgnoreLines` helper, before building the `FileMetadata`. This mirrors what the Helm sink already does (`getOriginalIgnoreLines`) and what the secrets inspector already did (which it doesn't need to do anymore since it's caught upstream).
- Remove the now-redundant `model.GetIgnoreLines` call in the secrets inspector: `FileMetadata.LinesIgnore` now carries correct file coordinates when it reaches the engines. This also avoids re-parsing the same file once per secrets query.
- Add a regression test (`TestKics_sinkIgnoreLinesWithResolvedFiles`) with fixtures under `test/fixtures/resolve_ignore_lines/`: a compose file with an `include` (ignore lines must stay `[6, 7]`, previously `[12, 13]`) and one without (unchanged path).

Files without resolved references are untouched.

I submit this contribution under the Apache-2.0 license.