### PR TITLE
fix(query): fix FP on unpinned package version in pip install for dockerfile

### DIFF
--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/query.rego
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/query.rego
@@ -15,13 +15,22 @@ CxPolicy[result] {
 	yum != null
 
 	packages = dockerLib.getPackages(commands, yum)
-    refactorPackages = [ x | x := packages[_]; x != ""]
-    length := count(refactorPackages)
+	refactorPackages = [ x | x := packages[_]; x != ""]
 
 	count({x | x := refactorPackages[_]; x == flags[_]}) == 0
 
+	cleanPackages = [ p |
+		some k
+		p := refactorPackages[k]
+		not startswith(p, "-")
+		not contains(p, "://")
+		not contains(p, "/")
+		not isFlagArgument(refactorPackages, k)
+	]
+	length := count(cleanPackages)
+
 	some j
-	analyzePackages(j, refactorPackages[j], packages, length)
+	analyzePackages(j, cleanPackages[j], cleanPackages, length)
 
 	result := {
 		"documentId": input.document[i].id,
@@ -73,4 +82,11 @@ analyzePackages(j, currentPackage, packages, length) {
 	regex.match("^[a-zA-Z]", currentPackage) == true
 	packages[plus(j, 1)] != "-v"
 	not dockerLib.withVersion(currentPackage)
+}
+
+isFlagArgument(arr, k) {
+	k > 0
+	regex.match("^-", arr[k - 1])
+	not startswith(arr[k], "-")
+	contains(arr[k], ".")
 }

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/query.rego
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/query.rego
@@ -53,6 +53,10 @@ CxPolicy[result] {
 	resource.Value[j] != "pip"
 	resource.Value[j] != "pip3"
 
+	not contains(resource.Value[j], "://")
+	not contains(resource.Value[j], "/")
+	not isFlagArgument(resource.Value, j)
+
 	regex.match("^[a-zA-Z]", resource.Value[j]) == true
 	not dockerLib.withVersion(resource.Value[j])
 
@@ -88,5 +92,5 @@ isFlagArgument(arr, k) {
 	k > 0
 	regex.match("^-", arr[k - 1])
 	not startswith(arr[k], "-")
-	contains(arr[k], ".")
+	regex.match(`[.:/]`, arr[k])
 }

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/negative4.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/negative4.dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+RUN pip install \
+    --no-cache-dir \
+    --index-url https://example.com/simple \
+    --trusted-host example.com \
+    requests==2.28.0 \
+    flask==2.3.0
+
+FROM python:3.11-slim
+
+RUN pip3 install --no-cache-dir --index-url https://example.com/simple --trusted-host example.com numpy==1.24.0

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/negative5.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/negative5.dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir --index-url https://example.com/simple --trusted-host example.com flask==2.3.0

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/negative6.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/negative6.dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+
+RUN ["pip", "install", "--no-cache-dir", "requests==2.28.0"]
+
+RUN ["pip", "install", "--trusted-host", "example.com", "requests==2.28.0"]

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive2.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive2.dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+RUN pip install \
+    --no-cache-dir \
+    --index-url https://example.com/simple \
+    --trusted-host example.com \
+    requests \
+    flask
+
+FROM python:3.11-slim
+
+RUN pip3 install --no-cache-dir --index-url https://example.com/simple --trusted-host example.com numpy

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive3.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive3.dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir --index-url https://example.com/simple --trusted-host example.com flask

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive4.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive4.dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.12-slim
+
+RUN ["pip", "install", "--no-cache-dir", "requests"]

--- a/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive_expected_result.json
+++ b/assets/queries/dockerfile/unpinned_package_version_in_pip_install/test/positive_expected_result.json
@@ -22,5 +22,29 @@
     "severity": "MEDIUM",
     "line": 18,
     "filename": "positive1.dockerfile"
+  },
+  {
+    "queryName": "Unpinned Package Version in Pip Install",
+    "severity": "MEDIUM",
+    "line": 3,
+    "filename": "positive2.dockerfile"
+  },
+  {
+    "queryName": "Unpinned Package Version in Pip Install",
+    "severity": "MEDIUM",
+    "line": 12,
+    "filename": "positive2.dockerfile"
+  },
+  {
+    "queryName": "Unpinned Package Version in Pip Install",
+    "severity": "MEDIUM",
+    "line": 3,
+    "filename": "positive3.dockerfile"
+  },
+  {
+    "queryName": "Unpinned Package Version in Pip Install",
+    "severity": "MEDIUM",
+    "line": 3,
+    "filename": "positive4.dockerfile"
   }
 ]


### PR DESCRIPTION
**Reason for the proposed changes:**
- The query was producing false positive findings on `RUN pip install` commands that used flags which accept and argument.
- For example, the following command was being incorrectly flagged despite having a pinned version:
```
RUN pip install \
      --no-cache-dir \
      --index-url https://pypi.example.com/simple \
      --trusted-host pypi.example.com \
      requests==2.28.0
```

**Proposed changes:**
- To fix this False Positive, a `cleanPackages` intermediate list was introduced to strip all non-package tokens before version analysis. The filtering works in the three layers:
	- `not startswith(p, "-")`: removes all flags themselves (e.g., `--no-cache-dir`, `--index-url`, `--trusted-host`, etc.).
	- `not contains(p, "://")` and `not contains(p, "/")`: removes URL arguments and filesystem path arguments (e.g., `tmp/constraints.txt`) that "survived" the verification mentioned above, because they do not start with a dash.
	- `not isFlagArgument(refactorPackages, k)`: handles the remaining edge cases, that are arguments to lags and that survive all three previous filters because they do not start with `-`, do not contain `://`, and do not contain `/`.
- The three previous filters take into account the valid package names defined by the [[Python Packaging User Guide documentation](https://packaging.python.org/en/latest/specifications/name-normalization/)](https://packaging.python.org/en/latest/specifications/name-normalization/) by the `[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?` regex. This means package names can only contain alphanumeric characters, `.`, `_`, and `-`, and must start with an alphanumeric character. As a direct consequence:
	- Any token starting with `-` is guaranteed not to be a package name.
	- Any token containing `://`  is a URL in almost every scenario and cannot be a package name.
	- Any token containing `/` cannot be a valid package name - whether it is a filesystem path (e.g., `tmp/constraints.txt`) or a URL without protocol scheme (`pypi.example.com/example`)
	- Explicar melhor aqui, a query em si.
- However, hostnames such as `pypi.example.com` satisfy all three rules, as they start with a letter, contain not `://` and no `/`, yet they are not package names. `isFlagArgument` handles these by checking positional context: if the preceding token is a flag(`regex.match("^-", arr[k - 1])`) and the current token contains `.` or `:`, it is classified as a flag argument and excluded (e.g., `pypi.example.com` after `--trusted-host` or `sha256:abc123` after `--hash`).
- Added new test cases that cover some patterns that were previously causing false positive results.

I submit this contribution under the Apache-2.0 license.