### PR TITLE
feat(queries): new queries to check if synapse workspace managed virtual network is enabled

### DIFF
--- a/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/metadata.json
+++ b/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "8221c5b3-0031-4233-a9a2-08ec4cd20ced",
   "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
-  "severity": "",
+  "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "Azure Synapse workspaces should have Managed Virtual Network enabled",
   "descriptionUrl": "https://learn.microsoft.com/en-us/azure/templates/microsoft.synapse/workspaces?pivots=deployment-language-bicep#workspaceproperties",
@@ -9,5 +9,5 @@
   "descriptionID": "8221c5b3",
   "cloudProvider": "azure",
   "cwe": "732",
-  "riskScore": ""
+  "riskScore": "1.0"
 }

--- a/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/query.rego
+++ b/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/query.rego
@@ -1,0 +1,46 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.azureresourcemanager as arm_lib
+
+CxPolicy[result] {
+	doc := input.document[i]
+	[path, value] = walk(doc)
+
+	value.type == "Microsoft.Synapse/workspaces"
+	res := get_res(doc, value, path)
+
+	result := {
+		"documentId": doc.id,
+		"resourceType": value.type,
+		"resourceName": value.name,
+		"searchKey": res.sk,
+		"issueType": res.it,
+		"keyExpectedValue": res.kev,
+		"keyActualValue": res.kav,
+		"searchLine": res.sl,
+	}
+}
+
+get_res(doc, value, path) = res {
+    not common_lib.valid_key(value.properties, "managedVirtualNetwork")
+    
+    res := {
+        "sk": sprintf("%s.name=%s", [common_lib.concat_path(path), value.name]),
+        "it": "MissingAttribute",
+        "kev": "resource with type 'Microsoft.Synapse/workspaces' should have 'managedVirtualNetwork' defined and set to 'default'",
+        "kav": "resource with type 'Microsoft.Synapse/workspaces' doesn't have 'managedVirtualNetwork' defined",
+        "sl": common_lib.build_search_line(path, [])
+    }
+} else = res {
+    [mvn_val, mvn_val_type] := arm_lib.getDefaultValueFromParametersIfPresent(doc, value.properties.managedVirtualNetwork)
+	mvn_val != "default"
+
+    res := {
+        "sk": sprintf("%s.name=%s.properties.managedVirtualNetwork", [common_lib.concat_path(path), value.name]),
+        "it": "IncorrectValue",
+        "kev": sprintf("resource with type 'Microsoft.Synapse/workspaces' should have 'managedVirtualNetwork' %s set to 'default'", [mvn_val_type]),
+        "kav": sprintf("resource with type 'Microsoft.Synapse/workspaces' has 'managedVirtualNetwork' set to '%s'", [mvn_val]),
+        "sl": common_lib.build_search_line(path, ["properties", "managedVirtualNetwork"])
+    }
+}

--- a/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/negative1.bicep
+++ b/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/negative1.bicep
@@ -1,0 +1,12 @@
+resource negative1 'Microsoft.Synapse/workspaces@2021-06-01' = {
+  name: 'negative1'
+  location: 'location1'
+  properties: {
+    defaultDataLakeStorage: {
+      accountUrl: 'https://accountname.dfs.core.windows.net'
+      filesystem: 'filesystem1'
+    }
+    sqlAdministratorLogin: 'sqladminuser'
+    managedVirtualNetwork: 'default'
+  }
+}

--- a/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/negative1.json
+++ b/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/negative1.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Synapse/workspaces",
+      "apiVersion": "2021-06-01",
+      "name": "negative1",
+      "location": "location1",
+      "properties": {
+        "defaultDataLakeStorage": {
+          "accountUrl": "https://accountname.dfs.core.windows.net",
+          "filesystem": "filesystem1"
+        },
+        "sqlAdministratorLogin": "sqladminuser",
+        "managedVirtualNetwork": "default"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive1.bicep
+++ b/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive1.bicep
@@ -1,0 +1,11 @@
+resource positive1 'Microsoft.Synapse/workspaces@2021-06-01' = {
+  name: 'positive1'
+  location: 'location1'
+  properties: {
+    defaultDataLakeStorage: {
+      accountUrl: 'https://accountname.dfs.core.windows.net'
+      filesystem: 'filesystem1'
+    }
+    sqlAdministratorLogin: 'sqladminuser'
+  }
+}

--- a/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive1.json
+++ b/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive1.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Synapse/workspaces",
+      "apiVersion": "2021-06-01",
+      "name": "positive1",
+      "location": "location1",
+      "properties": {
+        "defaultDataLakeStorage": {
+          "accountUrl": "https://accountname.dfs.core.windows.net",
+          "filesystem": "filesystem1"
+        },
+        "sqlAdministratorLogin": "sqladminuser"
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive2.bicep
+++ b/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive2.bicep
@@ -1,0 +1,12 @@
+resource positive2 'Microsoft.Synapse/workspaces@2021-06-01' = {
+  name: 'positive2'
+  location: 'location1'
+  properties: {
+    defaultDataLakeStorage: {
+      accountUrl: 'https://accountname.dfs.core.windows.net'
+      filesystem: 'filesystem1'
+    }
+    sqlAdministratorLogin: 'sqladminuser'
+    managedVirtualNetwork: ''
+  }
+}

--- a/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive2.json
+++ b/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive2.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Synapse/workspaces",
+      "apiVersion": "2021-06-01",
+      "name": "positive2",
+      "location": "location1",
+      "properties": {
+        "defaultDataLakeStorage": {
+          "accountUrl": "https://accountname.dfs.core.windows.net",
+          "filesystem": "filesystem1"
+        },
+        "sqlAdministratorLogin": "sqladminuser",
+        "managedVirtualNetwork": ""
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive_expected_result.json
@@ -1,0 +1,26 @@
+[
+  {
+    "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
+    "severity": "MEDIUM",
+    "line": 8,
+    "fileName": "positive1.json"
+  },
+  {
+    "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
+    "severity": "MEDIUM",
+    "line": 18,
+    "fileName": "positive2.json"
+  },
+  {
+    "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
+    "severity": "MEDIUM",
+    "line": 1,
+    "fileName": "positive1.bicep"
+  },
+  {
+    "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
+    "severity": "MEDIUM",
+    "line": 10,
+    "fileName": "positive2.bicep"
+  }
+]

--- a/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/azureResourceManager/synapse_workspace_managed_virtual_network_not_enabled/test/positive_expected_result.json
@@ -1,25 +1,25 @@
 [
   {
     "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "line": 8,
     "fileName": "positive1.json"
   },
   {
     "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "line": 18,
     "fileName": "positive2.json"
   },
   {
     "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "line": 1,
     "fileName": "positive1.bicep"
   },
   {
     "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "line": 10,
     "fileName": "positive2.bicep"
   }

--- a/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/metadata.json
+++ b/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "cb76b715-5dbf-44a7-b3c6-486cd1e066f4",
   "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
-  "severity": "",
+  "severity": "LOW",
   "category": "Networking and Firewall",
   "descriptionText": "Azure Synapse workspaces should have Managed Virtual Network enabled",
   "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/synapse_workspace#managed_virtual_network_enabled",
@@ -9,5 +9,5 @@
   "descriptionID": "cb76b715",
   "cloudProvider": "azure",
   "cwe": "732",
-  "riskScore": ""
+  "riskScore": "1.0"
 }

--- a/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/metadata.json
+++ b/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/metadata.json
@@ -1,12 +1,12 @@
 {
-  "id": "8221c5b3-0031-4233-a9a2-08ec4cd20ced",
+  "id": "cb76b715-5dbf-44a7-b3c6-486cd1e066f4",
   "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
   "severity": "",
   "category": "Networking and Firewall",
   "descriptionText": "Azure Synapse workspaces should have Managed Virtual Network enabled",
-  "descriptionUrl": "https://learn.microsoft.com/en-us/azure/templates/microsoft.synapse/workspaces?pivots=deployment-language-bicep#workspaceproperties",
-  "platform": "AzureResourceManager",
-  "descriptionID": "8221c5b3",
+  "descriptionUrl": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/synapse_workspace#managed_virtual_network_enabled",
+  "platform": "Terraform",
+  "descriptionID": "cb76b715",
   "cloudProvider": "azure",
   "cwe": "732",
   "riskScore": ""

--- a/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/query.rego
+++ b/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/query.rego
@@ -1,0 +1,41 @@
+package Cx
+
+import data.generic.common as common_lib
+import data.generic.terraform as tf_lib
+
+CxPolicy[result] {
+	resource := input.document[i].resource.azurerm_synapse_workspace[name]
+	
+    res := get_res(resource, name)
+
+	result := {
+		"documentId": input.document[i].id,
+		"resourceType": "azurerm_synapse_workspace",
+		"resourceName": tf_lib.get_resource_name(resource, name),
+		"searchKey": res.sk,
+		"issueType": res.it,
+        "searchLine": res.sl,
+		"keyExpectedValue": res.kev,
+		"keyActualValue": res.kav,
+	}
+}
+
+get_res(resource, name) = res {
+    not common_lib.valid_key(resource, "managed_virtual_network_enabled")
+    res := {
+        "sk": sprintf("azurerm_synapse_workspace[%s]", [name]),
+        "it": "MissingAttribute",
+        "kev": "'managed_virtual_network_enabled' should be defined and set to true",
+        "kav": "'managed_virtual_network_enabled' is not defined",
+        "sl": common_lib.build_search_line(["resource", "azurerm_synapse_workspace", name], [])
+    }
+} else = res {
+    resource.managed_virtual_network_enabled == false
+    res := {
+        "sk": sprintf("azurerm_synapse_workspace[%s].managed_virtual_network_enabled", [name]),
+        "it": "IncorrectValue",
+        "kev": "'managed_virtual_network_enabled' should be defined and set to true",
+        "kav": "'managed_virtual_network_enabled' is set to false",
+        "sl": common_lib.build_search_line(["resource", "azurerm_synapse_workspace", name, "managed_virtual_network_enabled"], [])
+    }
+}

--- a/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/test/negative1.tf
+++ b/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/test/negative1.tf
@@ -1,0 +1,14 @@
+resource "azurerm_synapse_workspace" "negative1" {
+  name                                 = "example"
+  resource_group_name                  = azurerm_resource_group.example.name
+  location                             = azurerm_resource_group.example.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.example.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+
+  managed_virtual_network_enabled = true
+
+  identity {
+    type = "SystemAssigned"
+  }
+}

--- a/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/test/positive1.tf
+++ b/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/test/positive1.tf
@@ -1,0 +1,12 @@
+resource "azurerm_synapse_workspace" "positive1" {
+  name                                 = "example"
+  resource_group_name                  = azurerm_resource_group.example.name
+  location                             = azurerm_resource_group.example.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.example.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+
+  identity {
+    type = "SystemAssigned"
+  }
+}

--- a/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/test/positive2.tf
+++ b/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/test/positive2.tf
@@ -1,0 +1,14 @@
+resource "azurerm_synapse_workspace" "positive2" {
+  name                                 = "example"
+  resource_group_name                  = azurerm_resource_group.example.name
+  location                             = azurerm_resource_group.example.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.example.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+
+  managed_virtual_network_enabled = false
+
+  identity {
+    type = "SystemAssigned"
+  }
+}

--- a/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/test/positive_expected_result.json
@@ -1,0 +1,14 @@
+[
+  {
+    "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
+    "severity": "MEDIUM",
+    "line": 1,
+    "fileName": "positive1.tf"
+  },
+  {
+    "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
+    "severity": "MEDIUM",
+    "line": 9,
+    "fileName": "positive2.tf"
+  }
+]

--- a/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/test/positive_expected_result.json
+++ b/assets/queries/terraform/azure/synapse_workspace_managed_virtual_network_not_enabled/test/positive_expected_result.json
@@ -1,13 +1,13 @@
 [
   {
     "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "line": 1,
     "fileName": "positive1.tf"
   },
   {
     "queryName": "Synapse Workspace Managed Virtual Network Not Enabled",
-    "severity": "MEDIUM",
+    "severity": "LOW",
     "line": 9,
     "fileName": "positive2.tf"
   }


### PR DESCRIPTION
Closes #

**Reason for Proposed Changes**
- Currently, no queries check's if a synapse workspace managed virtual network is enabled.

**Proposed Changes**
- Implemented two queries called `"Synapse Workspace Managed Virtual Network Not Enabled"` for Terraform/Azure and AzureResourceManager.
- Both queries return a positive result if the field `managed_virtual_network_enabled` for the Terraform `azurerm_synapse_workspace` resource type and the field `managedVirtualResource` for the AzureResourceManager `Microsoft.Synapse/workspaces` resource type are not defined or defined to false/value different from `default`, respectively.

I submit this contribution under the Apache-2.0 license.