### PR TITLE
AST-171789 Point kics CODEOWNERS at cx-maintainers-kics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*      @checkmarx/kics
+*      @Checkmarx/cx-maintainers-kics


### PR DESCRIPTION
Points default code ownership at the cx-maintainers-kics team, aligning CODEOWNERS with the reviewer team required by the kics merge-protection ruleset.

Previously ownership pointed at a different team, which meant a PR needed approvals from two separate teams to satisfy both the ruleset and the code-owner rule. cx-maintainers-kics has push access to the repo, so the ownership rule resolves correctly.
