### PR TITLE
fix(queries): fixed FN on run/script block injection query for github/cicd

### DIFF
--- a/assets/queries/cicd/github/run_block_injection/query.rego
+++ b/assets/queries/cicd/github/run_block_injection/query.rego
@@ -62,7 +62,8 @@ CxPolicy[result] {
 	patterns := [
     "github.event.comment.body",
 	"github.event.issue.body",
-	"github.event.issue.title"
+	"github.event.issue.title",
+	"github.event.comment.user.login"
 	]
 
 	matched = containsPatterns(run, patterns)
@@ -174,8 +175,6 @@ CxPolicy[result] {
 		"searchValue": matched[m]
 	}
 }
-
-
 
 containsPatterns(str, patterns) = matched {
     matched := {pattern |

--- a/assets/queries/cicd/github/run_block_injection/query.rego
+++ b/assets/queries/cicd/github/run_block_injection/query.rego
@@ -32,6 +32,31 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
+	input.document[i].on["push"]
+	run := input.document[i].jobs[j].steps[k].run
+
+	patterns := [
+	"github.event.head_commit.message",
+	"github.event.head_commit.author.email",
+	"github.event.head_commit.author.name",
+	"github.event.commits.*.author.email",
+	"github.event.commits.*.author.name"
+	]
+
+	matched = containsPatterns(run, patterns)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("run={{%s}}", [run]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Run block does not contain dangerous input controlled by user.",
+		"keyActualValue": "Run block contains dangerous input controlled by user.",
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "run"],[]),
+		"searchValue": matched[m]
+	}
+}
+
+CxPolicy[result] {
 
 	input.document[i].on["issues"]
 	run := input.document[i].jobs[j].steps[k].run

--- a/assets/queries/cicd/github/run_block_injection/test/negative8.yaml
+++ b/assets/queries/cicd/github/run_block_injection/test/negative8.yaml
@@ -1,0 +1,14 @@
+name: Push Safe Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Static Message
+        run: |
+          echo "A new push was received."

--- a/assets/queries/cicd/github/run_block_injection/test/negative9.yaml
+++ b/assets/queries/cicd/github/run_block_injection/test/negative9.yaml
@@ -1,0 +1,15 @@
+name: Push Safe Context Vars Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Safe Context Vars
+        run: |
+          echo "SHA: ${{ github.sha }}"
+          echo "Ref: ${{ github.ref }}"

--- a/assets/queries/cicd/github/run_block_injection/test/positive10.yaml
+++ b/assets/queries/cicd/github/run_block_injection/test/positive10.yaml
@@ -1,0 +1,14 @@
+name: Push Head Commit Author Email Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Commit Author Email
+        run: |
+          echo "Author email: ${{ github.event.head_commit.author.email }}"

--- a/assets/queries/cicd/github/run_block_injection/test/positive11.yaml
+++ b/assets/queries/cicd/github/run_block_injection/test/positive11.yaml
@@ -1,0 +1,14 @@
+name: Push Head Commit Author Name Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Commit Author Name
+        run: |
+          echo "Author name: ${{ github.event.head_commit.author.name }}"

--- a/assets/queries/cicd/github/run_block_injection/test/positive12.yaml
+++ b/assets/queries/cicd/github/run_block_injection/test/positive12.yaml
@@ -1,0 +1,14 @@
+name: Push Commits Author Email Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Commits Author Email
+        run: |
+          echo "Commit author email: ${{ github.event.commits[0].author.email }}"

--- a/assets/queries/cicd/github/run_block_injection/test/positive13.yaml
+++ b/assets/queries/cicd/github/run_block_injection/test/positive13.yaml
@@ -1,0 +1,14 @@
+name: Push Commits Author Name Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Commits Author Name
+        run: |
+          echo "Commit author: ${{ github.event.commits[0].author.name }}"

--- a/assets/queries/cicd/github/run_block_injection/test/positive8.yaml
+++ b/assets/queries/cicd/github/run_block_injection/test/positive8.yaml
@@ -1,0 +1,14 @@
+name: Issue Comment User Login Workflow
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  process_issue_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Commenter Login
+        run: |
+          echo "Commenter: ${{ github.event.comment.user.login }}"

--- a/assets/queries/cicd/github/run_block_injection/test/positive9.yaml
+++ b/assets/queries/cicd/github/run_block_injection/test/positive9.yaml
@@ -1,0 +1,14 @@
+name: Push Commit Message Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Commit Message
+        run: |
+          echo "Commit message: ${{ github.event.head_commit.message }}"

--- a/assets/queries/cicd/github/run_block_injection/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/run_block_injection/test/positive_expected_result.json
@@ -52,5 +52,35 @@
     "severity": "HIGH",
     "line": 13,
     "fileName": "positive8.yaml"
+  },
+  {
+    "queryName": "Run Block Injection",
+    "severity": "HIGH",
+    "line": 13,
+    "fileName": "positive9.yaml"
+  },
+  {
+    "queryName": "Run Block Injection",
+    "severity": "HIGH",
+    "line": 13,
+    "fileName": "positive10.yaml"
+  },
+  {
+    "queryName": "Run Block Injection",
+    "severity": "HIGH",
+    "line": 13,
+    "fileName": "positive11.yaml"
+  },
+  {
+    "queryName": "Run Block Injection",
+    "severity": "HIGH",
+    "line": 13,
+    "fileName": "positive12.yaml"
+  },
+  {
+    "queryName": "Run Block Injection",
+    "severity": "HIGH",
+    "line": 13,
+    "fileName": "positive13.yaml"
   }
 ]

--- a/assets/queries/cicd/github/run_block_injection/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/run_block_injection/test/positive_expected_result.json
@@ -46,5 +46,11 @@
     "severity": "HIGH",
     "line": 13,
     "fileName": "positive7.yaml"
+  },
+  {
+    "queryName": "Run Block Injection",
+    "severity": "HIGH",
+    "line": 13,
+    "fileName": "positive8.yaml"
   }
 ]

--- a/assets/queries/cicd/github/script_block_injection/query.rego
+++ b/assets/queries/cicd/github/script_block_injection/query.rego
@@ -151,6 +151,37 @@ CxPolicy[result] {
 }
 
 CxPolicy[result] {
+	
+	input.document[i].on["push"]
+	
+	uses := input.document[i].jobs[j].steps[k].uses
+
+	startswith(uses, "actions/github-script")
+
+	script := input.document[i].jobs[j].steps[k]["with"].script
+
+	patterns := [
+	"github.event.head_commit.message",
+	"github.event.head_commit.author.email",
+	"github.event.head_commit.author.name",
+	"github.event.commits.*.author.email",
+	"github.event.commits.*.author.name"
+	]
+
+	matched = containsPatterns(script, patterns)
+
+	result := {
+		"documentId": input.document[i].id,
+		"searchKey": sprintf("script={{%s}}", [script]),
+		"issueType": "IncorrectValue",
+		"keyExpectedValue": "Script block does not contain dangerous input controlled by user.",
+		"keyActualValue": "Script block contains dangerous input controlled by user.",
+		"searchLine": common_lib.build_search_line(["jobs", j, "steps", k, "with", "script"],[]),
+		"searchValue": matched[m]
+	}
+}
+
+CxPolicy[result] {
 
 	input.document[i].on["workflow_run"]
 	

--- a/assets/queries/cicd/github/script_block_injection/query.rego
+++ b/assets/queries/cicd/github/script_block_injection/query.rego
@@ -48,7 +48,8 @@ CxPolicy[result] {
 
 	patterns := [
     "github.event.issue.body",
-	"github.event.issue.title"
+	"github.event.issue.title",
+	"github.event.comment.user.login"
 	]
 
 	matched = containsPatterns(script, patterns)

--- a/assets/queries/cicd/github/script_block_injection/test/negative8.yaml
+++ b/assets/queries/cicd/github/script_block_injection/test/negative8.yaml
@@ -1,0 +1,24 @@
+name: Push Safe Script Workflow
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run script
+        uses: actions/github-script@latest
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'A new push was received.'
+            });

--- a/assets/queries/cicd/github/script_block_injection/test/negative9.yaml
+++ b/assets/queries/cicd/github/script_block_injection/test/negative9.yaml
@@ -1,0 +1,20 @@
+name: Push Safe Context Vars Script Workflow
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run script
+        uses: actions/github-script@latest
+        with:
+          script: |
+            const sha = '${{ github.sha }}';
+            const ref = '${{ github.ref }}';
+            console.log('SHA: ' + sha + ', Ref: ' + ref);

--- a/assets/queries/cicd/github/script_block_injection/test/positive10.yaml
+++ b/assets/queries/cicd/github/script_block_injection/test/positive10.yaml
@@ -1,0 +1,24 @@
+name: Push Head Commit Author Name Script Workflow
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run script
+        uses: actions/github-script@latest
+        with:
+          script: |
+            const name = '${{ github.event.head_commit.author.name }}';
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Author: ' + name
+            });

--- a/assets/queries/cicd/github/script_block_injection/test/positive11.yaml
+++ b/assets/queries/cicd/github/script_block_injection/test/positive11.yaml
@@ -1,0 +1,24 @@
+name: Push Commits Author Email Script Workflow
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run script
+        uses: actions/github-script@latest
+        with:
+          script: |
+            const email = '${{ github.event.commits[0].author.email }}';
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Commit author email: ' + email
+            });

--- a/assets/queries/cicd/github/script_block_injection/test/positive12.yaml
+++ b/assets/queries/cicd/github/script_block_injection/test/positive12.yaml
@@ -1,0 +1,24 @@
+name: Push Commits Author Name Script Workflow
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run script
+        uses: actions/github-script@latest
+        with:
+          script: |
+            const name = '${{ github.event.commits[0].author.name }}';
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Commit author: ' + name
+            });

--- a/assets/queries/cicd/github/script_block_injection/test/positive8.yaml
+++ b/assets/queries/cicd/github/script_block_injection/test/positive8.yaml
@@ -1,0 +1,24 @@
+name: Push Commit Author Email Script Workflow
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run script
+        uses: actions/github-script@latest
+        with:
+          script: |
+            const author = '${{ github.event.head_commit.author.email }}';
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Pushed by: ' + author
+            });

--- a/assets/queries/cicd/github/script_block_injection/test/positive9.yaml
+++ b/assets/queries/cicd/github/script_block_injection/test/positive9.yaml
@@ -1,0 +1,24 @@
+name: Push Head Commit Message Script Workflow
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  process_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run script
+        uses: actions/github-script@latest
+        with:
+          script: |
+            const message = '${{ github.event.head_commit.message }}';
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Latest commit: ' + message
+            });

--- a/assets/queries/cicd/github/script_block_injection/test/positive_expected_result.json
+++ b/assets/queries/cicd/github/script_block_injection/test/positive_expected_result.json
@@ -40,5 +40,35 @@
 		"severity": "HIGH",
 		"line": 17,
 		"fileName": "positive7.yaml"
+	},
+    {
+		"queryName": "Script Block Injection",
+		"severity": "HIGH",
+		"line": 17,
+		"fileName": "positive8.yaml"
+	},
+    {
+		"queryName": "Script Block Injection",
+		"severity": "HIGH",
+		"line": 17,
+		"fileName": "positive9.yaml"
+	},
+    {
+		"queryName": "Script Block Injection",
+		"severity": "HIGH",
+		"line": 17,
+		"fileName": "positive10.yaml"
+	},
+    {
+		"queryName": "Script Block Injection",
+		"severity": "HIGH",
+		"line": 17,
+		"fileName": "positive11.yaml"
+	},
+    {
+		"queryName": "Script Block Injection",
+		"severity": "HIGH",
+		"line": 17,
+		"fileName": "positive12.yaml"
 	}
 ]


### PR DESCRIPTION
**Reason for Proposed Changes**
- Currently, the queries `Run Block Injection` and `Script Block Injection` do not cover some scenarios and patterns, more specifically: 
    - contexts exclusive to `push` events:
        -  github.event.head_commit.message
        - github.event.head_commit.author.email
        - github.event.head_commit.author.name
        - github.event.commits.*.author.email
        - github.event.commits.*.author.name
    - context  not covered by `issue_comment` events:
        - github.event.comment.user.login

**Proposed Changes**
- Added the patterns mentioned above for the respective event types.
- Added tests to cover the new pattern coverage.

I submit this contribution under the Apache-2.0 license.