### PR TITLE
fix(query): fixed FP on default azure storage account network is too permissive for arm

### DIFF
--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/query.rego
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/query.rego
@@ -1,6 +1,7 @@
 package Cx
 
 import data.generic.common as common_lib
+import data.generic.azureresourcemanager as arm_lib
 
 CxPolicy[result] {
 	doc := input.document[i]
@@ -8,8 +9,8 @@ CxPolicy[result] {
 
 	value.type == "Microsoft.Storage/storageAccounts"
 
-	res1 := publicNetworkAccessEnabled(value.properties)
-    res2 := aclsDefaultActionAllow(value.properties)
+	res1 := publicNetworkAccessEnabled(doc, value.properties)
+    res2 := aclsDefaultActionAllow(doc, value.properties)
 
     issue := prepare_issue(res1, res2)
 
@@ -25,18 +26,48 @@ CxPolicy[result] {
 	}
 }
 
-publicNetworkAccessEnabled(properties) = reason {
+publicNetworkAccessEnabled(doc, properties) = reason {
 	not properties.publicNetworkAccess
     reason := "not defined"
 } else = reason {
+	common_lib.valid_key(properties, "publicNetworkAccess")
+    [publicNetworkAcessFromParams, _] := arm_lib.getDefaultValueFromParametersIfPresent(doc, properties.publicNetworkAccess)
+    is_array(publicNetworkAcessFromParams)
+    lower(publicNetworkAcessFromParams[_]) == "enabled"
+    reason := "enabled"
+} else = reason {
+	common_lib.valid_key(properties, "publicNetworkAccess")
+    [publicNetworkAcessFromParams, _] := arm_lib.getDefaultValueFromParametersIfPresent(doc, properties.publicNetworkAccess)
+    not is_array(publicNetworkAcessFromParams)
+    lower(publicNetworkAcessFromParams) == "enabled"
+    reason := "enabled"
+} else = reason {
 	properties.publicNetworkAccess
+    not arm_lib.isParameterReference(properties.publicNetworkAccess)
 	lower(properties.publicNetworkAccess) == "enabled"
     reason := "enabled"
 }
 
-aclsDefaultActionAllow(properties) = reason {
-	not properties.networkAcls.defaultAction
+aclsDefaultActionAllow(doc, properties) = reason {
+	not common_lib.valid_key(properties, "networkAcls")
     reason := "not defined"
+} else = reason {
+    common_lib.valid_key(properties, "networkAcls")
+    not common_lib.valid_key(properties.networkAcls, "defaultAction")
+    not arm_lib.isParameterReference(properties.networkAcls)
+    reason := "not defined"
+} else = reason {
+	common_lib.valid_key(properties, "networkAcls")
+    [networkAclsFromParams, _] := arm_lib.getDefaultValueFromParametersIfPresent(doc, properties.networkAcls)
+    is_array(networkAclsFromParams)
+    lower(networkAclsFromParams[_].defaultAction) == "allow"
+    reason := "allow"
+} else = reason {
+	common_lib.valid_key(properties, "networkAcls")
+    [networkAclsFromParams, _] := arm_lib.getDefaultValueFromParametersIfPresent(doc, properties.networkAcls)
+    not is_array(networkAclsFromParams)
+    lower(networkAclsFromParams.defaultAction) == "allow"
+    reason := "allow"
 } else = reason {
 	properties.networkAcls.defaultAction
     lower(properties.networkAcls.defaultAction) == "allow"
@@ -64,8 +95,8 @@ prepare_issue(val1, val2) = issue {
     val2 == "allow"
     issue := {
     	"kav": "resource with type 'Microsoft.Storage/storageAccounts' networkAcls.defaultAction is set to 'Allow')",
-        "sk": ".properties.networkAcls.defaultAction",
-        "sl": ["properties", "networkAcls", "defaultAction"],
+        "sk": ".properties.networkAcls",
+        "sl": ["properties", "networkAcls"],
         "issueType": "IncorrectValue"
     }
 }

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative3.bicep
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative3.bicep
@@ -1,0 +1,22 @@
+param supportLogStorageAccountType string
+
+param networkAcls object = {
+  defaultAction: 'Deny'
+}
+
+var computeLocation = 'comloc'
+
+resource negative3 'Microsoft.Storage/storageAccounts@2021-06-01' = {
+  kind: 'Storage'
+  location: computeLocation
+  name: 'negative3'
+  properties: {
+    publicNetworkAccess: 'Enabled'
+    networkAcls: networkAcls
+  }
+  sku: {
+    name: supportLogStorageAccountType
+  }
+  tags: {}
+  dependsOn: []
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative3.json
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative3.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "networkAcls": {
+            "type": "object",
+            "defaultValue": {
+                "defaultAction": "Deny"
+            }
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2021-06-01",
+            "dependsOn": [],
+            "kind": "Storage",
+            "location": "[variables('computeLocation')]",
+            "name": "negative3",
+            "properties": {
+                "publicNetworkAccess": "Enabled",
+                "networkAcls": "[parameters('networkAcls')]"
+            },
+            "sku": {
+                "name": "[parameters('supportLogStorageAccountType')]"
+            },
+            "tags": {},
+            "type": "Microsoft.Storage/storageAccounts"
+        }
+    ]
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative4.bicep
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative4.bicep
@@ -1,0 +1,19 @@
+param supportLogStorageAccountType string
+
+param publicNetworkAccess string = 'Disabled'
+
+var computeLocation = 'comloc'
+
+resource negative4 'Microsoft.Storage/storageAccounts@2021-06-01' = {
+  kind: 'Storage'
+  location: computeLocation
+  name: 'negative4'
+  properties: {
+    publicNetworkAccess: publicNetworkAccess
+  }
+  sku: {
+    name: supportLogStorageAccountType
+  }
+  tags: {}
+  dependsOn: []
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative4.json
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative4.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "publicNetworkAccess": {
+            "type": "string",
+            "defaultValue": "Disabled"
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2021-06-01",
+            "dependsOn": [],
+            "kind": "Storage",
+            "location": "[variables('computeLocation')]",
+            "name": "negative4",
+            "properties": {
+                "publicNetworkAccess": "[parameters('publicNetworkAccess')]"
+            },
+            "sku": {
+                "name": "[parameters('supportLogStorageAccountType')]"
+            },
+            "tags": {},
+            "type": "Microsoft.Storage/storageAccounts"
+        }
+    ]
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative5.bicep
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative5.bicep
@@ -1,0 +1,21 @@
+param supportLogStorageAccountType string
+
+param networkAcls object = {
+  defaultAction: 'Deny'
+}
+
+var computeLocation = 'comloc'
+
+resource negative5 'Microsoft.Storage/storageAccounts@2021-06-01' = {
+  kind: 'Storage'
+  location: computeLocation
+  name: 'negative5'
+  properties: {
+    networkAcls: networkAcls
+  }
+  sku: {
+    name: supportLogStorageAccountType
+  }
+  tags: {}
+  dependsOn: []
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative5.json
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/negative5.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "networkAcls": {
+            "type": "object",
+            "defaultValue": {
+                "defaultAction": "Deny"
+            }
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2021-06-01",
+            "dependsOn": [],
+            "kind": "Storage",
+            "location": "[variables('computeLocation')]",
+            "name": "negative5",
+            "properties": {
+                "networkAcls": "[parameters('networkAcls')]"
+            },
+            "sku": {
+                "name": "[parameters('supportLogStorageAccountType')]"
+            },
+            "tags": {},
+            "type": "Microsoft.Storage/storageAccounts"
+        }
+    ]
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive4.bicep
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive4.bicep
@@ -1,0 +1,22 @@
+param supportLogStorageAccountType string
+
+param networkAcls object = {
+  defaultAction: 'Allow'
+}
+
+var computeLocation = 'comloc'
+
+resource positive4 'Microsoft.Storage/storageAccounts@2021-06-01' = {
+  kind: 'Storage'
+  location: computeLocation
+  name: 'positive4'
+  properties: {
+    publicNetworkAccess: 'Enabled'
+    networkAcls: networkAcls
+  }
+  sku: {
+    name: supportLogStorageAccountType
+  }
+  tags: {}
+  dependsOn: []
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive4.json
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive4.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "networkAcls": {
+            "type": "object",
+            "defaultValue": {
+                "defaultAction": "Allow"
+            }
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2021-06-01",
+            "dependsOn": [],
+            "kind": "Storage",
+            "location": "[variables('computeLocation')]",
+            "name": "positive4",
+            "properties": {
+                "publicNetworkAccess": "Enabled",
+                "networkAcls": "[parameters('networkAcls')]"
+            },
+            "sku": {
+                "name": "[parameters('supportLogStorageAccountType')]"
+            },
+            "tags": {},
+            "type": "Microsoft.Storage/storageAccounts"
+        }
+    ]
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive5.bicep
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive5.bicep
@@ -1,0 +1,20 @@
+param supportLogStorageAccountType string
+param storageApiVersion string = '2021-06-01'
+
+param publicNetworkAccess string = 'Enabled'
+
+var computeLocation = 'comloc'
+
+resource positive5 'Microsoft.Storage/storageAccounts@storageApiVersion' = {
+  kind: 'Storage'
+  location: computeLocation
+  name: 'positive5'
+  properties: {
+    publicNetworkAccess: publicNetworkAccess
+  }
+  sku: {
+    name: supportLogStorageAccountType
+  }
+  tags: {}
+  dependsOn: []
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive5.json
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive5.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "publicNetworkAccess": {
+            "type": "string",
+            "defaultValue": "Enabled"
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2021-06-01",
+            "dependsOn": [],
+            "kind": "Storage",
+            "location": "[variables('computeLocation')]",
+            "name": "positive5",
+            "properties": {
+                "publicNetworkAccess": "[parameters('publicNetworkAccess')]"
+            },
+            "sku": {
+                "name": "[parameters('supportLogStorageAccountType')]"
+            },
+            "tags": {},
+            "type": "Microsoft.Storage/storageAccounts"
+        }
+    ]
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive6.bicep
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive6.bicep
@@ -1,0 +1,21 @@
+param supportLogStorageAccountType string
+
+param networkAcls object = {
+  defaultAction: 'Allow'
+}
+
+var computeLocation = 'comloc'
+
+resource positive6 'Microsoft.Storage/storageAccounts@2021-06-01' = {
+  kind: 'Storage'
+  location: computeLocation
+  name: 'positive6'
+  properties: {
+    networkAcls: networkAcls
+  }
+  sku: {
+    name: supportLogStorageAccountType
+  }
+  tags: {}
+  dependsOn: []
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive6.json
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive6.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "networkAcls": {
+            "type": "object",
+            "defaultValue": {
+                "defaultAction": "Allow"
+            }
+        }
+    },
+    "resources": [
+        {
+            "apiVersion": "2021-06-01",
+            "dependsOn": [],
+            "kind": "Storage",
+            "location": "[variables('computeLocation')]",
+            "name": "positive6",
+            "properties": {
+                "networkAcls": "[parameters('networkAcls')]"
+            },
+            "sku": {
+                "name": "[parameters('supportLogStorageAccountType')]"
+            },
+            "tags": {},
+            "type": "Microsoft.Storage/storageAccounts"
+        }
+    ]
+}

--- a/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/default_azure_storage_account_network_access_is_too_permissive/test/positive_expected_result.json
@@ -2,7 +2,7 @@
   {
     "queryName": "Default Azure Storage Account Network Access Is Too Permissive",
     "severity": "HIGH",
-    "line": 13,
+    "line": 12,
     "fileName": "positive1.json"
   },
   {
@@ -20,7 +20,25 @@
   {
     "queryName": "Default Azure Storage Account Network Access Is Too Permissive",
     "severity": "HIGH",
-    "line": 12,
+    "line": 20,
+    "fileName": "positive4.json"
+  },
+  {
+    "queryName": "Default Azure Storage Account Network Access Is Too Permissive",
+    "severity": "HIGH",
+    "line": 18,
+    "fileName": "positive5.json"
+  },
+  {
+    "queryName": "Default Azure Storage Account Network Access Is Too Permissive",
+    "severity": "HIGH",
+    "line": 20,
+    "fileName": "positive6.json"
+  },
+  {
+    "queryName": "Default Azure Storage Account Network Access Is Too Permissive",
+    "severity": "HIGH",
+    "line": 11,
     "fileName": "positive1.bicep"
   },
   {
@@ -34,5 +52,23 @@
     "severity": "HIGH",
     "line": 11,
     "fileName": "positive3.bicep"
+  },
+  {
+    "queryName": "Default Azure Storage Account Network Access Is Too Permissive",
+    "severity": "HIGH",
+    "line": 14,
+    "fileName": "positive4.bicep"
+  },
+  {
+    "queryName": "Default Azure Storage Account Network Access Is Too Permissive",
+    "severity": "HIGH",
+    "line": 13,
+    "fileName": "positive5.bicep"
+  },
+  {
+    "queryName": "Default Azure Storage Account Network Access Is Too Permissive",
+    "severity": "HIGH",
+    "line": 14,
+    "fileName": "positive6.bicep"
   }
 ]


### PR DESCRIPTION
**Reason for the Proposed Changes**:
-  Currently the query does not support the scenarios when the fields `publicNetworkAccess` and `networkAcls.defaultAction` are defined inside parameters.

**Proposed Changes**:
- The only changes on the query was on the `publicNetworkAccessEnabled` and `aclsDefaultActionAllow` helper functions.
- For both I added to return a something when the fields `publicNetworkAccess` and `networkAcls.defaultAction`are defined inside parameters using the `getDefaultValueFromParametersIfPresent`  helper function from AzureResourceManager library under `assets/libraries` when the respective field's are referencing parameters (checked by using the helper function `isParameterReference` from AzureResourceManager library under `assets/libraries`).
- Added new tests to cover the cases were the fields are defined inside parameters.

I submit this contribution under the Apache-2.0 license.