### PR TITLE
fix(query): fix false positive in schema_required_property_undefined

### DIFF
--- a/assets/queries/openAPI/general/schema_required_property_undefined/query.rego
+++ b/assets/queries/openAPI/general/schema_required_property_undefined/query.rego
@@ -12,7 +12,7 @@ CxPolicy[result] {
 
 	requiredProperty := schema.required[_]
 
-	all([property | property != requiredProperty; _ := schema.properties[property]])
+	not schema.properties[requiredProperty]
 	result := {
 		"documentId": docs.id,
 		"searchKey": sprintf("%s.schema", [openapi_lib.concat_path(path)]),
@@ -33,7 +33,7 @@ CxPolicy[result] {
 
 	requiredProperty := schema.required[_]
 
-	all([property | property != requiredProperty; _ := schema.properties[property]])
+	not schema.properties[requiredProperty]
 	newPath := [path[_], schemaName]
 	result := {
 		"documentId": docs.id,

--- a/assets/queries/openAPI/general/schema_required_property_undefined/test/negative7.yaml
+++ b/assets/queries/openAPI/general/schema_required_property_undefined/test/negative7.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.com
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                    - status: CURRENT
+                      updated: '2011-01-21T11:33:21Z'
+                      id: v2.0
+                      links:
+                      - href: http://127.0.0.1:8774/v2/
+                        rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      required:
+      - code
+      properties:
+        code:
+          type: integer
+          format: int32

--- a/assets/queries/openAPI/general/schema_required_property_undefined/test/positive7.yaml
+++ b/assets/queries/openAPI/general/schema_required_property_undefined/test/positive7.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Simple API Overview
+  version: 1.0.0
+  contact:
+    name: contact
+    url: https://www.google.com/
+    email: user@gmail.com
+paths:
+  "/":
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: 200 response
+          content:
+            application/json:
+              examples:
+                foo:
+                  value:
+                    versions:
+                    - status: CURRENT
+                      updated: '2011-01-21T11:33:21Z'
+                      id: v2.0
+                      links:
+                      - href: http://127.0.0.1:8774/v2/
+                        rel: self
+components:
+  schemas:
+    GeneralError:
+      type: object
+      discriminator:
+        propertyName: petType
+      required:
+      - message
+      properties:
+        code:
+          type: integer
+          format: int32

--- a/assets/queries/openAPI/general/schema_required_property_undefined/test/positive_expected_result.json
+++ b/assets/queries/openAPI/general/schema_required_property_undefined/test/positive_expected_result.json
@@ -34,5 +34,11 @@
     "severity": "INFO",
     "line": 17,
     "filename": "positive6.yaml"
+  },
+  {
+    "queryName": "Schema Has A Required Property Undefined (v3)",
+    "severity": "INFO",
+    "line": 31,
+    "filename": "positive7.yaml"
   }
 ]


### PR DESCRIPTION
[…when](url) sole required property

The predicate `all([property | property != requiredProperty; _ := schema.properties[property]])` was logically inverted, producing two failure modes:

- False positive: when `requiredProperty` is the only entry in `properties`, the comprehension yields `[]` and `all([])` is vacuously true — the rule fires even though the property is correctly defined.

- False negative: when `requiredProperty` is genuinely absent but sibling properties exist, the comprehension yields a non-empty list of strings and `all(["sibling"])` is false — the rule does not fire, missing a real violation.

Replace with a direct absence check: `not schema.properties[requiredProperty]` This evaluates to true if and only if the required property has no entry in `properties`, regardless of how many siblings exist.

Fixes #8081

Tests:
- negative7.yaml: sole required property present — must not fire (was false positive)
- positive7.yaml: required property absent with sibling present — must fire (was false negative)
- All six existing positive fixtures continue to fire (regression-checked locally)

Closes #

**Reason for Proposed Changes**
-

**Proposed Changes**
-
-
-

I submit this contribution under the Apache-2.0 license.