### PR TITLE
fix(query): avoid false positives on exec-form RUN in package manager queries

### DIFF
--- a/assets/libraries/dockerfile.rego
+++ b/assets/libraries/dockerfile.rego
@@ -61,6 +61,12 @@ arrayContains(array, list) {
 	contains(array[_], list[_])
 }
 
+# every element of list must be found in some element of array
+arrayContainsAll(array, list) {
+	matched := {item | item := list[_]; contains(array[_], item)}
+	count(matched) == count(list)
+}
+
 check_multi_stage(imageName, images) {
     unsortedIndex := {x |
         images[name][i].Cmd == "from"

--- a/assets/queries/dockerfile/apt_get_install_pin_version_not_defined/query.rego
+++ b/assets/queries/dockerfile/apt_get_install_pin_version_not_defined/query.rego
@@ -34,7 +34,7 @@ CxPolicy[result] {
 
 	count(resource.Value) > 1
 
-	dockerLib.arrayContains(resource.Value, {"apt-get", "install"})
+	dockerLib.arrayContainsAll(resource.Value, {"apt-get", "install"})
 
 	resource.Value[j] != "install"
 	resource.Value[j] != "apt-get"

--- a/assets/queries/dockerfile/apt_get_install_pin_version_not_defined/test/negative.dockerfile
+++ b/assets/queries/dockerfile/apt_get_install_pin_version_not_defined/test/negative.dockerfile
@@ -1,2 +1,3 @@
 FROM busybox
 RUN apt-get install python=2.7
+RUN ["pwsh.exe", "-NoLogo", "-Command", "vcpkg integrate install"]

--- a/assets/queries/dockerfile/apt_get_missing_flags_to_avoid_manual_input/query.rego
+++ b/assets/queries/dockerfile/apt_get_missing_flags_to_avoid_manual_input/query.rego
@@ -30,7 +30,7 @@ CxPolicy[result] {
 
     count(resource.Value) > 1
 
-    dockerLib.arrayContains(resource.Value, {"apt-get", "install"})
+    dockerLib.arrayContainsAll(resource.Value, {"apt-get", "install"})
 
     not avoidManualInputInList(resource.Value)
     

--- a/assets/queries/dockerfile/apt_get_missing_flags_to_avoid_manual_input/test/negative1.dockerfile
+++ b/assets/queries/dockerfile/apt_get_missing_flags_to_avoid_manual_input/test/negative1.dockerfile
@@ -2,3 +2,4 @@ FROM node:12
 RUN apt-get -y install apt-utils
 RUN apt-get -qy install git gcc
 RUN ["apt-get", "-y", "install", "apt-utils"]
+RUN ["pwsh.exe", "-NoLogo", "-Command", "vcpkg integrate install"]

--- a/assets/queries/dockerfile/gem_install_without_version/query.rego
+++ b/assets/queries/dockerfile/gem_install_without_version/query.rego
@@ -33,7 +33,7 @@ CxPolicy[result] {
 
 	count(resource.Value) > 1
 
-    dockerLib.arrayContains(resource.Value, {"gem", "install"})
+    dockerLib.arrayContainsAll(resource.Value, {"gem", "install"})
 
 	resource.Value[j] != "install"
 	resource.Value[j] != "gem"

--- a/assets/queries/dockerfile/gem_install_without_version/test/negative.dockerfile
+++ b/assets/queries/dockerfile/gem_install_without_version/test/negative.dockerfile
@@ -11,3 +11,4 @@ CMD ["python", "/usr/src/app/app.py"]
 ENV GRPC_VERSION 1.0.0
 RUN gem install grpc -v ${GRPC_RUBY_VERSION}
 RUN gem install grpc:${GRPC_VERSION} grpc-tools:${GRPC_VERSION}
+RUN ["pwsh.exe", "-NoLogo", "-Command", "vcpkg integrate install"]

--- a/assets/queries/dockerfile/unpinned_package_version_in_apk_add/query.rego
+++ b/assets/queries/dockerfile/unpinned_package_version_in_apk_add/query.rego
@@ -95,7 +95,7 @@ CxPolicy[result] {
 
 	count(resource.Value) > 1
 
-	docker_lib.arrayContains(resource.Value, {"apk", "add"})
+	docker_lib.arrayContainsAll(resource.Value, {"apk", "add"})
 
 	resource.Value[j] != "apk"
 	resource.Value[j] != "add"

--- a/assets/queries/dockerfile/unpinned_package_version_in_apk_add/test/negative.dockerfile
+++ b/assets/queries/dockerfile/unpinned_package_version_in_apk_add/test/negative.dockerfile
@@ -18,3 +18,4 @@ COPY app.py /usr/src/app/
 COPY templates/index.html /usr/src/app/templates/
 EXPOSE 5000
 CMD ["python", "/usr/src/app/app.py"]
+RUN ["pwsh.exe", "-NoLogo", "-Command", "vcpkg integrate install"]

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/query.rego
@@ -26,7 +26,7 @@ CxPolicy[result] {
 	resource.Cmd == "run"
 	count(resource.Value) > 1
 
-    dockerLib.arrayContains(resource.Value, {"yum", "install"})
+    dockerLib.arrayContainsAll(resource.Value, {"yum", "install"})
 
 	not avoidManualInputInList(resource.Value)
 

--- a/assets/queries/dockerfile/yum_install_allows_manual_input/test/negative.dockerfile
+++ b/assets/queries/dockerfile/yum_install_allows_manual_input/test/negative.dockerfile
@@ -7,3 +7,4 @@ COPY app.py /usr/src/app/
 COPY templates/index.html /usr/src/app/templates/
 EXPOSE 5000
 CMD ["python", "/usr/src/app/app.py"] 
+RUN ["pwsh.exe", "-NoLogo", "-Command", "vcpkg integrate install"]

--- a/assets/queries/dockerfile/yum_install_without_version/query.rego
+++ b/assets/queries/dockerfile/yum_install_without_version/query.rego
@@ -36,7 +36,7 @@ CxPolicy[result] {
 
 	count(resource.Value) > 1
 
-	docker_lib.arrayContains(resource.Value, {"yum", "install"})
+	docker_lib.arrayContainsAll(resource.Value, {"yum", "install"})
 
 	resource.Value[j] != "install"
 	resource.Value[j] != "yum"

--- a/assets/queries/dockerfile/yum_install_without_version/test/negative.dockerfile
+++ b/assets/queries/dockerfile/yum_install_without_version/test/negative.dockerfile
@@ -6,3 +6,4 @@ HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1
 FROM opensuse/leap:15.3
 ENV RETHINKDB_PACKAGE_VERSION 2.4.0~0trusty
 RUN yum install -y rethinkdb-$RETHINKDB_PACKAGE_VERSION && yum clean all
+RUN ["pwsh.exe", "-NoLogo", "-Command", "vcpkg integrate install"]

--- a/assets/queries/dockerfile/zypper_install_without_version/query.rego
+++ b/assets/queries/dockerfile/zypper_install_without_version/query.rego
@@ -36,7 +36,7 @@ CxPolicy[result] {
 
 	count(resource.Value) > 1
 
-	docker_lib.arrayContains(resource.Value, {"zypper", "install"})
+	docker_lib.arrayContainsAll(resource.Value, {"zypper", "install"})
 
 	resource.Value[j] != "install"
 	resource.Value[j] != "zypper"

--- a/assets/queries/dockerfile/zypper_install_without_version/test/negative.dockerfile
+++ b/assets/queries/dockerfile/zypper_install_without_version/test/negative.dockerfile
@@ -1,3 +1,4 @@
 FROM opensuse/leap:15.2
 RUN zypper install -y httpd=2.4.46 && zypper clean
 HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1
+RUN ["pwsh.exe", "-NoLogo", "-Command", "vcpkg integrate install"]


### PR DESCRIPTION
Closes #8100

**Reason for Proposed Changes**
- Six Dockerfile package-manager queries raise false positives on any JSON exec-form `RUN` whose arguments merely contain the word `install`. The Dockerfile reported in #8100 gets 8 findings, all on one line:

```dockerfile
RUN ["pwsh.exe", "-NoLogo", "-Command", "vcpkg integrate install"]
```

- The cause is the shared `arrayContains` helper in `assets/libraries/dockerfile.rego`, which succeeds when *any* element of the array contains *any* item of the list:

```rego
arrayContains(array, list) {
	contains(array[_], list[_])
}
```

  The queries call it as `arrayContains(resource.Value, {"yum", "install"})` intending "both are present", so in practice they match on the bare word `install` and fire regardless of which package manager (if any) is involved.

**Proposed Changes**
- Add `arrayContainsAll` to `assets/libraries/dockerfile.rego`, which requires every item of the list to be found in some element of the array.
- Use it in the six affected queries: `apt_get_install_pin_version_not_defined`, `apt_get_missing_flags_to_avoid_manual_input`, `gem_install_without_version`, `unpinned_package_version_in_apk_add`, `yum_install_allows_manual_input`, `yum_install_without_version`, `zypper_install_without_version`. `arrayContains` is left untouched, since its two remaining callers (`add_instead_of_copy` and `apt_get_not_avoiding_additional_packages`) genuinely want any-of semantics.
- Add the offending instruction to each affected query's negative test fixture as a regression check.

**Verification**

Scanning the Dockerfile from #8100 goes from 14 findings to 8; every remaining finding is a genuine hit on another line, and the eight false positives on the `pwsh.exe` line are gone:

| Query | before | after |
| --- | --- | --- |
| Apt Get Install Pin Version Not Defined | 2 | 0 |
| Gem Install Without Version | 1 | 0 |
| Yum install Without Version | 2 | 0 |
| Zypper Install Without Version | 2 | 0 |
| APT-GET Missing Flags To Avoid Manual Input | 1 | 0 |
| Yum Install Allows Manual Input | 1 | 0 |

All 96 Dockerfile query subtests (`go test ./test/ -run "TestQueries/.*dockerfile.*"`) pass.

**Not addressed here**

The issue also notes that `Add Instead of Copy` and `Curl or Wget Instead of Add` both fire on the same `ADD <url>` line and give contradictory advice (`COPY` cannot take a URL). That is a real inconsistency, but resolving it means changing a query's intent and metadata rather than fixing a defect, so I left it for maintainers to decide which of the two rules should own remote `ADD`.

I submit this contribution under the Apache-2.0 license.