### PR TITLE
fix(query): fixed FP for website azure active directory disabled for arm

### DIFF
--- a/assets/queries/azureResourceManager/website_azure_active_directory_disabled/query.rego
+++ b/assets/queries/azureResourceManager/website_azure_active_directory_disabled/query.rego
@@ -57,4 +57,8 @@ is_valid_identity(identity) {
 } else {
 	identity.type == "UserAssigned"
 	common_lib.valid_key(identity, "userAssignedIdentities")
+} else {
+	contains(identity.type, "SystemAssigned")
+	contains(identity.type, "UserAssigned")
+	common_lib.valid_key(identity, "userAssignedIdentities")
 }

--- a/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/negative3.bicep
+++ b/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/negative3.bicep
@@ -1,5 +1,5 @@
-resource webSiteNegative1 'Microsoft.Web/sites@2019-08-01' = {
-  name: 'webSiteNegative1'
+resource webSiteNegative3 'Microsoft.Web/sites@2019-08-01' = {
+  name: 'webSiteNegative3'
   location: 'location1'
   identity: {
     type: 'SystemAssigned'

--- a/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/negative5.bicep
+++ b/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/negative5.bicep
@@ -1,0 +1,17 @@
+var identityName = 'value'
+
+resource webSiteNegative5 'Microsoft.Web/sites@2020-12-01' = {
+  name: 'webSiteNegative5'
+  location: 'location1'
+  tags: {}
+  identity: {
+    type: 'SystemAssigned, UserAssigned'
+    userAssignedIdentities: {
+      '${resourceId('Microsoft.ManagedIdentity/userAssignedIdentities',identityName)}': {}
+    }
+  }
+  properties: {
+    enabled: true
+    httpsOnly: true
+  }
+}

--- a/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/negative5.json
+++ b/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/negative5.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.45.15.27210",
+      "templateHash": "17356636387580071421"
+    }
+  },
+  "variables": {
+    "identityName": "value"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-12-01",
+      "name": "webSiteNegative5",
+      "location": "location1",
+      "tags": {},
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName')))]": {}
+        }
+      },
+      "properties": {
+        "enabled": true,
+        "httpsOnly": true
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/positive8.bicep
+++ b/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/positive8.bicep
@@ -1,5 +1,5 @@
-resource webSiteNegative6 'Microsoft.Web/sites@2019-08-01' = {
-  name: 'webSiteNegative6'
+resource webSiteNegative8 'Microsoft.Web/sites@2019-08-01' = {
+  name: 'webSiteNegative8'
   location: 'location1'
   identity: {
     type: 'SystemAssigned, UserAssigned'

--- a/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/positive8.bicep
+++ b/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/positive8.bicep
@@ -1,0 +1,12 @@
+resource webSiteNegative6 'Microsoft.Web/sites@2019-08-01' = {
+  name: 'webSiteNegative6'
+  location: 'location1'
+  identity: {
+    type: 'SystemAssigned, UserAssigned'
+  }
+  tags: {}
+  properties: {
+    enabled: true
+    httpsOnly: true
+  }
+}

--- a/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/positive8.json
+++ b/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/positive8.json
@@ -9,12 +9,12 @@
       "functions": [],
       "resources": [
         {
-          "name": "webSiteNegative3",
+          "name": "webSiteNegative6",
           "type": "Microsoft.Web/sites",
           "apiVersion": "2019-08-01",
           "location": "location1",
           "identity": {
-            "type": "SystemAssigned"
+            "type": "SystemAssigned, UserAssigned"
           },
           "tags": {},
           "properties": {

--- a/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/positive8.json
+++ b/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/positive8.json
@@ -9,7 +9,7 @@
       "functions": [],
       "resources": [
         {
-          "name": "webSiteNegative6",
+          "name": "webSiteNegative8",
           "type": "Microsoft.Web/sites",
           "apiVersion": "2019-08-01",
           "location": "location1",

--- a/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/website_azure_active_directory_disabled/test/positive_expected_result.json
@@ -44,6 +44,12 @@
   {
     "queryName": "Website Azure Active Directory Disabled",
     "severity": "LOW",
+    "line": 16,
+    "fileName": "positive8.json"
+  },
+  {
+    "queryName": "Website Azure Active Directory Disabled",
+    "severity": "LOW",
     "line": 2,
     "fileName": "positive1.bicep"
   },
@@ -82,5 +88,11 @@
     "severity": "LOW",
     "line": 5,
     "fileName": "positive7.bicep"
+  },
+  {
+    "queryName": "Website Azure Active Directory Disabled",
+    "severity": "LOW",
+    "line": 4,
+    "fileName": "positive8.bicep"
   }
 ]


### PR DESCRIPTION
**Reason for Proposed Changes**.
- Currently the query returns a positive result when the field `identity.type` is defined to `SystemAssigned, UserAssigned` or vice versa.

**Proposed changes**:
- Added an extra verification on `is_valid_identity` helper function and a negative test in `.json` and `.bicep` format to support the scenario.

I submit this contribution under the Apache-2.0 license.