### PR TITLE
update(version): rename VERSION build-arg to ENGINE_VERSION

### DIFF
--- a/.github/workflows/go-ci-integration.yml
+++ b/.github/workflows/go-ci-integration.yml
@@ -53,7 +53,7 @@ jobs:
           push: false
           tags: kics:${{ env.PR_SHA }}
           build-args: |
-            VERSION=${GITHUB_SHA_SHORT}
+            ENGINE_VERSION=${GITHUB_SHA_SHORT}
             COMMIT=${GITHUB_SHA}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/go-e2e-debian.yaml
+++ b/.github/workflows/go-e2e-debian.yaml
@@ -97,7 +97,7 @@ jobs:
           tags: kics:e2e-${{ matrix.config.tag_suffix }}-${{ github.sha }}
           platforms: ${{ matrix.config.platform }}
           build-args: |
-            VERSION=development
+            ENGINE_VERSION=development
             COMMIT=${{ github.sha }}
             BUILDPLATFORM=${{ matrix.config.platform }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/go-e2e.yaml
+++ b/.github/workflows/go-e2e.yaml
@@ -108,7 +108,7 @@ jobs:
           tags: kics:e2e-${{ matrix.config.tag_suffix }}-${{ github.sha }}
           platforms: ${{ matrix.config.platform }}
           build-args: |
-            VERSION=development
+            ENGINE_VERSION=development
             COMMIT=${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/release-dkr-image.yml
+++ b/.github/workflows/release-dkr-image.yml
@@ -87,7 +87,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: checkmarx/kics:latest,checkmarx/kics:${{ steps.get-version.outputs.version }}
           build-args: |
-            VERSION=${{ steps.get-version.outputs.version }}
+            ENGINE_VERSION=${{ steps.get-version.outputs.version }}
             COMMIT=${{ github.sha }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             DESCRIPTIONS_URL=${{ secrets.DESCRIPTIONS_URL }}
@@ -102,7 +102,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: checkmarx/kics:alpine,checkmarx/kics:${{ steps.get-version.outputs.version }}-alpine
           build-args: |
-            VERSION=${{ steps.get-version.outputs.version }}
+            ENGINE_VERSION=${{ steps.get-version.outputs.version }}
             COMMIT=${{ github.sha }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             DESCRIPTIONS_URL=${{ secrets.DESCRIPTIONS_URL }}
@@ -117,7 +117,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: checkmarx/kics:debian,checkmarx/kics:${{ steps.get-version.outputs.version }}-debian
           build-args: |
-            VERSION=${{ steps.get-version.outputs.version }}
+            ENGINE_VERSION=${{ steps.get-version.outputs.version }}
             COMMIT=${{ github.sha }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             DESCRIPTIONS_URL=${{ secrets.DESCRIPTIONS_URL }}
@@ -132,7 +132,7 @@ jobs:
           tags: checkmarx/kics:ubi8,checkmarx/kics:${{ steps.get-version.outputs.version }}-ubi8
           platforms: linux/amd64,linux/arm64
           build-args: |
-            VERSION=${{ steps.get-version.outputs.version }}
+            ENGINE_VERSION=${{ steps.get-version.outputs.version }}
             COMMIT=${{ github.sha }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             DESCRIPTIONS_URL=${{ secrets.DESCRIPTIONS_URL }}

--- a/.github/workflows/release-docker-github-actions.yaml
+++ b/.github/workflows/release-docker-github-actions.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Check out the tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ GIT_VERSION }}
+          ref: ${{ env.GIT_VERSION }}
           persist-credentials: false
       - name: Setup QEMU
         uses: step-security/setup-qemu-action@109c6ed9f089be1a250c75fd6a534e30df44e030 # v4.0.0
@@ -45,8 +45,8 @@ jobs:
       - name: Login to DockerHub
         uses: step-security/docker-login-action@870af644803bf9f204aed474adbad2958fec048b # v4.1.0
         with:
-          username: ${{ DOCKER_USERNAME }}
-          password: ${{ DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
       - name: Get current date
         run: echo "CREATED_AT=$(date --rfc-3339=seconds)" >> $GITHUB_ENV
       - name: Docker meta
@@ -56,7 +56,7 @@ jobs:
           images: "checkmarx/kics"
           labels: |
             org.opencontainers.image.title=KICS
-            org.opencontainers.image.version=${{ GIT_VERSION }}
+            org.opencontainers.image.version=${{ env.GIT_VERSION }}
             org.opencontainers.image.vendor=Checkmarx
             org.opencontainers.image.authors=KICS
             org.opencontainers.image.description=Find security vulnerabilities, compliance issues, and infrastructure misconfigurations early in the development cycle of your infrastructure-as-code with KICS by Checkmarx.
@@ -64,7 +64,7 @@ jobs:
             org.opencontainers.image.url=https://github.com/Checkmarx/kics
             org.opencontainers.image.source=https://github.com/Checkmarx/kics
             org.opencontainers.image.licenses=Apache-2.0
-            org.opencontainers.image.revision=${{ PR_SHA }}
+            org.opencontainers.image.revision=${{ env.PR_SHA }}
             org.opencontainers.image.created=${{ env.CREATED_AT }}
       - name: Push Github Action Image to Docker Hub
         uses: step-security/docker-build-push-action@846549baaf047e867d038826129a64d81df0f704 # v7.1.0

--- a/.github/workflows/release-docker-github-actions.yaml
+++ b/.github/workflows/release-docker-github-actions.yaml
@@ -75,7 +75,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: checkmarx/kics:gh-action-kics2.0
           build-args: |
-            VERSION=${{ GIT_VERSION }}
+            ENGINE_VERSION=${{ GIT_VERSION }}
             COMMIT=${{ PR_SHA }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
             DESCRIPTIONS_URL=${{ secrets.DESCRIPTIONS_URL }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -171,7 +171,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: checkmarx/kics:nightly
           build-args: |
-            VERSION=nightly-${{ needs.pre_release_job.outputs.sha8 }}
+            ENGINE_VERSION=nightly-${{ needs.pre_release_job.outputs.sha8 }}
             COMMIT=${{ github.sha }}
             DESCRIPTIONS_URL=${{ secrets.DESCRIPTIONS_URL }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -185,7 +185,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: checkmarx/kics:nightly-alpine
           build-args: |
-            VERSION=nightly-${{ needs.pre_release_job.outputs.sha8 }}
+            ENGINE_VERSION=nightly-${{ needs.pre_release_job.outputs.sha8 }}
             COMMIT=${{ github.sha }}
             DESCRIPTIONS_URL=${{ secrets.DESCRIPTIONS_URL }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -199,7 +199,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: checkmarx/kics:nightly-debian
           build-args: |
-            VERSION=nightly-${{ needs.pre_release_job.outputs.sha8 }}
+            ENGINE_VERSION=nightly-${{ needs.pre_release_job.outputs.sha8 }}
             COMMIT=${{ github.sha }}
             DESCRIPTIONS_URL=${{ secrets.DESCRIPTIONS_URL }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -213,7 +213,7 @@ jobs:
           tags: checkmarx/kics:nightly-ubi8
           platforms: linux/amd64
           build-args: |
-            VERSION=nightly-${{ needs.pre_release_job.outputs.sha8 }}
+            ENGINE_VERSION=nightly-${{ needs.pre_release_job.outputs.sha8 }}
             COMMIT=${{ github.sha }}
             DESCRIPTIONS_URL=${{ secrets.DESCRIPTIONS_URL }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/sec-checks.yaml
+++ b/.github/workflows/sec-checks.yaml
@@ -66,7 +66,7 @@ jobs:
           push: false
           tags: kics:sec-trivy-tests-${{ github.sha }}
           build-args: |
-            VERSION=development
+            ENGINE_VERSION=development
             COMMIT=${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -135,7 +135,7 @@ jobs:
           push: false
           tags: kics:sec-tests-${{ github.sha }}
           build-args: |
-            VERSION=development
+            ENGINE_VERSION=development
             COMMIT=${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ${GO_BASE_IMAGE} AS build_env
 WORKDIR /app
 
 ENV GOPRIVATE=github.com/Checkmarx/*
-ARG VERSION="development"
+ARG ENGINE_VERSION="development"
 ARG COMMIT="NOCOMMIT"
 ARG SENTRY_DSN=""
 ARG DESCRIPTIONS_URL=""
@@ -25,7 +25,7 @@ COPY . .
 
 # Build the Go app
 RUN CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-    -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
+    -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${ENGINE_VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
     -a -installsuffix cgo \
     -o bin/kics cmd/console/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -131,12 +131,12 @@ podman: ## build podman image
 .PHONY: docker-compose
 dkr-compose: ## build docker image and runs docker-compose up
 	$(call print-target)
-	VERSION=${VERSION} COMMIT=${COMMIT} IMAGE_TAG=${IMAGE_TAG} docker-compose up --build
+	ENGINE_VERSION=${VERSION} COMMIT=${COMMIT} IMAGE_TAG=${IMAGE_TAG} docker-compose up --build
 
 .PHONY: podman-compose
 podman-compose: ## build podman image and runs podman-compose up
 	$(call print-target)
-	VERSION=${VERSION} COMMIT=${COMMIT} IMAGE_TAG=${IMAGE_TAG} podman-compose up --build
+	ENGINE_VERSION=${VERSION} COMMIT=${COMMIT} IMAGE_TAG=${IMAGE_TAG} podman-compose up --build
 
 .PHONY: dkr-build-antlr
 dkr-build-antlr: ## build ANTLRv4 docker image and generate parser based on given grammar

--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,12 @@ cover: test
 .PHONY: docker
 docker: ## build docker image
 	$(call print-target)
-	@docker build --build-arg VERSION=${VERSION} --build-arg COMMIT=${COMMIT} -t "kics:${IMAGE_TAG}" .
+	@docker build --build-arg ENGINE_VERSION=${VERSION} --build-arg COMMIT=${COMMIT} -t "kics:${IMAGE_TAG}" .
 
 .PHONY: podman
 podman: ## build podman image
 	$(call print-target)
-	@podman build --build-arg VERSION=${VERSION} --build-arg COMMIT=${COMMIT} -t "kics:${IMAGE_TAG}" .
+	@podman build --build-arg ENGINE_VERSION=${VERSION} --build-arg COMMIT=${COMMIT} -t "kics:${IMAGE_TAG}" .
 
 .PHONY: docker-compose
 dkr-compose: ## build docker image and runs docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       context: ./
       dockerfile: Dockerfile
       args:
-        VERSION: ${VERSION:-local}
+        ENGINE_VERSION: ${VERSION:-local}
         COMMIT: ${COMMIT}
         DESCRIPTIONS_URL: ${DESCRIPTIONS_URL}
     command: scan -p /path/ -v

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -4,7 +4,7 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.26.2@sha256:b54cbf583d390
 WORKDIR /app
 
 ENV GOPRIVATE=github.com/Checkmarx/*
-ARG VERSION="development"
+ARG ENGINE_VERSION="development"
 ARG COMMIT="NOCOMMIT"
 ARG SENTRY_DSN=""
 ARG DESCRIPTIONS_URL=""
@@ -22,7 +22,7 @@ COPY . .
 
 # Build the Go app
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-    -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
+    -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${ENGINE_VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
     -a -installsuffix cgo \
     -o bin/kics cmd/console/main.go
 

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -15,7 +15,7 @@ WORKDIR /app
 
 ENV GOPRIVATE=github.com/Checkmarx/*
 
-ARG VERSION="development"
+ARG ENGINE_VERSION="development"
 ARG COMMIT="NOCOMMIT"
 ARG SENTRY_DSN=""
 ARG DESCRIPTIONS_URL=""
@@ -36,7 +36,7 @@ USER root
 
 # Build the Go app
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-  -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
+  -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${ENGINE_VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
   -a -installsuffix cgo \
   -o bin/kics cmd/console/main.go
 

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -12,7 +12,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 COPY --from=go_toolchain /usr/local/go /usr/local/go
 
 ENV GOPRIVATE=github.com/Checkmarx/*
-ARG VERSION="development"
+ARG ENGINE_VERSION="development"
 ARG COMMIT="NOCOMMIT"
 ARG SENTRY_DSN=""
 ARG DESCRIPTIONS_URL=""
@@ -29,17 +29,17 @@ COPY . .
 
 # Build the Go app
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
-  -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
+  -ldflags "-s -w -X github.com/Checkmarx/kics/v2/internal/constants.Version=${ENGINE_VERSION} -X github.com/Checkmarx/kics/v2/internal/constants.SCMCommit=${COMMIT} -X github.com/Checkmarx/kics/v2/internal/constants.SentryDSN=${SENTRY_DSN} -X github.com/Checkmarx/kics/v2/internal/constants.BaseURL=${DESCRIPTIONS_URL}" \
   -a -installsuffix cgo \
   -o bin/kics cmd/console/main.go
 
 FROM redhat/ubi8:latest@sha256:a94c5e31450d30190afe6f7a09628dd1dd7a3dc98784ba5ed1d19fd77098fcb2
 
 ARG RELEASE
-ARG VERSION
+ARG ENGINE_VERSION
 
 ENV RELEASE=$RELEASE \
-  VERSION=$VERSION
+  VERSION=$ENGINE_VERSION
 
 LABEL name="KICS" \
   summary="Provides the latest release of the KICS (Keeping Infrastructure as Code Secure) scanner" \


### PR DESCRIPTION
**Reason for Proposed Changes**
- VERSION is a common build-arg name, colliding with a same-named arg if injected by any CI step, causing the wrong value to get baked into release binaries. Renamed to ENGINE_VERSION everywhere it's used: the Dockerfile variants, Makefile, docker-compose.yml and CI workflows. No functional change otherwise.

**Proposed Changes**
- Rename `VERSION` dockerfile parameter to `ENGINE_VERSION`;

I submit this contribution under the Apache-2.0 license.