### PR TITLE
fix(query): fixed FP for web app not using tls last version

### DIFF
--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/query.rego
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/query.rego
@@ -11,7 +11,7 @@ CxPolicy[result] { # resource of type Microsoft.Web/sites without child resource
 	value := site.value
 	path := site.path
 
-	children_array := arm_lib.get_children(doc, value, path)
+	children_array := get_children_ext(doc, value, path)
 
 	count(children_array) == 0
 	not is_last_tls(doc, value)
@@ -38,10 +38,11 @@ CxPolicy[result] {
 	value := site.value
 	path := site.path
 
-	children_array := arm_lib.get_children(doc, value, path)
+	children_array := get_children_ext(doc, value, path)
 	not count(children_array) == 0
 	child_resource := children_array[_]
 	is_sites_config(child_resource.value.type) # is a resource of type Microsoft.Web/sites/config
+	is_web_config_name(child_resource.value.name) # only the 'web' configuration resource
 	child_resource_status := get_child_resource_info(doc, child_resource.value)
 
 	res := check_tls_version(doc, value, path, child_resource, child_resource_status)
@@ -79,6 +80,25 @@ web_site_resources(doc) = result {
 	]
 
 	result := array.concat(array.concat(root_resources, template_resources), nested_resources)
+}
+
+get_children_ext(doc, parent, path) = children {
+	base := arm_lib.get_children(doc, parent, path)
+	extra := format_config_children(doc, parent)
+	children := array.concat(base, extra)
+}
+
+format_config_children(doc, parent) = extra {
+	extra := [{"value": resource, "path": ["resources", idx]} |
+		resource := doc.resources[idx]
+		is_sites_config(resource.type)
+		contains(resource.name, "format(")
+		contains(resource.name, sprintf("'%s'", [parent.name]))
+	]
+}
+
+is_web_config_name(name) {
+	regex.match(`(^|/|')web('|$)`, name)
 }
 
 check_tls_version(doc, value, path, child_resource, child_resource_status) = res {

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative1.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative1.bicep
@@ -1,5 +1,5 @@
 resource App 'Microsoft.Web/sites@2020-12-01' = {
-  name: 'App'
+  name: 'web'
   location: resourceGroup().location
   properties: {
     siteConfig: {

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative1.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative1.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Web/sites",
       "apiVersion": "2020-12-01",
-      "name": "App",
+      "name": "web",
       "location": "[resourceGroup().location]",
       "properties": {
         "siteConfig": {

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative2.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative2.bicep
@@ -1,5 +1,5 @@
 resource App 'Microsoft.Web/sites@2020-12-01' = {
-  name: 'App'
+  name: 'web'
   location: resourceGroup().location
   properties: {
     siteConfig: {

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative2.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative2.json
@@ -7,7 +7,7 @@
         {
           "type": "Microsoft.Web/sites",
           "apiVersion": "2020-12-01",
-          "name": "App",
+          "name": "web",
           "location": "[resourceGroup().location]",
           "properties": {
             "siteConfig": {

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative3.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative3.bicep
@@ -1,11 +1,11 @@
-resource meuAppService 'Microsoft.Web/sites@2022-09-01' = {
-  name: 'meuAppService'
+resource myAppService 'Microsoft.Web/sites@2022-09-01' = {
+  name: 'myAppService'
   location: 'West Europe'
   properties: {}
 }
 
-resource meuAppService_web 'Microsoft.Web/sites/config@2022-09-01' = {
-  parent: meuAppService
+resource myAppService_web 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: myAppService
   name: 'web'
   properties: {
     minTlsVersion: '1.2'

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative3.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative3.json
@@ -5,16 +5,16 @@
     {
       "type": "Microsoft.Web/sites",
       "apiVersion": "2022-09-01",
-      "name": "meuAppService",
+      "name": "myAppService",
       "location": "West Europe",
       "properties": {}
     },
     {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2022-09-01",
-      "name": "meuAppService/web",
+      "name": "myAppService/web",
       "dependsOn": [
-        "Microsoft.Web/sites/meuAppService"
+        "Microsoft.Web/sites/myAppService"
       ],
       "properties": {
         "minTlsVersion": "1.2"

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative4.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative4.bicep
@@ -1,0 +1,13 @@
+resource meuAppService 'Microsoft.Web/sites@2022-09-01' = {
+  name: 'meuAppService'
+  location: 'West Europe'
+  properties: {}
+}
+
+resource meuAppService_web 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: meuAppService
+  name: 'config'
+  properties: {
+    minTlsVersion: '1.1'
+  }
+}

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative4.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative4.bicep
@@ -1,11 +1,11 @@
-resource meuAppService 'Microsoft.Web/sites@2022-09-01' = {
-  name: 'meuAppService'
+resource myAppService 'Microsoft.Web/sites@2022-09-01' = {
+  name: 'myAppService'
   location: 'West Europe'
   properties: {}
 }
 
-resource meuAppService_web 'Microsoft.Web/sites/config@2022-09-01' = {
-  parent: meuAppService
+resource myApppService_web 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: myAppService
   name: 'config'
   properties: {
     minTlsVersion: '1.1'

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative4.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative4.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.45.15.27210",
+      "templateHash": "17759918091789917637"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2022-09-01",
+      "name": "meuAppService",
+      "location": "West Europe",
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2022-09-01",
+      "name": "[format('{0}/{1}', 'meuAppService', 'config')]",
+      "properties": {
+        "minTlsVersion": "1.1"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', 'meuAppService')]"
+      ]
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative4.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/negative4.json
@@ -12,19 +12,19 @@
     {
       "type": "Microsoft.Web/sites",
       "apiVersion": "2022-09-01",
-      "name": "meuAppService",
+      "name": "myAppService",
       "location": "West Europe",
       "properties": {}
     },
     {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}/{1}', 'meuAppService', 'config')]",
+      "name": "[format('{0}/{1}', 'myAppService', 'config')]",
       "properties": {
         "minTlsVersion": "1.1"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', 'meuAppService')]"
+        "[resourceId('Microsoft.Web/sites', 'myAppService')]"
       ]
     }
   ]

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive1.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive1.bicep
@@ -1,5 +1,5 @@
 resource App 'Microsoft.Web/sites@2020-12-01' = {
-  name: 'App'
+  name: 'web'
   location: resourceGroup().location
   properties: {
     siteConfig: {

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive1.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive1.json
@@ -7,7 +7,7 @@
         {
           "type": "Microsoft.Web/sites",
           "apiVersion": "2020-12-01",
-          "name": "App",
+          "name": "web",
           "location": "[resourceGroup().location]",
           "properties": {
             "siteConfig": {

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive2.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive2.bicep
@@ -1,5 +1,5 @@
 resource App 'Microsoft.Web/sites@2020-12-01' = {
-  name: 'App'
+  name: 'web'
   location: resourceGroup().location
   properties: {}
 }

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive2.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive2.json
@@ -7,7 +7,7 @@
         {
           "type": "Microsoft.Web/sites",
           "apiVersion": "2020-12-01",
-          "name": "App",
+          "name": "web",
           "location": "[resourceGroup().location]",
           "properties": {}
         }

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive3.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive3.bicep
@@ -1,5 +1,5 @@
 resource App 'Microsoft.Web/sites@2020-12-01' = {
-  name: 'App'
+  name: 'web'
   location: resourceGroup().location
   properties: {
     siteConfig: {

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive3.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive3.json
@@ -7,7 +7,7 @@
         {
           "type": "Microsoft.Web/sites",
           "apiVersion": "2020-12-01",
-          "name": "App",
+          "name": "web",
           "location": "[resourceGroup().location]",
           "properties": {
             "siteConfig": {

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive4.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive4.bicep
@@ -1,5 +1,5 @@
 resource App 'Microsoft.Web/sites@2020-12-01' = {
-  name: 'App'
+  name: 'web'
   location: resourceGroup().location
   properties: {
     siteConfig: {}

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive4.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive4.json
@@ -7,7 +7,7 @@
         {
           "type": "Microsoft.Web/sites",
           "apiVersion": "2020-12-01",
-          "name": "App",
+          "name": "web",
           "location": "[resourceGroup().location]",
           "properties": {
             "siteConfig": {}

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive5.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive5.bicep
@@ -1,11 +1,11 @@
-resource meuAppService 'Microsoft.Web/sites@2022-09-01' = {
-  name: 'meuAppService'
+resource myAppService 'Microsoft.Web/sites@2022-09-01' = {
+  name: 'myAppService'
   location: 'West Europe'
   properties: {}
 }
 
-resource meuAppService_web 'Microsoft.Web/sites/config@2022-09-01' = {
-  parent: meuAppService
+resource myAppService_web 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: myAppService
   name: 'web'
   properties: {
     minTlsVersion: '1.1'

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive5.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive5.json
@@ -12,19 +12,19 @@
     {
       "type": "Microsoft.Web/sites",
       "apiVersion": "2022-09-01",
-      "name": "meuAppService",
+      "name": "myAppService",
       "location": "West Europe",
       "properties": {}
     },
     {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}/{1}', 'meuAppService', 'web')]",
+      "name": "[format('{0}/{1}', 'myAppService', 'web')]",
       "properties": {
         "minTlsVersion": "1.1"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', 'meuAppService')]"
+        "[resourceId('Microsoft.Web/sites', 'myAppService')]"
       ]
     }
   ]

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive6.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive6.bicep
@@ -1,11 +1,11 @@
-resource meuAppService 'Microsoft.Web/sites@2022-09-01' = {
-  name: 'meuAppService'
+resource myAppService 'Microsoft.Web/sites@2022-09-01' = {
+  name: 'myAppService'
   location: 'West Europe'
   properties: {}
 }
 
-resource meuAppService_web 'Microsoft.Web/sites/config@2022-09-01' = {
-  parent: meuAppService
+resource myAppService_web 'Microsoft.Web/sites/config@2022-09-01' = {
+  parent: myAppService
   name: 'web'
   properties: {}
 }

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive6.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive6.json
@@ -12,17 +12,17 @@
     {
       "type": "Microsoft.Web/sites",
       "apiVersion": "2022-09-01",
-      "name": "meuAppService",
+      "name": "myAppService",
       "location": "West Europe",
       "properties": {}
     },
     {
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}/{1}', 'meuAppService', 'web')]",
+      "name": "[format('{0}/{1}', 'myAppService', 'web')]",
       "properties": {},
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites', 'meuAppService')]"
+        "[resourceId('Microsoft.Web/sites', 'myAppService')]"
       ]
     }
   ]

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive7.bicep
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive7.bicep
@@ -1,0 +1,9 @@
+resource App 'Microsoft.Web/sites@2020-12-01' = {
+  name: 'app'
+  location: resourceGroup().location
+  properties: {
+    siteConfig: {
+      minTlsVersion: '1.1'
+    }
+  }
+}

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive7.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive7.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.45.15.27210",
+      "templateHash": "1190265637075827825"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-12-01",
+      "name": "app",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "siteConfig": {
+          "minTlsVersion": "1.1"
+        }
+      }
+    }
+  ]
+}

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive_expected_result.json
@@ -38,6 +38,12 @@
   {
     "queryName": "Web App Not Using TLS Last Version",
     "severity": "MEDIUM",
+    "line": 19,
+    "filename": "positive7.json"
+  },
+  {
+    "queryName": "Web App Not Using TLS Last Version",
+    "severity": "MEDIUM",
     "line": 6,
     "filename": "positive1.bicep"
   },
@@ -70,5 +76,11 @@
     "severity": "MEDIUM",
     "line": 10,
     "filename": "positive6.bicep"
+  },
+  {
+    "queryName": "Web App Not Using TLS Last Version",
+    "severity": "MEDIUM",
+    "line": 6,
+    "filename": "positive7.bicep"
   }
 ]

--- a/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/web_app_not_using_tls_last_version/test/positive_expected_result.json
@@ -26,13 +26,13 @@
   {
     "queryName": "Web App Not Using TLS Last Version",
     "severity": "MEDIUM",
-    "line": 17,
+    "line": 24,
     "filename": "positive5.json"
   },
   {
     "queryName": "Web App Not Using TLS Last Version",
     "severity": "MEDIUM",
-    "line": 17,
+    "line": 23,
     "filename": "positive6.json"
   },
   {


### PR DESCRIPTION
**Reason for Proposed Changes**
- Currently, the query `Web App Not Using TLS Last Version` flags resources of type `Microsoft.Web/sites` that do not defined `properties.siteConfig.minTlsVersion` as `1.2` or `1.3` for any configurations of that resource type but, we should only flag the "web" configuration as shown on the following [documentation](https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites/config-web?pivots=deployment-language-bicep#options-for-name-property).

**Proposed Changes**
- Using the helper function `is_web_config_name`, it is now confirmed if the name of the resource is web.
- Implemented two extra helper functions, which are `get_children` and `format_config_children`. Basically, these helper functions just extend the get_children helper function from the AzureResourceManager library under `assets/libraries` to fetch the children that use the same format as the example below in the name field: 
    - `"name": "[format('{0}/{1}', <fatherResourceName>, 'web')]",`

I submit this contribution under the Apache-2.0 license.