### PR TITLE
fix(action): remove concurrent group from run projects github action

### DIFF
--- a/.github/workflows/run-projects.yaml
+++ b/.github/workflows/run-projects.yaml
@@ -8,10 +8,6 @@ on:
         required: true
         type: number
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 env:
   ENGINE: "kics"
   CES_ENVIRONMENT: "prod"


### PR DESCRIPTION
**Reason for Proposed Changes**
- The concurrency group to run-projects and ci-projects were cancelling each other.

**Proposed Changes**
- Remove the concurrency group from run-projects action;

I submit this contribution under the Apache-2.0 license.