### PR TITLE
fix(test): normalize timestamp comparison in TestInitCycloneDxReport

### DIFF
--- a/pkg/report/model/cyclonedx_test.go
+++ b/pkg/report/model/cyclonedx_test.go
@@ -49,6 +49,7 @@ func TestInitCycloneDxReport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := InitCycloneDxReport()
 			got.SerialNumber = "urn:uuid:" // set to "urn:uuid:" because it will be different for every report
+			got.Metadata.Timestamp = tt.want.Metadata.Timestamp // set to want's value because it depends on the current time and would otherwise be flaky
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("InitCycloneDxReport() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
**Reason for Proposed Changes**
- TestInitCycloneDxReport has a flaky behaviour due to how we compare the fields inside the generated CycloneDxReport (see logs below);

<img width="641" height="107" alt="image" src="https://github.com/user-attachments/assets/0a21dedb-079c-499d-b92c-422743aed3ed" />

**Proposed Changes**
- TestInitCycloneDxReport sometimes failed because it compared a timestamp captured once at package-var initialization against a timestamp generated at call time by InitCycloneDxReport();
- Normalized `Timestamp` field before comparison, the same way SerialNumber field is already normalized, since neither field is meant to be asserted for exact equality.

I submit this contribution under the Apache-2.0 license.