### PR TITLE
fix(query): fixed FP for sql server database without auditing for arm

### DIFF
--- a/assets/queries/azureResourceManager/sql_server_database_without_auditing/query.rego
+++ b/assets/queries/azureResourceManager/sql_server_database_without_auditing/query.rego
@@ -18,13 +18,6 @@ CxPolicy[result] {
 	childrenArr := [x | x := childrenArr_full[ch_index]
 						childrenArr_full[ch_index].type == types[_]]
 
-	count([x |
-		child := childrenArr[_]
-		[val, _] := arm_lib.getDefaultValueFromParametersIfPresent(doc, child.properties.state)
-		lower(val) == "enabled"
-		x := child
-	]) == 0
-
 	# Case of "child" database resource with auditingsettings as "brother" resource
 	depth_path := array.slice(path, 0, count(path)-1)
 	brothersArr_full := object.get(doc, depth_path, [])
@@ -32,11 +25,18 @@ CxPolicy[result] {
 						brothersArr_full[ch_index].type == types[_]
 						count(split(brothersArr_full[ch_index].name, "/")) < count(split(value.name, "/")) + 2]	# Prevents /servers from capturing ../databases/auditingSettings
 
+	dependencyToken := get_dependency_token(value)
+	dependentArr := get_dependent_resources(doc, types, value.type, dependencyToken)
+
+	linkedArr := array.concat(array.concat(childrenArr, brothersArr), dependentArr)
+
+	not server_exempted_via_audited_database(doc, db_resources, value, path, linkedArr, types)
+
 	count([x |
-		brother := brothersArr[_]
-		[val, _] := arm_lib.getDefaultValueFromParametersIfPresent(doc, brother.properties.state)
+		linked := linkedArr[_]
+		[val, _] := arm_lib.getDefaultValueFromParametersIfPresent(doc, linked.properties.state)
 		lower(val) == "enabled"
-		x := brother
+		x := linked
 	]) == 0
 
 	result := {
@@ -44,7 +44,7 @@ CxPolicy[result] {
 		"resourceType": value.type,
 		"resourceName": value.name,
 		"searchKey": sprintf("%s.name=%s", [common_lib.concat_path(path), value.name]),
-		"issueType": get_issue_type(childrenArr, brothersArr),
+		"issueType": get_issue_type(linkedArr),
 		"keyExpectedValue": sprintf("resource '%s' should have an enabled 'auditingsettings' resource", [value.name]),
 		"keyActualValue": sprintf("resource '%s' is missing an enabled 'auditingsettings' resource", [value.name]),
 		"searchLine": common_lib.build_search_line(path, ["name"]),
@@ -123,7 +123,80 @@ get_outer_children_resources(doc, nameParent) = result {
 	result := array.concat(array.concat(root_children, nested_l1_children), nested_l2_children)
 }
 
-get_issue_type(childrenArr,brothersArr) = "MissingAttribute"{
-	childrenArr == []
-	brothersArr == []
+get_issue_type(linkedArr) = "MissingAttribute" {
+	linkedArr == []
 } else = "IncorrectValue" # When associated with an auditing resource with "state" != enabled
+
+is_child_database(serverValue, serverPath, dbValue, dbPath) {
+	count(dbPath) > count(serverPath)
+	array.slice(dbPath, 0, count(serverPath)) == serverPath
+} else {
+	dep := dbValue.dependsOn[_]
+	type_referenced_in_dependency(dep, serverValue.type)
+	serverToken := get_dependency_token(serverValue)
+	contains(dep, serverToken)
+}
+
+server_exempted_via_audited_database(doc, db_resources, value, path, linkedArr, types) {
+	value.type == "Microsoft.Sql/servers"
+	linkedArr == []
+
+	db_candidate := db_resources[_]
+	dbValue := db_candidate.value
+	dbPath := db_candidate.path
+	dbValue.type != "Microsoft.Sql/servers"
+	is_child_database(value, path, dbValue, dbPath)
+
+	# Same "child"/"brother"/"dependsOn" matching as above, but for the candidate database
+	dbChildrenArr_full := get_children(doc, dbValue, dbPath)
+	dbChildrenArr := [x | x := dbChildrenArr_full[ch_index]
+						dbChildrenArr_full[ch_index].type == types[_]]
+
+	dbDepth_path := array.slice(dbPath, 0, count(dbPath)-1)
+	dbBrothersArr_full := object.get(doc, dbDepth_path, [])
+	dbBrothersArr := [x | x := dbBrothersArr_full[ch_index]
+						dbBrothersArr_full[ch_index].type == types[_]
+						count(split(dbBrothersArr_full[ch_index].name, "/")) < count(split(dbValue.name, "/")) + 2]
+
+	dbDependencyToken := get_dependency_token(dbValue)
+	dbDependentArr := get_dependent_resources(doc, types, dbValue.type, dbDependencyToken)
+
+	child := array.concat(array.concat(dbChildrenArr, dbBrothersArr), dbDependentArr)[_]
+	[val, _] := arm_lib.getDefaultValueFromParametersIfPresent(doc, child.properties.state)
+	lower(val) == "enabled"
+}
+
+get_dependency_token(resource) = token {
+	token := sprintf("parameters('%s')", [arm_lib.isParameterReference(resource.name)])
+} else = token {
+	token := resource.name
+}
+
+leaf_type(resourceType) = leaf {
+	parts := split(resourceType, "/")
+	leaf := parts[count(parts)-1]
+}
+
+type_referenced_in_dependency(dependsOnEntry, resourceType) {
+	leaf := leaf_type(resourceType)
+	contains(dependsOnEntry, sprintf("/%s'", [leaf]))
+} else {
+	leaf := leaf_type(resourceType)
+	contains(dependsOnEntry, sprintf("('%s'", [leaf]))
+}
+
+get_dependent_resources(doc, types, parentType, token) = result {
+	root := [x | x := doc.resources[_]]
+	nested_l1 := [x | parent := doc.resources[_]; x := parent.resources[_]]
+	nested_l2 := [x | parent := doc.resources[_]; child := parent.resources[_]; x := child.resources[_]]
+	template := [x | x := doc.properties.template.resources[_]]
+	candidates := array.concat(array.concat(array.concat(root, nested_l1), nested_l2), template)
+
+	result := [item |
+		item := candidates[_]
+		item.type == types[_]
+		dep := item.dependsOn[_]
+		type_referenced_in_dependency(dep, parentType)
+		contains(dep, token)
+	]
+}

--- a/assets/queries/azureResourceManager/sql_server_database_without_auditing/test/negative14.json
+++ b/assets/queries/azureResourceManager/sql_server_database_without_auditing/test/negative14.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "sqlServerName": {
+      "type": "String",
+      "defaultValue": "contoso-sql-server"
+    },
+    "sqlDatabaseName": {
+      "type": "String",
+      "defaultValue": "contoso-db"
+    },
+    "sqlLocation": {
+      "type": "String",
+      "defaultValue": "eastus2"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2022-05-01-preview",
+      "name": "[parameters('sqlServerName')]",
+      "location": "[parameters('sqlLocation')]",
+      "properties": {
+        "administratorLogin": "contosoadmin"
+      },
+      "resources": [
+        {
+          "type": "databases",
+          "apiVersion": "2022-05-01-preview",
+          "name": "[parameters('sqlDatabaseName')]",
+          "location": "[parameters('sqlLocation')]",
+          "dependsOn": [
+            "[parameters('sqlServerName')]"
+          ],
+          "properties": {
+            "collation": "SQL_Latin1_General_CP1_CI_AS"
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers/databases/auditingSettings",
+      "apiVersion": "2022-05-01-preview",
+      "name": "[format('{0}/{1}/Default', parameters('sqlServerName'), parameters('sqlDatabaseName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers/databases', parameters('sqlServerName'), parameters('sqlDatabaseName'))]"
+      ],
+      "properties": {
+        "state": "Enabled",
+        "isAzureMonitorTargetEnabled": true,
+        "retentionDays": 180
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Reason for the Proposed Changes**:
-  Currently, when a Microsoft.Sql/servers/databases/auditingSettings resource is declared as a root-level resource and linked to its databases/servers parent only through dependsOn/resourceId(), with resource names built using ARM template functions such as parameters() or format(), the query returns a false positive, since it is unable to match the two resources.

**Proposed Changes**:
- To tackle the problem mentioned above, I created new helper functions that will be described below:
- `get_dependency_token(resource):` builds the string used to search for a resource's identity inside another resource's dependsOn entries. If resource.name is an ARM parameter reference (e.g. "[parameters('DatabaseName')]"), it returns the bare parameters('DatabaseName') call, since that's the part that still shows up unchanged inside a `dependsOn/resourceId()` string even when the name itself is built with format(); otherwise, it returns the literal resource.name.
- That dependencyToken variable produced by the helper function mentioned on the point above, will be taken as an argument to the other new helper function_called `get_dependent_resources`, which will use it to check if a determined resource is dependent from another "father" resource. This `get_dependent_resources` helper function, uses another two new helper functions called `leaf_type` and `type_referenced_in_dependency`.
- `leaf_type(resourceType):` returns the last segment of a resource type (e.g. "Microsoft.Sql/servers/databases" → "databases").
- `type_referenced_in_dependency(dependsOnEntry, resourceType):` checks whether a dependsOn entry references a resource of resourceType, by looking for that type's leaf segment immediately followed by a closing quote (/servers' or ('servers') inside the entry. Called from `get_dependent_resources` and from `is_child_database`.


I submit this contribution under the Apache-2.0 license.