### PR TITLE
fix(query): correct keyExpectedValue and keyActualValue in redshift_not_encrypted

### DIFF
--- a/assets/queries/terraform/aws/redshift_not_encrypted/query.rego
+++ b/assets/queries/terraform/aws/redshift_not_encrypted/query.rego
@@ -32,8 +32,8 @@ CxPolicy[result] {
 		"searchKey": sprintf("aws_redshift_cluster[%s].encrypted", [name]),
 		"searchLine": common_lib.build_search_line(["resource", "aws_redshift_cluster", name, "encrypted"], []),
 		"issueType": "IncorrectValue",
-		"keyExpectedValue": "aws_redshift_cluster.encrypted should be set to false",
-		"keyActualValue": "aws_redshift_cluster.encrypted is true",
+		"keyExpectedValue": "aws_redshift_cluster.encrypted should be set to true",
+		"keyActualValue": "aws_redshift_cluster.encrypted is false",
 		"remediation": json.marshal({
 			"before": "false",
 			"after": "true"


### PR DESCRIPTION
**Reason for Proposed Changes**
- The second rule in the `redshift_not_encrypted` query had reversed `keyExpectedValue` and `keyActualValue` fields. When a cluster has encrypted = false, the finding is correctly detected, but the displayed messages on expected vs actual values were backwards, telling users the opposite of what was actually wrong.

**Proposed Changes**
- Fixed keyExpectedValue to read: "aws_redshift_cluster.encrypted should be set to true" (was incorrectly set to "false").
- Fixed keyActualValue to read: "aws_redshift_cluster.encrypted is false" (was incorrectly set to "true").
- The remediation field remains correct and consistent with the fix: before: "false", after: "true"

I submit this contribution under the Apache-2.0 license.