### PR TITLE
fix(query): skip Fargate local volumes in EFS transit encryption check

### DIFF
--- a/assets/queries/terraform/aws/efs_volume_with_disabled_transit_encryption/query.rego
+++ b/assets/queries/terraform/aws/efs_volume_with_disabled_transit_encryption/query.rego
@@ -51,8 +51,12 @@ CxPolicy[result] {
 	}
 }
 
+# Missing efs_volume_configuration only matters when the task may use host/EC2
+# volumes that should be EFS-backed. Fargate tasks use platform-managed local
+# storage for plain volume blocks, so requiring EFS transit encryption is an FP.
 CxPolicy[result] {
 	resource := input.document[i].resource.aws_ecs_task_definition[name]
+	not is_fargate_task(resource)
 	vol_info := get_volumes(resource)[_]
 	not common_lib.valid_key(vol_info.volume, "efs_volume_configuration")
 
@@ -69,6 +73,10 @@ CxPolicy[result] {
 		"keyExpectedValue": "aws_ecs_task_definition.volume.efs_volume_configuration value should be defined",
 		"keyActualValue": "aws_ecs_task_definition.volume.efs_volume_configuration is not set",
 	}
+}
+
+is_fargate_task(resource) {
+	resource.requires_compatibilities[_] == "FARGATE"
 }
 
 get_volumes(resource) = volumes {

--- a/assets/queries/terraform/aws/efs_volume_with_disabled_transit_encryption/test/negative3.tf
+++ b/assets/queries/terraform/aws/efs_volume_with_disabled_transit_encryption/test/negative3.tf
@@ -1,0 +1,12 @@
+resource "aws_ecs_task_definition" "fargate_local" {
+  family                   = "service"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  container_definitions    = file("task-definitions/service.json")
+
+  volume {
+    name = "local-storage"
+  }
+}

--- a/assets/queries/terraform/aws/efs_volume_with_disabled_transit_encryption/test/negative4.tf
+++ b/assets/queries/terraform/aws/efs_volume_with_disabled_transit_encryption/test/negative4.tf
@@ -1,0 +1,16 @@
+resource "aws_ecs_task_definition" "fargate_multi_local" {
+  family                   = "service"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  container_definitions    = file("task-definitions/service.json")
+
+  volume {
+    name = "local-storage-1"
+  }
+
+  volume {
+    name = "local-storage-2"
+  }
+}

--- a/assets/queries/terraform/aws/efs_volume_with_disabled_transit_encryption/test/positive8.tf
+++ b/assets/queries/terraform/aws/efs_volume_with_disabled_transit_encryption/test/positive8.tf
@@ -1,0 +1,19 @@
+resource "aws_ecs_task_definition" "fargate_efs_disabled" {
+  family                   = "service"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  container_definitions    = file("task-definitions/service.json")
+
+  volume {
+    name = "efs-storage"
+
+    efs_volume_configuration {
+      file_system_id          = aws_efs_file_system.fs.id
+      root_directory          = "/opt/data"
+      transit_encryption      = "DISABLED"
+      transit_encryption_port = 2999
+    }
+  }
+}

--- a/assets/queries/terraform/aws/efs_volume_with_disabled_transit_encryption/test/positive_expected_result.json
+++ b/assets/queries/terraform/aws/efs_volume_with_disabled_transit_encryption/test/positive_expected_result.json
@@ -58,5 +58,11 @@
     "severity": "MEDIUM",
     "line": 26,
     "filename": "positive7.tf"
+  },
+  {
+    "queryName": "EFS Volume With Disabled Transit Encryption",
+    "severity": "MEDIUM",
+    "line": 15,
+    "filename": "positive8.tf"
   }
 ]


### PR DESCRIPTION
Closes #8031

**Reason for Proposed Changes**
- Query `4d46ff3b` (`EFS Volume With Disabled Transit Encryption`) treats every plain `volume` block on `aws_ecs_task_definition` as a missing EFS transit encryption setting.
- Fargate tasks use platform-managed local storage for plain volume blocks. Requiring `efs_volume_configuration` there is a false positive (reported for Fargate local volumes).

**Proposed Changes**
- Skip the “missing `efs_volume_configuration`” branch when `requires_compatibilities` includes `FARGATE`.
- Keep reporting `DISABLED` / missing `transit_encryption` whenever `efs_volume_configuration` is present, including Fargate + EFS.
- Add negative fixtures for Fargate local volumes and a positive fixture for Fargate + EFS with transit encryption disabled.

**How tested**
- Static review of `query.rego` guard placement and fixture set.
- Host lacks full KICS/OPA suite; fixtures follow the existing query test layout.

I submit this contribution under the Apache-2.0 license.
